### PR TITLE
TINY-2911: Restored and improved the documentation for the reenabled mentions APIs

### DIFF
--- a/_includes/codepens/mentions/style.css
+++ b/_includes/codepens/mentions/style.css
@@ -1,0 +1,37 @@
+textarea#mentions {
+  height: 350px;
+}
+
+div.card {
+  width: 300px;
+  background: white;
+  border: 3px inset grey;
+  padding: 10px;
+  font-size: 16px;
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+div.card::after {
+  content: "";
+  clear: both;
+  display: table;
+}
+
+div.card h1 {
+  font-size: large;
+  font-weight: bold;
+  margin: 0;
+  padding: 0;
+  line-height: normal;
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+div.card p {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+div.card img.avatar {
+  width: 50px;
+  height: 50px;
+  margin-right: 5px;
+  float: left;
+}


### PR DESCRIPTION
I've recently re-enabled the mentions APIs: `mentions_menu_hover`, `mentions_selector` and `mentions_select` so they will work with TinyMCE 5.

Note that the current public release of mentions has some known problems which have been fixed in the latest internal build so it might be sensible to wait for those to become public before merging this.
