### PR TITLE
add webcopy to plugins/autosave.md

### DIFF
--- a/plugins/autosave.md
+++ b/plugins/autosave.md
@@ -7,7 +7,9 @@ controls: toolbar button, menu item
 keywords: autosave_ask_before_unload autosave_interval autosave_prefix autosave_prefix autosave_restore_when_empty autosave_retention
 ---
 
-This plugin gives the user a warning if they made modifications to the content within an editor instance but didn't submit the changes. It also adds a menu item "Restore last draft" under the `File` menu.
+This plugin gives the user a warning if they made modifications to the content within an editor instance but didn't submit the changes. It also adds a menu item "Restore last draft" under the `File` menu. It also adds an optional button to the toolbar, which is useful if you don't intend to use menus.
+
+on click will open a dialog box to accept raw code input.
 
 **Type:** `String`
 


### PR DESCRIPTION
[+] added webcopy noting that a toolbar button can be added (the doc previously required deduction to learn this).