### PR TITLE
fixes reversion to enterprise/server.md

### DIFF
--- a/enterprise/server.md
+++ b/enterprise/server.md
@@ -5,7 +5,7 @@ description: Power your premium plugins like spelling as-you-type.
 keywords: enterprise tinymcespellchecker spell check checker pro pricing imagetools server
 ---
 
-## Server-Side Component Installation
+## Server-side Component Installation
 
 
 *Spell checking* and *image tools proxy* require the deployment of several server-side components onto a J2EE compatible application server.  We currently support Jetty, Apache Tomcat, and WebSphere Application Server.  To discuss support for additional Java application servers, please contact us: <mailto:sales@ephox.com>

--- a/enterprise/server.md
+++ b/enterprise/server.md
@@ -1,35 +1,37 @@
 ---
 layout: default
-title: Install Spell Checker Pro Server
-description: Spell Checker Pro is a premium plugin and server to check spelling as-you-type.
-keywords: enterprise tinymcespellchecker spell check checker pro pricing
+title: Install Server-side Components
+description: Power your premium plugins like spelling as-you-type.
+keywords: enterprise tinymcespellchecker spell check checker pro pricing imagetools server
 ---
 
 ## Server-Side Component Installation
 
 
-Spell checking requires the deployment of several server-side components onto a J2EE compatible application server (e.g. Jetty, or Apache Tomcat).  
+*Spell checking* and *image tools proxy* require the deployment of several server-side components onto a J2EE compatible application server.  We currently support Jetty, Apache Tomcat, and WebSphere Application Server.  To discuss support for additional Java application servers, please contact us: <mailto:sales@ephox.com>
 
-The following server-side components are required to enable spell checking:
+The following server-side components are packaged with the TinyMCE SDK:
 
 |Component                      | File							| Description |
-|:-----------------------------	|:-------						|:----------|
-| Allowed Origins				| ephox-allowed-origins.war 	| Supplies configuration for server components to communicate with your application.|
-| Spellchecking 				| ephox-spelling.war			|Spell checking service for TinyMCE Enterprise.|
+|:-----------------------------	|:-------						|:----------- |
+| Allowed Origins				| ephox-allowed-origins.war 	| Supplies configuration for server components to communicate with your application. In order to use the *Spellchecking* or *Image Tools Proxy* features, you **must** install and configure this component.|
+| [Spellchecking]({{ site.baseurl }}/enterprise/check-spelling/) 				| ephox-spelling.war		|Spell checking service for TinyMCE Enterprise.|
+| [Image Tools Proxy]({{ site.baseurl }}/plugins/imagetools/)				| ephox-image-proxy.war		|Image proxy service for the Image Tools plugin.|
 
 
-This guide will help you set up the Spelling server-side components, and show you how to use them in conjunction with editor clients. The steps required are:
+This guide will help you set up the server-side components for the above-mentioned features, and show you how to use them in conjunction with editor clients. The steps required are:
+
 1. Install a Java application server (or use existing)
 2. Deploy server-side components
 3. Create a configuration file and configure the allowed origins service
 4. Pass the configuration file to the Java application server
 5. Restart the Java application server
-6. Set up editor client instances to use the spelling service
+6. Set up editor client instances to use the server-side functionality
 
 
 ### Step 1. Install a Java Application Server
 
-Server-side components require a Java Application Server to run.  
+Server-side components require a Java Application Server to run.
 
 If you don't already have a Java application server installed you can easily install [Tomcat](http://tomcat.apache.org/) or [Jetty](http://www.eclipse.org/jetty/) with their default settings.
 
@@ -41,70 +43,74 @@ These are both simple, open source Java application servers and they're easy to 
 ### Step 2. Deploy Server-side Components
 
 You’ll need to ensure you deploy the following WAR files packaged with the TinyMCE Enterprise SDK:
-* ephox-allowed-origins.war
-* ephox-spelling.war
 
-The easiest way to deploy these files is to simply drag and drop them into the webapps directory of your Tomcat/Jetty server (or equivalent folder of another Java application server), and then restart the server.  
+- ephox-allowed-origins.war
+- ephox-spelling.war
+- ephox-image-proxy.war
+
+The easiest way to deploy these files is to simply drag and drop them into the webapps directory of your Tomcat/Jetty server (or equivalent folder of another Java application server), and then restart the server.
 
 More information on deploying components/applications:
