### PR TITLE
fix default value for allow_conditional_comments

### DIFF
--- a/_includes/configuration/allow-conditional-comments.md
+++ b/_includes/configuration/allow-conditional-comments.md
@@ -4,7 +4,7 @@ This option allows you to specify whether the editor should parse and keep condi
 
 **Type:** `Boolean`
 
-**Default Value:** `true`  // confirmation required
+**Default Value:** `false`
 
 **Possible Values:** `true`, `false`
 
@@ -13,6 +13,6 @@ This option allows you to specify whether the editor should parse and keep condi
 ```js
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  allow_conditional_comments: false
+  allow_conditional_comments: true
 });
 ```


### PR DESCRIPTION
Default value in docs for this property is not accurate. There is no defined value for `allow_conditional_comments` in the default settings, so default is false. https://github.com/tinymce/tinymce/blob/114e2d6878c58d6fe452db39353cc177f842d8bd/src/core/src/main/js/EditorSettings.js#L61

This causes confusion for users, ex https://github.com/tinymce/tinymce/issues/1620. And we can now remove the `// confirmation required` comment left by original contributor 😄 . 


  