### PR TITLE
TINY-3174: Fixed issues with Tiny Drive demos

### DIFF
--- a/_includes/codepens/drive-demo/example.js
+++ b/_includes/codepens/drive-demo/example.js
@@ -1,0 +1,8 @@
+tinymce.init({
+  selector: 'textarea#drive-demo',
+  plugins: 'image media link tinydrive code imagetools',
+  api_key: 'YOUR_API_KEY',
+  height: 600,
+  tinydrive_token_provider: 'URL_TO_YOUR_TOKEN_PROVIDER',
+  toolbar: 'insertfile image link | code'
+});

--- a/_includes/codepens/drive-demo/index.html
+++ b/_includes/codepens/drive-demo/index.html
@@ -1,0 +1,16 @@
+<textarea id="drive-demo">
+<h2>The world's first rich text editor in the cloud</h2>
+<p>Have you heard about Tiny Cloud? It's the first step in our journey to help you deliver great content creation experiences, no matter your level of expertise. 50,000 developers already agree. They get free access to our global Content Delivery Network, image proxy services and auto updates to the TinyMCE editor. They're also ready for some exciting updates coming soon.</p>
+<p>One of these enhancements is <strong>Tiny Drive</strong>: imagine file management for TinyMCE, in the cloud, made super easy. Learn more at <a href="tinydrive/">our working demo</a>, where you'll find an opportunity to provide feedback to the product team.</p>
+<h3>An editor for every project</h3>
+<p>Here are some of our customer's most common use cases for TinyMCE:</p>
+<ul>
+<li>Content Management Systems (<em>WordPress, Umbraco</em>)</li>
+<li>Learning Management Systems (<em>Blackboard</em>)</li>
+<li>Customer Relationship Management and marketing automation (<em>Marketo</em>)</li>
+<li>Email marketing (<em>Constant Contact</em>)</li>
+<li>Content creation in SaaS systems (<em>Eventbrite, Evernote, GoFundMe, Zendesk</em>)</li>
+</ul>
+<p>&nbsp;</p>
+<p>And those use cases are just the start. TinyMCE is incredibly flexible, and with hundreds of APIs there's likely a solution for your editor project. If you haven't experienced Tiny Cloud, get started today. You'll even get a free premium plugin trial &ndash; no credit card required!</p>
+</textarea>

--- a/_includes/codepens/drive-demo/index.html
+++ b/_includes/codepens/drive-demo/index.html
@@ -1,16 +1,31 @@
 <textarea id="drive-demo">
