### PR TITLE
Added note about using pagebreak with valid_elements

### DIFF
--- a/plugins/pagebreak.md
+++ b/plugins/pagebreak.md
@@ -67,3 +67,5 @@ tinymce.init({
   pagebreak_split_block: true
 });
 ```
+
+> If you use pagebreak with `valid_elements` you need to allow the `img` tag with a class attribute for the pagebreak to work regardless of the `pagebreak_separator` defined. So `valid_elements` needs to include `img[class]` or more specifically `img[class<mce-pagebreak]` to just allow the pagebreak image.


### PR DESCRIPTION
This amend to the documentation is to address this issue https://github.com/tinymce/tinymce/issues/3102.