### PR TITLE
fix links to Community

### DIFF
--- a/_includes/configuration/style-formats.md
+++ b/_includes/configuration/style-formats.md
@@ -119,4 +119,4 @@ tinymce.init({
 });
 ```
 
-Hopefully we'll have an [exact replica of the defaults](http://www.tinymce.com/forum/viewtopic.php?id=33648) soon.
+Hopefully we'll have an [exact replica of the defaults](https://community.tinymce.com/communityQuestion?id=90661000000Mrw1AAC) soon.

--- a/get-started/get-support.md
+++ b/get-started/get-support.md
@@ -5,7 +5,7 @@ description: Community and pro-grade support options.
 keywords: forum forums url absolute relative security xss
 ---
 
-> If you landed here having worked through the [Get Started Guide]({{ site.baseurl }}/get-started/first-steps), congratulations, you are on you way to TinyMCE ninjahood :-) It's now time to deep-dive into [configuring the editor]({{ site.baseurl }}/configure/) and explor [plugin options]({{ site.baseurl }}/plugins/). We wish you well, and welcome you to TinyMCE. If you get stuck a great place to start is the [TinyMCE Forum](http://www.tinymce.com/forum/).
+> If you landed here having worked through the [Get Started Guide]({{ site.baseurl }}/get-started/first-steps), congratulations, you are on you way to TinyMCE ninjahood :-) It's now time to deep-dive into [configuring the editor]({{ site.baseurl }}/configure/) and explor [plugin options]({{ site.baseurl }}/plugins/). We wish you well, and welcome you to TinyMCE. If you get stuck a great place to start is the [TinyMCE Forum](https://community.tinymce.com/).
 
 
 ## Premium Support
@@ -15,7 +15,7 @@ If you are a TinyMCE Enterprise customer in good standing please [review what in
 
 
 ## Forums
-Users of the open source Community Edition have free access to the [TinyMCE Forum](http://www.tinymce.com/forum/). Sign up [here](http://www.tinymce.com/forum/register.php).
+Users of the open source Community Edition have free access to the [TinyMCE Forum](https://community.tinymce.com/). Sign up [here](https://community.tinymce.com/).
 
 
 ## FAQ & Troubleshooting

--- a/plugins/link.md
+++ b/plugins/link.md
@@ -70,9 +70,9 @@ tinymce.init({
 
 ### `link_assume_external_targets`
 
-This option allows you to set whether TinyMCE should prompt the user to prepend a `http://` prefix if the supplied link does not already contain a protocol prefix. 
+This option allows you to set whether TinyMCE should prompt the user to prepend a `http://` prefix if the supplied link does not already contain a protocol prefix.
 
-With the default setting the user will only be prompted to prepend `http://` if the url entered starts with `www`, all other urls without a protocol will be added without prompt. With the setting set to `true` all urls will be assumed to be external and the user will be prompted on all urls. 
+With the default setting the user will only be prompted to prepend `http://` if the url entered starts with `www`, all other urls without a protocol will be added without prompt. With the setting set to `true` all urls will be assumed to be external and the user will be prompted on all urls.
 
 **Type:** `Boolean`
 
@@ -144,11 +144,11 @@ tinymce.init({
   menubar: "insert",
   toolbar: "link",
   link_list: [
-    {title: 'TinyMCE', value: 'http://www.tinymce.com'},
-    {title: 'Moxiecode', value: 'http://www.ephox.com'},
+    {title: 'TinyMCE', value: 'https://www.tinymce.com'},
+    {title: 'Moxiecode', value: 'https://www.ephox.com'},
     {title: 'TinyMCE resources', menu: [
-      {title: 'TinyMCE documentation', value: 'http://www.tinymce.com/docs/'},
-      {title: 'TinyMCE forum', value: 'http://www.tinymce.com/forum/'}
+    {title: 'TinyMCE documentation', value: 'https://www.tinymce.com/docs/'},
+    {title: 'TinyMCE forum', value: 'https://community.tinymce.com/'}
     ]}
   ]
 });


### PR DESCRIPTION
[+] fixes links pointing to interim forum url `tinymce.com/forum`, now points to https://community.tinymce.com/