### PR TITLE
Fix incorrect name of configuration option

### DIFF
--- a/_includes/configuration/images-upload-handler.md
+++ b/_includes/configuration/images-upload-handler.md
@@ -4,7 +4,7 @@ This option allows you to specify a function that will be used to replace TinyMC
 
 The upload handler function takes three arguments: `blobInfo`, a `success` callback and a `failure` callback. When this option is not set, TinyMCE utilizes an XMLHttpRequest to upload images one at a time to the server, and calls the success callback with the location of the remote image.
 
-Please note that when using this option, no other image uploader options are necessary. Additionally, if you would like TinyMCE to replace the `<image>` tag's `src` attribute with the remote location, please use the success callback defined in the `image_upload_handler` function with the returned JSON object's location property.
+Please note that when using this option, no other image uploader options are necessary. Additionally, if you would like TinyMCE to replace the `<image>` tag's `src` attribute with the remote location, please use the success callback defined in the `images_upload_handler` function with the returned JSON object's location property.
 
 **Type:** `JavaScript Function`
 


### PR DESCRIPTION
one of the references to `images_upload_handler` was called `image_upload_handler`.