### PR TITLE
Fix to Cat Dog Machine codepen

### DIFF
--- a/_includes/codepens/dialog-pet-machine/index.js
+++ b/_includes/codepens/dialog-pet-machine/index.js
@@ -31,11 +31,11 @@ var dialogConfig =  {
   ],
   initialData: {
     catdata: 'initial Cat',
-    isdog: false
+    isdog: 'unchecked'
   },
   onSubmit: function (api) {
     var data = api.getData();
-    var pet = data.isdog ? 'dog' : 'cat';
+    var pet = data.isdog == 'checked' ? 'dog' : 'cat';
 
     tinymce.activeEditor.execCommand('mceInsertContent', false, '<p>My ' + pet +'\'s name is: <strong>' + data.catdata + '</strong></p>');
     api.close();


### PR DESCRIPTION
initialData for isdog is expecting a string of “checked”, “unchecked” or “indeterminate”, not boolean.

Fix changes this for the initialData, as well as the onSubmit logic to correctly select “cat” or “dog”

Signed-off-by: Marty Friedel <marty@mity.com.au>