### PR TITLE
Modified the nonbreaking space entity and added block code on the entity encoding

### DIFF
--- a/_includes/configuration/entity-encoding.md
+++ b/_includes/configuration/entity-encoding.md
@@ -8,9 +8,9 @@ The base entities `<` `>` `&` `'` and `"` will always be entity encoded into the
 
 | Name     | Summary          |
 |----------|------------------|
-| named    |Characters will be converted into named entities based on the entities option. For example, a non-breaking space could be encoded as &nbsp;. This value is default. |
-| numeric  | Characters will be converted into numeric entities. For example, a non-breaking space would be encoded as &#160;. |
-| raw      |All characters will be stored in non-entity form except these XML default entities: &amp; &lt; &gt; &quot; |
+| named    |Characters will be converted into named entities based on the entities option. For example, a non-breaking space could be encoded as `&nbsp;`. This value is default. |
+| numeric  | Characters will be converted into numeric entities. For example, a non-breaking space would be encoded as `&#160;`. |
+| raw      |All characters will be stored in non-entity form except these XML default entities: ```&``` ```<``` ```>``` ```"``` |
 
 **Type:** `String`
 


### PR DESCRIPTION
The `&nsbp; `and `&#160;` entities were not seen on 
https://www.tinymce.com/docs/configure/content-filtering/#entity_encoding  page so modified the page to put them in code block. Also placed & < > " entities in code block


