### PR TITLE
improve lists and advlist plugins

### DIFF
--- a/plugins/advlist.md
+++ b/plugins/advlist.md
@@ -6,9 +6,9 @@ description: Create styled number and bulleted lists.
 keywords: advlist advlist_bullet_styles advlist_number_styles
 ---
 
-The `advlist` plugin extends the core `bullist` and `numlist` toolbar controls by adding CSS `list-style-type` styled number formats and bullet types to the controls. 
+The `advlist` plugin extends the core `bullist` and `numlist` toolbar controls by adding CSS `list-style-type` styled number formats and bullet types to the controls.
 
-> **Important note:** The `lists` plugin has to be activated for the `advlist` plugin to work. 
+> **Important note:** The [Lists](../lists) (`lists`) plugin must be activated for the `advlist` plugin to work. 
 
 **Type:** `String`
 

--- a/plugins/lists.md
+++ b/plugins/lists.md
@@ -6,7 +6,9 @@ description: Normalizes list behavior between browsers.
 keywords: list lists browser normalize
 ---
 
-This list plugin normalizes list behavior between browsers. Enable it if you have problems with consistency making lists.
+The `lists` plugin allows you to add numbered and bulleted lists to TinyMCE. To enable advanced lists (e.g. alpha numbered lists, square bullets) you should also enable the [Advanced List](../advlist/) (`advlist`) plugin.
+
+The plugin also normalizes list behavior between browsers. Enable it if you have problems with consistency making lists.
 
 ##### Example
 
@@ -24,4 +26,4 @@ These settings affect the execution of the `lists` plugin.
 
 ### `lists_indent_on_tab`
 
-This boolean option allows to disable the indent on tab key functionality. It's default value is set to true.
+This boolean option allows to disable the indent on tab key functionality. It's default value is set to `true`.


### PR DESCRIPTION
[+] lists.md explain that the `advlist` plugin is required to enable extended list types
[+] lists.md add link to `advlist` plugin
[+] advlist.md add link to `lists` plugin