### PR TITLE
Fixed a minor spacing issue in the jQuery integration example

### DIFF
--- a/integrations/jquery.md
+++ b/integrations/jquery.md
@@ -13,9 +13,9 @@ You need to add some custom logic when rendering TinyMCE instances inside jQuery
 ```js
 // Prevent jQuery UI dialog from blocking focusin
 $(document).on('focusin', function(e) {
-    if ($(e.target).closest(".tox-tinymce-aux, .moxman-window, .tam-assetmanager-root").length) {
-		e.stopImmediatePropagation();
-	}
+  if ($(e.target).closest(".tox-tinymce-aux, .moxman-window, .tam-assetmanager-root").length) {
+    e.stopImmediatePropagation();
+  }
 });
 ```
 


### PR DESCRIPTION
Just a very minor thing I noticed when double checking some changes I made yesterday. Sorry for not catching them yesterday :disappointed: 