### PR TITLE
Changed the event type in the example of 'Blur' event listener

### DIFF
--- a/advanced/events.md
+++ b/advanced/events.md
@@ -100,7 +100,7 @@ Here is an example off how to listen for blur events.
 tinymce.init({
   selector: 'textarea',
   init_instance_callback: function (editor) {
-    editor.on('focus', function (e) {
+    editor.on('blur', function (e) {
       console.log('Editor was blurred!');
     });
   }


### PR DESCRIPTION
Obvious change in the provided example of 'Blur' event listener. It was faulty, probably due to c/p of the 'Focus' event listener example.