-<h2>The world's first rich text editor in the cloud</h2>
-<p>Have you heard about Tiny Cloud? It's the first step in our journey to help you deliver great content creation experiences, no matter your level of expertise. 50,000 developers already agree. They get free access to our global Content Delivery Network, image proxy services and auto updates to the TinyMCE editor. They're also ready for some exciting updates coming soon.</p>
-<p>One of these enhancements is <strong>Tiny Drive</strong>: imagine file management for TinyMCE, in the cloud, made super easy. Learn more at <a href="tinydrive/">our working demo</a>, where you'll find an opportunity to provide feedback to the product team.</p>
-<h3>An editor for every project</h3>
-<p>Here are some of our customer's most common use cases for TinyMCE:</p>
-<ul>
-<li>Content Management Systems (<em>WordPress, Umbraco</em>)</li>
-<li>Learning Management Systems (<em>Blackboard</em>)</li>
-<li>Customer Relationship Management and marketing automation (<em>Marketo</em>)</li>
-<li>Email marketing (<em>Constant Contact</em>)</li>
-<li>Content creation in SaaS systems (<em>Eventbrite, Evernote, GoFundMe, Zendesk</em>)</li>
-</ul>
-<p>&nbsp;</p>
-<p>And those use cases are just the start. TinyMCE is incredibly flexible, and with hundreds of APIs there's likely a solution for your editor project. If you haven't experienced Tiny Cloud, get started today. You'll even get a free premium plugin trial &ndash; no credit card required!</p>
+  <h2>The world's first rich text editor in the cloud</h2>
+
+  <p>
+    Have you heard about Tiny Cloud? It's the first step in our journey to help you deliver great content creation experiences, no matter your level of expertise. 50,000 developers already agree. They get free access to our global Content Delivery Network, image proxy services and auto updates to the TinyMCE editor. They're also ready for some exciting updates coming soon.
+  </p>
+
+  <p>
+    One of these enhancements is <strong>Tiny Drive</strong>: imagine file management for TinyMCE, in the cloud, made super easy. Learn more at <a href="tinydrive/">our working demo</a>, where you'll find an opportunity to provide feedback to the product team.
+  </p>
+
+  <h3>An editor for every project</h3>
+
+  <p>
+    Here are some of our customer's most common use cases for TinyMCE:
+  </p>
+
+  <ul>
+    <li>Content Management Systems (<em>WordPress, Umbraco</em>)</li>
+    <li>Learning Management Systems (<em>Blackboard</em>)</li>
+    <li>Customer Relationship Management and marketing automation (<em>Marketo</em>)</li>
+    <li>Email marketing (<em>Constant Contact</em>)</li>
+    <li>Content creation in SaaS systems (<em>Eventbrite, Evernote, GoFundMe, Zendesk</em>)</li>
+  </ul>
+
+  <p>&nbsp;</p>
+
+  <p>
+    And those use cases are just the start. TinyMCE is incredibly flexible, and with hundreds of APIs there's likely a solution for your editor project. If you haven't experienced Tiny Cloud, get started today. You'll even get a free premium plugin trial &ndash; no credit card required!
+  </p>
 </textarea>

