### PR TITLE
add Codepen to plugins/codesample.md

### DIFF
--- a/plugins/codesample.md
+++ b/plugins/codesample.md
@@ -80,3 +80,7 @@ You need to add `prism.js` and `prism.css` to your page in order to get the synt
 <script src="prism.js"></script>
 <pre class="language-markup"><code>...</code></pre>
 ```
+
+## Live example
+
+{% include codepen.html id="mpyXwj" %}


### PR DESCRIPTION
[+] adds a live Codepen to the Code Sample plugin page. Resolves GH-626. Helps explain how the plugin works for the end user.