### PR TITLE
TINY-3090: Added docs on new TinyMCE 5 spellchecker events

### DIFF
--- a/plugins/tinymcespellchecker.md
+++ b/plugins/tinymcespellchecker.md
@@ -11,7 +11,6 @@ keywords: tinymcespellchecker spellchecker_language spellchecker_languages spell
 The following languages are supported:
 
 * English (US & UK)
-* English - with additional medical terms (US & UK)
 * Danish
 * Dutch
 * Finnish
@@ -26,7 +25,9 @@ The following languages are supported:
 ## Cloud Installation
 To enable the TinyMCE Enterprise Spellchecking plugin with [TinyMCE Cloud]({{ site.baseurl }}/cloud-deployment-guide/editor-and-features):
 
-1. If you are currently using the 'spellchecker' plugin provided with TinyMCE, disable it by removing it from the 'plugins' list.
+Follow these steps to upgrade to the latest version of 'spellchecker':
+
+1. For an already existing instance of the 'spellchecker' plugin provided with TinyMCE, disable it by removing it from the 'plugins' list.
 2. Add 'tinymcespellchecker' to the 'plugins' list.
 
 With TinyMCE Cloud the server-side spellchecking component is automatically configured, so the `spellchecker_rpc_url` parameter does not need to be set.
