### PR TITLE
Fixed typo in listing of options for powerpaste_html_import

### DIFF
--- a/enterprise/paste-from-word.md
+++ b/enterprise/paste-from-word.md
@@ -51,7 +51,7 @@ This setting controls how content being pasted from Microsoft Word is filtered. 
 This setting controls how content being pasted from sources other than Microsoft Word is filtered. Note that this includes content copied from TinyMCE itself. The supported values are:
 
 * `clean` - Preserve the structure of the content such as headings, tables and lists but remove inline styles and classes. This results in simple content that uses the site's CSS stylesheet while retaining the semantic structure from the original document.
-merge (Default) - Preserve the inline formatting and structure of the original document. Invalid and proprietary styles, tags and attributes are still removed ensuring that the HTML is valid while more closely matching the original document formatting.
+* `merge` (Default) - Preserve the inline formatting and structure of the original document. Invalid and proprietary styles, tags and attributes are still removed ensuring that the HTML is valid while more closely matching the original document formatting.
 * `prompt` - Prompt the user to choose between the clean and merge options after attempting to paste HTML content.
 
 ### powerpaste_block_drop


### PR DESCRIPTION
 by fixing the list formatting for merge as it was not setup as a list item.  
![image](https://cloud.githubusercontent.com/assets/2193139/16083194/54dcc46e-32d1-11e6-95a2-f5109ba44d12.png)
