### PR TITLE
Advlist plugin documentation mistakes

### DIFF
--- a/plugins/advlist.md
+++ b/plugins/advlist.md
@@ -34,8 +34,8 @@ This option allows you to include specific unordered list item markers in the de
 
 **Possible Values:**
 
-  * `circle`: a filled circle
-  * `disc`: a hollow circle
+  * `circle`: a hollow circle
+  * `disc`: a filled circle
   * `square`: a filled square
 
 #### Example:


### PR DESCRIPTION
The decription regarding un orderd list (ul) is not correct. The list-style-type: circle, shall produce a hollow circle, where as for 'disc' it is filled.