@@ -45,7 +46,7 @@ tinymce.init({
 ## Self-hosted Installation
 To enable the TinyMCE Enterprise Spellchecking plugin:
 
-1. If you are currently using the 'spellchecker' plugin provided with TinyMCE, disable it by removing it from the 'plugins' list.
+1. For an already existing instance of the 'spellchecker' plugin provided with TinyMCE,, disable it by removing it from the 'plugins' list.
 2. Add 'tinymcespellchecker' to the 'plugins' list.
 
 For information on installing the server-side component for spell checking, please see the [server-side component installation guide]({{ site.baseurl }}/enterprise/server/).
@@ -63,25 +64,25 @@ tinymce.init({
 
 ## Usage
 
-The TinyMCE Enterprise Spellchecking plugin activates automatically when users type content into the editor. To see and select a spelling suggestion after a word has been misspelled, please right click the misspelled red underlined word.
+The TinyMCE Enterprise Spellchecking plugin activates automatically when users type content into the editor. To see and select a spelling suggestion after a word has been misspelled, right-click the misspelled red underlined word.
 
 
 ## Configuration Options
 
 ### `spellchecker_rpc_url`
-This setting enables you to specify the URL to be used for the server side ephox-spelling service. Check the [server-side component installation guide]({{ site.baseurl }}/enterprise/server/) for details on how to setup your own spellchecker server.
+This setting enables specifying the URL to be used for the server side ephox-spelling service. Check the [server-side component installation guide]({{ site.baseurl }}/enterprise/server/) for details on how to setup a spellchecker server.
 
 **Note:** `spellchecker_rpc_url` is **not** required when enabling this plugin via [TinyMCE Cloud]({{ site.baseurl }}/cloud-deployment-guide/editor-and-features/)
 
 ### `spellchecker_languages`
-This optional setting allows you to specify the languages that are available to the user, provided as a comma delimited string. The default value for this setting is:
+This optional setting allows specifying the languages that are available to the user, provided as a comma delimited string. The default value for this setting is:
 
 ````
 'US English=en,UK English=en_gb,Danish=da,Dutch=nl,Finnish=fi,French=fr,German=de,Italian=it,Norwegian=nb,Brazilian Portuguese=pt_BR,Iberian Portuguese=pt_PT,Spanish=es,Swedish=sv'
 ````
 
 ### `spellchecker_language`
-This optional setting allows you to specify the language code that will be used by default. This defaults to "en".
+This optional setting allows specifying the language code that will be used by default. This defaults to "en".
 
 The following languages are supported:
 
@@ -102,22 +103,22 @@ The following languages are supported:
 | Swedish                      | sv     |
 
 ### `spellchecker_dialog`
-This optional setting allows you to specify the mode of operation of the spellchecker. When set to true, the spellchecker will open a dialog that will check all of the document's contents at once. This also allows a user to step through each error, to ignore errors and accept recommended fixes. If the spellchecker dialog is enabled, the default as-you-type spellchecking will be disabled.
+This optional setting allows specifying the mode of operation of the spellchecker. When set to true, the spellchecker will open a dialog that will check all of the document's contents at once. This also allows a user to step through each error, to ignore errors and accept recommended fixes. If the spellchecker dialog is enabled, the default as-you-type spellchecking will be disabled.
 
 ### `spellchecker_whitelist`
-This option lets you specify an array of words that you want to ignore this can for example be the current company name or internal products. You can populate this field from a file by just getting the white list array from an external JS file.
+This option allows to specify an array of words that should be ignored. This can, for example, be the current company name or internal products. This field can be populated from a file by just getting the white list array from an external JS file.
 
 ### `spellchecker_on_load`
 This option lets run the spellchecker when the contents is loaded into the editor. This option defaults to "false" so it's disabled by default.
 
 ### `spellchecker_active`
-This option lets you decide if the spellchecker should be initialized as active or not. With this set to `false` the spellchecker will not be activated automatically on text input, you will have to press the toolbar button or the menu item to start the spellchecking. Only applicable when using the default as-you-type spellchecking, not while using the dialog mode. Defaults to `true`.
+This option helps in deciding if the spellchecker should be initialized as active or not. With this set to `false` the spellchecker will not be activated automatically on text input. The toolbar button or the menu item will have to be pressed to start the spellchecking. Only applicable when using the default as-you-type spellchecking, not while using the dialog mode. Defaults to `true`.
 
 ## Toolbar Buttons
 
 ### `spellchecker`
 
-This button allows the user to perform a spellcheck on the entire document. In addition, the drop down menu attached to this button allows you to specify the language that is currently used when spellchecking. You'll find more information about customizing the toolbar in the [Editor Appearance section of the documentation]({{ site.baseurl }}/configure/editor-appearance/#toolbar).
+This button allows the user to perform a spellcheck on the entire document. In addition, the drop-down menu attached to this button allows specifying the language that is currently used when spellchecking. For more information about customizing the toolbar, refer to the [Editor appearance section of the documentation]({{ site.baseurl }}/configure/editor-appearance/#toolbar).
 
 Example TinyMCE Configuration:
 
@@ -127,7 +128,7 @@ tinymce.init({
   plugins: 'tinymcespellchecker',
   toolbar: 'spellchecker',
   spellchecker_rpc_url: 'localhost/ephox-spelling',
-  spellchecker_language: 'en'
+  spellchecker_language: 'en' runs in the background of all applications and spell checks everything that is typed in real-time, everywhere: online, off-line, in dialog boxes, in console windows, etc., to make the content mistake-free.
 });
 ````
 
@@ -137,7 +138,7 @@ tinymce.init({
 This menu item allows the user to perform a spell check on the entire document.
 
 #### spellcheckerlanguage
-This menu item allows you to change the current language for the spell checking process.
+This menu item allows to change the current language for the spell checking process.
 
 Example TinyMCE Configuration:
 
@@ -195,7 +196,9 @@ tinymce.init({
 
 #### SpellcheckStart event
 
-This event gets fired when the user enables as-you-type spellchecking.
+This event gets fired when the user **enables** the `spellchecker` to display spelling errors by putting a red wavy line underneath the misspelled words in real-time, as the user types.
+
+> Note: This event is not effective if `spellchecker_dialog` is enabled.
 
 Here is an example of using the event:
 
@@ -214,7 +217,9 @@ tinymce.init({
 
 #### SpellcheckEnd event
 
-This event gets fired when the user disables as-you-type spellchecking.
+This event gets fired when the user **disables** the `spellchecker`.
+
+> Note: This event is not effective if `spellchecker_dialog` is enabled.
 
 Here is an example of using the event:
 
@@ -233,6 +238,6 @@ tinymce.init({
 
 ## Downloading Spell Checker Pro
 
-A [TinyMCE Enterprise](https://www.tinymce.com/pricing/) subscription includes the ability to download and install a spell check as-you-type feature for the editor.
+A [TinyMCE Enterprise](https://www.tinymce.com/pricing/) subscription includes the ability to download and install a spell checker as-you-type feature for the editor.
 
 Spell Checker Pro requires both a client-side plugin to be configured and a server-side component to be installed and configured.

--- a/plugins/tinymcespellchecker.md
+++ b/plugins/tinymcespellchecker.md
@@ -25,10 +25,8 @@ The following languages are supported:
 ## Cloud Installation
 To enable the TinyMCE Enterprise Spellchecking plugin with [TinyMCE Cloud]({{ site.baseurl }}/cloud-deployment-guide/editor-and-features):
 
-Follow these steps to upgrade to the latest version of 'spellchecker':
-
-1. For an already existing instance of the 'spellchecker' plugin provided with TinyMCE, disable it by removing it from the 'plugins' list.
-2. Add 'tinymcespellchecker' to the 'plugins' list.
+1. If configured, disable the `spellchecker` plugin provided with TinyMCE, by removing it from the `plugins` list.
+2. Add `tinymcespellchecker` to the `plugins` list.
 
 With TinyMCE Cloud the server-side spellchecking component is automatically configured, so the `spellchecker_rpc_url` parameter does not need to be set.
 
@@ -46,10 +44,10 @@ tinymce.init({
 ## Self-hosted Installation
 To enable the TinyMCE Enterprise Spellchecking plugin:
 
-1. For an already existing instance of the 'spellchecker' plugin provided with TinyMCE,, disable it by removing it from the 'plugins' list.
-2. Add 'tinymcespellchecker' to the 'plugins' list.
+1. If configured, disable the `spellchecker` plugin provided with TinyMCE, by removing it from the `plugins` list.
+2. Add `tinymcespellchecker` to the `plugins` list.
 
-For information on installing the server-side component for spell checking, please see the [server-side component installation guide]({{ site.baseurl }}/enterprise/server/).
+For information on installing the server-side component for spell checking, please see the [server-side component installation guide]({{site.baseurl}}/enterprise/server/).
 
 ##### Example TinyMCE Configuration
 
@@ -70,9 +68,9 @@ The TinyMCE Enterprise Spellchecking plugin activates automatically when users t
 ## Configuration Options
 
 ### `spellchecker_rpc_url`
-This setting enables specifying the URL to be used for the server side ephox-spelling service. Check the [server-side component installation guide]({{ site.baseurl }}/enterprise/server/) for details on how to setup a spellchecker server.
+This setting enables specifying the URL to be used for the server side ephox-spelling service. Check the [server-side component installation guide]({{site.baseurl}}/enterprise/server/) for details on how to setup a spellchecker server.
 
-**Note:** `spellchecker_rpc_url` is **not** required when enabling this plugin via [TinyMCE Cloud]({{ site.baseurl }}/cloud-deployment-guide/editor-and-features/)
+**Note:** `spellchecker_rpc_url` is **not** required when enabling this plugin via [TinyMCE Cloud]({{site.baseurl}}/cloud-deployment-guide/editor-and-features/)
 
 ### `spellchecker_languages`
 This optional setting allows specifying the languages that are available to the user, provided as a comma delimited string. The default value for this setting is:
@@ -106,7 +104,7 @@ The following languages are supported:
 This optional setting allows specifying the mode of operation of the spellchecker. When set to true, the spellchecker will open a dialog that will check all of the document's contents at once. This also allows a user to step through each error, to ignore errors and accept recommended fixes. If the spellchecker dialog is enabled, the default as-you-type spellchecking will be disabled.
 
 ### `spellchecker_whitelist`
-This option allows to specify an array of words that should be ignored. This can, for example, be the current company name or internal products. This field can be populated from a file by just getting the white list array from an external JS file.
+This option allows an array of words to be configured, that should be ignored. This can, for example, be the current company name or internal products. This field can be populated from a file by just getting the white list array from an external JS file.
 
 ### `spellchecker_on_load`
 This option lets run the spellchecker when the contents is loaded into the editor. This option defaults to "false" so it's disabled by default.
@@ -118,7 +116,7 @@ This option helps in deciding if the spellchecker should be initialized as activ
 
 ### `spellchecker`
 
-This button allows the user to perform a spellcheck on the entire document. In addition, the drop-down menu attached to this button allows specifying the language that is currently used when spellchecking. For more information about customizing the toolbar, refer to the [Editor appearance section of the documentation]({{ site.baseurl }}/configure/editor-appearance/#toolbar).
+This button allows the user to perform a spellcheck on the entire document. In addition, the drop-down menu attached to this button allows specifying the language that is currently used when spellchecking. For more information about customizing the toolbar, refer to the [Editor appearance section of the documentation]({{site.baseurl}}/configure/editor-appearance/#toolbar).
 
 Example TinyMCE Configuration:
 

--- a/plugins/tinymcespellchecker.md
+++ b/plugins/tinymcespellchecker.md
@@ -53,10 +53,10 @@ For information on installing the server-side component for spell checking, plea
 
 ```js
 tinymce.init({
-	selector: 'textarea',
-	plugins: 'tinymcespellchecker',
-	spellchecker_rpc_url: 'localhost/ephox-spelling',
-	spellchecker_language: 'en'
+  selector: 'textarea',
+  plugins: 'tinymcespellchecker',
+  spellchecker_rpc_url: 'localhost/ephox-spelling',
+  spellchecker_language: 'en'
 });
 ```
 

--- a/plugins/tinymcespellchecker.md
+++ b/plugins/tinymcespellchecker.md
@@ -146,7 +146,7 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'tinymcespellchecker',
   menu: {
-	tools: {title: 'Tools', items: 'spellchecker spellcheckerlanguage'}
+    tools: {title: 'Tools', items: 'spellchecker spellcheckerlanguage'}
   },
   spellchecker_rpc_url: 'localhost/ephox-spelling',
   spellchecker_language: 'en'
@@ -155,7 +155,7 @@ tinymce.init({
 
 ## Events
 
-#### SpellCheckerIgnore event
+#### SpellcheckerIgnore event
 
 This event gets fired when the user selects ignore word on a misspelled word.
 
@@ -167,14 +167,14 @@ tinymce.init({
   plugins: 'tinymcespellchecker',
   toolbar: 'spellchecker',
   init_instance_callback: function (editor) {
-    editor.on('SpellCheckerIgnore', function (e) {
+    editor.on('SpellcheckerIgnore', function (e) {
       console.log('Ignore word', e.word);
     });
   }
 });
 ````
 
-#### SpellCheckerIgnoreAll event
+#### SpellcheckerIgnoreAll event
 
 This event gets fired when the user selects ignore word on a misspelled word.
 
@@ -186,8 +186,46 @@ tinymce.init({
   plugins: 'tinymcespellchecker',
   toolbar: 'spellchecker',
   init_instance_callback: function (editor) {
-    editor.on('SpellCheckerIgnoreAll', function (e) {
+    editor.on('SpellcheckerIgnoreAll', function (e) {
       console.log('Ignore word (all)', e.word);
+    });
+  }
+});
+````
+
+#### SpellcheckStart event
+
+This event gets fired when the user enables as-you-type spellchecking.
+
+Here is an example of using the event:
+
+````
+tinymce.init({
+  selector: 'textarea',
+  plugins: 'tinymcespellchecker',
+  toolbar: 'spellchecker',
+  init_instance_callback: function (editor) {
+    editor.on('SpellcheckStart', function (e) {
+      console.log('Started spellchecking');
+    });
+  }
+});
+````
+
+#### SpellcheckEnd event
+
+This event gets fired when the user disables as-you-type spellchecking.
+
+Here is an example of using the event:
+
+````
+tinymce.init({
+  selector: 'textarea',
+  plugins: 'tinymcespellchecker',
+  toolbar: 'spellchecker',
+  init_instance_callback: function (editor) {
+    editor.on('SpellcheckEnd', function (e) {
+      console.log('Stopped spellchecking');
     });
   }
 });


### PR DESCRIPTION
I've also fixed a couple typos in the other existing event names.

Note: These two new events only exist in the v5 implementation.