### PR TITLE
Update importcss.md

### DIFF
--- a/plugins/importcss.md
+++ b/plugins/importcss.md
@@ -170,9 +170,9 @@ article, aside, footer, header, main, nav, section {display: block;}
 .ui-helper-hidden { display: none; }
 
 /* Custom Styles */
-.myCustomStyleStart {display:none;}
+.myCustomStyleStart {-custom-noop: noop;}
        // INCLUDE ALL MY CLASSES HERE IN THE Formats menu!
-.myCustomStyleEnd {display:none;}
+.myCustomStyleEnd {-custom-noop: noop;}
 
 /* Any other possible styles afterward ... */
 ```


### PR DESCRIPTION
Use a custom no-op attribute (using vendor prefix notation) instead of `display:none` for the custom style start and end tags.