### PR TITLE
Fixed URL to language pack downloads

### DIFF
--- a/_includes/configuration/language.md
+++ b/_includes/configuration/language.md
@@ -4,9 +4,9 @@ This option allows you to specify the language that TinyMCE's user interface wil
 
 If you wish to use a language other than English, please follow these steps:
 
-1. Download the language pack you wish to use [from here](http://www.tinymce.com/i18n/index.php).
+1. Download the language pack you wish to use [from here](https://www.tinymce.com/download/language-packages/).
 2. Unpack the language file into your `tinymce/js/langs` folder.
-3. Set the [`language`](/configure/localization/#language) option in your TinyMCE configuration to the language code in the list below (which you'll also find on the language pack [download page](http://www.tinymce.com/i18n/index.php).
+3. Set the [`language`](/configure/localization/#language) option in your TinyMCE configuration to the language code in the list below (which you'll also find on the language pack [download page](https://www.tinymce.com/download/language-packages/).
 4. Confirm that the language has been set successfully by loading TinyMCE.
 
 Please note, the language code you set in your TinyMCE configuration must match the filename of the language file. If the language file is not found, TinyMCE will not load.
@@ -86,7 +86,6 @@ The available language codes for use with this option are as follows:
 | Portuguese (Portugal)         | pt_PT   |
 | Romanian                      | ro      |
 | Russian                       | ru      |
-| Russian Petrine orthography   | ru@petr1708 |
 | Serbian                       | sr      |
 | Sinhala (Sri Lanka)           | si_LK   |
 | Slovak                        | sk      |


### PR DESCRIPTION
The URL was pointing to a page on the old TinyMCE site.  I also removed Russian Petrine from language list as its not on the new language pack download page.