### PR TITLE
WEBSITE-1358 - Add sitemap.xml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,5 @@ group :development, :test do
   gem 'jekyll-sitemap', '~> 1.2.0'
   gem 'rouge', '~> 3.2.1'
   gem 'nokogiri', '~> 1.8.4'
+  gem "jekyll-last-modified-at", "~> 1.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,9 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
+    jekyll-last-modified-at (1.0.1)
+      jekyll (~> 3.3)
+      posix-spawn (~> 0.3.9)
     jekyll-redirect-from (0.14.0)
       jekyll (~> 3.3)
     jekyll-sass-converter (1.5.2)
@@ -47,6 +50,7 @@ GEM
       mini_portile2 (~> 2.3.0)
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
+    posix-spawn (0.3.13)
     public_suffix (3.0.3)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
@@ -65,10 +69,11 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 3.8.4)
+  jekyll-last-modified-at (~> 1.0)
   jekyll-redirect-from (~> 0.14.0)
   jekyll-sitemap (~> 1.2.0)
   nokogiri (~> 1.8.4)
   rouge (~> 3.2.1)
 
 BUNDLED WITH
-   1.16.2
+   1.17.3

--- a/_config-local.sample.yml
+++ b/_config-local.sample.yml
@@ -1,3 +1,5 @@
-shared_baseurl: "https://www.tinymce.com"
+shared_baseurl: "https://www.tiny.cloud"
 plugins:
+  - jekyll-last-modified-at
   - jekyll-redirect-from
+  - jekyll-sitemap

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,6 @@
+url: "https://www.tiny.cloud"
 permalink: pretty
-origin: "https://www.tinymce.com"
+origin: "https://www.tiny.cloud"
 baseurl: ""
 shared_baseurl: ""
 syntax_highlight_theme: "tomorrow-night"
@@ -27,5 +28,7 @@ kramdown:
     css_class: 'prettyprint'
 
 plugins:
+  - jekyll-last-modified-at
   - jekyll-redirect-from
   - jekyll-sitemap
+

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,1 @@
+# Ignore this file; stops addition of robots.txt from sitemap generator.


### PR DESCRIPTION
Related Ticket: [WEBSITE-1358](https://ephocks.atlassian.net/browse/WEBSITE-1358)

Description of Changes:
* Added last-modified-at plugin to Jekyll for use in sitemaps.
* Modified local configuration to output sitemap.xml for testing purposes.
* Added empty robots.txt to prevent sitemap generator from outputting misleading information for search bots.
* Updated site configuration with origin and URL to point to https://www.tiny.cloud instead of https://www.tinymce.com
