### PR TITLE
TINY-3382: Added docs and examples for the new URL dialog functionality

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -577,8 +577,6 @@
   - url: "#Components"
   - url: "#Plugins"
   - url: "#Other removed component configuration settings"
-  - url: "#Components"
-  - url: "#Premium features"
 
 - url: "release-notes"
   pages:

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -461,6 +461,13 @@
     - url: "#tabpanel"
     - url: "#textarea"
     - url: "#urlinput"
+  - url: "urldialog"
+    pages:
+    - url: "#Overview"
+    - url: "#URL dialog configuration"
+    - url: "#URL dialog instance API"
+    - url: "#URL dialog messaging"
+    - url: "#Example configuration"
   - url: "autocompleter"
   - url: "contextmenu"
     pages:

--- a/_includes/codepens/url-dialog/index.html
+++ b/_includes/codepens/url-dialog/index.html
@@ -1,0 +1,3 @@
+<textarea class="urldialog">
+  <p>Click on the custom {;} toolbar button.</p>
+</textarea>

--- a/_includes/codepens/url-dialog/index.js
+++ b/_includes/codepens/url-dialog/index.js
@@ -1,0 +1,20 @@
+var config = {
+  title: 'URL Dialog Demo',
+  url: '../../demo/url-dialog-demo/external-page.html',
+  height: 640,
+  width: 640
+};
+
+tinymce.init({
+  selector: 'textarea.urldialog',
+  toolbar: 'urldialog',
+  height: 300,
+  setup: function (editor) {
+    editor.ui.registry.addButton('urldialog', {
+      icon: 'code-sample',
+      onAction: function () {
+        editor.windowManager.openUrl(config)
+      }
+    })
+  }
+});

--- a/demo/url-dialog-demo/external-page.html
+++ b/demo/url-dialog-demo/external-page.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>External Page Demo</title>
+
+  <style>
+    body {
+      background-color: #1976D2;
+      color: #ffffff;
+      font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+    }
+
+    h1 {
+      text-align: center;
+    }
+
+    .footer {
+
+    }
+  </style>
+</head>
+<body>
+<h1>Example External Page</h1>
+<p>This is a demo page that is loaded via an external URL. This page doesn't do anything fancy, but it's meant to show that an external page can be loaded to show or create very complex applications that can then be run inside a TinyMCE dialog.</p>
+<div class="footer"><button id="close">Close</button></div>
+<script>
+  var closeButton = document.getElementById('close');
+  closeButton.addEventListener('click', function () {
+    window.postMessage({ mceAction: 'close' });
+  })
+</script>
+</body>
+</html>

--- a/migration-from-4x.md
+++ b/migration-from-4x.md
@@ -378,11 +378,11 @@ Dialogs are still opened via the `editor.windowManager.open(config)` api, howeve
 
 | **Removed setting** | **Description** |
 | ------------------- | --------------- |
