### PR TITLE
Cloud Get Started index now treated as folder

### DIFF
--- a/get-started-cloud/editor-plugin-version.md
+++ b/get-started-cloud/editor-plugin-version.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title: Specify Editor & Plugin Versions
-description_short: Specifying Editor and Plugin Versions for Cloud Deployments
-description: Specifying Editor and Plugin Versions for Cloud Deployments
+description_short: Specifying editor and plugin versions for Cloud deployments.
+description: Specifying editor and plugin versions for Cloud deployments.
 keywords: tinymce cloud script textarea apiKey
 ---
 

--- a/get-started-cloud/index.md
+++ b/get-started-cloud/index.md
@@ -1,9 +1,9 @@
 ---
 layout: default
 title: Cloud Get Started
-description_short: Learn how to setup the TinyMCE editor and plugins via our Cloud.
 description: TinyMCE Cloud customers, you'll be up and running in less than 5 minutes.
-keywords: tinymce cloud script textarea apiKey
+type: folder
 ---
+
 {% assign links = site.data.nav[1].pages %}
 {% include index.html links=links %}


### PR DESCRIPTION
[+] the top level url for the updated Cloud docs at get-started-cloud/index.md was treated as a page, not a folder. It’s now a folder.
[+] fix minor typos in meta section of editor-plugin-version.md