### PR TITLE
TINY-2712: Added fixed_toolbar_container back to the nav

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -74,6 +74,7 @@
     - url: "#custom_ui_selector"
     - url: "#elementpath"
     - url: "#event_root"
+    - url: "#fixed_toolbar_container"
     - url: "#height"
     - url: "#icons"
     - url: "#inline"


### PR DESCRIPTION
Missed this sorry @shikhanansi in the previous PR when bringing this setting back