### PR TITLE
Fix types of code_dialog_width and height

### DIFF
--- a/plugins/code.md
+++ b/plugins/code.md
@@ -32,7 +32,7 @@ This configuration option sets the *internal, editable area* height of the `code
 
 Note that the external dimensions of the actual modal will be slightly larger than the value set.
 
-**Type:** `String`
+**Type:** `Number`
 
 ##### Example
 
@@ -52,7 +52,7 @@ This configuration option sets the *internal, editable area* width of the `code`
 
 Note that the external dimensions of the actual modal will be slightly larger than the value set.
 
-**Type:** `String`
+**Type:** `Number`
 
 ##### Example
 


### PR DESCRIPTION
I noticed that `code_dialog_width` and `code_dialog_height` were both listed as `string`s, when they should be `number`s. This PR fixes that.