### PR TITLE
Re-add visualchars_default_state option for visualchars plugin

### DIFF
--- a/plugins/visualblocks.md
+++ b/plugins/visualblocks.md
@@ -43,7 +43,7 @@ tinymce.init({
   selector: "textarea",  // change this value according to your HTML
   plugins: "visualblocks",
   menubar: "view",
-  toolbar: "visualblocks"
+  toolbar: "visualblocks",
   visualblocks_default_state: true
 });
 ```

--- a/plugins/visualchars.md
+++ b/plugins/visualchars.md
@@ -7,7 +7,7 @@ keywords: visualchars
 controls: toolbar button, menu item
 ---
 
-This plugin adds the ability for users to see invisible characters like `&nbsp;` displayed in the editable area. It also adds a toolbar control and a menu item `Show invisible characters` under the `View` menu.
+This plugin adds the ability to see invisible characters like `&nbsp;` displayed in the editable area. It also adds a toolbar control and a menu item `Show invisible characters` under the `View` menu.
 
 > It's worth noting that at present the toolbar button icon is the same for both [Visual Blocks](../visualblocks/) and Visual Characters plugins.
 
@@ -21,5 +21,29 @@ tinymce.init({
   plugins: "visualchars",
   menubar: "view",
   toolbar: "visualchars"
+});
+```
+
+### Options
+
+This setting affects the execution of the `visualchars` plugin. Characters can be configured to be visible by default using this option.
+
+### `visualchars_default_state`
+
+This option enables specifying the default state of the Visual Blocks plugin.
+
+**Type:** `Boolean`
+
+**Default Value:** `false`
+
+**Possible Values:** `true`, `false`
+
+```js
+tinymce.init({
+  selector: "textarea",  // change this value according to the HTML
+  plugins: "visualchars",
+  menubar: "view",
+  toolbar: "visualchars",
+  visualchars_default_state: true
 });
 ```


### PR DESCRIPTION
This reinstates the original version (https://github.com/tinymce/tinymce-docs/pull/795) that got reverted in commit 9af454417b7e361c168fb0dfe5f491f5ed05c617 due to it being merged ahead of time.