### PR TITLE
TINY-2848: Updated dialog checkbox codepen examples to match checkbox state changes

### DIFF
--- a/_includes/codepens/dialog-pet-machine/index.js
+++ b/_includes/codepens/dialog-pet-machine/index.js
@@ -26,16 +26,16 @@ var dialogConfig =  {
       type: 'submit',
       name: 'submitButton',
       text: 'Do Cat Thing',
-      primary: true,
+      primary: true
     }
   ],
   initialData: {
     catdata: 'initial Cat',
-    isdog: 'unchecked'
+    isdog: false
   },
   onSubmit: function (api) {
     var data = api.getData();
-    var pet = data.isdog === 'checked' ? 'dog' : 'cat';
+    var pet = data.isdog ? 'dog' : 'cat';
 
     tinymce.activeEditor.execCommand('mceInsertContent', false, '<p>My ' + pet +'\'s name is: <strong>' + data.catdata + '</strong></p>');
     api.close();

--- a/_includes/codepens/redial/index.js
+++ b/_includes/codepens/redial/index.js
@@ -15,7 +15,7 @@ var config = {
     }]
   },
   initialData: {
-    anyterms: 'unchecked'
+    anyterms: false
   },
   buttons: [
     {
@@ -34,7 +34,7 @@ var config = {
   onChange: function (dialogApi, changeData) {
     var data = dialogApi.getData();
     /* Example of enabling and disabling a button, based on the checkbox state. */
-    var toggle = data.anyterms === 'checked' ? dialogApi.enable : dialogApi.disable;
+    var toggle = data.anyterms ? dialogApi.enable : dialogApi.disable;
     toggle('uniquename');
   },
   onAction: function (dialogApi, actionData) {


### PR DESCRIPTION
Previously checkboxes were represented as a string of either "checked", "unchecked" or "intermediate", however it was decided to make them just have two states and make them use a boolean (true/false) instead of a string.

I couldn't find any mention of the data types returned for each UI component, so there should only be these examples that need updating.