### PR TITLE
Updated distraction free codepen for inlite plugin rename

### DIFF
--- a/_includes/codepens/editor-dfree/index.js
+++ b/_includes/codepens/editor-dfree/index.js
@@ -1,38 +1,38 @@
 var dfreeHeaderConfig = {
-    selector: '.dfree-header',
-    menubar: false,
-    inline: true,
-    plugins: [ 'inlite' ],
-    insert_toolbar: 'undo redo',
-    selection_toolbar: 'italic underline'
-  };
+  selector: '.dfree-header',
+  menubar: false,
+  inline: true,
+  plugins: [ 'quickbars' ],
+  quickbars_insert_toolbar: 'undo redo',
+  quickbars_selection_toolbar: 'italic underline'
+};
 
-  var dfreeBodyConfig = {
-    selector: '.dfree-body',
-    menubar: false,
-    inline: true,
-    plugins: [
-      'autolink',
-      'codesample',
-      'link',
-      'lists',
-      'media',
-      'powerpaste',
-      'table',
-      'textcolor',
-      'image',
-      'inlite'
-    ],
-    toolbar: [
-      'undo redo | bold italic underline | fontselect fontsizeselect',
-      'forecolor backcolor | alignleft aligncenter alignright alignfull | link unlink | numlist bullist outdent indent'
-    ],
-    insert_toolbar: 'quicktable image',
-    selection_toolbar: 'bold italic | h2 h3 | blockquote quicklink',
-    contextmenu: 'inserttable | cell row column deletetable',
-    powerpaste_word_import: 'clean',
-    powerpaste_html_import: 'clean'
-  };
+var dfreeBodyConfig = {
+  selector: '.dfree-body',
+  menubar: false,
+  inline: true,
+  plugins: [
+    'autolink',
+    'codesample',
+    'link',
+    'lists',
+    'media',
+    'powerpaste',
+    'table',
+    'textcolor',
+    'image',
+    'quickbars'
+  ],
+  toolbar: [
+    'undo redo | bold italic underline | fontselect fontsizeselect',
+    'forecolor backcolor | alignleft aligncenter alignright alignfull | link unlink | numlist bullist outdent indent'
+  ],
+  quickbars_insert_toolbar: 'quicktable image',
+  quickbars_selection_toolbar: 'bold italic | h2 h3 | blockquote quicklink',
+  contextmenu: 'inserttable | cell row column deletetable',
+  powerpaste_word_import: 'clean',
+  powerpaste_html_import: 'clean'
+};
 
 tinymce.init(dfreeHeaderConfig);
 tinymce.init(dfreeBodyConfig);


### PR DESCRIPTION
Updated the distraction free codepen example to "quickbars" as the inlite plugin has been renamed