--- a/_includes/codepens/drive-demo/index.js
+++ b/_includes/codepens/drive-demo/index.js
@@ -1,0 +1,16 @@
+tinymce.init({
+  selector: 'textarea#drive-demo',
+  plugins: 'image media link tinydrive code imagetools',
+  api_key: 'fake-key',
+  content_css: [
+    "//fonts.googleapis.com/css?family=Lato|Lobster|Noto+Serif|Permanent+Marker|Raleway|Roboto|Source+Code+Pro",
+    "//tiny.cloud/css/content-standard.min.css"
+  ],
+  height: 600,
+  imagetools_cors_hosts: ['picsum.photos'],
+  tinydrive_token_provider: function (success, failure) {
+    success ({ token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJqb2huZG9lIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.Ks_BdfH4CWilyzLNk8S2gDARFhuxIauLa8PwhdEQhEo' });
+  },
+  tinydrive_demo_files_url: '{{ site.baseurl }}/demo/tiny-drive-demo/demo_files.json',
+  toolbar: 'insertfile image link | code'
+});

--- a/_includes/codepens/drive-demo/index.js
+++ b/_includes/codepens/drive-demo/index.js
@@ -9,7 +9,7 @@ tinymce.init({
   height: 600,
   imagetools_cors_hosts: ['picsum.photos'],
   tinydrive_token_provider: function (success, failure) {
-    success ({ token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJqb2huZG9lIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.Ks_BdfH4CWilyzLNk8S2gDARFhuxIauLa8PwhdEQhEo' });
+    success({ token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJqb2huZG9lIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.Ks_BdfH4CWilyzLNk8S2gDARFhuxIauLa8PwhdEQhEo' });
   },
   tinydrive_demo_files_url: '{{ site.baseurl }}/demo/tiny-drive-demo/demo_files.json',
   toolbar: 'insertfile image link | code'

--- a/_includes/codepens/drive/index.js
+++ b/_includes/codepens/drive/index.js
@@ -8,13 +8,9 @@ tinymce.init({
   ],
   height: 600,
   imagetools_cors_hosts: ['picsum.photos'],
-  tinydrive_token_provider: (success, failure) => {
+  tinydrive_token_provider: function (success, failure) {
     success({ token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJqb2huZG9lIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.Ks_BdfH4CWilyzLNk8S2gDARFhuxIauLa8PwhdEQhEo' });
   },
   tinydrive_demo_files_url: '{{ site.baseurl }}/demo/tiny-drive-demo/demo_files.json',
-  toolbar: 'insertfile image link | code',
-  content_css: [
-    '//fonts.googleapis.com/css?family=Lato:300,300i,400,400i',
-    '//www.tiny.cloud/css/codepen.min.css'
-  ]
+  toolbar: 'insertfile image link | code'
 });

--- a/demo/drive.md
+++ b/demo/drive.md
@@ -11,52 +11,7 @@ keywords: tinydrive .net php relative_urls
 
 This example shows you how to use Tiny Drive for your file and image management. For more information on the Tiny Drive plugin, see the [docs]({{site.baseurl}}/plugins/drive/).
 
-<textarea>
-<h2>The world's first rich text editor in the cloud</h2>
-<p>Have you heard about Tiny Cloud? It's the first step in our journey to help you deliver great content creation experiences, no matter your level of expertise. 50,000 developers already agree. They get free access to our global Content Delivery Network, image proxy services and auto updates to the TinyMCE editor. They're also ready for some exciting updates coming soon.</p>
-<p>One of these enhancements is <strong>Tiny Drive</strong>: imagine file management for TinyMCE, in the cloud, made super easy. Learn more at <a href="tinydrive/">our working demo</a>, where you'll find an opportunity to provide feedback to the product team.</p>
-<h3>An editor for every project</h3>
-<p>Here are some of our customer's most common use cases for TinyMCE:</p>
-<ul>
-<li>Content Management Systems (<em>WordPress, Umbraco</em>)</li>
-<li>Learning Management Systems (<em>Blackboard</em>)</li>
-<li>Customer Relationship Management and marketing automation (<em>Marketo</em>)</li>
-<li>Email marketing (<em>Constant Contact</em>)</li>
-<li>Content creation in SaaS systems (<em>Eventbrite, Evernote, GoFundMe, Zendesk</em>)</li>
-</ul>
-<p>&nbsp;</p>
-<p>And those use cases are just the start. TinyMCE is incredibly flexible, and with hundreds of APIs there's likely a solution for your editor project. If you haven't experienced Tiny Cloud, get started today. You'll even get a free premium plugin trial &ndash; no credit card required!</p>
-</textarea>
-<style>
-  button.olark-launch-button {
-    z-index: 1 !important;
-  }
-  .menu {
-    z-index: 1000 !important;
-  }
-</style>
-
-<script src="https://devpreview.tiny.cloud/demo/tinymce.min.js"></script>
-<script>
-
-tinymce.init({
-  selector: 'textarea',
-  plugins: 'image media link tinydrive code imagetools',
-  api_key: 'fake-key',
-  content_css: [
-    "//fonts.googleapis.com/css?family=Lato|Lobster|Noto+Serif|Permanent+Marker|Raleway|Roboto|Source+Code+Pro",
-    "//tiny.cloud/css/content-standard.min.css"
-  ],
-  height: 600,
-  imagetools_cors_hosts: ['picsum.photos'],
-  tinydrive_token_provider: (success, failure) => {
-    success({ token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJqb2huZG9lIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.Ks_BdfH4CWilyzLNk8S2gDARFhuxIauLa8PwhdEQhEo' });
-  },
-  tinydrive_demo_files_url: '{{ site.baseurl }}/demo/tiny-drive-demo/demo_files.json',
-  toolbar: 'insertfile image link | code'
-});
-
-</script>
+{% include codepen.html id="drive-demo" %}
 
 ### Code:
 

--- a/demo/tiny-drive-demo/demo_files.json
+++ b/demo/tiny-drive-demo/demo_files.json
@@ -3,202 +3,202 @@
     {
       "path": "/Hero Backgrounds",
       "name": "action-adventure-bicycle-71104.jpg",
-      "url": "../tiny-drive-demo/images/Hero Backgrounds/action-adventure-bicycle-71104.jpg",
+      "url": "../../demo/tiny-drive-demo/images/Hero Backgrounds/action-adventure-bicycle-71104.jpg",
       "date": "2018-06-13 16:49:10",
       "size": 756767,
-      "thumbUrl": "../tiny-drive-demo/images/Hero Backgrounds/action-adventure-bicycle-71104_thumb.jpg"
+      "thumbUrl": "../../demo/tiny-drive-demo/images/Hero Backgrounds/action-adventure-bicycle-71104_thumb.jpg"
     },
     {
       "path": "/Hero Backgrounds",
       "name": "adventure-altitude-cold-1145378.jpg",
-      "url": "../tiny-drive-demo/images/Hero Backgrounds/adventure-altitude-cold-1145378.jpg",
+      "url": "../../demo/tiny-drive-demo/images/Hero Backgrounds/adventure-altitude-cold-1145378.jpg",
       "date": "2018-06-13 16:49:10",
       "size": 1180390,
-      "thumbUrl": "../tiny-drive-demo/images/Hero Backgrounds/adventure-altitude-cold-1145378_thumb.jpg"
+      "thumbUrl": "../../demo/tiny-drive-demo/images/Hero Backgrounds/adventure-altitude-cold-1145378_thumb.jpg"
     },
     {
       "path": "/Hero Backgrounds",
       "name": "adventure-backpack-backpacking-12057.jpg",
-      "url": "../tiny-drive-demo/images/Hero Backgrounds/adventure-backpack-backpacking-12057.jpg",
+      "url": "../../demo/tiny-drive-demo/images/Hero Backgrounds/adventure-backpack-backpacking-12057.jpg",
       "date": "2018-06-13 16:49:10",
       "size": 942994,
-      "thumbUrl": "../tiny-drive-demo/images/Hero Backgrounds/adventure-backpack-backpacking-12057_thumb.jpg"
+      "thumbUrl": "../../demo/tiny-drive-demo/images/Hero Backgrounds/adventure-backpack-backpacking-12057_thumb.jpg"
     },
     {
       "path": "/Hero Backgrounds",
       "name": "adventure-beach-bicycle-462036.jpg",
-      "url": "../tiny-drive-demo/images/Hero Backgrounds/adventure-beach-bicycle-462036.jpg",
+      "url": "../../demo/tiny-drive-demo/images/Hero Backgrounds/adventure-beach-bicycle-462036.jpg",
       "date": "2018-06-13 16:49:10",
       "size": 621651,
-      "thumbUrl": "../tiny-drive-demo/images/Hero Backgrounds/adventure-beach-bicycle-462036_thumb.jpg"
+      "thumbUrl": "../../demo/tiny-drive-demo/images/Hero Backgrounds/adventure-beach-bicycle-462036_thumb.jpg"
     },
     {
       "path": "/Hero Backgrounds",
       "name": "adventure-bicycle-bike-161172.jpg",
-      "url": "../tiny-drive-demo/images/Hero Backgrounds/adventure-bicycle-bike-161172.jpg",
+      "url": "../../demo/tiny-drive-demo/images/Hero Backgrounds/adventure-bicycle-bike-161172.jpg",
       "date": "2018-06-13 16:49:10",
       "size": 1444217,
-      "thumbUrl": "../tiny-drive-demo/images/Hero Backgrounds/adventure-bicycle-bike-161172_thumb.jpg"
+      "thumbUrl": "../../demo/tiny-drive-demo/images/Hero Backgrounds/adventure-bicycle-bike-161172_thumb.jpg"
     },
     {
       "path": "/Hero Backgrounds",
       "name": "adventure-bikers-bikes-163407.jpg",
-      "url": "../tiny-drive-demo/images/Hero Backgrounds/adventure-bikers-bikes-163407.jpg",
+      "url": "../../demo/tiny-drive-demo/images/Hero Backgrounds/adventure-bikers-bikes-163407.jpg",
       "date": "2018-06-13 16:49:10",
       "size": 3679714,
-      "thumbUrl": "../tiny-drive-demo/images/Hero Backgrounds/adventure-bikers-bikes-163407_thumb.jpg"
+      "thumbUrl": "../../demo/tiny-drive-demo/images/Hero Backgrounds/adventure-bikers-bikes-163407_thumb.jpg"
     },
     {
       "path": "/Hero Backgrounds",
       "name": "aluminium-antique-coffee-6255.jpg",
-      "url": "../tiny-drive-demo/images/Hero Backgrounds/aluminium-antique-coffee-6255.jpg",
+      "url": "../../demo/tiny-drive-demo/images/Hero Backgrounds/aluminium-antique-coffee-6255.jpg",
       "date": "2018-06-13 16:49:10",
       "size": 845594,
-      "thumbUrl": "../tiny-drive-demo/images/Hero Backgrounds/aluminium-antique-coffee-6255_thumb.jpg"
+      "thumbUrl": "../../demo/tiny-drive-demo/images/Hero Backgrounds/aluminium-antique-coffee-6255_thumb.jpg"
     },
     {
       "path": "/Hero Backgrounds",
       "name": "ash-bonfire-burn-164168.jpg",
-      "url": "../tiny-drive-demo/images/Hero Backgrounds/ash-bonfire-burn-164168.jpg",
+      "url": "../../demo/tiny-drive-demo/images/Hero Backgrounds/ash-bonfire-burn-164168.jpg",
       "date": "2018-06-13 16:49:10",
       "size": 689043,
-      "thumbUrl": "../tiny-drive-demo/images/Hero Backgrounds/ash-bonfire-burn-164168_thumb.jpg"
+      "thumbUrl": "../../demo/tiny-drive-demo/images/Hero Backgrounds/ash-bonfire-burn-164168_thumb.jpg"
     },
     {
       "path": "/Hero Backgrounds",
       "name": "background-clouds-daylight-747964.jpg",
-      "url": "../tiny-drive-demo/images/Hero Backgrounds/background-clouds-daylight-747964.jpg",
+      "url": "../../demo/tiny-drive-demo/images/Hero Backgrounds/background-clouds-daylight-747964.jpg",
       "date": "2018-06-13 16:49:10",
       "size": 949082,
-      "thumbUrl": "../tiny-drive-demo/images/Hero Backgrounds/background-clouds-daylight-747964_thumb.jpg"
+      "thumbUrl": "../../demo/tiny-drive-demo/images/Hero Backgrounds/background-clouds-daylight-747964_thumb.jpg"
     },
     {
       "path": "/Hero Backgrounds",
       "name": "boat-daylight-lake-675764.jpg",
-      "url": "../tiny-drive-demo/images/Hero Backgrounds/boat-daylight-lake-675764.jpg",
+      "url": "../../demo/tiny-drive-demo/images/Hero Backgrounds/boat-daylight-lake-675764.jpg",
       "date": "2018-06-13 16:49:10",
       "size": 805382,
-      "thumbUrl": "../tiny-drive-demo/images/Hero Backgrounds/boat-daylight-lake-675764_thumb.jpg"
+      "thumbUrl": "../../demo/tiny-drive-demo/images/Hero Backgrounds/boat-daylight-lake-675764_thumb.jpg"
     },
     {
       "path": "/Hero Backgrounds",
       "name": "countryside-dawn-daylight-1009355.jpg",
-      "url": "../tiny-drive-demo/images/Hero Backgrounds/countryside-dawn-daylight-1009355.jpg",
+      "url": "../../demo/tiny-drive-demo/images/Hero Backgrounds/countryside-dawn-daylight-1009355.jpg",
       "date": "2018-06-13 16:49:10",
       "size": 2103708,
-      "thumbUrl": "../tiny-drive-demo/images/Hero Backgrounds/countryside-dawn-daylight-1009355_thumb.jpg"
+      "thumbUrl": "../../demo/tiny-drive-demo/images/Hero Backgrounds/countryside-dawn-daylight-1009355_thumb.jpg"
     },
     {
       "path": "/Hero Backgrounds",
       "name": "forest-landscape-mountain-range-129105.jpg",
-      "url": "../tiny-drive-demo/images/Hero Backgrounds/forest-landscape-mountain-range-129105.jpg",
+      "url": "../../demo/tiny-drive-demo/images/Hero Backgrounds/forest-landscape-mountain-range-129105.jpg",
       "date": "2018-06-13 16:49:10",
       "size": 1204626,
-      "thumbUrl": "../tiny-drive-demo/images/Hero Backgrounds/forest-landscape-mountain-range-129105_thumb.jpg"
+      "thumbUrl": "../../demo/tiny-drive-demo/images/Hero Backgrounds/forest-landscape-mountain-range-129105_thumb.jpg"
     },
     {
       "path": "/Hero Backgrounds",
       "name": "forest-landscape-nature-6921.jpg",
-      "url": "../tiny-drive-demo/images/Hero Backgrounds/forest-landscape-nature-6921.jpg",
+      "url": "../../demo/tiny-drive-demo/images/Hero Backgrounds/forest-landscape-nature-6921.jpg",
       "date": "2018-06-13 16:49:10",
       "size": 1469476,
-      "thumbUrl": "../tiny-drive-demo/images/Hero Backgrounds/forest-landscape-nature-6921_thumb.jpg"
+      "thumbUrl": "../../demo/tiny-drive-demo/images/Hero Backgrounds/forest-landscape-nature-6921_thumb.jpg"
     },
     {
       "path": "/Hero Backgrounds",
       "name": "modern-adventure-background-220147.jpg",
-      "url": "../tiny-drive-demo/images/Hero Backgrounds/modern-adventure-background-220147.jpg",
+      "url": "../../demo/tiny-drive-demo/images/Hero Backgrounds/modern-adventure-background-220147.jpg",
       "date": "2018-06-13 16:49:10",
       "size": 696115,
-      "thumbUrl": "../tiny-drive-demo/images/Hero Backgrounds/modern-adventure-background-220147_thumb.jpg"
+      "thumbUrl": "../../demo/tiny-drive-demo/images/Hero Backgrounds/modern-adventure-background-220147_thumb.jpg"
     },
     {
       "path": "/",
       "name": "hero-background-campaign-alternate.png",
-      "url": "../tiny-drive-demo/images/hero-background-campaign-alternate.png",
+      "url": "../../demo/tiny-drive-demo/images/hero-background-campaign-alternate.png",
       "date": "2018-06-13 16:49:10",
       "size": 527006,
-      "thumbUrl": "../tiny-drive-demo/images/hero-background-campaign-alternate_thumb.png"
+      "thumbUrl": "../../demo/tiny-drive-demo/images/hero-background-campaign-alternate_thumb.png"
     },
     {
       "path": "/",
       "name": "hero-background-campaign.png",
-      "url": "../tiny-drive-demo/images/hero-background-campaign.png",
+      "url": "../../demo/tiny-drive-demo/images/hero-background-campaign.png",
       "date": "2018-06-13 16:49:10",
       "size": 367324,
-      "thumbUrl": "../tiny-drive-demo/images/hero-background-campaign_thumb.png"
+      "thumbUrl": "../../demo/tiny-drive-demo/images/hero-background-campaign_thumb.png"
     },
     {
       "path": "/logos",
       "name": "logo-on-black.eps",
-      "url": "../tiny-drive-demo/images/logos/logo-on-black.eps",
+      "url": "../../demo/tiny-drive-demo/images/logos/logo-on-black.eps",
       "date": "2018-06-13 16:09:01",
       "size": 32456
     },
     {
       "path": "/logos",
       "name": "logo-on-black.png",
-      "url": "../tiny-drive-demo/images/logos/logo-on-black.png",
+      "url": "../../demo/tiny-drive-demo/images/logos/logo-on-black.png",
       "date": "2018-06-13 16:09:01",
       "size": 36994,
-      "thumbUrl": "../tiny-drive-demo/images/logos/logo-on-black_thumb.png"
+      "thumbUrl": "../../demo/tiny-drive-demo/images/logos/logo-on-black_thumb.png"
     },
     {
       "path": "/logos",
       "name": "logo-on-black.svg",
-      "url": "../tiny-drive-demo/images/logos/logo-on-black.svg",
+      "url": "../../demo/tiny-drive-demo/images/logos/logo-on-black.svg",
       "date": "2018-06-13 16:09:01",
       "size": 7060
     },
     {
       "path": "/logos",
       "name": "logo-on-white.eps",
-      "url": "../tiny-drive-demo/images/logos/logo-on-white.eps",
+      "url": "../../demo/tiny-drive-demo/images/logos/logo-on-white.eps",
       "date": "2018-06-13 16:09:01",
       "size": 32510
     },
     {
       "path": "/logos",
       "name": "logo-on-white.png",
-      "url": "../tiny-drive-demo/images/logos/logo-on-white.png",
+      "url": "../../demo/tiny-drive-demo/images/logos/logo-on-white.png",
       "date": "2018-06-13 16:09:01",
       "size": 39630,
-      "thumbUrl": "../tiny-drive-demo/images/logos/logo-on-white_thumb.png"
+      "thumbUrl": "../../demo/tiny-drive-demo/images/logos/logo-on-white_thumb.png"
     },
     {
       "path": "/logos",
       "name": "logo-on-white.svg",
-      "url": "../tiny-drive-demo/images/logos/logo-on-white.svg",
+      "url": "../../demo/tiny-drive-demo/images/logos/logo-on-white.svg",
       "date": "2018-06-13 16:09:01",
       "size": 7060
     },
     {
       "path": "/",
       "name": "pricelist-latest.pdf",
-      "url": "../tiny-drive-demo/images/pricelist-latest.pdf",
+      "url": "../../demo/tiny-drive-demo/images/pricelist-latest.pdf",
       "date": "2018-06-13 16:09:01",
       "size": 8727
     },
     {
       "path": "/",
       "name": "Promo-bike-rentals.jpg",
-      "url": "../tiny-drive-demo/images/Promo-bike-rentals.jpg",
+      "url": "../../demo/tiny-drive-demo/images/Promo-bike-rentals.jpg",
       "date": "2018-06-13 16:49:10",
       "size": 45021,
-      "thumbUrl": "../tiny-drive-demo/images/Promo-bike-rentals_thumb.jpg"
+      "thumbUrl": "../../demo/tiny-drive-demo/images/Promo-bike-rentals_thumb.jpg"
     },
     {
       "path": "/",
       "name": "Promo-may-love-coffee.jpg",
-      "url": "../tiny-drive-demo/images/Promo-may-love-coffee.jpg",
+      "url": "../../demo/tiny-drive-demo/images/Promo-may-love-coffee.jpg",
       "date": "2018-06-13 16:49:10",
       "size": 27871,
-      "thumbUrl": "../tiny-drive-demo/images/Promo-may-love-coffee_thumb.jpg"
+      "thumbUrl": "../../demo/tiny-drive-demo/images/Promo-may-love-coffee_thumb.jpg"
     },
     {
       "path": "/",
       "name": "summer-competition-presentation.pdf",
-      "url": "../tiny-drive-demo/images/summer-competition-presentation.pdf",
+      "url": "../../demo/tiny-drive-demo/images/summer-competition-presentation.pdf",
       "date": "2018-06-13 16:09:01",
       "size": 8727
     }


### PR DESCRIPTION
The drive demo was using an old version of TinyMCE, so moved it to being a codepen, so it'll use the same  TinyMCE version as the rest of the demos. Also fixed an issue where the images would 404 in the drive plugin demo, because the image paths needed to move up one more level.