### PR TITLE
DOC-182: Documented the autocompleter api

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -419,7 +419,7 @@
     - url: "#visualblocks_default_state"
   - url: "visualchars"
   - url: "wordcount"
-    
+
 - url: "ui-components"
   pages:
   - url: "dialog"
@@ -448,6 +448,7 @@
     - url: "#tabpanel"
     - url: "#textarea"
     - url: "#urlinput"
+  - url: "autocompleter"
   - url: "contextmenu"
     pages:
     - url: "#Live example"
@@ -471,7 +472,7 @@
     - url: "#Context form buttons"
     - url: "#Form API"
     - url: "#Example configuration"
-  - url: "customsidebar"  
+  - url: "customsidebar"
   - url: "toolbarbuttons"
   - url: "typesoftoolbarbuttons"
     pages:

--- a/_includes/codepens/autocompleter/index.html
+++ b/_includes/codepens/autocompleter/index.html
@@ -1,0 +1,4 @@
+<textarea id="autocompleter">
+  <p>Type <b>:</b> below and then keep typing to reduce further matches. For example, typing <b>:amp</b> should show the ampersand item in the menu. Pressing esc should close the autocomplete menu.</p>
+  <p></p>
+</textarea>

--- a/_includes/codepens/autocompleter/index.js
+++ b/_includes/codepens/autocompleter/index.js
@@ -1,0 +1,44 @@
+var specialChars = [
+  { text: 'exclamation mark', value: '!' },
+  { text: 'at', value: '@' },
+  { text: 'hash', value: '#' },
+  { text: 'dollars', value: '$' },
+  { text: 'percent sign', value: '%' },
+  { text: 'caret', value: '^' },
+  { text: 'ampersand', value: '&' },
+  { text: 'asterisk', value: '*' }
+];
+
+tinymce.init({
+  selector: 'textarea#autocompleter',
+  height: 250,
+  setup: function (editor) {
+    /* An autocompleter that allows you to insert special characters */
+    editor.ui.registry.addAutocompleter('specialchars', {
+      ch: ':',
+      minChars: 1,
+      columns: 'auto',
+      fetch: function (pattern) {
+        var matchedChars = specialChars.filter(function (char) {
+          return char.text.indexOf(pattern) !== -1;
+        });
+
+        return new tinymce.util.Promise(function (resolve) {
+          var results = matchedChars.map(function (char) {
+            return {
+              value: char.value,
+              text: char.text,
+              icon: char.value
+            }
+          });
+          resolve(results);
+        });
+      },
+      onAction: function (autocompleteApi, rng, value) {
+        editor.selection.setRng(rng);
+        editor.insertContent(value);
+        autocompleteApi.hide();
+      }
+    });
+  }
+});

--- a/migration-from-4x.md
+++ b/migration-from-4x.md
@@ -189,7 +189,7 @@ The following new methods have been added for creating and using new components:
 
 | **New method** | **Description** |
 | -------------- | --------------- |