-* [Deploying applications with Tomcat 6.0](https://tomcat.apache.org/tomcat-6.0-doc/deployer-howto.html)
-* [Deploying applications with Jetty](https://wiki.eclipse.org/Jetty/Howto/Deploy_Web_Applications)
+
+- [Deploying applications with Tomcat 6.0](https://tomcat.apache.org/tomcat-6.0-doc/deployer-howto.html)
+- [Deploying applications with Jetty](https://wiki.eclipse.org/Jetty/Howto/Deploy_Web_Applications)
 
 
 ### Step 3. Create a configuration file and configure the allowed origins service
 
 > **Note:** It is recommended that you use a plain text editor (eg: gedit, vim, emacs, notepad etc) when creating or editing the application.conf file. Do not use editors like Evernote as there is a good chance of smart quotes being used where plain quotes should be used and this will cause the services to fail.
 
-Services requires a configuration file named `application.conf` to be referenced by the application server.
+Services require a configuration file named `application.conf` to be referenced by the application server.
 
-The SDK comes packaged with an example configuration file (`examples/sample_application.conf`) that can be used as a reference guide. You can use this example file (after modifying it with your settings).  We recommend that you make a backup of the file before editing it.
+This configuration file will require you to enter two pieces of information:
 
-The `allowed-origins` configuration element will need to be specified in order for the spelling server-side component to work.
-
+- `origins` - which domains are allowed to communicate with the server-side editor features.
+- `url` - the location of the allowed-origins checking service itself.
 
 #### allowed-origins
 
-This element configures the allowed-origins service which allows all server-side components to communicate with specified domains.  
+This element configures the allowed-origins service which allows all server-side components to communicate with specified domains.
 
 The `origins` attribute must list all the domains that instances of the editor will be hosted on.  Only requests from the listed origins will be processed by the server-side components. Requests from any other domains will be rejected. An array of strings representing the domains allowed to communicate with the services.
 
 > Note: Be sure to include the protocol (https or http) and any required port number (eg:8080) in the string.
 
 The `url` attribute defines the location of the allowed-origins service. This string is a concatenation of two values:
-* String 1: The URL location of the allowed-origins service
-* String 2: The API to access in the service (/cors).
+
+- String 1: The URL location of the allowed-origins service
+- String 2: The API to access in the service (/cors).
 
 Example:
 
 ````
 ephox {
-    allowed-origins {
-        origins = [ "http://myserver", "http://myserver:8080", "http://myotherserver", "http://myotherserver:9090", "https://mysecureserver" ]
-        url = "http://myserver:8080/ephox-allowed-origins/cors"
-    }
+	allowed-origins {
+		origins = [ "http://myserver", "http://myserver:8080", "http://myotherserver", "http://myotherserver:9090", "https://mysecureserver" ]
+		url = "http://myserver:8080/ephox-allowed-origins/cors"
+	}
 }
 ````
 
-#### Entering Origins
+##### Additional Information Around Entering Origins
 
-The origins are matched by protocol, host name, and port. You may need a combination of all three, depending on which browser you use. If you are serving the editor and services from `http://localhost:80`, then the list of origins should have an entry for `http://localhost:80` and any other servers with ports, like so:
+The origins are matched by protocol, host name, and port. So you may need a combination of all three, depending on which browsers you use. If you are serving the editor and services from `http://localhost` & port 80, then the list of origins should have an entry for `http://localhost` and any other servers with ports, like so:
 
 ````
 ephox{
    allowed-origins{
-       origins=["http://localhost", "http://any-other-servers:port"]
-       url = "http://localhost/ephox-allowed-origins/cors"
+	   origins=["http://localhost", "http://any-other-servers:port"]
+	   url = "http://localhost/ephox-allowed-origins/cors"
   }
 }
 ````
 
-This only applies to port 80 because this is the default HTTP port, and browsers omit it when talking to the server. For every other port and host name, the recommended setting is to make one entry with the port and one without the port. This is because different browsers behave differently with regards to the Origin header. So the config file should resemble:
+This only applies to port 80 because this being the default HTTP port, browsers omit it when talking to the server. For every other port and host name, the recommended setting is to make one entry with the port and one without the port. This is because different browsers behave differently with regards to the Origin header. So the config file should resemble:
 
 ````
 ephox{
    allowed-origins{
-       origins=["http://hostname", "http://hostname:1234"]
-       url = "http://hostname:1234/ephox-allowed-origins/cors"
+	   origins=["http://hostname", "http://hostname:1234"]
+	   url = "http://hostname:1234/ephox-allowed-origins/cors"
   }
 }
 ````
@@ -115,7 +121,28 @@ Ensure that you have the right protocol specified, and for more examples see the
 
 Depending on your configuration and the browser you use, you may need to specify the port number as well when listing the origin. If you observe that requests are failing with services not being available, it may be because the port number is required. Refer to troubleshooting guide - section titled Investigating Using the Browser's Network Tools.
 
+##### Example application.conf
 
+TinyMCE is deployed to an environment and displayed to end users on the following domains:
+
+- http://myCMS
+- https://myCMS
+- http://myCMS:4141
+
+The `allowed-origins` service has been installed and is accessible via the following URL:
+
+- http://myCMS:8080/ephox-allowed-origins
+
+For this example, here is what the contents of `application.conf` should look like:
+
+````
+ephox{
+   allowed-origins{
+           origins=["http://myCMS", "https://myCMS", "http://myCMS:4141"]
+           url = "http://myCMS:8080/ephox-allowed-origins/cors"
+  }
+}
+````
 
 ### Step 4. Pass the configuration file to the Java application server
 
@@ -130,7 +157,7 @@ The following examples demonstrate how to reference application.conf for Tomcat 
 
 Make/edit a script at `/tomcat/install/directory/bin/setenv.sh`
 
-Ensure the file contains a single line:
+Ensure the file contains a single line, like (this must be the absolute path as before):
 
 `CATALINA_OPTS=" -Dconfig.file=/config/file/location/application.conf"`
 
@@ -178,17 +205,22 @@ The first new lines of the file should read:
 
 Once you have created a configuration file, configured the allowed origins service, and passed the configuration file to the Java application server you must restart the Java application server.
 
-With the above steps completed you can now direct TinyMCE instances to use the server-side spelling component.
+### Step 6: Set up editor client instances to use the server-side functionality
+
+With the above steps completed you can now direct TinyMCE instances to use the image editing and server-side spelling components.
 
 Set the TinyMCE `spellchecker_rpc_url` configuration property to the URL of the deployed server side spelling component. This URL is provided to you by your Java application server.
+Set the TinyMCE `imagetools_proxy` configuration property to the URL of the deployed server-side image proxy component.
 
 Example of TinyMCE client configuration:
 
 ````
 tinymce.init({
-    selector: 'textarea',
-    plugins: 'tinymcespellchecker',
-    spellchecker_rpc_url: 'http://yourspelling.server.com/ephox-spelling/'
+	selector: 'textarea', // change this value according to your HTML
+	toolbar: 'image',
+	plugins: 'tinymcespellchecker image imagetools',
+	spellchecker_rpc_url: 'http://yourspelling.server.com/ephox-spelling/',
+	imagetools_proxy: 'http://yourproxy.server.com/ephox-image-proxy/image'
 });
 ````
 
@@ -201,7 +233,7 @@ To write the spelling-service specific logs to a specific file, you’ll need to
 
 #### Create a logging configuration XML file
 
-The spelling service use the [Logback](http://logback.qos.ch/manual/configuration.html) logging format.
+The spelling service uses the [Logback](http://logback.qos.ch/manual/configuration.html) logging format.
 
 For easy implementation, here is a sample XML configuration with a tokenized value you can populate where {$LOG_LOCATION} is the location and name of the file you would like to write the logs to (e.g. /tmp/tinymce_services.log).
 
@@ -209,28 +241,28 @@ For easy implementation, here is a sample XML configuration with a tokenized val
 <configuration>
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-    </encoder>
+	<encoder>
+	  <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+	</encoder>
   </appender>
 
   <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-    <file>{$LOG_LOCATION}</file>
-    <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-    </encoder>
+	<file>{$LOG_LOCATION}</file>
+	<encoder>
+	  <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+	</encoder>
   </appender>
 
   <!-- This results in all ephox logging going to file.
-       Change/uncomment this part here if spellchecking specific logging is required -->
+	   Change/uncomment this part here if spellchecking specific logging is required -->
   <logger name="com.ephox" level="INFO"/>
   <!-- <logger name="com.ephox.ironbark" level="INFO"/> -->
 
   <root level="INFO">
-    <appender-ref ref="FILE" />
-    <!-- If you want logging to go to the container as well uncomment
-    the following line -->
-    <!-- <appender-ref ref="STDOUT" /> -->
+	<appender-ref ref="FILE" />
+	<!-- If you want logging to go to the container as well uncomment
+	the following line -->
+	<!-- <appender-ref ref="STDOUT" /> -->
   </root>
 
 </configuration>


### PR DESCRIPTION
+ fixes commit 2c21b9 in file enterprise/server.md which reverted the file back to setting up spell check server-side components