### PR TITLE
Removed comment from automatic-uploads definition

### DIFF
--- a/_includes/configuration/automatic-uploads.md
+++ b/_includes/configuration/automatic-uploads.md
@@ -4,7 +4,7 @@ Enable or disable TinyMCE from automatically uploading local images.
 
 **Type:** `Boolean`
 
-**Default Value:** `true`  // confirmation required
+**Default Value:** `true`
 
 **Possible Values:** `true`, `false`
 


### PR DESCRIPTION
...just cleaned up the markdown by removing a comment that was visible on the site.