-| editor.ui.registry.addAutocompleter: (name, spec) | Autocompleter |
+| editor.ui.registry.addAutocompleter: (name, spec) | [Autocompleter]({{site.baseurl}}/ui-components/autocompleter/) |
 | editor.ui.registry.addContextForm: (name, spec) | [Context form]({{site.baseurl}}/ui-components/contextform/) |
 | editor.ui.registry.addContextMenu: (name, spec) | [Context menu]({{site.baseurl}}/ui-components/contextmenu/) |
 | editor.ui.registry.addMenuButton: (name, spec) | [Menu Button]({{site.baseurl}}/ui-components/typesoftoolbarbuttons/#menubutton) |

--- a/ui-components/autocompleter.md
+++ b/ui-components/autocompleter.md
@@ -46,45 +46,9 @@ The `fetch` function is called whenever the trigger `char` is pressed and the `m
 | ---- | ----- | ----------- |
 | hide | () => void | Hides the autocompleter menu. |
 
-### Example of an autocompleter that completes an email address domain:
-
-```js
-tinymce.init({
-  selector: '#editor',
-  setup: (editor) => {
-    editor.ui.registry.addAutocompleter('myCustomAutocompleter', {
-      ch: '@',
-      columns: 1,
-      matches: (rng) => rng.startOffset !== 0,
-      fetch: (text) => {
-        return new Promise((resolve) => {
-          resolve([
-            {
-              value: '@example.com',
-              text: 'example.com',
-              icon: 'user'
-            },
-            {
-              value: '@tiny.cloud',
-              text: 'tiny.cloud',
-              icon: 'user'
-            }
-          ]);
-        });
-      },
-      onAction: (api, rng, value) => {
-        editor.selection.setRng(rng);
-        editor.insertContent(value);
-        api.hide();
-      }
-    });
-  }
-});
-```
-
 ## Example
 
 This example shows how the charmap plugin adds the standard autocompleter. The autocompleter will show whenever a `:` character is typed plus at least one additional character.
 
-{% include codepen.html id="autocompleter" height="300" %}
+{% include codepen.html id="autocompleter" height="300" tab="js" %}
 

--- a/ui-components/autocompleter.md
+++ b/ui-components/autocompleter.md
@@ -6,20 +6,24 @@ description: Add a custom autocompleter to TinyMCE 5.0.
 keywords: autcomplete
 ---
 
+## Overview
+
+An `autocompleter` enables users to quickly find and select from a pre-populated list of values as they type, leveraging searching and filtering. 
+
 ## Use cases
 
-* Create an autocompleter that shows options to insert into the content while the user is typing.
+An `autocompleter`  provides suggestions to insert while the user is typing into the field. For example, typing <b>:amp</b> should show the ampersand item in the menu. Pressing `esc` should close the autocomplete menu.</p>
 
 ## How to create custom autocompleters
 
-The method for adding a custom autocompleter is in the UI Registry part of the editor API `editor.ui.registry`:
+The method for adding a custom autocompleter is in the **UI Registry** part of the editor API `editor.ui.registry`:
 
 * `editor.ui.registry.addAutocompleter(name, configuration)`
 
 The two arguments this method take are:
 
-* `name` - a unique name for the autocompleter
-* `configuration` - an object containing your configuration.
+* `name` - A unique name for the autocompleter.
+* `configuration` - An object containing the user's configuration.
 
 ### Configuration options
 
@@ -28,12 +32,12 @@ The two arguments this method take are:
 | ch | string | Required | The character to trigger the autocompleter. |
 | fetch |  (pattern: string, maxResults: number) => Promise<AutocompleterItem[]> | Required | A function that is passed the current matched text pattern and the maximum number of expected results. The function should return a promise containing matching results. |
 | onAction | (api, rng: Range, value: string) => void | Required | A function invoked when a fetched item is selected. |
-| columns | number or 'auto' | Optional | default: auto - The number of columns to show. If set to 1 column, then icons and text are displayed, otherwise only icons are displayed. |
+| columns | number or 'auto' | Optional | default: auto - The number of columns to show. If set to `1` column, then icons and text are displayed, otherwise only icons are displayed. |
 | matches | (rng: Range, text: string, pattern: string) => boolean | Optional | default: isStartOfWord - A predicate function that takes a range, the current text node content and the matched text content and returns a boolean indicating if the autocompleter should trigger. |
 | maxResults | number | Optional | default: 10 - The maximum number of results that should be fetched. |
 | minChars | number | Optional | default: 1 - The minimum number of characters that must be typed before the autocompleter will trigger (excluding the trigger char). |
 
-The `fetch` function is called whenever the trigger `char` is pressed and the `matches` predicate returns true. It is a function that takes the matched text pattern and returns a promise containing matching results. This allows for asynchronous fetching of the autocompleter items. The results should be a list of objects with the following details:
+The `fetch` function is called whenever the trigger `char` is pressed and the `matches` predicate returns `true`. It is a function that takes the matched text pattern and returns a promise containing matching results. This allows for asynchronous fetching of the autocompleter items. The results should be a list of objects with the following details:
 * `value`: Value of the item. This will be passed to the `onAction` callback when selected.
 * `text`: Text to display for the item.
 * `icon`: Name of the icon to be displayed. Must a single unicode character or correspond to an icon in the icon pack.

--- a/ui-components/autocompleter.md
+++ b/ui-components/autocompleter.md
@@ -8,7 +8,7 @@ keywords: autcomplete
 
 ## Overview and use case
 
-An `autocompleter` enables users to quickly find and select from a pre-populated list of values as they type, leveraging searching and filtering. It provides suggestions to insert while the user is typing into the content. For example, typing **:amp** should show the ampersand item in the menu. Pressing `esc` should close the autocomplete menu.
+An `autocompleter` enables users to quickly find and select from a pre-populated list of values as they type, leveraging searching and filtering. It provides suggestions to insert while the user is typing into the content. For example, with the [charmap]({{site.baseurl}}/plugins/charmap/) plugin enabled, typing **:amp** should show the ampersand item in the menu. Pressing `esc` should close the autocomplete menu.
 
 ## How to create custom autocompleters
 

--- a/ui-components/autocompleter.md
+++ b/ui-components/autocompleter.md
@@ -36,7 +36,7 @@ The two arguments this method take are:
 The `fetch` function is called whenever the trigger `char` is pressed and the `matches` predicate returns `true`. It is a function that takes the matched text pattern and returns a promise containing matching results. This allows for asynchronous fetching of the autocompleter items. The results should be a list of objects with the following details:
 * `value`: Value of the item. This will be passed to the `onAction` callback when selected.
 * `text`: Text to display for the item.
-* `icon`: Name of the icon to be displayed. Must a single unicode character or correspond to an icon in the icon pack.
+* `icon`: Name of the icon to be displayed. Must be a single unicode character or correspond to an icon in the icon pack.
 
 > Note: If two or more autocompleters use the same trigger character, then the fetched results will be merged together before being displayed.
 

--- a/ui-components/autocompleter.md
+++ b/ui-components/autocompleter.md
@@ -6,13 +6,9 @@ description: Add a custom autocompleter to TinyMCE 5.0.
 keywords: autcomplete
 ---
 
-## Overview
+## Overview and use case
 
-An `autocompleter` enables users to quickly find and select from a pre-populated list of values as they type, leveraging searching and filtering. 
-
-## Use cases
-
-An `autocompleter`  provides suggestions to insert while the user is typing into the field. For example, typing <b>:amp</b> should show the ampersand item in the menu. Pressing `esc` should close the autocomplete menu.</p>
+An `autocompleter` enables users to quickly find and select from a pre-populated list of values as they type, leveraging searching and filtering. It provides suggestions to insert while the user is typing into the field. For example, typing <b>:amp</b> should show the ampersand item in the menu. Pressing `esc` should close the autocomplete menu.</p>
 
 ## How to create custom autocompleters
 

--- a/ui-components/autocompleter.md
+++ b/ui-components/autocompleter.md
@@ -8,7 +8,7 @@ keywords: autcomplete
 
 ## Overview and use case
 
-An `autocompleter` enables users to quickly find and select from a pre-populated list of values as they type, leveraging searching and filtering. It provides suggestions to insert while the user is typing into the field. For example, typing <b>:amp</b> should show the ampersand item in the menu. Pressing `esc` should close the autocomplete menu.</p>
+An `autocompleter` enables users to quickly find and select from a pre-populated list of values as they type, leveraging searching and filtering. It provides suggestions to insert while the user is typing into the content. For example, typing **:amp** should show the ampersand item in the menu. Pressing `esc` should close the autocomplete menu.
 
 ## How to create custom autocompleters
 

--- a/ui-components/autocompleter.md
+++ b/ui-components/autocompleter.md
@@ -1,0 +1,90 @@
+---
+layout: default
+title: Autocompleter
+title_nav: Autocompleter
+description: Add a custom autocompleter to TinyMCE 5.0.
+keywords: autcomplete
+---
+
+## Use cases
+
+* Create an autocompleter that shows options to insert into the content while the user is typing.
+
+## How to create custom autocompleters
+
+The method for adding a custom autocompleter is in the UI Registry part of the editor API `editor.ui.registry`:
+
+* `editor.ui.registry.addAutocompleter(name, configuration)`
+
+The two arguments this method take are:
+
+* `name` - a unique name for the autocompleter
+* `configuration` - an object containing your configuration.
+
+### Configuration options
+
+| Name | Value | Requirement | Description |
+| ---- | ----- | ----------- | ----------- |
+| ch | string | Required | The character to trigger the autocompleter. |
+| fetch |  (pattern: string, maxResults: number) => Promise<AutocompleterItem[]> | Required | A function that is passed the current matched text pattern and the maximum number of expected results. The function should return a promise containing matching results. |
+| onAction | (api, rng: Range, value: string) => void | Required | A function invoked when a fetched item is selected. |
+| columns | number or 'auto' | Optional | default: auto - The number of columns to show. If set to 1 column, then icons and text are displayed, otherwise only icons are displayed. |
+| matches | (rng: Range, text: string, pattern: string) => boolean | Optional | default: isStartOfWord - A predicate function that takes a range, the current text node content and the matched text content and returns a boolean indicating if the autocompleter should trigger. |
+| maxResults | number | Optional | default: 10 - The maximum number of results that should be fetched. |
+| minChars | number | Optional | default: 1 - The minimum number of characters that must be typed before the autocompleter will trigger (excluding the trigger char). |
+
+The `fetch` function is called whenever the trigger `char` is pressed and the `matches` predicate returns true. It is a function that takes the matched text pattern and returns a promise containing matching results. This allows for asynchronous fetching of the autocompleter items. The results should be a list of objects with the following details:
+* `value`: Value of the item. This will be passed to the `onAction` callback when selected.
+* `text`: Text to display for the item.
+* `icon`: Name of the icon to be displayed. Must a single unicode character or correspond to an icon in the icon pack.
+
+> Note: If two or more autocompleters use the same trigger character, then the fetched results will be merged together before being displayed.
+
+### API
+
+| Name | Value | Description |
+| ---- | ----- | ----------- |
+| hide | () => void | Hides the autocompleter menu. |
+
+### Example of an autocompleter that completes an email address domain:
+
+```js
+tinymce.init({
+  selector: '#editor',
+  setup: (editor) => {
+    editor.ui.registry.addAutocompleter('myCustomAutocompleter', {
+      ch: '@',
+      columns: 1,
+      matches: (rng) => rng.startOffset !== 0,
+      fetch: (text) => {
+        return new Promise((resolve) => {
+          resolve([
+            {
+              value: '@example.com',
+              text: 'example.com',
+              icon: 'user'
+            },
+            {
+              value: '@tiny.cloud',
+              text: 'tiny.cloud',
+              icon: 'user'
+            }
+          ]);
+        });
+      },
+      onAction: (api, rng, value) => {
+        editor.selection.setRng(rng);
+        editor.insertContent(value);
+        api.hide();
+      }
+    });
+  }
+});
+```
+
+## Example
+
+This example shows how the charmap plugin adds the standard autocompleter. The autocompleter will show whenever a `:` character is typed plus at least one additional character.
+
+{% include codepen.html id="autocompleter" height="300" %}
+


### PR DESCRIPTION
I should note that the autocompleter defaults in 5.0.0 are a little different, as we've just adjusted them a little different. For example the default `minChars` in 5.0.0 was 0 instead of 1 and the default `matches` predicate was just to always return true, instead of it matching at the start of a word. So I've targeted this more so at the 5.0.1 release.

As always, please feel free to change anything if you want :smiley: 