### PR TITLE
`textcolor_map` should be a list of strings, not a string itself

### DIFF
--- a/plugins/textcolor.md
+++ b/plugins/textcolor.md
@@ -66,7 +66,7 @@ tinymce.init({
 
 This option allows you to specify a map of the text colors that will appear in the grid.
 
-**Type:** `List`
+**Type:** `Array`
 
 ##### Example
 

--- a/plugins/textcolor.md
+++ b/plugins/textcolor.md
@@ -66,7 +66,7 @@ tinymce.init({
 
 This option allows you to specify a map of the text colors that will appear in the grid.
 
-**Type:** `String`
+**Type:** `List`
 
 ##### Example
 


### PR DESCRIPTION
Not sure what the exact type definition should be
- `List`
- `Array`
- `Array<String>`
- `String[]`

Or, even better,

- `Object<String, String>`