-| height | The dialog component now uses CSS3 and a predefined `small`, `medium`, and `large` template to specify the dimensions. |
-| width | The dialog component now uses CSS3 and a predefined `small`, `medium`, and `large` template to specify the dimensions. |
+| `height` | The dialog component now uses CSS3 and a predefined `small`, `medium`, and `large` template to specify the dimensions. |
+| `width` | The dialog component now uses CSS3 and a predefined `small`, `medium`, and `large` template to specify the dimensions. |
 | bodyType | `bodyType` has been merged into the `body` setting. |
 | onpostrender | `onpostrender` has been removed for the dialog configuration. The dialog configuration now includes an `initialData` setting for providing the initial state and an API to fetch or update the data. Refer to [this]({{site.baseurl}}/ui-components/dialog/#interactiveexampleusingredialconfigvoid) section for more information on how to configure `initialData`. |
-| url | HTML page dialogs are no longer supported, as such the `url` setting has been removed. |
+| url | URL dialogs now have their own API. For more information, see [`Custom URL dialogs`](#customurldialogs). |
 
 ##### New settings:
 
@@ -442,6 +442,42 @@ const config = {
 ```
 
 For more information about the new dialog configuration, see the [`Dialog`]({{site.baseurl}}/ui-components/dialog/) and [`Dialog components`]({{site.baseurl}}/ui-components/dialogcomponents/) docs.
+
+### Custom URL dialogs
+
+URL dialogs in TinyMCE 4.x were included as part of the `editor.windowManager.open()` API, however in TinyMCE 5.0 they've been moved to a new API `editor.windowManager.openUrl()`. This allows for clear separation and configuration between the two different types of dialogs in TinyMCE.
+
+##### Removed settings:
+
+| **Removed setting** | **Description** |
+| ------------------- | --------------- |
+| `file` | The `file` setting has been replaced by `url`, and as such has been removed. |
+
+##### New settings:
+
+| **New setting** | **Description** |
+| --------------- | --------------- |
+| `onCancel` | A callback that is called when the dialog is cancelled without submitting any changes. |
+| `onMessage` | A callback that is called when the dialog receives a message via the browser `window.postMessage` API. |
+
+#### TinyMCE 4.x
+
+```js
+editor.windowManager.open({
+  title: 'URL Dialog Demo',
+  url: 'http://mysite.com/external-page.html'
+});
+```
+#### TinyMCE 5.0
+
+```js
+editor.windowManager.openUrl({
+  title: 'URL Dialog Demo',
+  url: 'http://mysite.com/external-page.html'
+});
+```
+
+For more information about the new URL dialog configuration, see the [`URL dialog`]({{site.baseurl}}/ui-components/urldialog/) docs.
 
 <!-- ### Custom sidebars
 

--- a/migration-from-4x.md
+++ b/migration-from-4x.md
@@ -445,13 +445,13 @@ For more information about the new dialog configuration, see the [`Dialog`]({{si
 
 ### Custom URL dialogs
 
-URL dialogs in TinyMCE 4.x were included as part of the `editor.windowManager.open()` API, however in TinyMCE 5.0 they've been moved to a new API `editor.windowManager.openUrl()`. This allows for clear separation and configuration between the two different types of dialogs in TinyMCE.
+In TinyMCE 4.x, URL dialogs were included as part of the `editor.windowManager.open()` API. However, in TinyMCE 5.0 they've been moved to a new API `editor.windowManager.openUrl()`. This allows for clear separation and configuration between the two different types of dialogs in TinyMCE.
 
 ##### Removed settings:
 
-| **Removed setting** | **Description** |
-| ------------------- | --------------- |
-| `file` | The `file` setting has been replaced by `url`, and as such has been removed. |
+| **Old setting** | **New setting** | **Description** |
+| --------------- | --------------- | --------------- |
+| `file` | `url` | The `file` setting has been removed in TinyMCE 5.0 and replaced with `url`. |
 
 ##### New settings:
 

--- a/ui-components/dialog.md
+++ b/ui-components/dialog.md
@@ -40,6 +40,21 @@ A Dialog configuration framework has three main parts:
 
 * **Footer** This section consists of a [button]({{site.baseurl}}/ui-components/dialogcomponents/#button) or list of buttons.
 
+### Config options
+
+| Name | Value | Requirement | Description |
+| ---- | ----- | ----------- | ----------- |
+| title | string | required | The title of the dialog. |
+| body | Panel or TabPanel | required | The configuration for the body of the dialog. See [Body components](#bodycomponents) configuration. |
+| buttons | DialogButton[] | required | An optional array of button configurations to render in the footer. See [Footer components](#footercomponents) configuration. |
+| size | 'normal', 'medium' or 'large' | optional | default: `normal` - The size to use when rendering the dialog. |
+| initialData | object | optional | An object containing the initial value for the dialog components. |
+| onAction | (api) => void | optional | Function invoked when a custom button is clicked. |
+| onCancel | (api) => void | optional | Function invoked when the dialog is cancelled either by a cancel button or the close button in the dialog header. |
+| onChange | (api, data) => void | optional | Function invoked when a dialog component changes it's value. |
+| onClose | () => void | optional | Function invoked when the dialog has been closed. |
+| onSubmit | (api) => void | optional | Function invoked when the dialog is submitted. |
+
 ### Body components
 
 #### Panel
@@ -78,7 +93,7 @@ var tabPanelConfig = {
 
 #### Button
 
-The following configuration is used to create a button inside the dialog body:
+The following configuration is used to create a button inside the dialog footer:
 
 ```js
 var buttonConfig = {

--- a/ui-components/urldialog.md
+++ b/ui-components/urldialog.md
@@ -1,0 +1,215 @@
+---
+layout: default
+title: URL dialog
+title_nav: URL dialog
+description: URL dialogs are a TinyMCE UI component used to display an external page.
+keywords: dialog urldialog api
+---
+## Overview
+
+A URL dialog is a special TinyMCE UI component which loads an external web page inside a dialog (sometimes referred to as modals). This differs to regular dialogs which use supported components to render an interactive dialog inside the application. URL dialogs are useful for very complex use cases, where the supported dialog components aren't able to be used, for example in a custom file manager.
+
+The most basic configuration structure is:
+
+```js
+const urlDialogConfig = {
+   title: 'Just a title',
+   url: 'http://www.tiny.cloud/example.html'
+}
+```
+
+## URL dialog configuration
+
+A URL Dialog configuration has two main parts:
+
+* **Title** This is the title of a dialog.
+
+* **URL** The external pages URL to load inside the dialog.
+
+### Config options
+
+| Name    | Value  | Requirement | Description |
+| ------- | ------ | ----------- | ----------- |
+| title   | string | required    | The title of the dialog. |
+| url     | string | required    | The url to the external page to load. |
+| width   | number | optional    | The width of the dialog in pixels. |
+| height  | number | optional    | The height of the dialog in pixels. |
+| buttons | UrlDialogButton[] | optional | An optional array of button configurations to render in the footer. See [Footer components](#footercomponents) configuration. |
+| onAction | (api) => void | optional | Function invoked when a custom button is clicked. |
+| onCancel | (api) => void | optional | Function invoked when the dialog is cancelled. |
+| onClose | () => void | optional | Function invoked when the dialog has been closed. |
+| onMessage | (api, data) => void | optional | Function invoked when a message is received from the external page. |
+
+### Footer components
+
+#### Button
+
+The following configuration is used to create a button inside the dialog footer:
+
+```js
+var buttonConfig = {
+  type: 'button',
+  name: string,
+  text: string,
+  icon: string,
+  disabled: boolean,
+  primary: boolean,
+  align: 'start' | 'end'
+}
+```
+
+**Name:** The name property on the button is used as an id attribute to identify the dialog component. For example, when `name: foobutton` is defined and a user clicks on that button, the dialog `onAction()` handler will fire and provide an object containing the name of the dialog component, e.g. `details.name = 'foobutton'`. This will allow developers to create a click handler for **foobutton**.
+
+**Text:** This will be the text displayed on the button. For example, `text: ‘do magic’` will create a button with text **do magic**.
+
+**Icon:** This will be the name of the icon to be displayed on the button, instead of any text. The name must correspond to an icon in the icon pack. Dialog buttons do not support mixing icons and text at the moment.
+
+**Disabled:** (Value: Boolean; Default: False): When set to true, the button will be disabled when the dialog loads.
+
+**Primary:** (Default: False): When set to true, the button will be colored to stand out. The color will depend on the chosen [skin]({{site.baseurl}}/general-configuration-guide/customize-ui/#skins).
+
+**Align:** (Default: 'end'): This will define the position of the button in the footer. When set to `end`, the button will be positioned on the right side of the dialog. When set to `start`, the button will be positioned on the left side of the dialog.
+
+#### Button types
+
+The **Close** button is pre-wired to abort and close the dialog.
+
+The **Cancel** button dismisses an action request.
+
+The **Custom** button can be used to specify a custom operation.
+
+## URL dialog instance API
+
+When a URL dialog is created, a dialog instance API is returned. For example, `const instanceApi = editor.windowManager.openUrl(config);`
+
+The instance API is a javascript object containing methods attached to the dialog instance. When the dialog is closed, the instance API is destroyed.
+
+### Instance API methods
+
+| Methods | Description |
+|---------|-------------|
+| `block(message: string): void` | Calling `block()` and passing a message string will disable the entire dialog window and show a loading image. This is useful for handling asynchronous data. The message is used for screen reader accessibility. When the data is ready use `unblock()` to unlock the dialog. |
+| `unblock(): void` | Calling `unblock()` will unlock the dialog instance restoring functionality. |
+| `close(): void` | Calling the `close()` method will close the dialog. When closing the dialog, all DOM elements and dialog data are destroyed.  When `open(config)` is called again, all DOM elements and data are recreated from the config. |
+| `sendMessage(data: any): void` | Calling the `sendMessage()` method will attempt to send a message to the external page via `window.postMesssage()`. |
+
+## URL dialog messaging
+
+When using a URL dialog, there needs to be a way to communicate between TinyMCE and the external page, as the two components are no longer running in the same window. To allow this, TinyMCE makes use of the browsers [`window.postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) API to allow sending data across different origins. The following is an example of how to send messages back to TinyMCE from within an external page:
+
+```js
+window.parent.postMessage({
+  mceAction: 'insertContent',
+  content: 'Some content'
+}, '*');
+```
+
+Likewise to send messages from TinyMCE back to the external page, then the `api.sendMessage()` function can be used to send messages and then in the external page an event listener can be added to receive the message:
+
+```js
+window.addEventListener('message', function (event) {
+  var data = event.data;
+  
+  // Do something with the data received here
+  console.log('message received from TinyMCE', data);
+});
+
+```
+
+> Note: If possible when sending a message it's recommended to specify the target origin of where TinyMCE is running, instead of using a wildcard (`'*'`). Likewise when receiving messages also validate that `event.origin` matches the origin of where TinyMCE is running. For example if TinyMCE is running on *http://mysite.com/tinymce.html*, then if `event.origin` doesn't match `http://mysite.com` the message should be ignored.
+
+### Supported message actions
+
+These actions are built into the URL dialog functionality and will perform an action inside the editor, based on the `mceAction` specified. The actions supported are:
+
+##### insertContent
+
+Inserts content into the editor at the current selection. The `content` property specifies what content should be inserted into the editor.
+
+ ```js
+{
+  mceAction: 'setContent',
+  content: 'My custom content'
+}
+```
+
+##### setContent
+
+Set the editors content. The `content` property specifies what content should be set inside the editor.
+
+```js
+{
+  mceAction: 'setContent',
+  content: 'My custom content'
+}
+```
+
+##### execCommand
+
+Executes a command inside the editor. The options available for this action are:
+
+**cmd:** The name of the command to be executed inside the editor.
+
+**ui:** An optional boolean to specify if a UI (dialog) should be presented or not.
+
+**value:** An optional value to be used by the command.
+
+```js
+{
+  mceAction: 'execCommand',
+  cmd: 'mceInsertLink',
+  value: 'https://www.tiny.cloud'
+}
+```
+
+##### close
+
+Closes the open URL dialog. This is the same as using the `api.close()` function.
+
+```js
+{
+  mceAction: 'close'
+}
+```
+
+##### block
+
+Disables the entire dialog window and shows a loading image. This is the same as using the `api.block(message)` function.
+
+```js
+{
+  mceAction: 'block',
+  message: 'Loading…'
+}
+```
+
+##### unblock
+
+Unblocks the window/dialog. This is the same as using the `api.unblock()` function.
+
+```js
+{
+  mceAction: 'unblock'
+}
+```
+
+### Custom message actions
+
+A custom message, is one that contains a `mceAction` not listed in the above supported actions. For example, the following snippet could be used to send a message back to TinyMCE and then be processed via the `onMessage` callback to perform custom actions inside TinyMCE.
+
+```js
+{
+  mceAction: 'customAction',
+  data: {
+    customField: 'custom value'
+  }
+}
+```
+
+> Note: TinyMCE will ignore all messages received that don't contain a `mceAction` property.
+
+## Example configuration
+
+This example shows a very basic toolbar button, that opens an external URL inside a 640x640px dialog without any footer. The dialog can be opened by clicking the `{;}` toolbar button.
+
+{% include codepen.html id="url-dialog" height="300" tab="js" %}

--- a/ui-components/urldialog.md
+++ b/ui-components/urldialog.md
@@ -7,7 +7,7 @@ keywords: dialog urldialog api
 ---
 ## Overview
 
-A URL dialog is a special TinyMCE UI component which loads an external web page inside a dialog (sometimes referred to as `modals`). This differs from the regular dialogs that use supported components to render an interactive dialog inside the application. URL dialogs are useful for very complex use cases, where the supported dialog components cannot be used — for example, dialogs in a custom file manager.
+A URL dialog is a special TinyMCE UI component which loads an external web page inside a dialog (sometimes referred to as `modals`). This differs from the regular dialogs that use supported components to render an interactive dialog inside the application. URL dialogs are useful for very complex use cases, where the supported dialog components cannot be used — for example, a custom file manager that is loaded inside a TinyMCE dialog.
 
 The most basic configuration structure is:
 
@@ -124,7 +124,7 @@ These actions are built into the URL dialog functionality and will perform an ac
 
 ##### insertContent
 
-This option inserts content into the editor at the current selection. The `content` property specifies what content should be inserted into the editor.
+This action inserts content into the editor at the current selection. The `content` property specifies what content should be inserted into the editor.
 
  ```js
 {
@@ -135,7 +135,7 @@ This option inserts content into the editor at the current selection. The `conte
 
 ##### setContent
 
-This option is used to set the editors content. The `content` property specifies what content should be set inside the editor.
+This action is used to set the editors content. The `content` property specifies what content should be set inside the editor.
 
 ```js
 {
@@ -146,7 +146,7 @@ This option is used to set the editors content. The `content` property specifies
 
 ##### execCommand
 
-This option executes a command inside the editor. The options available for this action are:
+This action executes a command inside the editor. The options available for this action are:
 
 **cmd:** The name of the command to be executed inside the editor.
 
@@ -164,7 +164,7 @@ This option executes a command inside the editor. The options available for this
 
 ##### close
 
-This option closes the open URL dialog. This is the same as using the `api.close()` function.
+This action closes the open URL dialog. This is the same as using the `api.close()` function.
 
 ```js
 {
@@ -174,7 +174,7 @@ This option closes the open URL dialog. This is the same as using the `api.close
 
 ##### block
 
-This option disables the entire dialog window and shows a loading image. This is the same as using the `api.block(message)` function.
+This action disables the entire dialog window and shows a loading image. This is the same as using the `api.block(message)` function.
 
 ```js
 {
@@ -185,7 +185,7 @@ This option disables the entire dialog window and shows a loading image. This is
 
 ##### unblock
 
-This option unblocks the window/dialog. This is the same as using the `api.unblock()` function.
+This action unblocks the window/dialog. This is the same as using the `api.unblock()` function.
 
 ```js
 {

--- a/ui-components/urldialog.md
+++ b/ui-components/urldialog.md
@@ -7,7 +7,7 @@ keywords: dialog urldialog api
 ---
 ## Overview
 
-A URL dialog is a special TinyMCE UI component which loads an external web page inside a dialog (sometimes referred to as modals). This differs to regular dialogs which use supported components to render an interactive dialog inside the application. URL dialogs are useful for very complex use cases, where the supported dialog components aren't able to be used, for example in a custom file manager.
+A URL dialog is a special TinyMCE UI component which loads an external web page inside a dialog (sometimes referred to as `modals`). This differs from the regular dialogs that use supported components to render an interactive dialog inside the application. URL dialogs are useful for very complex use cases, where the supported dialog components cannot be used — for example, dialogs in a custom file manager.
 
 The most basic configuration structure is:
 
@@ -31,7 +31,7 @@ A URL Dialog configuration has two main parts:
 | Name    | Value  | Requirement | Description |
 | ------- | ------ | ----------- | ----------- |
 | title   | string | required    | The title of the dialog. |
-| url     | string | required    | The url to the external page to load. |
+| url     | string | required    | The URL to the external page to load. |
 | width   | number | optional    | The width of the dialog in pixels. |
 | height  | number | optional    | The height of the dialog in pixels. |
 | buttons | UrlDialogButton[] | optional | An optional array of button configurations to render in the footer. See [Footer components](#footercomponents) configuration. |
@@ -58,15 +58,15 @@ var buttonConfig = {
 }
 ```
 
-**Name:** The name property on the button is used as an id attribute to identify the dialog component. For example, when `name: foobutton` is defined and a user clicks on that button, the dialog `onAction()` handler will fire and provide an object containing the name of the dialog component, e.g. `details.name = 'foobutton'`. This will allow developers to create a click handler for **foobutton**.
+**Name:** The name property on the button is used as an ID attribute to identify the dialog component. For example, when `name: foobutton` is defined and a user clicks on that button, the dialog `onAction()` handler will fire and provide an object containing the name of the dialog component, e.g., `details.name = 'foobutton'`. This will allow developers to create a click handler for **foobutton**.
 
 **Text:** This will be the text displayed on the button. For example, `text: ‘do magic’` will create a button with text **do magic**.
 
-**Icon:** This will be the name of the icon to be displayed on the button, instead of any text. The name must correspond to an icon in the icon pack. Dialog buttons do not support mixing icons and text at the moment.
+**Icon:** This will be the name of the icon to be displayed on the button, in place of any text. The name must correspond to an icon in the icon pack. Dialog buttons do not support mixing icons and text at the moment.
 
-**Disabled:** (Value: Boolean; Default: False): When set to true, the button will be disabled when the dialog loads.
+**Disabled:** (Value: Boolean; Default: `False`): When set to `true`, the button will be disabled when the dialog loads.
 
-**Primary:** (Default: False): When set to true, the button will be colored to stand out. The color will depend on the chosen [skin]({{site.baseurl}}/general-configuration-guide/customize-ui/#skins).
+**Primary:** (Default: `False`): When set to `true`, the button will be colored to stand out. The color will depend on the chosen [skin]({{site.baseurl}}/general-configuration-guide/customize-ui/#skins).
 
 **Align:** (Default: 'end'): This will define the position of the button in the footer. When set to `end`, the button will be positioned on the right side of the dialog. When set to `start`, the button will be positioned on the left side of the dialog.
 
@@ -80,7 +80,7 @@ The **Custom** button can be used to specify a custom operation.
 
 ## URL dialog instance API
 
-When a URL dialog is created, a dialog instance API is returned. For example, `const instanceApi = editor.windowManager.openUrl(config);`
+When a URL dialog is created, a dialog instance API is returned. For example, `const instanceApi = editor.windowManager.openUrl(config);`.
 
 The instance API is a javascript object containing methods attached to the dialog instance. When the dialog is closed, the instance API is destroyed.
 
@@ -104,27 +104,27 @@ window.parent.postMessage({
 }, '*');
 ```
 
-Likewise to send messages from TinyMCE back to the external page, then the `api.sendMessage()` function can be used to send messages and then in the external page an event listener can be added to receive the message:
+Similarly, to send messages from TinyMCE back to the external page, the `api.sendMessage()` function can be used to send messages, and then in the external page an event listener can be added to receive the messages:
 
 ```js
 window.addEventListener('message', function (event) {
   var data = event.data;
-  
+ 
   // Do something with the data received here
   console.log('message received from TinyMCE', data);
 });
 
 ```
 
-> Note: If possible when sending a message it's recommended to specify the target origin of where TinyMCE is running, instead of using a wildcard (`'*'`). Likewise when receiving messages also validate that `event.origin` matches the origin of where TinyMCE is running. For example if TinyMCE is running on *http://mysite.com/tinymce.html*, then if `event.origin` doesn't match `http://mysite.com` the message should be ignored.
+> Note: When sending a message it is recommended to specify the target origin of where TinyMCE is running, instead of using a wildcard (`'*'`). Similarly, when receiving messages, also validate that `event.origin` matches the origin of where TinyMCE is running. For example, if TinyMCE is running on *http://mysite.com/tinymce.html*, then if `event.origin` doesn't match `http://mysite.com` the message should be ignored.
 
 ### Supported message actions
 
-These actions are built into the URL dialog functionality and will perform an action inside the editor, based on the `mceAction` specified. The actions supported are:
+These actions are built into the URL dialog functionality and will perform an action inside the editor based on the `mceAction` specified. The actions supported are:
 
 ##### insertContent
 
-Inserts content into the editor at the current selection. The `content` property specifies what content should be inserted into the editor.
+This option inserts content into the editor at the current selection. The `content` property specifies what content should be inserted into the editor.
 
  ```js
 {
@@ -135,7 +135,7 @@ Inserts content into the editor at the current selection. The `content` property
 
 ##### setContent
 
-Set the editors content. The `content` property specifies what content should be set inside the editor.
+This option is used to set the editors content. The `content` property specifies what content should be set inside the editor.
 
 ```js
 {
@@ -146,7 +146,7 @@ Set the editors content. The `content` property specifies what content should be
 
 ##### execCommand
 
-Executes a command inside the editor. The options available for this action are:
+This option executes a command inside the editor. The options available for this action are:
 
 **cmd:** The name of the command to be executed inside the editor.
 
@@ -164,7 +164,7 @@ Executes a command inside the editor. The options available for this action are:
 
 ##### close
 
-Closes the open URL dialog. This is the same as using the `api.close()` function.
+This option closes the open URL dialog. This is the same as using the `api.close()` function.
 
 ```js
 {
@@ -174,7 +174,7 @@ Closes the open URL dialog. This is the same as using the `api.close()` function
 
 ##### block
 
-Disables the entire dialog window and shows a loading image. This is the same as using the `api.block(message)` function.
+This option disables the entire dialog window and shows a loading image. This is the same as using the `api.block(message)` function.
 
 ```js
 {
@@ -185,7 +185,7 @@ Disables the entire dialog window and shows a loading image. This is the same as
 
 ##### unblock
 
-Unblocks the window/dialog. This is the same as using the `api.unblock()` function.
+This option unblocks the window/dialog. This is the same as using the `api.unblock()` function.
 
 ```js
 {
@@ -195,7 +195,7 @@ Unblocks the window/dialog. This is the same as using the `api.unblock()` functi
 
 ### Custom message actions
 
-A custom message, is one that contains a `mceAction` not listed in the above supported actions. For example, the following snippet could be used to send a message back to TinyMCE and then be processed via the `onMessage` callback to perform custom actions inside TinyMCE.
+A custom message is one that contains a `mceAction` not listed in the above-supported actions. For example, the following snippet could be used to send a message back to TinyMCE and then be processed via the `onMessage` callback to perform custom actions inside TinyMCE.
 
 ```js
 {
@@ -210,6 +210,8 @@ A custom message, is one that contains a `mceAction` not listed in the above sup
 
 ## Example configuration
 
-This example shows a very basic toolbar button, that opens an external URL inside a 640x640px dialog without any footer. The dialog can be opened by clicking the `{;}` toolbar button.
+This example shows a very basic toolbar button that opens an external URL inside a 640x640px dialog without any footer. The dialog can be opened by clicking the `{;}` toolbar button.
 
 {% include codepen.html id="url-dialog" height="300" tab="js" %}
+
+


### PR DESCRIPTION
This is my initial draft for the URL dialog functionality that we are bringing back, though with a different/new API in comparison to v4. @shikhanansi let me know if you have any questions or want something clarified :smile: 

Note: I haven't been able to test the new example works correctly, as the new API isn't deployed to cloud yet.