### PR TITLE
Add quotes to literal on JS example

### DIFF
--- a/get-started/filter-content.md
+++ b/get-started/filter-content.md
@@ -85,7 +85,7 @@ tinymce.init({
     strikethrough: {inline : 'del'},
     forecolor: {inline : 'span', classes : 'forecolor', styles : {color : '%value'}},
     hilitecolor: {inline : 'span', classes : 'hilitecolor', styles : {backgroundColor : '%value'}},
-    custom_format: {block : 'h1', attributes : {title : 'Header'}, styles : {color : red}}
+    custom_format: {block : 'h1', attributes : {title : 'Header'}, styles : {color : 'red'}}
   }
 });
 ```


### PR DESCRIPTION
It throws an "red is not defined" error