### PR TITLE
add toolbar icon to plugins/autosave.md

### DIFF
--- a/plugins/autosave.md
+++ b/plugins/autosave.md
@@ -3,11 +3,11 @@ layout: default
 title: Autosave Plugin
 title_nav: Autosave
 description: Automatically save content in your local browser.
-controls: menu item
+controls: toolbar button, menu item
 keywords: autosave_ask_before_unload autosave_interval autosave_prefix autosave_prefix autosave_restore_when_empty autosave_retention
 ---
 
-This plugin gives the user a warning if they made modifications to the content within an editor instance but didn't submit the changes. It also adds a menu item `Restore last draft` under the `File` menu.
+This plugin gives the user a warning if they made modifications to the content within an editor instance but didn't submit the changes. It also adds a menu item "Restore last draft" under the `File` menu.
 
 **Type:** `String`
 


### PR DESCRIPTION
[+] added the toolbar icon to the docs header section. Fixes #439 by @MichaelFromin.