### PR TITLE
Remove spaces after semicolon in block_formats configuration

### DIFF
--- a/_includes/configuration/block-formats.md
+++ b/_includes/configuration/block-formats.md
@@ -9,6 +9,6 @@ The enables you to specify a list of block formats for the block listbox. The fo
 ```js
 tinymce.init({
   selector: 'textarea',  // change this value according to your html
-  block_formats: 'Paragraph=p; Header 1=h1; Header 2=h2; Header 3=h3'
+  block_formats: 'Paragraph=p;Header 1=h1;Header 2=h2;Header 3=h3'
 });
 ```


### PR DESCRIPTION
If there are spaces after the semicolon in the block_formats configuration the translation doesn't work.