### PR TITLE
fix incorrect baseurl refs

### DIFF
--- a/get-started-cloud/editor-and-features.md
+++ b/get-started-cloud/editor-and-features.md
@@ -8,7 +8,7 @@ keywords: tinymce cloud script textarea apiKey
 
 TinyMCE Cloud is the easiest way to integrate TinyMCE and upgrade to our premium plugins.
 
-You can start with [TinyMCE CDN]({{ site.baseurl }}/download/) completely free of charge.
+You can start with [TinyMCE CDN](https://www.tinymce.com/download/) completely free of charge.
 
 In order to use our premium plugins, you’ll need to signup for an API key and update the script tag used to load the editor code into your application.
 
@@ -42,7 +42,7 @@ Lastly, you just need to extend your TinyMCE configuration to include any of the
 
 ### Step 1: Replace existing reference to tinymce.min.js
 
-Migrating from the SDK to the Cloud is a relatively straightforward process. Please remove your existing script tag that loads TinyMCE’s JavaScript (typically a reference to tinymce.min.js either hosted in your own application or available via our [CDN]({{ site.baseurl }}/download/)) and replace this script tag with the following:
+Migrating from the SDK to the Cloud is a relatively straightforward process. Please remove your existing script tag that loads TinyMCE’s JavaScript (typically a reference to `tinymce.min.js` either hosted in your own application or available via our [CDN](https://www.tinymce.com/download/)) and replace this script tag with the following:
 
 ```js
 <script src="http://cloud.tinymce.com/stable/tinymce.min.js?apiKey=your_API_key"></script>

--- a/get-started-cloud/features-only.md
+++ b/get-started-cloud/features-only.md
@@ -6,7 +6,7 @@ description: TinyMCE Cloud customers, you'll be up and running in less than 5 mi
 keywords: tinymce cloud script textarea apiKey
 ---
 
-If you’re already comfortable hosting and maintaining [TinyMCE Community edition]({{ site.baseurl }}/download/), or you’re running a web application where you have no control over the TinyMCE instance, you’re still able to load our premium TinyMCE plugins from TinyMCE Cloud.
+If you’re already comfortable hosting and maintaining [TinyMCE Community edition](https://www.tinymce.com/download/), or you’re running a web application where you have no control over the TinyMCE instance, you’re still able to load our premium TinyMCE plugins from TinyMCE Cloud.
 
 In order to use oue premium plugins, you’ll need to select what plugins you’d like to purchase and you’ll be setup with an API key for your account.
 

--- a/get-started-cloud/plugin-editor-version-compatibility.md
+++ b/get-started-cloud/plugin-editor-version-compatibility.md
@@ -8,7 +8,7 @@ keywords: tinymce cloud script textarea apiKey
 
 Some of our premium plugins are only compatible with certain versions versions of TinyMCE.
 
-If you’re deploying [both the TinyMCE editor and premium plugins via the Cloud]({{ site.baseurl }}/get-started-cloud/editor-and-features), use the following matrix in conjunction with the optional parameters for specifying editor version and plugin version ({{ site.baseurl }}/get-started-cloud/editor-plugin-version) to ensure your editor and plugins are compatible.
+If you’re deploying [both the TinyMCE editor and premium plugins via the Cloud]({{ site.baseurl }}/get-started-cloud/editor-and-features), use the following matrix in conjunction with the optional parameters for specifying editor version and [plugin version]({{ site.baseurl }}/get-started-cloud/editor-plugin-version) to ensure your editor and plugins are compatible.
 
 If you’re deploying [premium plugins *only* via the Cloud]({{ site.baseurl }}/get-started-cloud/features-only), you’ll need to ensure you’re either only loading plugins supported for your editor version, or that your editor is upgraded to the required release.
 


### PR DESCRIPTION
[+] `site.baseurl` = `tinymce.com/docs` and referencing this broke intended links to the download page. This should now be fixed.