### PR TITLE
Added more details around image upload script requirements 

### DIFF
--- a/advanced/handle-async-image-uploads.md
+++ b/advanced/handle-async-image-uploads.md
@@ -7,11 +7,11 @@ description: How to manage asynchronous image uploads wtih jQuery, CORS.
 keywords: asynchronous async paste_data_images image cors
 ---
 
-Please note, this image upload feature is available for TinyMCE version 4.2 and above. Alternatively, the Ephox PowerPaste plugin is capable of this functionality in versions of TinyMCE 4.0 and above.  
+Please note, this image upload feature is available for TinyMCE version 4.2 and above. Alternatively, the Ephox PowerPaste plugin is capable of this functionality in versions of TinyMCE 4.0 and above.
 
 The image uploader is designed to complement the new image editing functionality of TinyMCE 4.2. Images that are edited within TinyMCE can be uploaded using this function. Local images that are added through other means - for example drag and drop when using the [paste_data_images]({{ site.baseurl }}/plugins/paste/#paste_data_images) configuration property or using Ephox's PowerPaste Plugin - can also be uploaded using this functionality.
 
-Once uploaded, TinyMCE will automatically update the `<image>` src attribute with the new path to the remote image.  
+Once uploaded, TinyMCE will automatically update the `<image>` src attribute with the new path to the remote image.
 
 Local images can be uploaded to TinyMCE through the use of the new `editor.uploadImages()` function.  This functionality is handled asynchronously, meaning that it is possible for users to save their content before all images have completed uploading.  If this occurs, no server path to the remote image will be available and the images will be stored as Base64.
 
@@ -24,7 +24,7 @@ Examples of this function are below:
 ```js
 tinymce.activeEditor.uploadImages(function(success) {
   $.post('ajax/post.php', tinymce.activeEditor.getContent()).done(function() {
-    console.log("Uploaded images and posted content as an ajax request.");
+	console.log("Uploaded images and posted content as an ajax request.");
   });
 });
 ```
@@ -42,6 +42,21 @@ tinymce.activeEditor.uploadImages(function(success) {
 In order to upload local images to the remote server, you will need a server-side upload handler script that accepts the images on the server, stores them appropriately, and returns a JSON object containing the location that they were uploaded to.
 
 An example PHP upload handler implementation is available [here](../php-upload-handler/).
+
+Images will be sent to the Image Uploader via HTTP POST with each post containing a single image. The image handler at the URL referenced in the `images_upload_url` has to do whatever needs to be done to "store" the image in your application. Some examples would include:
+
+ * Store the item in a folder on your web server
+ * Store the item on a CDN server
+ * Store the item in a database
+ * Store the item in an asset management system
+
+When the image is uploaded it will have a standardized name in the post (e.g. `blobid0`, `blobid1`, `imagetools0`, `imagetools1`).
+
+*You will need to ensure that your upload handler script takes each uploaded file and generates a unique name prior to storing the image*.
+
+For example, you could append the current time (in milliseconds) to the end of the file name which would lead to file names like `blobid0-1458428901092` or `blobid0-1460405299-0114.png`.  Take care to make sure that the file name is unique as you don't want to accidentally overwrite a previously uploaded image!
+
+
 
 This server-side upload handler must return a JSON object that contains a "location" property. This property should represent the remote location or filename of the newly uploaded image.
 
@@ -66,10 +81,10 @@ An example of a typical setup is below:
 
 ```js
 tinymce.init({
-    selector: 'textarea',  // change this value according to your HTML
-    images_upload_url: 'postAcceptor.php',
-    images_upload_base_path: '/some/basepath',
-    images_upload_credentials: true
+	selector: 'textarea',  // change this value according to your HTML
+	images_upload_url: 'postAcceptor.php',
+	images_upload_base_path: '/some/basepath',
+	images_upload_credentials: true
 });
 ```
 
@@ -85,34 +100,34 @@ An example of this setup is below:
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
   images_upload_handler: function (blobInfo, success, failure) {
-    var xhr, formData;
+	var xhr, formData;
 
-    xhr = new XMLHttpRequest();
-    xhr.withCredentials = false;
-    xhr.open('POST', 'postAcceptor.php');
+	xhr = new XMLHttpRequest();
+	xhr.withCredentials = false;
+	xhr.open('POST', 'postAcceptor.php');
 
-    xhr.onload = function() {
-      var json;
+	xhr.onload = function() {
+	  var json;
 
-      if (xhr.status != 200) {
-        failure('HTTP Error: ' + xhr.status);
-        return;
-      }
+	  if (xhr.status != 200) {
+		failure('HTTP Error: ' + xhr.status);
+		return;
+	  }
 
-      json = JSON.parse(xhr.responseText);
+	  json = JSON.parse(xhr.responseText);
 
-      if (!json || typeof json.location != 'string') {
-        failure('Invalid JSON: ' + xhr.responseText);
-        return;
-      }
+	  if (!json || typeof json.location != 'string') {
+		failure('Invalid JSON: ' + xhr.responseText);
+		return;
+	  }
 
-      success(json.location);
-    };
+	  success(json.location);
+	};
 
-    formData = new FormData();
-    formData.append('file', blobInfo.blob(), fileName(blobInfo));
+	formData = new FormData();
+	formData.append('file', blobInfo.blob(), fileName(blobInfo));
 
-    xhr.send(formData);
+	xhr.send(formData);
   }
 });
 ```


### PR DESCRIPTION
The docs were not very clear on the fact that the name of the uploaded images are going to be repeated and that you need to come up with a unique name when you save the content. If you don't do this the second `blobid0` will overwrite the prior `blobid0`.