### PR TITLE
Feature/faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ If you would like to contribute to the TinyMCE project please read our contribut
 https://www.tinymce.com/docs/advanced/contributing-docs/
 
 ### See the [TinyMCE Docs Wiki](https://github.com/tinymce/tinymce-docs/wiki) for additional, miscellaneous info, including init error handling.
+
+### Why is HTML minification disabled?
+
+It's very slow and the minifier is using regex to parse HTML. We may add a different minifier in the future.

--- a/_config-local.sample.yml
+++ b/_config-local.sample.yml
@@ -1,3 +1,3 @@
 shared_baseurl: "https://www.tinymce.com"
-gems:
+plugins:
   - jekyll-redirect-from

--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,8 @@ exclude:
   - vendor
   - wercker.yml
   - node_modules
+  - .idea
+  - .git
 
 markdown: redcarpet
 
@@ -24,7 +26,7 @@ redcarpet:
     - tables
     - prettify
 
-gems:
+plugins:
   - jekyll-redirect-from
   - octopress-minify-html
   - jekyll-sitemap

--- a/_config.yml
+++ b/_config.yml
@@ -30,3 +30,5 @@ plugins:
   - jekyll-redirect-from
   - octopress-minify-html
   - jekyll-sitemap
+
+minify_html: false


### PR DESCRIPTION
That HTML minifier was taking about 3 minutes on my local machine. The parser in the HTML minifier uses regex. I don't trust it and I don't think we really need it.