### PR TITLE
fix #521 broken links on enterprise server setting

### DIFF
--- a/enterprise/server/index.md
+++ b/enterprise/server/index.md
@@ -16,7 +16,7 @@ The following server-side components are packaged with the TinyMCE SDK:
 |:-----------------------------	|:-------						|:----------- |
 | [Spellchecking]({{ site.baseurl }}/enterprise/check-spelling/) 				| ephox-spelling.war		|Spell checking service for TinyMCE Enterprise.|
 | [Image Tools Proxy]({{ site.baseurl }}/plugins/imagetools/)				| ephox-image-proxy.war		|Image proxy service for the Image Tools plugin.|
-| [Link Checker and Enhanced Media Embed]({{ site.baseurl }}/enterprise/check-links-and-embed-media/)				| ephox-hyperlinking.war		|Link Checker and Enhanced Media Embed service for TinyMCE Enterprise.|
+| [Enhanced Media Embed]({{ site.baseurl }}/enterprise/embed-media/), [Link Checker]({{ site.baseurl }}/enterprise/check-links/)				| ephox-hyperlinking.war		|Link Checker and Enhanced Media Embed service for TinyMCE Enterprise.|
 
 > **Note:** The "Allowed Origins" service (ephox-allowed-origins.war) has been deprecated. Trusted domains can now simply be specified via `application.conf`, as documented below.
 


### PR DESCRIPTION
[+] fixes issue #521, where the link behind the text "Link Checker and Enhanced Media Embed" at the top of the page gives a 404.