### PR TITLE
Update documentation to reflect list plugin change

### DIFF
--- a/advanced/editor-control-identifiers.md
+++ b/advanced/editor-control-identifiers.md
@@ -30,8 +30,6 @@ Here is a list of the toolbar/menu controls that the core and plugins provides. 
 | cut | core | Cuts the current selection into clipboard. |
 | copy | core | Copies the current selection into clipboard. |
 | paste | core | Pastes the current clipboard into the editor. |
-| bullist | core | Formats the current selection as a bullet list. |
-| numlist | core | Formats the current selection as a numbered list. |
 | outdent | core | Outdents the current list item or block element. |
 | indent | core | Indents the current list item or block element. |
 | blockquote | core | Applies block quote format to the current block level element. |
@@ -43,6 +41,8 @@ Here is a list of the toolbar/menu controls that the core and plugins provides. 
 | visualaid | core | Toggles the visual aids for invisible elements. |
 | insert | core | Groups various insert actions into one button. |
 | hr | [hr]({{ site.baseurl }}/plugins/hr/) | Inserts a horizontal rule into the editor. |
+| bullist | [link]({{ site.baseurl }}/plugins/link/) | Formats the current selection as a bullet list. |
+| numlist | [link]({{ site.baseurl }}/plugins/link/) | Formats the current selection as a numbered list. |
 | link | [link]({{ site.baseurl }}/plugins/link/) | Creates/Edits links within the editor. |
 | unlink | [link]({{ site.baseurl }}/plugins/link/) | Removes links from the current selection. |
 | openlink | [link]({{ site.baseurl }}/plugins/link/) | Opens the selected link in a new tab. |


### PR DESCRIPTION
Per https://github.com/tinymce/tinymce/issues/3342 `bullist` and `numlist` have been moved to list plugin but docs still show core