### PR TITLE
fixes path delimiter in integrations/angular2.md

### DIFF
--- a/integrations/angular2.md
+++ b/integrations/angular2.md
@@ -61,7 +61,7 @@ cp -r node_modules/tinymce/skins src/assets/skins
 **Windows**
 
 ```
-xcopy /I /E node_modules/tinymce/skins src/assets/skins
+xcopy /I /E node_modules\tinymce\skins src\assets\skins
 ```
 
 Then, when initializing a TinyMCE instance, just add the `skin_url` setting with the correct url like this:


### PR DESCRIPTION
[+] the file system delimiter for the Windows example used slashes rather than backslashes. Fixed issue #514 from @markgoho