### PR TITLE
DOC-112: Fixed the custom menu item codepen/example

### DIFF
--- a/_includes/codepens/custom-menu-item/index.html
+++ b/_includes/codepens/custom-menu-item/index.html
@@ -1,4 +1,4 @@
-<textarea id="custom-toolbar-menu-item">
+<textarea id="custom-menu-item">
   <p style="text-align: center; font-size: 15px;">
     <img title="TinyMCE Logo" src="//www.tiny.cloud/images/glyph-tinymce@2x.png" alt="TinyMCE Logo" width="110" height="97" />
   </p>

--- a/_includes/codepens/custom-menu-item/index.js
+++ b/_includes/codepens/custom-menu-item/index.js
@@ -1,5 +1,5 @@
 tinymce.init({
-  selector: "textarea#custom-toolbar-menu-item",
+  selector: "textarea#custom-menu-item",
   height: 500,
   toolbar: false,
   menubar: "custom",
@@ -11,8 +11,6 @@ tinymce.init({
     '//www.tiny.cloud/css/codepen.min.css'
   ],
   setup: function (editor) {
-    // Menu items are recreated when the menu is closed and opened, so we need
-    // a variable to store the toggle menu item state.
     var toggleState = false;
 
     editor.ui.registry.addMenuItem('basicitem', {


### PR DESCRIPTION
@shikhanansi noticed this demo wasn't working on the staging site. Turned out to be that the codepens don't seem to like the comments in the JS file. I also removed the style.css which got removed in DOC-170 (this was missed, as it was on review at the time).