### PR TITLE
DX-874 Restored linking headers anchors

### DIFF
--- a/_plugins/headers_anchors.rb
+++ b/_plugins/headers_anchors.rb
@@ -1,0 +1,13 @@
+require 'nokogiri'
+
+# Adds linkable anchors for documentation headers
+class Kramdown::Converter::Html
+  def convert_header(el, indent)
+    text = el.options[:raw_text]
+    level = el.options[:level]
+    anchor = Nokogiri::HTML(text).text.gsub(/[^a-zA-Z0-9\-_]/, "").downcase
+
+    "<a class=\"anchor\" id=\"#{anchor}\"></a>" +
+        "<h#{level}><a class=\"anchorable\" href=\"##{anchor}\">#{text}</a></h#{level}>"
+  end
+end


### PR DESCRIPTION
Header anchors creation was removed with redcarpet.. :feelsbadman:
Restored with Kramdown

![image](https://user-images.githubusercontent.com/1758655/46507274-142fa700-c87b-11e8-9b15-56a5cee3122e.png)

/cc @shikhanansi 