### PR TITLE
Fix codepens to be ES5 compatible

### DIFF
--- a/_includes/codepens/annotations/index.js
+++ b/_includes/codepens/annotations/index.js
@@ -9,15 +9,15 @@ var settings = {
   setup: function (editor) {
     editor.ui.registry.addButton('annotate-alpha', {
       text: 'Annotate',
-      onAction() {
-        const comment = prompt('Comment with?');
+      onAction: function() {
+        var comment = prompt('Comment with?');
         editor.annotator.annotate('alpha', {
           uid: 'custom-generated-id',
           comment: comment
         });
         editor.focus();
       },
-      onSetup (btnApi) {
+      onSetup: function (btnApi) {
         editor.annotator.annotationChanged('alpha', function (state, name, obj) {
           console.log('Current selection has an annotation: ', state);
           btnApi.setDisabled(state);

--- a/_includes/codepens/basic-example/index.js
+++ b/_includes/codepens/basic-example/index.js
@@ -10,5 +10,6 @@ tinymce.init({
   toolbar: 'undo redo | formatselect | bold italic backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | removeformat | help',
   content_css: [
     '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
-    '//www.tiny.cloud/css/codepen.min.css']
+    '//www.tiny.cloud/css/codepen.min.css'
+  ]
 });

--- a/_includes/codepens/bbcode/index.js
+++ b/_includes/codepens/bbcode/index.js
@@ -5,5 +5,6 @@ tinymce.init({
   toolbar: 'undo redo | bold italic underline | code',
   content_css: [
     '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
-    '//www.tiny.cloud/css/codepen.min.css']
+    '//www.tiny.cloud/css/codepen.min.css'
+  ]
 });

--- a/_includes/codepens/classic/index.js
+++ b/_includes/codepens/classic/index.js
@@ -33,12 +33,11 @@ var demoBaseConfig = {
     "//fonts.googleapis.com/css?family=Lato:300,300i,400,400i",
     "//www.tiny.cloud/css/content-standard.min.css"
   ],
-  api_key: 'fake-key',
   spellchecker_rpc_url: 'https://spelling.tinymce.com/',
   spellchecker_api_key: 'h22wb7h8xi78b4fyo46hhx5k7fbh46vt5f6yqmvd492iy00c',
   spellchecker_dialog: true,
   spellchecker_whitelist: ['Ephox', 'Moxiecode'],
-  api_key: 'fakekey',
+  api_key: 'fakekey'
 };
 
 var mentionsFetchFunction = function (query, success) {
@@ -142,7 +141,7 @@ var table = '<p>This table uses features of the non-editable plugin to make the 
 '            </tr> ' +
 '            <tr> ' +
 '                <td class="mceNonEditable">Central Region</td> ' +
-'                <td>100</td> <td>110</td> <td>115</td> <td>130</td> ' + 
+'                <td>100</td> <td>110</td> <td>115</td> <td>130</td> ' +
 '            </tr> ' +
 '            <tr> ' +
 '                <td class="mceNonEditable">West Region</td> ' +
@@ -173,6 +172,6 @@ var table2 = '<div> ' +
 '        </tr> ' +
 '        </tbody> ' +
 '        </table> ' +
-'    </div> '; 
+'    </div> ';
 
 tinymce.init(demoBaseConfig);

--- a/_includes/codepens/classic/index.js
+++ b/_includes/codepens/classic/index.js
@@ -41,89 +41,89 @@ var demoBaseConfig = {
 };
 
 var mentionsFetchFunction = function (query, success) {
-      var users = [
-        "Terry Green", "Edward Carroll", "Virginia Turner", "Alexander Schneider", "Gary Vasquez", "Randy Howell",
-        "Katherine Moore", "Betty Washington", "Grace Chapman", "Christina Nguyen", "Danielle Rose", "Thomas Freeman",
-        "Thomas Armstrong", "Vincent Lee", "Brittany Kelley", "Brenda Wheeler", "Amy Price", "Hannah Harvey",
-        "Bobby Howard", "Frank Fox", "Diane Hopkins", "Johnny Hawkins", "Sean Alexander", "Emma Roberts", "Thomas Snyder",
-        "Thomas Allen", "Rebecca Ross", "Amy Boyd", "Kenneth Watkins", "Sarah Tucker", "Lawrence Burke", "Emma Carr",
-        "Zachary Mason", "John Scott", "Michelle Davis", "Nicholas Cole", "Gerald Nelson", "Emily Smith", "Christian Stephens",
-        "Grace Carr", "Arthur Watkins", "Frances Baker", "Katherine Cook", "Roger Wallace", "Pamela Arnold", "Linda Barnes",
-        "Jacob Warren", "Billy Ramirez", "Pamela Walsh", "Paul Wade", "Katherine Campbell", "Jeffrey Berry", "Patrick Bowman",
-        "Dennis Alvarez", "Crystal Lucas", "Howard Mendoza", "Patricia Wallace", "Peter Stone", "Tiffany Lane", "Joe Perkins",
-        "Gloria Reynolds", "Willie Fernandez", "Doris Harper", "Heather Sandoval", "Danielle Franklin", "Ann Ellis",
-        "Christopher Hernandez", "Pamela Perry", "Matthew Henderson", "Jesse Mitchell", "Olivia Reed", "David Clark", "Juan Taylor",
-        "Michael Garrett", "Gerald Guerrero", "Jerry Coleman", "Joyce Vasquez", "Jane Bryant", "Sean West", "Deborah Bradley",
-        "Phillip Castillo", "Martha Coleman", "Ryan Santos", "Harold Hanson", "Frances Hoffman", "Heather Fisher", "Martha Martin",
-        "George Gray", "Rachel Herrera", "Billy Hart", "Kelly Campbell", "Kelly Marshall", "Doris Simmons", "Julie George",
-        "Raymond Burke", "Ruth Hart", "Jack Schmidt", "Billy Schmidt", "Ruth Wagner", "Zachary Estrada", "Olivia Griffin", "Ann Hayes",
-        "Julia Weaver", "Anna Nelson", "Willie Anderson", "Anna Schneider", "Debra Torres", "Jordan Holmes", "Thomas Dean",
-        "Maria Burton", "Terry Long", "Danielle McDonald", "Kyle Flores", "Cheryl Garcia", "Judy Delgado", "Karen Elliott",
-        "Vincent Ortiz", "Ann Wright", "Ann Ramos", "Roy Jensen", "Keith Cunningham", "Mary Campbell", "Jesse Ortiz", "Joseph Mendoza",
-        "Nathan Bishop", "Lori Valdez", "Tammy Jacobs", "Mary West", "Juan Mitchell", "Thomas Adams", "Christian Martinez", "James Ramos",
-        "Deborah Ross", "Eric Holmes", "Thomas Diaz", "Sharon Morales", "Kathryn Hamilton", "Helen Edwards", "Betty Powell",
-        "Harry Campbell", "Raymond Perkins", "Melissa Wallace", "Danielle Hicks", "Harold Brewer", "Jack Burns", "Anna Robinson",
-        "Dorothy Nguyen", "Jane Dean", "Janice Hunter", "Ryan Moore", "Brian Riley", "Brittany Bradley", "Phillip Ortega", "William Fisher",
-        "Jennifer Schultz", "Samantha Perez", "Linda Carr", "Ann Brown", "Shirley Kim", "Jeremy Alvarez", "Dylan Oliver", "Roy Gomez",
-        "Ethan Brewer", "Ruth Lucas", "Marilyn Myers", "Danielle Wright", "Jose Meyer", "Bobby Brown", "Angela Crawford", "Brandon Willis",
-        "Kyle McDonald", "Aaron Valdez", "Kevin Webb", "Ashley Gordon", "Karen Jenkins", "Johnny Santos", "Ashley Henderson", "Amy Walters",
-        "Amber Rodriguez", "Thomas Ross", "Dorothy Wells", "Jennifer Murphy", "Douglas Phillips", "Helen Johnston", "Nathan Hawkins",
-        "Roger Mitchell", "Michael Young", "Eugene Cruz", "Kevin Snyder", "Frank Ryan", "Tiffany Peters", "Beverly Garza", "Maria Wright",
-        "Shirley Jensen", "Carolyn Munoz", "Kathleen Day", "Ethan Meyer", "Rachel Fields", "Joan Bell", "Ashley Sims", "Sara Fields",
-        "Elizabeth Willis", "Ralph Torres", "Charles Lopez", "Aaron Green", "Arthur Hanson", "Betty Snyder", "Jose Romero", "Linda Martinez",
-        "Zachary Tran", "Sean Matthews", "Eric Elliott", "Kimberly Welch", "Jason Bennett", "Nicole Patel", "Emily Guzman", "Lori Snyder",
-        "Sandra White", "Christina Lawson", "Jacob Campbell", "Ruth Foster", "Mark McDonald", "Carol Williams", "Alice Washington",
-        "Brandon Ross", "Judy Burns", "Zachary Hawkins", "Julie Chavez", "Randy Duncan", "Lisa Robinson", "Jacqueline Reynolds", "Paul Weaver",
-        "Edward Gilbert", "Deborah Butler", "Frances Fox", "Joshua Schmidt", "Ashley Oliver", "Martha Chavez", "Heather Hudson",
-        "Lauren Collins", "Catherine Marshall", "Katherine Wells", "Robert Munoz", "Pamela Nelson", "Dylan Bowman", "Virginia Snyder",
-        "Janet Ruiz", "Ralph Burton", "Jose Bryant", "Russell Medina", "Brittany Snyder", "Richard Cruz", "Matthew Jimenez", "Danielle Graham",
-        "Steven Guerrero", "Benjamin Matthews", "Janet Mendoza", "Harry Brewer", "Scott Cooper", "Alexander Keller", "Virginia Gordon",
-        "Randy Scott", "Kimberly Olson", "Helen Lynch", "Ronald Garcia", "Joseph Willis", "Philip Walker", "Tiffany Harris", "Brittany Weber",
-        "Gregory Harris", "Sean Owens", "Wayne Meyer", "Roy McCoy", "Keith Lucas", "Christian Watkins", "Christopher Porter", "Sandra Lopez",
-        "Harry Ward", "Julie Sims", "Albert Keller", "Lori Ortiz", "Virginia Henry", "Samuel Green", "Judith Cole", "Ethan Castillo", "Angela Ellis",
-        "Amy Reid", "Jason Brewer", "Aaron Clark", "Aaron Elliott", "Doris Herrera", "Howard Castro", "Kenneth Davis", "Austin Spencer",
-        "Jonathan Marshall", "Phillip Nelson", "Julia Guzman", "Robert Hansen", "Kevin Anderson", "Gerald Arnold", "Austin Castro", "Zachary Moore",
-        "Joseph Cooper", "Barbara Black", "Albert Mendez", "Marie Lane", "Jacob Nichols", "Virginia Marshall", "Aaron Miller", "Linda Harvey",
-        "Christopher Morris", "Emma Fields", "Scott Guzman", "Olivia Alexander", "Kelly Garrett", "Jesse Hanson", "Henry Wong", "Billy Vasquez",
-        "Larry Ramirez", "Bryan Brooks", "Alan Berry", "Nicole Powell", "Stephen Bowman", "Eric Hughes", "Elizabeth Obrien", "Timothy Ramos",
-        "Michelle Russell", "Denise Ruiz", "Sean Carter", "Amanda Barnett", "Kathy Black", "Terry Gutierrez", "John Jensen", "Grace Sanchez",
-        "Tiffany Harvey", "Jacqueline Sims", "Wayne Lee", "Roy Foster", "Joyce Hart", "Joseph Russell", "Harold Washington", "Beverly Cox",
-        "Nicole Morales", "Anna Carpenter", "Jesse Ray", "Ann Snyder", "Mark Diaz", "Elizabeth Harper", "Andrew Guerrero", "Cheryl Silva",
-        "Michelle Hudson", "Jeffrey Santos", "Victoria Vasquez", "Matthew Meyer", "Jacob Murray", "Jose Munoz", "Edward Howell", "Vincent Hunter",
-        "Daniel Walters", "Samantha Obrien", "Laura Elliott", "Richard Olson", "Daniel Graham", "Carol Lee", "Grace Sullivan", "Nancy Rodriguez",
-        "Tyler Tran", "Crystal Shaw", "Madison Allen", "Ralph Sims", "Joe Jenkins", "Dennis Ray", "Arthur Davidson", "Victoria Allen", "Arthur Jackson",
-        "Joan Thomas", "Daniel Hopkins", "Gloria Hicks", "Danielle Price", "Craig Keller", "Alan Morgan", "Gregory Silva", "Samantha Kelly",
-        "Rachel Williamson", "Bruce Garrett", "Jacob Smith", "Kathleen Nichols", "Sarah Long", "Carol Pearson", "Virginia Mendez", "Judy Valdez",
-        "Jason Garza", "Brenda Fowler", "Karen Edwards", "Alexander Anderson", "Pamela Wallace", "Ruth Howell", "Walter Hernandez", "George Lucas",
-        "Samantha Long", "Margaret Garza", "Kathleen Schultz", "Frances Guerrero", "Amber Meyer", "Rachel Morales", "Teresa Curtis", "Heather Bell",
-        "Grace Johnson", "Melissa King", "Zachary Cook", "Carol Schultz", "Jane Beck", "Karen Stone", "Roger Brooks", "Carolyn Fuller", "Nicholas Coleman",
-        "William Bishop", "Christine May", "Linda George", "Jean Meyer", "Cheryl Armstrong", "Danielle Welch", "Amanda Graham", "Janice Carter",
-        "Catherine Brooks", "Lawrence Gonzalez", "Amy Russell", "Eugene Jimenez", "Joseph Carlson", "Peter McCoy", "Jerry Washington", "Carolyn Obrien",
-        "Mark Walker", "Stephanie Hoffman", "Julie Pena", "Karen Curtis", "Bryan Cruz", "Madison Shaw", "Rachel Graham", "Susan Simpson", "Andrea Harrison",
-        "Bryan Miller", "Vincent McDonald", "Jesse McCoy", "Christine Ramos", "Dorothy Riley", "Karen Warren", "Ashley Weber", "Judith Robinson",
-        "Alan Mendez", "Donna Medina", "Helen Lane", "Douglas Clark", "Brenda Romero", "Doris Wells", "Patrick Howell", "Doris Lawrence", "Harry Jacobs",
-        "Phillip Rose", "Deborah Patel", "Bryan Day", "Rachel Butler", "Paul Butler", "Judy Knight", "Willie Wallace", "Phillip Anderson", "Emma Black",
-        "Lisa Lynch", "Kimberly Freeman", "Ronald West", "Kathleen Harris", "Martha Ruiz", "Phillip Moreno", "Robert Vargas", "Jesse Diaz", "Christine Weber",
-        "Karen Stanley", "Theresa Edwards", "Kathryn Chavez", "Sarah Rios", "Danielle Wong", "Kathy Carr", "Joan Diaz", "Albert Walters",
-        "Denise Kim", "Katherine Pearson", "Diana Richardson", "Harry Ford", "Eric Mills", "Sean Hicks", "Joe Brown", "Judith Morgan", "Harry Hunter",
-        "Matthew Bryant", "Tyler Rose", "Mildred Delgado", "Emma Peters", "Walter Delgado", "Lauren Gilbert", "Christopher Romero"
-    ];
+  var users = [
+    "Terry Green", "Edward Carroll", "Virginia Turner", "Alexander Schneider", "Gary Vasquez", "Randy Howell",
+    "Katherine Moore", "Betty Washington", "Grace Chapman", "Christina Nguyen", "Danielle Rose", "Thomas Freeman",
+    "Thomas Armstrong", "Vincent Lee", "Brittany Kelley", "Brenda Wheeler", "Amy Price", "Hannah Harvey",
+    "Bobby Howard", "Frank Fox", "Diane Hopkins", "Johnny Hawkins", "Sean Alexander", "Emma Roberts", "Thomas Snyder",
+    "Thomas Allen", "Rebecca Ross", "Amy Boyd", "Kenneth Watkins", "Sarah Tucker", "Lawrence Burke", "Emma Carr",
+    "Zachary Mason", "John Scott", "Michelle Davis", "Nicholas Cole", "Gerald Nelson", "Emily Smith", "Christian Stephens",
+    "Grace Carr", "Arthur Watkins", "Frances Baker", "Katherine Cook", "Roger Wallace", "Pamela Arnold", "Linda Barnes",
+    "Jacob Warren", "Billy Ramirez", "Pamela Walsh", "Paul Wade", "Katherine Campbell", "Jeffrey Berry", "Patrick Bowman",
+    "Dennis Alvarez", "Crystal Lucas", "Howard Mendoza", "Patricia Wallace", "Peter Stone", "Tiffany Lane", "Joe Perkins",
+    "Gloria Reynolds", "Willie Fernandez", "Doris Harper", "Heather Sandoval", "Danielle Franklin", "Ann Ellis",
+    "Christopher Hernandez", "Pamela Perry", "Matthew Henderson", "Jesse Mitchell", "Olivia Reed", "David Clark", "Juan Taylor",
+    "Michael Garrett", "Gerald Guerrero", "Jerry Coleman", "Joyce Vasquez", "Jane Bryant", "Sean West", "Deborah Bradley",
+    "Phillip Castillo", "Martha Coleman", "Ryan Santos", "Harold Hanson", "Frances Hoffman", "Heather Fisher", "Martha Martin",
+    "George Gray", "Rachel Herrera", "Billy Hart", "Kelly Campbell", "Kelly Marshall", "Doris Simmons", "Julie George",
+    "Raymond Burke", "Ruth Hart", "Jack Schmidt", "Billy Schmidt", "Ruth Wagner", "Zachary Estrada", "Olivia Griffin", "Ann Hayes",
+    "Julia Weaver", "Anna Nelson", "Willie Anderson", "Anna Schneider", "Debra Torres", "Jordan Holmes", "Thomas Dean",
+    "Maria Burton", "Terry Long", "Danielle McDonald", "Kyle Flores", "Cheryl Garcia", "Judy Delgado", "Karen Elliott",
+    "Vincent Ortiz", "Ann Wright", "Ann Ramos", "Roy Jensen", "Keith Cunningham", "Mary Campbell", "Jesse Ortiz", "Joseph Mendoza",
+    "Nathan Bishop", "Lori Valdez", "Tammy Jacobs", "Mary West", "Juan Mitchell", "Thomas Adams", "Christian Martinez", "James Ramos",
+    "Deborah Ross", "Eric Holmes", "Thomas Diaz", "Sharon Morales", "Kathryn Hamilton", "Helen Edwards", "Betty Powell",
+    "Harry Campbell", "Raymond Perkins", "Melissa Wallace", "Danielle Hicks", "Harold Brewer", "Jack Burns", "Anna Robinson",
+    "Dorothy Nguyen", "Jane Dean", "Janice Hunter", "Ryan Moore", "Brian Riley", "Brittany Bradley", "Phillip Ortega", "William Fisher",
+    "Jennifer Schultz", "Samantha Perez", "Linda Carr", "Ann Brown", "Shirley Kim", "Jeremy Alvarez", "Dylan Oliver", "Roy Gomez",
+    "Ethan Brewer", "Ruth Lucas", "Marilyn Myers", "Danielle Wright", "Jose Meyer", "Bobby Brown", "Angela Crawford", "Brandon Willis",
+    "Kyle McDonald", "Aaron Valdez", "Kevin Webb", "Ashley Gordon", "Karen Jenkins", "Johnny Santos", "Ashley Henderson", "Amy Walters",
+    "Amber Rodriguez", "Thomas Ross", "Dorothy Wells", "Jennifer Murphy", "Douglas Phillips", "Helen Johnston", "Nathan Hawkins",
+    "Roger Mitchell", "Michael Young", "Eugene Cruz", "Kevin Snyder", "Frank Ryan", "Tiffany Peters", "Beverly Garza", "Maria Wright",
+    "Shirley Jensen", "Carolyn Munoz", "Kathleen Day", "Ethan Meyer", "Rachel Fields", "Joan Bell", "Ashley Sims", "Sara Fields",
+    "Elizabeth Willis", "Ralph Torres", "Charles Lopez", "Aaron Green", "Arthur Hanson", "Betty Snyder", "Jose Romero", "Linda Martinez",
+    "Zachary Tran", "Sean Matthews", "Eric Elliott", "Kimberly Welch", "Jason Bennett", "Nicole Patel", "Emily Guzman", "Lori Snyder",
+    "Sandra White", "Christina Lawson", "Jacob Campbell", "Ruth Foster", "Mark McDonald", "Carol Williams", "Alice Washington",
+    "Brandon Ross", "Judy Burns", "Zachary Hawkins", "Julie Chavez", "Randy Duncan", "Lisa Robinson", "Jacqueline Reynolds", "Paul Weaver",
+    "Edward Gilbert", "Deborah Butler", "Frances Fox", "Joshua Schmidt", "Ashley Oliver", "Martha Chavez", "Heather Hudson",
+    "Lauren Collins", "Catherine Marshall", "Katherine Wells", "Robert Munoz", "Pamela Nelson", "Dylan Bowman", "Virginia Snyder",
+    "Janet Ruiz", "Ralph Burton", "Jose Bryant", "Russell Medina", "Brittany Snyder", "Richard Cruz", "Matthew Jimenez", "Danielle Graham",
+    "Steven Guerrero", "Benjamin Matthews", "Janet Mendoza", "Harry Brewer", "Scott Cooper", "Alexander Keller", "Virginia Gordon",
+    "Randy Scott", "Kimberly Olson", "Helen Lynch", "Ronald Garcia", "Joseph Willis", "Philip Walker", "Tiffany Harris", "Brittany Weber",
+    "Gregory Harris", "Sean Owens", "Wayne Meyer", "Roy McCoy", "Keith Lucas", "Christian Watkins", "Christopher Porter", "Sandra Lopez",
+    "Harry Ward", "Julie Sims", "Albert Keller", "Lori Ortiz", "Virginia Henry", "Samuel Green", "Judith Cole", "Ethan Castillo", "Angela Ellis",
+    "Amy Reid", "Jason Brewer", "Aaron Clark", "Aaron Elliott", "Doris Herrera", "Howard Castro", "Kenneth Davis", "Austin Spencer",
+    "Jonathan Marshall", "Phillip Nelson", "Julia Guzman", "Robert Hansen", "Kevin Anderson", "Gerald Arnold", "Austin Castro", "Zachary Moore",
+    "Joseph Cooper", "Barbara Black", "Albert Mendez", "Marie Lane", "Jacob Nichols", "Virginia Marshall", "Aaron Miller", "Linda Harvey",
+    "Christopher Morris", "Emma Fields", "Scott Guzman", "Olivia Alexander", "Kelly Garrett", "Jesse Hanson", "Henry Wong", "Billy Vasquez",
+    "Larry Ramirez", "Bryan Brooks", "Alan Berry", "Nicole Powell", "Stephen Bowman", "Eric Hughes", "Elizabeth Obrien", "Timothy Ramos",
+    "Michelle Russell", "Denise Ruiz", "Sean Carter", "Amanda Barnett", "Kathy Black", "Terry Gutierrez", "John Jensen", "Grace Sanchez",
+    "Tiffany Harvey", "Jacqueline Sims", "Wayne Lee", "Roy Foster", "Joyce Hart", "Joseph Russell", "Harold Washington", "Beverly Cox",
+    "Nicole Morales", "Anna Carpenter", "Jesse Ray", "Ann Snyder", "Mark Diaz", "Elizabeth Harper", "Andrew Guerrero", "Cheryl Silva",
+    "Michelle Hudson", "Jeffrey Santos", "Victoria Vasquez", "Matthew Meyer", "Jacob Murray", "Jose Munoz", "Edward Howell", "Vincent Hunter",
+    "Daniel Walters", "Samantha Obrien", "Laura Elliott", "Richard Olson", "Daniel Graham", "Carol Lee", "Grace Sullivan", "Nancy Rodriguez",
+    "Tyler Tran", "Crystal Shaw", "Madison Allen", "Ralph Sims", "Joe Jenkins", "Dennis Ray", "Arthur Davidson", "Victoria Allen", "Arthur Jackson",
+    "Joan Thomas", "Daniel Hopkins", "Gloria Hicks", "Danielle Price", "Craig Keller", "Alan Morgan", "Gregory Silva", "Samantha Kelly",
+    "Rachel Williamson", "Bruce Garrett", "Jacob Smith", "Kathleen Nichols", "Sarah Long", "Carol Pearson", "Virginia Mendez", "Judy Valdez",
+    "Jason Garza", "Brenda Fowler", "Karen Edwards", "Alexander Anderson", "Pamela Wallace", "Ruth Howell", "Walter Hernandez", "George Lucas",
+    "Samantha Long", "Margaret Garza", "Kathleen Schultz", "Frances Guerrero", "Amber Meyer", "Rachel Morales", "Teresa Curtis", "Heather Bell",
+    "Grace Johnson", "Melissa King", "Zachary Cook", "Carol Schultz", "Jane Beck", "Karen Stone", "Roger Brooks", "Carolyn Fuller", "Nicholas Coleman",
+    "William Bishop", "Christine May", "Linda George", "Jean Meyer", "Cheryl Armstrong", "Danielle Welch", "Amanda Graham", "Janice Carter",
+    "Catherine Brooks", "Lawrence Gonzalez", "Amy Russell", "Eugene Jimenez", "Joseph Carlson", "Peter McCoy", "Jerry Washington", "Carolyn Obrien",
+    "Mark Walker", "Stephanie Hoffman", "Julie Pena", "Karen Curtis", "Bryan Cruz", "Madison Shaw", "Rachel Graham", "Susan Simpson", "Andrea Harrison",
+    "Bryan Miller", "Vincent McDonald", "Jesse McCoy", "Christine Ramos", "Dorothy Riley", "Karen Warren", "Ashley Weber", "Judith Robinson",
+    "Alan Mendez", "Donna Medina", "Helen Lane", "Douglas Clark", "Brenda Romero", "Doris Wells", "Patrick Howell", "Doris Lawrence", "Harry Jacobs",
+    "Phillip Rose", "Deborah Patel", "Bryan Day", "Rachel Butler", "Paul Butler", "Judy Knight", "Willie Wallace", "Phillip Anderson", "Emma Black",
+    "Lisa Lynch", "Kimberly Freeman", "Ronald West", "Kathleen Harris", "Martha Ruiz", "Phillip Moreno", "Robert Vargas", "Jesse Diaz", "Christine Weber",
+    "Karen Stanley", "Theresa Edwards", "Kathryn Chavez", "Sarah Rios", "Danielle Wong", "Kathy Carr", "Joan Diaz", "Albert Walters",
+    "Denise Kim", "Katherine Pearson", "Diana Richardson", "Harry Ford", "Eric Mills", "Sean Hicks", "Joe Brown", "Judith Morgan", "Harry Hunter",
+    "Matthew Bryant", "Tyler Rose", "Mildred Delgado", "Emma Peters", "Walter Delgado", "Lauren Gilbert", "Christopher Romero"
+  ];
 
-    users = $.map(users, function (fullName) {
-        var userName = fullName.replace(/ /g, '').toLowerCase();
+  users = $.map(users, function (fullName) {
+    var userName = fullName.replace(/ /g, '').toLowerCase();
 
-        return {
-          id: userName,
-          name: userName,
-          fullName: fullName
-        }
-    });
+    return {
+      id: userName,
+      name: userName,
+      fullName: fullName
+    }
+  });
 
-    users = $.grep(users, function (user) {
-        return user.name.indexOf(query.term) === 0
-    });
+  users = $.grep(users, function (user) {
+    return user.name.indexOf(query.term) === 0
+  });
 
-    success(users)
+  success(users)
 };
 
 var table = '<p>This table uses features of the non-editable plugin to make the text in the<br /><strong>top row</strong> and <strong>left column</strong> uneditable.</p>' +

--- a/_includes/codepens/codesample/index.js
+++ b/_includes/codepens/codesample/index.js
@@ -3,19 +3,20 @@ tinymce.init({
   height: 500,
   plugins: 'codesample code',
   codesample_languages: [
-        {text: 'HTML/XML', value: 'markup'},
-        {text: 'JavaScript', value: 'javascript'},
-        {text: 'CSS', value: 'css'},
-        {text: 'PHP', value: 'php'},
-        {text: 'Ruby', value: 'ruby'},
-        {text: 'Python', value: 'python'},
-        {text: 'Java', value: 'java'},
-        {text: 'C', value: 'c'},
-        {text: 'C#', value: 'csharp'},
-        {text: 'C++', value: 'cpp'}
-    ],
+    {text: 'HTML/XML', value: 'markup'},
+    {text: 'JavaScript', value: 'javascript'},
+    {text: 'CSS', value: 'css'},
+    {text: 'PHP', value: 'php'},
+    {text: 'Ruby', value: 'ruby'},
+    {text: 'Python', value: 'python'},
+    {text: 'Java', value: 'java'},
+    {text: 'C', value: 'c'},
+    {text: 'C#', value: 'csharp'},
+    {text: 'C++', value: 'cpp'}
+  ],
   toolbar: 'codesample code',
   content_css: [
     '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
-    '//www.tiny.cloud/css/codepen.min.css']
+    '//www.tiny.cloud/css/codepen.min.css'
+  ]
 });

--- a/_includes/codepens/contextmenu-section/index.js
+++ b/_includes/codepens/contextmenu-section/index.js
@@ -2,14 +2,14 @@ tinymce.PluginManager.add('my-example-plugin', function (editor) {
   editor.ui.registry.addMenuItem('image', {
     icon: 'image',
     text: 'Image',
-    onAction: () => {
+    onAction: function () {
       console.log('context menu clicked');
       alert('context menu clicked');
     }
   });
 
   editor.ui.registry.addContextMenu('image', {
-    update: (element) => {
+    update: function (element) {
       return !element.src ? '' : 'image';
     }
   });

--- a/_includes/codepens/creating-a-custom-button-1/index.js
+++ b/_includes/codepens/creating-a-custom-button-1/index.js
@@ -5,13 +5,13 @@ tinymce.init({
   content_css: [
     '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
     '//www.tiny.cloud/css/codepen.min.css'],
-  
-  setup: function(editor) {
-    
+
+  setup: function (editor) {
+
     function toTimeHtml(date) {
       return '<time datetime="' + date.toString() + '">' + date.toDateString() + '</time>';
     }
-    
+
     function insertDate() {
       var html = toTimeHtml(new Date());
       editor.insertContent(html);

--- a/_includes/codepens/creating-a-custom-button-2/index.js
+++ b/_includes/codepens/creating-a-custom-button-2/index.js
@@ -5,7 +5,8 @@ tinymce.init({
   toolbar: 'undo redo | currentdate',
   content_css: [
     '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
-    '//www.tiny.cloud/css/codepen.min.css'],
+    '//www.tiny.cloud/css/codepen.min.css'
+  ],
 
   setup: function (editor) {
 

--- a/_includes/codepens/creating-a-custom-button-2/index.js
+++ b/_includes/codepens/creating-a-custom-button-2/index.js
@@ -1,36 +1,38 @@
 tinymce.init({
   selector: 'textarea.tinymce',
-  height: 300,  
+  height: 300,
   plugins: 'code',
   toolbar: 'undo redo | currentdate',
   content_css: [
     '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
     '//www.tiny.cloud/css/codepen.min.css'],
-  
-  setup: function(editor) {
+
+  setup: function (editor) {
 
     function toTimeHtml(date) {
       return '<time datetime="' + date.toString() + '">' + date.toDateString() + '</time>';
     }
-    
+
     function insertDate() {
       var html = toTimeHtml(new Date());
       editor.insertContent(html);
     }
-    
+
     function monitorNodeChange(btnApi) {
-      const disable = (e) => {
-         btnApi.setDisabled(e.element.nodeName.toLowerCase() === 'time'); 
-      }
+      var disable = function (e) {
+         btnApi.setDisabled(e.element.nodeName.toLowerCase() === 'time');
+      };
       editor.on('nodechange', disable);
-      return () => { editor.off('NodeChange', disable) };
+      return function () {
+        editor.off('NodeChange', disable);
+      };
     }
 
     editor.ui.registry.addButton('currentdate', {
       icon: 'insert-time',
       tooltip: "Insert Current Date",
       onAction: insertDate,
-      onSetup: (btnApi) => {
+      onSetup: function (btnApi) {
         return monitorNodeChange(btnApi)
       }
     });

--- a/_includes/codepens/creating-a-custom-button-3/index.js
+++ b/_includes/codepens/creating-a-custom-button-3/index.js
@@ -1,27 +1,27 @@
 tinymce.init({
   selector: '#creating-a-custom-button-3',
-  height: 300,  
+  height: 300,
   plugins: 'code fullpage',
   toolbar: 'undo redo | strikeout | fullpage code',
   content_css: [
     '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
     '//www.tiny.cloud/css/codepen.min.css'],
-  
-  setup: function(editor) {
+
+  setup: function (editor) {
     editor.addButton('strikeout', {
       icon: 'strikethrough',
-      onclick: function() {
+      onclick: function () {
         editor.execCommand('mceToggleFormat', false, 'strikethrough');
       },
-      onpostrender: function() {
+      onpostrender: function () {
         var btn = this;
-        editor.on('init', function() {
-          editor.formatter.formatChanged('strikethrough', function(state) {
+        editor.on('init', function () {
+          editor.formatter.formatChanged('strikethrough', function (state) {
             btn.active(state);
           });
         });
       }
     });
   }
- 
+
 });

--- a/_includes/codepens/creating-a-custom-button-3/index.js
+++ b/_includes/codepens/creating-a-custom-button-3/index.js
@@ -5,7 +5,8 @@ tinymce.init({
   toolbar: 'undo redo | strikeout | fullpage code',
   content_css: [
     '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
-    '//www.tiny.cloud/css/codepen.min.css'],
+    '//www.tiny.cloud/css/codepen.min.css'
+  ],
 
   setup: function (editor) {
     editor.addButton('strikeout', {

--- a/_includes/codepens/custom-toolbar-button/index.js
+++ b/_includes/codepens/custom-toolbar-button/index.js
@@ -1,26 +1,34 @@
 tinymce.init({
   selector: 'textarea',
   toolbar: 'customInsertButton customDateButton',
-  setup: (editor) => {
+  setup: function (editor) {
 
     editor.ui.registry.addButton('customInsertButton', {
       text: 'My Button',
-      onAction: (_) => editor.insertContent('&nbsp;<strong>It\'s my button!</strong>&nbsp;')
+      onAction: function (_) {
+        editor.insertContent('&nbsp;<strong>It\'s my button!</strong>&nbsp;');
+      }
     });
 
-    const toTimeHtml = (date) => `<time datetime="${date.toString()}">${date.toDateString()}</time>`;
+    var toTimeHtml = function (date) {
+      return '<time datetime="' + date.toString() + '">' + date.toDateString() + '</time>';
+    };
 
     editor.ui.registry.addButton('customDateButton', {
       icon: 'insert-time',
       tooltip: 'Insert Current Date',
       disabled: true,
-      onAction: (_) => editor.insertContent(toTimeHtml(new Date())),
-      onSetup: (buttonApi) => {
-        const editorEventCallback = (eventApi) => buttonApi.setDisabled(eventApi.element.nodeName.toLowerCase() === 'time');
+      onAction: function (_) {
+        editor.insertContent(toTimeHtml(new Date()));
+      },
+      onSetup: function (buttonApi) {
+        var editorEventCallback = function (eventApi) {
+          buttonApi.setDisabled(eventApi.element.nodeName.toLowerCase() === 'time');
+        };
         editor.on('NodeChange', editorEventCallback);
-        
+
         /* onSetup should always return the unbind handlers */
-        return (buttonApi) => editor.off('NodeChange', editorEventCallback);
+        return function (buttonApi) { editor.off('NodeChange', editorEventCallback); };
       }
     });
   }

--- a/_includes/codepens/custom-toolbar-button/index.js
+++ b/_includes/codepens/custom-toolbar-button/index.js
@@ -28,7 +28,9 @@ tinymce.init({
         editor.on('NodeChange', editorEventCallback);
 
         /* onSetup should always return the unbind handlers */
-        return function (buttonApi) { editor.off('NodeChange', editorEventCallback); };
+        return function (buttonApi) {
+          editor.off('NodeChange', editorEventCallback);
+        };
       }
     });
   }

--- a/_includes/codepens/custom-toolbar-listbox/index.js
+++ b/_includes/codepens/custom-toolbar-listbox/index.js
@@ -4,10 +4,11 @@ tinymce.init({
   toolbar: 'mybutton',
   plugins: 'wordcount',
   menubar: false,
-    content_css: [
+  content_css: [
     '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
-    '//www.tiny.cloud/css/codepen.min.css'],
-  
+    '//www.tiny.cloud/css/codepen.min.css'
+  ],
+
   setup: function (editor) {
     editor.addButton('mybutton', {
       type: 'listbox',

--- a/_includes/codepens/custom-toolbar-menu-button/index.js
+++ b/_includes/codepens/custom-toolbar-menu-button/index.js
@@ -4,8 +4,9 @@ tinymce.init({
   toolbar: 'mybutton',
 
   content_css: [
-  '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
-  '//www.tiny.cloud/css/codepen.min.css'],
+    '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
+    '//www.tiny.cloud/css/codepen.min.css'
+  ],
 
   setup: function (editor) {
 
@@ -43,7 +44,7 @@ tinymce.init({
                     editor.insertContent('&nbsp;<em>You clicked Sub menu item 2!</em>');
                   }
                 }
-              ]
+              ];
             }
           }
         ];

--- a/_includes/codepens/custom-toolbar-menu-button/index.js
+++ b/_includes/codepens/custom-toolbar-menu-button/index.js
@@ -7,39 +7,45 @@ tinymce.init({
   '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
   '//www.tiny.cloud/css/codepen.min.css'],
 
-  setup: function(editor) {
+  setup: function (editor) {
 
     /* example, adding a toolbar menu button */
     editor.ui.registry.addMenuButton('mybutton', {
       text: 'My button',
-      fetch: (callback) => {
-        const items = [
+      fetch: function (callback) {
+        var items = [
           {
             type: 'menuitem',
             text: 'Menu item 1',
-            onAction: () => editor.insertContent('&nbsp;<em>You clicked menu item 1!</em>')
+            onAction: function () {
+              editor.insertContent('&nbsp;<em>You clicked menu item 1!</em>');
+            }
           },
           {
             type: 'nestedmenuitem',
             text: 'Menu item 2',
             icon: 'user',
-            getSubmenuItems: () => {
+            getSubmenuItems: function () {
               return [
                 {
                   type: 'menuitem',
                   text: 'Sub menu item 1',
                   icon: 'unlock',
-                  onAction: () => editor.insertContent('&nbsp;<em>You clicked Sub menu item 1!</em>')
+                  onAction: function () {
+                    editor.insertContent('&nbsp;<em>You clicked Sub menu item 1!</em>');
+                  }
                 },
                 {
                   type: 'menuitem',
                   text: 'Sub menu item 2',
                   icon: 'lock',
-                  onAction: () => editor.insertContent('&nbsp;<em>You clicked Sub menu item 2!</em>')
+                  onAction: function () {
+                    editor.insertContent('&nbsp;<em>You clicked Sub menu item 2!</em>');
+                  }
                 }
               ]
             }
-          },
+          }
         ];
         callback(items);
       }

--- a/_includes/codepens/custom-toolbar-menu-item/index.js
+++ b/_includes/codepens/custom-toolbar-menu-item/index.js
@@ -7,14 +7,14 @@ tinymce.init({
     content_css: [
     '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
     '//www.tiny.cloud/css/codepen.min.css'],
-  
-  setup: function(editor) {
+
+  setup: function (editor) {
     editor.addMenuItem('myitem', {
       text: 'My menu item',
       context: 'tools',
-      onclick: function() {
+      onclick: function () {
         editor.insertContent('&nbsp;Here\'s some content!&nbsp;');
       }
     });
-  },
+  }
 });

--- a/_includes/codepens/custom-toolbar-menu-item/index.js
+++ b/_includes/codepens/custom-toolbar-menu-item/index.js
@@ -4,9 +4,10 @@ tinymce.init({
   plugins: 'wordcount',
   toolbar: false,
   menubar: "tools",
-    content_css: [
+  content_css: [
     '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
-    '//www.tiny.cloud/css/codepen.min.css'],
+    '//www.tiny.cloud/css/codepen.min.css'
+  ],
 
   setup: function (editor) {
     editor.addMenuItem('myitem', {

--- a/_includes/codepens/custom-toolbar-split-button/index.js
+++ b/_includes/codepens/custom-toolbar-split-button/index.js
@@ -2,17 +2,17 @@ tinymce.init({
   selector: 'textarea',
   toolbar: 'myButton',
   menubar: false,
-  setup: (editor) => {
+  setup: function (editor) {
     editor.ui.registry.addSplitButton('myButton', {
       text: 'My Button',
-      onAction: () => {
-        editor.insertContent('<p>You clicked the main button</p>')
+      onAction: function () {
+        editor.insertContent('<p>You clicked the main button</p>');
       },
-      onItemAction: (api, value) => {
+      onItemAction: function (api, value) {
         editor.insertContent(value);
       },
-      fetch: (callback) => {
-        const items = [
+      fetch: function (callback) {
+        var items = [
           {
             type: 'choiceitem',
             text: 'Menu item 1',
@@ -22,7 +22,7 @@ tinymce.init({
             type: 'choiceitem',
             text: 'Menu item 2',
             value: '&nbsp;<em>You clicked menu item 2!</em>'
-          },
+          }
         ];
         callback(items);
       }

--- a/_includes/codepens/custom-toolbar-toggle-button/index.js
+++ b/_includes/codepens/custom-toolbar-toggle-button/index.js
@@ -1,17 +1,21 @@
 tinymce.init({
   selector: 'textarea',
   toolbar: 'customStrikethrough customToggleStrikethrough',
-  setup: (editor) => {
+  setup: function (editor) {
     editor.ui.registry.addToggleButton('customStrikethrough', {
       text: 'Strikethrough',
-      onAction: (_) => editor.execCommand('mceToggleFormat', false, 'strikethrough')
+      onAction: function (_) {
+        editor.execCommand('mceToggleFormat', false, 'strikethrough');
+      }
     });
 
     editor.ui.registry.addToggleButton('customToggleStrikethrough', {
       icon: 'strike-through',
-      onAction: (_) => editor.execCommand('mceToggleFormat', false, 'strikethrough'),
-      onSetup: (api) => {
-        editor.formatter.formatChanged('strikethrough', (state) => {
+      onAction: function (_) {
+        editor.execCommand('mceToggleFormat', false, 'strikethrough');
+      },
+      onSetup: function (api) {
+        editor.formatter.formatChanged('strikethrough', function (state) {
           api.setActive(state);
         });
       }

--- a/_includes/codepens/dialog-pet-machine/index.js
+++ b/_includes/codepens/dialog-pet-machine/index.js
@@ -1,5 +1,5 @@
 /* example dialog that inserts the name of a Pet into the editor content */
-const dialogConfig =  {
+var dialogConfig =  {
   title: 'Pet Name Machine',
   body: {
     type: 'panel',
@@ -33,9 +33,9 @@ const dialogConfig =  {
     catdata: 'initial Cat',
     isdog: 'unchecked'
   },
-  onSubmit: (api) => {
-    const data = api.getData();
-    const pet = data.isdog === 'checked' ? 'dog' : 'cat';
+  onSubmit: function (api) {
+    var data = api.getData();
+    var pet = data.isdog === 'checked' ? 'dog' : 'cat';
 
     tinymce.activeEditor.execCommand('mceInsertContent', false, '<p>My ' + pet +'\'s name is: <strong>' + data.catdata + '</strong></p>');
     api.close();
@@ -45,10 +45,10 @@ const dialogConfig =  {
 tinymce.init({
   selector: 'textarea.petMachine',
   toolbar: 'dialog-example-btn',
-  setup: (editor) => {
+  setup: function (editor) {
     editor.ui.registry.addButton('dialog-example-btn', {
       icon: 'code-sample',
-      onAction: () => {
+      onAction: function () {
         editor.windowManager.open(dialogConfig)
       }
     })

--- a/_includes/codepens/file-picker/index.js
+++ b/_includes/codepens/file-picker/index.js
@@ -3,7 +3,7 @@ tinymce.init({
   plugins: 'image code',
   toolbar: 'undo redo | link image | code',
   /* enable title field in the Image dialog*/
-  image_title: true, 
+  image_title: true,
   /* enable automatic uploads of images represented by blob or data URIs*/
   automatic_uploads: true,
   /*
@@ -11,13 +11,13 @@ tinymce.init({
     images_upload_url: 'postAcceptor.php',
     here we add custom filepicker only to Image dialog
   */
-  file_picker_types: 'image', 
+  file_picker_types: 'image',
   /* and here's our custom image picker*/
-  file_picker_callback: function(cb, value, meta) {
+  file_picker_callback: function (cb, value, meta) {
     var input = document.createElement('input');
     input.setAttribute('type', 'file');
     input.setAttribute('accept', 'image/*');
-    
+
     /*
       Note: In modern browsers input[type="file"] is functional without
       even adding it to the DOM, but that might not be the case in some older
@@ -26,9 +26,9 @@ tinymce.init({
       once you do not need it anymore.
     */
 
-    input.onchange = function() {
+    input.onchange = function () {
       var file = this.files[0];
-      
+
       var reader = new FileReader();
       reader.onload = function () {
         /*
@@ -47,7 +47,7 @@ tinymce.init({
       };
       reader.readAsDataURL(file);
     };
-    
+
     input.click();
   }
 });

--- a/_includes/codepens/format-custom/index.js
+++ b/_includes/codepens/format-custom/index.js
@@ -5,7 +5,7 @@ tinymce.init({
   content_css: [
     '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
     '//www.tiny.cloud/css/codepen.min.css'],
-  
+
   style_formats: [
     { title: 'Bold text', inline: 'strong' },
     { title: 'Red text', inline: 'span', styles: { color: '#ff0000' } },
@@ -22,6 +22,6 @@ tinymce.init({
     italic: { inline: 'span', 'classes': 'italic' },
     underline: { inline: 'span', 'classes': 'underline', exact: true },
     strikethrough: { inline: 'del' },
-    customformat: { inline: 'span', styles: { color: '#00ff00', fontSize: '20px' }, attributes: { title: 'My custom format' }, classes: 'example1' },
+    customformat: { inline: 'span', styles: { color: '#00ff00', fontSize: '20px' }, attributes: { title: 'My custom format' }, classes: 'example1' }
   }
 });

--- a/_includes/codepens/format-custom/index.js
+++ b/_includes/codepens/format-custom/index.js
@@ -4,7 +4,8 @@ tinymce.init({
   plugins: 'table wordcount',
   content_css: [
     '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
-    '//www.tiny.cloud/css/codepen.min.css'],
+    '//www.tiny.cloud/css/codepen.min.css'
+  ],
 
   style_formats: [
     { title: 'Bold text', inline: 'strong' },

--- a/_includes/codepens/format-html5/index.js
+++ b/_includes/codepens/format-html5/index.js
@@ -33,4 +33,4 @@ tinymce.init({
   ],
   visualblocks_default_state: true,
   end_container_on_empty_block: true
- });
+});

--- a/_includes/codepens/full-featured/index.js
+++ b/_includes/codepens/full-featured/index.js
@@ -1,13 +1,8 @@
 tinymce.init({
   selector: 'textarea',
-  height: 500,
   plugins: 'print preview fullpage powerpaste searchreplace autolink directionality advcode visualblocks visualchars fullscreen image link media template codesample table charmap hr pagebreak nonbreaking anchor toc insertdatetime advlist lists textcolor wordcount tinymcespellchecker a11ychecker imagetools colorpicker textpattern help',
   toolbar: 'formatselect | bold italic strikethrough forecolor backcolor | link | alignleft aligncenter alignright alignjustify  | numlist bullist outdent indent  | removeformat',
   image_advtab: true,
-  templates: [
-    { title: 'Test template 1', content: 'Test 1' },
-    { title: 'Test template 2', content: 'Test 2' }
-  ],
   content_css: [
     '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
     '//www.tiny.cloud/css/codepen.min.css'
@@ -26,7 +21,7 @@ tinymce.init({
   ],
   importcss_append: true,
   height: 400,
-  file_picker_callback (callback, value, meta) {
+  file_picker_callback: function (callback, value, meta) {
     /* Provide file and text for the link dialog */
     if (meta.filetype === 'file') {
       callback('https://www.google.com/logos/google.jpg', { text: 'My text' });
@@ -42,13 +37,13 @@ tinymce.init({
       callback('movie.mp4', { source2: 'alt.ogg', poster: 'https://www.google.com/logos/google.jpg' });
     }
   },
-  spellchecker_callback (method, text, success, failure) {
-    const words = text.match(this.getWordCharPattern());
+  spellchecker_callback: function (method, text, success, failure) {
+    var words = text.match(this.getWordCharPattern());
 
     if (method === 'spellcheck') {
-      const suggestions = {};
+      var suggestions = {};
 
-      for (let i = 0; i < words.length; i++) {
+      for (var i = 0; i < words.length; i++) {
         suggestions[words[i]] = ['First', 'Second'];
       }
 
@@ -66,11 +61,10 @@ tinymce.init({
   template_cdate_format: '[CDATE: %m/%d/%Y : %H:%M:%S]',
   template_mdate_format: '[MDATE: %m/%d/%Y : %H:%M:%S]',
   image_caption: true,
-  
 
   api_key: 'fake-key',
   spellchecker_rpc_url: 'https://spelling.tinymce.com/',
   spellchecker_api_key: 'h22wb7h8xi78b4fyo46hhx5k7fbh46vt5f6yqmvd492iy00c',
   spellchecker_dialog: true,
-  spellchecker_whitelist: ['Ephox', 'Moxiecode'],
+  spellchecker_whitelist: ['Ephox', 'Moxiecode']
  });

--- a/_includes/codepens/image-tools/index.js
+++ b/_includes/codepens/image-tools/index.js
@@ -2,10 +2,10 @@ tinymce.init({
   selector: 'textarea',
   height: 500,
   plugins: [
-        "advlist autolink lists link image charmap print preview anchor",
-        "searchreplace visualblocks code fullscreen",
-        "insertdatetime media table paste imagetools wordcount"
-    ],
+    "advlist autolink lists link image charmap print preview anchor",
+    "searchreplace visualblocks code fullscreen",
+    "insertdatetime media table paste imagetools wordcount"
+  ],
   toolbar: "insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
   content_css: [
     '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',

--- a/_includes/codepens/inline/index.js
+++ b/_includes/codepens/inline/index.js
@@ -1,51 +1,51 @@
-  var emailHeaderConfig = {
-    selector: '.tinymce-heading',
-    menubar: false,
-    inline: true,
-    plugins: [
-      'textcolor',
-      'lists',
-      'powerpaste',
-      'autolink'
-    ],
-    toolbar: 'undo redo | bold italic underline',
-    valid_elements: 'strong,em,span[style],a[href]',
-    valid_styles: {
-      '*': 'font-size,font-family,color,text-decoration,text-align'
-    },
-    powerpaste_word_import: 'clean',
-    powerpaste_html_import: 'clean',
-    content_css: [
-      '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
-    ]
-  };
+var emailHeaderConfig = {
+  selector: '.tinymce-heading',
+  menubar: false,
+  inline: true,
+  plugins: [
+    'textcolor',
+    'lists',
+    'powerpaste',
+    'autolink'
+  ],
+  toolbar: 'undo redo | bold italic underline',
+  valid_elements: 'strong,em,span[style],a[href]',
+  valid_styles: {
+    '*': 'font-size,font-family,color,text-decoration,text-align'
+  },
+  powerpaste_word_import: 'clean',
+  powerpaste_html_import: 'clean',
+  content_css: [
+    '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i'
+  ]
+};
 
-  var emailBodyConfig = {
-    selector: '.tinymce-body',
-    menubar: false,
-    inline: true,
-    plugins: [
-      'link',
-      'textcolor',
-      'lists',
-      'powerpaste',
-      'autolink',
-      'tinymcespellchecker'
-    ],
-    toolbar: [
-      'undo redo | bold italic underline | fontselect fontsizeselect',
-      'forecolor backcolor | alignleft aligncenter alignright alignfull | numlist bullist outdent indent'
-    ],
-    valid_elements: 'p[style],strong,em,span[style],a[href],ul,ol,li',
-    valid_styles: {
-      '*': 'font-size,font-family,color,text-decoration,text-align'
-    },
-    powerpaste_word_import: 'clean',
-    powerpaste_html_import: 'clean',
-    content_css: [
-      '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
-    ]
-  };
+var emailBodyConfig = {
+  selector: '.tinymce-body',
+  menubar: false,
+  inline: true,
+  plugins: [
+    'link',
+    'textcolor',
+    'lists',
+    'powerpaste',
+    'autolink',
+    'tinymcespellchecker'
+  ],
+  toolbar: [
+    'undo redo | bold italic underline | fontselect fontsizeselect',
+    'forecolor backcolor | alignleft aligncenter alignright alignfull | numlist bullist outdent indent'
+  ],
+  valid_elements: 'p[style],strong,em,span[style],a[href],ul,ol,li',
+  valid_styles: {
+    '*': 'font-size,font-family,color,text-decoration,text-align'
+  },
+  powerpaste_word_import: 'clean',
+  powerpaste_html_import: 'clean',
+  content_css: [
+    '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i'
+  ]
+};
 
 tinymce.init(emailHeaderConfig);
 tinymce.init(emailBodyConfig);

--- a/_includes/codepens/local-upload/index.js
+++ b/_includes/codepens/local-upload/index.js
@@ -2,15 +2,15 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'image code',
   toolbar: 'undo redo | image code',
-  
+
   /* without images_upload_url set, Upload tab won't show up*/
   images_upload_url: 'postAcceptor.php',
-  
+
   /* we override default upload handler to simulate successful upload*/
   images_upload_handler: function (blobInfo, success, failure) {
-    setTimeout(function() {
+    setTimeout(function () {
       /* no matter what you upload, we will turn it into TinyMCE logo :)*/
       success('http://moxiecode.cachefly.net/tinymce/v9/images/logo.png');
     }, 2000);
-  },
+  }
 });

--- a/_includes/codepens/mentions/index.js
+++ b/_includes/codepens/mentions/index.js
@@ -1,5 +1,5 @@
 var fakeMentionsServer = function (term, success) {
-  /* 
+  /*
     Fake mentions server, implementations will vary however data passed to success must be an object with these properties
 
     success({
@@ -94,9 +94,9 @@ var fakeMentionsServer = function (term, success) {
     var image = 'https://s3.amazonaws.com/uifaces/faces/twitter/' + images[Math.round(images.length * Math.random())] + '/128.jpg';
     return {
       id: name,
-      name,
-      fullName,
-      image
+      name: name,
+      fullName: fullName,
+      image: image
     };
   });
 
@@ -105,10 +105,10 @@ var fakeMentionsServer = function (term, success) {
     var matches = users.filter(function (user) {
       return user.name.indexOf(term.toLowerCase()) !== -1;
     });
-  
+
     /* fake async server delay */
-    var timeout = 30; 
-  
+    var timeout = 30;
+
     window.setTimeout(function () {
       success(matches);
     }, timeout);
@@ -118,7 +118,7 @@ var fakeMentionsServer = function (term, success) {
 };
 
 var mentions_menu_complete = function (editor, userinfo) {
-  const x = document.createElement('div');
+  var x = document.createElement('div');
 
   x.innerHTML = '<span style="color: green" class="mentionsmentionsmentions">@' + userinfo.name + '</span>';
 
@@ -132,7 +132,7 @@ var mentions_fetch = function (query, success) {
 tinymce.init({
   selector: "textarea",
   plugins: "mentions",
-  
+
   mentions_selector: '.mentionsmentionsmentions',
   mentions_fetch: mentions_fetch,
   mentions_menu_complete: mentions_menu_complete

--- a/_includes/codepens/paste-from-word/index.js
+++ b/_includes/codepens/paste-from-word/index.js
@@ -13,5 +13,6 @@ tinymce.init({
   powerpaste_html_import: 'prompt',
   content_css: [
     '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
-    '//www.tiny.cloud/css/codepen.min.css']
+    '//www.tiny.cloud/css/codepen.min.css'
+  ]
 });

--- a/_includes/codepens/redial/index.js
+++ b/_includes/codepens/redial/index.js
@@ -31,13 +31,13 @@ var config = {
       disabled: true
     }
   ],
-  onChange: (dialogApi, changeData) => {
+  onChange: function (dialogApi, changeData) {
     var data = dialogApi.getData();
     /* Example of enabling and disabling a button, based on the checkbox state. */
     var toggle = data.anyterms === 'checked' ? dialogApi.enable : dialogApi.disable;
     toggle('uniquename');
   },
-  onAction: (dialogApi, actionData) => {
+  onAction: function (dialogApi, actionData) {
     if (actionData.name === 'uniquename') {
       dialogApi.redial({
         title: 'Redial Demo - Page 2',
@@ -71,7 +71,7 @@ var config = {
         initialData: {
           choosydata: ''
         },
-        onAction: (dialogApi, actionData) => {
+        onAction: function (dialogApi, actionData) {
           var data = dialogApi.getData();
 
           var result = 'you chose wisely: ' + data.choosydata;
@@ -91,10 +91,10 @@ tinymce.init({
   selector: 'textarea.wizard',
   toolbar: 'wizardExample',
   height: '900px',
-  setup: (editor) => {
+  setup: function (editor) {
     editor.ui.registry.addButton('wizardExample', {
       icon: 'code-sample',
-      onAction: () => {
+      onAction: function () {
         editor.windowManager.open(config)
       }
     })

--- a/_includes/codepens/toolbar-button/index.js
+++ b/_includes/codepens/toolbar-button/index.js
@@ -1,135 +1,135 @@
 tinymce.init({
   selector: 'textarea',
-    toolbar: 'basicDateButton selectiveDateButton toggleDateButton splitDateButton menuDateButton',
-    setup: function (editor) {
+  toolbar: 'basicDateButton selectiveDateButton toggleDateButton splitDateButton menuDateButton',
+  setup: function (editor) {
 
-      /* Helper functions */
-      var toDateHtml = function (date) {
-        return '<time datetime="' + date.toString() + '">' + date.toDateString() + '</time>';
-      };
-      var toGmtHtml = function (date) {
-        return '<time datetime="' + date.toString() + '">' + date.toGMTString() + '</time>';
-      };
-      var toIsoHtml = function (date) {
-        return '<time datetime="' + date.toString() + '">' + date.toISOString() + '</time>';
-      };
+    /* Helper functions */
+    var toDateHtml = function (date) {
+      return '<time datetime="' + date.toString() + '">' + date.toDateString() + '</time>';
+    };
+    var toGmtHtml = function (date) {
+      return '<time datetime="' + date.toString() + '">' + date.toGMTString() + '</time>';
+    };
+    var toIsoHtml = function (date) {
+      return '<time datetime="' + date.toString() + '">' + date.toISOString() + '</time>';
+    };
 
-      /* Basic button that just inserts the date */
-      editor.ui.registry.addButton('basicDateButton', {
-        text: 'Insert Date',
-        tooltip: 'Insert Current Date',
-        onAction: function (_) {
-          editor.insertContent(toDateHtml(new Date()));
+    /* Basic button that just inserts the date */
+    editor.ui.registry.addButton('basicDateButton', {
+      text: 'Insert Date',
+      tooltip: 'Insert Current Date',
+      onAction: function (_) {
+        editor.insertContent(toDateHtml(new Date()));
+      }
+    });
+
+    /* Basic button that inserts the date, but only if the cursor isn't currently in a "time" element */
+    editor.ui.registry.addButton('selectiveDateButton', {
+      icon: 'insert-time',
+      tooltip: 'Insert Current Date',
+      disabled: true,
+      onAction: function (_) {
+        editor.insertContent(toDateHtml(new Date()));
+      },
+      onSetup: function (buttonApi) {
+        var editorEventCallback = function (eventApi) {
+          buttonApi.setDisabled(eventApi.element.nodeName.toLowerCase() === 'time');
+        };
+        editor.on('NodeChange', editorEventCallback);
+        return function (buttonApi) {
+          editor.off('NodeChange', editorEventCallback);
         }
-      });
+      }
+    });
 
-      /* Basic button that inserts the date, but only if the cursor isn't currently in a "time" element */
-      editor.ui.registry.addButton('selectiveDateButton', {
-        icon: 'insert-time',
-        tooltip: 'Insert Current Date',
-        disabled: true,
-        onAction: function (_) {
-          editor.insertContent(toDateHtml(new Date()));
-        },
-        onSetup: function (buttonApi) {
-          var editorEventCallback = function (eventApi) {
-            buttonApi.setDisabled(eventApi.element.nodeName.toLowerCase() === 'time');
-          };
-          editor.on('NodeChange', editorEventCallback);
-          return function (buttonApi) {
-            editor.off('NodeChange', editorEventCallback);
+    /* Toggle button that inserts the date, but becomes inactive when the cursor is in a "time" element */
+    /* so you can't insert a "time" element inside another one. Also gives visual feedback. */
+    editor.ui.registry.addToggleButton('toggleDateButton', {
+      icon: 'insert-time',
+      tooltip: 'Insert Current Date',
+      onAction: function (_) {
+        editor.insertContent(toDateHtml(new Date()));
+      },
+      onSetup: function (buttonApi) {
+        var editorEventCallback = function (eventApi) {
+          buttonApi.setActive(eventApi.element.nodeName.toLowerCase() === 'time');
+        };
+        editor.on('NodeChange', editorEventCallback);
+        return function (buttonApi) {
+          editor.off('NodeChange', editorEventCallback);
+        }
+      }
+    });
+
+    /* Split button that lists 3 formats, and inserts the date in the selected format when clicked */
+    editor.ui.registry.addSplitButton('splitDateButton', {
+      text: 'Insert Date',
+      onAction: function (_) {
+        editor.insertContent('<p>Its Friday!</p>')
+      },
+      onItemAction: function (buttonApi, value) {
+        editor.insertContent(value);
+      },
+      fetch: function (callback) {
+        var items = [
+          {
+            type: 'choiceitem',
+            text: 'Insert Date',
+            value: toDateHtml(new Date())
+          },
+          {
+            type: 'choiceitem',
+            text: 'Insert GMT Date',
+            value: toGmtHtml(new Date())
+          },
+          {
+            type: 'choiceitem',
+            text: 'Insert ISO Date',
+            value: toIsoHtml(new Date())
           }
-        }
-      });
+        ];
+        callback(items);
+      }
+    });
 
-      /* Toggle button that inserts the date, but becomes inactive when the cursor is in a "time" element */
-      /* so you can't insert a "time" element inside another one. Also gives visual feedback. */
-      editor.ui.registry.addToggleButton('toggleDateButton', {
-        icon: 'insert-time',
-        tooltip: 'Insert Current Date',
-        onAction: function (_) {
-          editor.insertContent(toDateHtml(new Date()));
-        },
-        onSetup: function (buttonApi) {
-          var editorEventCallback = function (eventApi) {
-            buttonApi.setActive(eventApi.element.nodeName.toLowerCase() === 'time');
-          };
-          editor.on('NodeChange', editorEventCallback);
-          return function (buttonApi) {
-            editor.off('NodeChange', editorEventCallback);
-          }
-        }
-      });
-
-      /* Split button that lists 3 formats, and inserts the date in the selected format when clicked */
-      editor.ui.registry.addSplitButton('splitDateButton', {
-        text: 'Insert Date',
-        onAction: function (_) {
-          editor.insertContent('<p>Its Friday!</p>')
-        },
-        onItemAction: function (buttonApi, value) {
-          editor.insertContent(value);
-        },
-        fetch: function (callback) {
-          var items = [
-            {
-              type: 'choiceitem',
-              text: 'Insert Date',
-              value: toDateHtml(new Date())
-            },
-            {
-              type: 'choiceitem',
-              text: 'Insert GMT Date',
-              value: toGmtHtml(new Date())
-            },
-            {
-              type: 'choiceitem',
-              text: 'Insert ISO Date',
-              value: toIsoHtml(new Date())
+    /* Menu button that has a simple "insert date" menu item, and a submenu containing other formats. */
+    /* Clicking the first menu item or one of the submenu items inserts the date in the selected format. */
+    editor.ui.registry.addMenuButton('menuDateButton', {
+      text: 'Date',
+      fetch: function (callback) {
+        var items = [
+          {
+            type: 'menuitem',
+            text: 'Insert Date',
+            onAction: function (_) {
+              editor.insertContent(toDateHtml(new Date()));
             }
-          ];
-          callback(items);
-        }
-      });
-
-      /* Menu button that has a simple "insert date" menu item, and a submenu containing other formats. */
-      /* Clicking the first menu item or one of the submenu items inserts the date in the selected format. */
-      editor.ui.registry.addMenuButton('menuDateButton', {
-        text: 'Date',
-        fetch: function (callback) {
-          var items = [
-            {
-              type: 'menuitem',
-              text: 'Insert Date',
-              onAction: function (_) {
-                editor.insertContent(toDateHtml(new Date()));
-              }
-            },
-            {
-              type: 'nestedmenuitem',
-              text: 'Other formats',
-              getSubmenuItems: function () {
-                return [
-                  {
-                    type: 'menuitem',
-                    text: 'GMT',
-                    onAction: function (_) {
-                      editor.insertContent(toGmtHtml(new Date()));
-                    }
-                  },
-                  {
-                    type: 'menuitem',
-                    text: 'ISO',
-                    onAction: function (_) {
-                      editor.insertContent(toIsoHtml(new Date()));
-                    }
+          },
+          {
+            type: 'nestedmenuitem',
+            text: 'Other formats',
+            getSubmenuItems: function () {
+              return [
+                {
+                  type: 'menuitem',
+                  text: 'GMT',
+                  onAction: function (_) {
+                    editor.insertContent(toGmtHtml(new Date()));
                   }
-                ];
-              }
+                },
+                {
+                  type: 'menuitem',
+                  text: 'ISO',
+                  onAction: function (_) {
+                    editor.insertContent(toIsoHtml(new Date()));
+                  }
+                }
+              ];
             }
-          ];
-          callback(items);
-        }
-      });
-    }
-  });
+          }
+        ];
+        callback(items);
+      }
+    });
+  }
+});

--- a/_includes/codepens/toolbar-button/index.js
+++ b/_includes/codepens/toolbar-button/index.js
@@ -1,18 +1,26 @@
 tinymce.init({
   selector: 'textarea',
     toolbar: 'basicDateButton selectiveDateButton toggleDateButton splitDateButton menuDateButton',
-    setup: (editor) => {
+    setup: function (editor) {
 
       /* Helper functions */
-      const toDateHtml = (date) => `<time datetime="${date.toString()}">${date.toDateString()}</time>`;
-      const toGmtHtml = (date) => `<time datetime="${date.toString()}">${date.toGMTString()}</time>`;
-      const toIsoHtml = (date) => `<time datetime="${date.toString()}">${date.toISOString()}</time>`;
+      var toDateHtml = function (date) {
+        return '<time datetime="' + date.toString() + '">' + date.toDateString() + '</time>';
+      };
+      var toGmtHtml = function (date) {
+        return '<time datetime="' + date.toString() + '">' + date.toGMTString() + '</time>';
+      };
+      var toIsoHtml = function (date) {
+        return '<time datetime="' + date.toString() + '">' + date.toISOString() + '</time>';
+      };
 
       /* Basic button that just inserts the date */
       editor.ui.registry.addButton('basicDateButton', {
         text: 'Insert Date',
         tooltip: 'Insert Current Date',
-        onAction: (_) => editor.insertContent(toDateHtml(new Date())),
+        onAction: function (_) {
+          editor.insertContent(toDateHtml(new Date()));
+        }
       });
 
       /* Basic button that inserts the date, but only if the cursor isn't currently in a "time" element */
@@ -20,13 +28,17 @@ tinymce.init({
         icon: 'insert-time',
         tooltip: 'Insert Current Date',
         disabled: true,
-        onAction: (_) => editor.insertContent(toDateHtml(new Date())),
-        onSetup: (buttonApi) => {
-          const editorEventCallback = (eventApi) => {
+        onAction: function (_) {
+          editor.insertContent(toDateHtml(new Date()));
+        },
+        onSetup: function (buttonApi) {
+          var editorEventCallback = function (eventApi) {
             buttonApi.setDisabled(eventApi.element.nodeName.toLowerCase() === 'time');
           };
           editor.on('NodeChange', editorEventCallback);
-          return (buttonApi) => editor.off('NodeChange', editorEventCallback);
+          return function (buttonApi) {
+            editor.off('NodeChange', editorEventCallback);
+          }
         }
       });
 
@@ -35,27 +47,31 @@ tinymce.init({
       editor.ui.registry.addToggleButton('toggleDateButton', {
         icon: 'insert-time',
         tooltip: 'Insert Current Date',
-        onAction: (_) => editor.insertContent(toDateHtml(new Date())),
-        onSetup: (buttonApi) => {
-          const editorEventCallback = (eventApi) => {
+        onAction: function (_) {
+          editor.insertContent(toDateHtml(new Date()));
+        },
+        onSetup: function (buttonApi) {
+          var editorEventCallback = function (eventApi) {
             buttonApi.setActive(eventApi.element.nodeName.toLowerCase() === 'time');
           };
           editor.on('NodeChange', editorEventCallback);
-          return (buttonApi) => editor.off('NodeChange', editorEventCallback);
+          return function (buttonApi) {
+            editor.off('NodeChange', editorEventCallback);
+          }
         }
       });
 
       /* Split button that lists 3 formats, and inserts the date in the selected format when clicked */
       editor.ui.registry.addSplitButton('splitDateButton', {
         text: 'Insert Date',
-        onAction: (_) => {
+        onAction: function (_) {
           editor.insertContent('<p>Its Friday!</p>')
         },
-        onItemAction: (buttonApi, value) => {
+        onItemAction: function (buttonApi, value) {
           editor.insertContent(value);
         },
-        fetch: (callback) => {
-          const items = [
+        fetch: function (callback) {
+          var items = [
             {
               type: 'choiceitem',
               text: 'Insert Date',
@@ -70,7 +86,7 @@ tinymce.init({
               type: 'choiceitem',
               text: 'Insert ISO Date',
               value: toIsoHtml(new Date())
-            },
+            }
           ];
           callback(items);
         }
@@ -80,31 +96,37 @@ tinymce.init({
       /* Clicking the first menu item or one of the submenu items inserts the date in the selected format. */
       editor.ui.registry.addMenuButton('menuDateButton', {
         text: 'Date',
-        fetch: (callback) => {
-          const items = [
+        fetch: function (callback) {
+          var items = [
             {
               type: 'menuitem',
               text: 'Insert Date',
-              onAction: (_) => editor.insertContent(toDateHtml(new Date()))
+              onAction: function (_) {
+                editor.insertContent(toDateHtml(new Date()));
+              }
             },
             {
               type: 'nestedmenuitem',
               text: 'Other formats',
-              getSubmenuItems: () => {
+              getSubmenuItems: function () {
                 return [
                   {
                     type: 'menuitem',
                     text: 'GMT',
-                    onAction: (_) => editor.insertContent(toGmtHtml(new Date()))
+                    onAction: function (_) {
+                      editor.insertContent(toGmtHtml(new Date()));
+                    }
                   },
                   {
                     type: 'menuitem',
                     text: 'ISO',
-                    onAction: (_) => editor.insertContent(toIsoHtml(new Date()))
+                    onAction: function (_) {
+                      editor.insertContent(toIsoHtml(new Date()));
+                    }
                   }
                 ];
               }
-            },
+            }
           ];
           callback(items);
         }

--- a/_includes/codepens/url-conversion-absolute-2/index.js
+++ b/_includes/codepens/url-conversion-absolute-2/index.js
@@ -6,5 +6,6 @@ tinymce.init({
   remove_script_host: false,
   content_css: [
     '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
-    '//www.tiny.cloud/css/codepen.min.css']
+    '//www.tiny.cloud/css/codepen.min.css'
+  ]
 });

--- a/_includes/codepens/url-conversion-none/index.js
+++ b/_includes/codepens/url-conversion-none/index.js
@@ -5,5 +5,6 @@ tinymce.init({
   convert_urls: false,
   content_css: [
     '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
-    '//www.tiny.cloud/css/codepen.min.css']
+    '//www.tiny.cloud/css/codepen.min.css'
+  ]
 });

--- a/_includes/codepens/url-conversion-relative-1/index.js
+++ b/_includes/codepens/url-conversion-relative-1/index.js
@@ -5,5 +5,6 @@ tinymce.init({
   relative_urls: true,
   content_css: [
     '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
-    '//www.tiny.cloud/css/codepen.min.css']
+    '//www.tiny.cloud/css/codepen.min.css'
+  ]
 });

--- a/_includes/codepens/url-conversion-relative-2/index.js
+++ b/_includes/codepens/url-conversion-relative-2/index.js
@@ -6,5 +6,6 @@ tinymce.init({
   document_base_url: '//www.tiny.cloud/demo/',
   content_css: [
     '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
-    '//www.tiny.cloud/css/codepen.min.css']
+    '//www.tiny.cloud/css/codepen.min.css'
+  ]
 });

--- a/_includes/codepens/whats-new/index.js
+++ b/_includes/codepens/whats-new/index.js
@@ -15,5 +15,5 @@ tinymce.init({
   content_style: [
     'body{max-width:700px; padding:30px; margin:auto;font-size:16px;font-family:Lato,"Helvetica Neue",Helvetica,Arial,sans-serif; line-height:1.3; letter-spacing: -0.03em;color:#222} h1,h2,h3,h4,h5,h6 {font-weight:400;margin-top:1.2em} h1 {} h2{} .tiny-table {width:100%; border-collapse: collapse;} .tiny-table td, th {border: 1px solid #555D66; padding:10px; text-align:left;font-size:16px;font-family:Lato,"Helvetica Neue",Helvetica,Arial,sans-serif; line-height:1.6;} .tiny-table th {background-color:#E2E4E7}'
   ],
-  visual_table_class: 'tiny-table',
+  visual_table_class: 'tiny-table'
  });


### PR DESCRIPTION
Updated all codepens so that they are ES5 compatible and fixed a couple minor formatting/syntax issues. 

This basically just removes all use of ES6 syntax, as that syntax won't work on older supported browsers such as IE11.