### PR TITLE
add content_css setting to all examples

### DIFF
--- a/plugins/importcss.md
+++ b/plugins/importcss.md
@@ -18,7 +18,8 @@ By default selectors like `".my-class"`, `".my-class1.my-class2"` and `"p.my-cla
 tinymce.init({
   selector: "textarea",  // change this value according to your HTML
   plugins: "importcss",
-  menubar: "format"
+  menubar: "format",
+  content_css: "/my-styles.css"
 });
 ```
 
@@ -41,6 +42,7 @@ tinymce.init({
   selector: "textarea",  // change this value according to your HTML
   plugins: "importcss",
   menubar: "format",
+  content_css: "/my-styles.css",
   importcss_append: true
 });
 ```
@@ -58,7 +60,8 @@ tinymce.init({
   selector: "textarea",  // change this value according to your HTML
   plugins: "importcss",
   menubar: "format",
-  importcss_file_filter: "my-styles.css"
+  content_css: "/my-styles.css",
+  importcss_file_filter: "/my-styles.css"
 });
 ```
 
@@ -75,6 +78,7 @@ tinymce.init({
   selector: "textarea",  // change this value according to your HTML
   plugins: "importcss",
   menubar: "format",
+  content_css: "/my-styles.css",
   importcss_selector_filter: ".my-prefix-"
 });
 ```
@@ -86,6 +90,7 @@ tinymce.init({
   selector: "textarea",  // change this value according to your HTML
   plugins: "importcss",
   menubar: "format",
+  content_css: "/my-styles.css",
   importcss_selector_filter: /\.prefix|\.otherprefix/
 });
 ```
@@ -95,8 +100,9 @@ tinymce.init({
 ```js
 tinymce.init({
   selector: "textarea",  // change this value according to your HTML
-  plugins: "importcss"
+  plugins: "importcss",
   menubar: "format",
+  content_css: "/my-styles.css",
   importcss_selector_filter: function(selector) {
     return selector.indexOf('myprefix') !== -1;
   }
@@ -114,6 +120,7 @@ tinymce.init({
   selector: "textarea",  // change this value according to your HTML
   plugins: "importcss"
   menubar: "format",
+  content_css: "/my-styles.css",
   importcss_groups: [
     {title: 'Table styles', filter: /^(td|tr)\./}, // td.class and tr.class
     {title: 'Block styles', filter: /^(div|p)\./}, // div.class and p.class
@@ -134,6 +141,7 @@ This option is used in cases where the class attribute should be replaced or mer
 tinymce.init({
   selector: "textarea",  // change this value according to your html
   plugins: "importcss"
+  content_css: "/my-styles.css",
   menubar: "format",
   importcss_merge_classes: false
 });
@@ -151,6 +159,7 @@ This option allows you to override the default selector to format converter func
 tinymce.init({
   selector: "textarea",  // change this value according to your HTML
   plugins: "importcss"
+  content_css: "/my-styles.css",
   menubar: "format",
   importcss_selector_converter: function(selector) {
     // Custom logic


### PR DESCRIPTION
We recently had a customer confused on how this plugin works, not understanding that the importcss plugin only uses the css brought in by the content_css setting so I thought it would be better if the content_css setting is set on all of the examples.