### PR TITLE
Corrects $name variable to be $username

### DIFF
--- a/plugins/template.md
+++ b/plugins/template.md
@@ -211,7 +211,7 @@ tinymce.init({
 This can then be used in a template or snippet that looks like this:
 
 ```html
-<p>Name: {$name}, StaffID: {$staffid}</p>
+<p>Name: {$username}, StaffID: {$staffid}</p>
 ``` 
 
 And that will be changed to: 


### PR DESCRIPTION
Corrects $name variable to be $username in the first example of the use of 'username'.