### PR TITLE
TINY-2253: Updated the docs to match changes to the UI elements menu item references

### DIFF
--- a/_includes/codepens/contextmenu-section/index.js
+++ b/_includes/codepens/contextmenu-section/index.js
@@ -13,10 +13,16 @@ tinymce.PluginManager.add('my-example-plugin', function (editor) {
       return !element.src ? [] : ['image'];
     }
   });
+
+  editor.ui.registry.addContextMenu('link', {
+    update: (element) => {
+      return !element.href ? 'link' : 'link unlink openlink';
+    }
+  });
 });
 
 tinymce.init({
   selector: "textarea",
-  contextmenu: "image",
+  contextmenu: "link image",
   plugins: 'my-example-plugin'
 });

--- a/ui-elements/contextmenu.md
+++ b/ui-elements/contextmenu.md
@@ -67,13 +67,13 @@ In the menu shown to the user, sections are delineated by separators. Sections c
 
 ```typescript
 type ContextMenuApi = {
-  update: (element: Element) => Array<ContextMenuContents>
+  update: (element: Element) => string | Array<ContextMenuContents>
 }
 
 editor.ui.registry.addContextMenu(name: string, feature: ContextMenuApi);
 ```
 
-Every time the user opens the context menu, the selected element is passed to the update function which must return an array of items to display. The types of the items returned are as follows:
+Every time the user opens the context menu, the selected element is passed to the update function which must return either a space separated string or an array of items to display. The types of the items returned are as follows:
 
 ```typescript
 type ContextMenuContents = string | ContextMenuItem | SeparatorMenuItemApi | ContextSubMenu
@@ -88,7 +88,7 @@ type ContextSubMenu = {
   type: 'submenu';
   text: string;
   icon?: string;
-  getSubmenuItems: () => Array<ContextMenuContents>;
+  getSubmenuItems: () => string | Array<ContextMenuContents>;
 }
 
 type SeparatorMenuItemApi = {


### PR DESCRIPTION
When specifying menu items for context menus, menu buttons and sub menus, they can now be represented by a space separated list of menu items (the same as in the init config) or alternatively as an array of menu items. This differs from the previous behaviour which was to only allow an array of menu items.

If it helps, here's an example from the table menu button showing using the space separated string format:
```
  editor.ui.registry.addMenuButton('table', {
    tooltip: 'Table',
    icon: 'table',
    fetch: (callback) => callback('inserttable tableprops deletetable | cell row column')
  });
```

Note: This hasn't been released yet, so we maybe should hold off merging for now.