### PR TITLE
DOC-307 - Category/product index cards are not visible

### DIFF
--- a/_includes/index.html
+++ b/_includes/index.html
@@ -3,7 +3,7 @@
   {% capture path %}{{url}}index.html{% endcapture %}
   {% assign_page link_data = path %}
 <div>
-  <h2><a href="{{ site.baseurl }}{{ url }}">{{ link_data.title }}</a></h2>
+  <h2><a href="{{ site.baseurl }}{{ url }}">{{ link_data.title_nav | or:link_data.title }}</a></h2>
   <p>{{ link_data.description_short | or:link_data.description }}</p>
 </div>
 {% endfor %}

--- a/advanced/index.md
+++ b/advanced/index.md
@@ -5,6 +5,11 @@ title_nav: Advanced topics
 description: Information and guides for developers wanting to build advanced capabilities into TinyMCE.
 type: folder
 ---
+{% assign navigaton = site.data.nav %}
+{% for entry in navigaton %}
+  {% if entry.url == "advanced" %}
+    {% assign links = entry.pages %}
+  {% endif %}
+{% endfor %}
 
-{% assign links = site.data | where_exp:"nav", "nav.url == 'advanced'" | first | map: "pages" %}
 {% include index.html links=links %}

--- a/cloud-deployment-guide/index.md
+++ b/cloud-deployment-guide/index.md
@@ -5,6 +5,11 @@ title_nav: Cloud deployment guide
 description: Start here for Tiny Cloud.
 type: folder
 ---
+{% assign navigaton = site.data.nav %}
+{% for entry in navigaton %}
+  {% if entry.url == "cloud-deployment-guide" %}
+    {% assign links = entry.pages %}
+  {% endif %}
+{% endfor %}
 
-{% assign links = site.data | where_exp:"nav", "nav.url == 'cloud-deployment-guide'" | first | map: "pages" %}
 {% include index.html links=links %}

--- a/configure/index.md
+++ b/configure/index.md
@@ -6,6 +6,11 @@ description_short: The most customizable rich text editor.
 description: TinyMCE is not only the most advanced rich text editor it's also the most customizable.
 type: folder
 ---
+{% assign navigaton = site.data.nav %}
+{% for entry in navigaton %}
+  {% if entry.url == "configure" %}
+    {% assign links = entry.pages %}
+  {% endif %}
+{% endfor %}
 
-{% assign links = site.data | where_exp:"nav", "nav.url == 'configure'" | first | map: "pages" %}
 {% include index.html links=links %}

--- a/demo/index.md
+++ b/demo/index.md
@@ -12,6 +12,11 @@ redirect_from:
   - /example-tutorial/
   - /try-tinymce/
 ---
+{% assign navigaton = site.data.nav %}
+{% for entry in navigaton %}
+  {% if entry.url == "demo" %}
+    {% assign links = entry.pages %}
+  {% endif %}
+{% endfor %}
 
-{% assign links = site.data | where_exp:"nav", "nav.url == 'demo'" | first | map: "pages" %}
 {% include index.html links=links %}

--- a/enterprise/index.md
+++ b/enterprise/index.md
@@ -5,6 +5,11 @@ title_nav: Premium features
 description: Premium features from the makers of TinyMCE.
 type: folder
 ---
+{% assign navigaton = site.data.nav %}
+{% for entry in navigaton %}
+  {% if entry.url == "enterprise" %}
+    {% assign links = entry.pages %}
+  {% endif %}
+{% endfor %}
 
-{% assign links = site.data | where_exp:"nav", "nav.url == 'enterprise'" | first | map: "pages" %}
 {% include index.html links=links %}

--- a/general-configuration-guide/index.md
+++ b/general-configuration-guide/index.md
@@ -5,6 +5,11 @@ title_nav: Introduction &amp; getting started
 description: New to self-hosting TinyMCE? Start here.
 type: folder
 ---
+{% assign navigaton = site.data.nav %}
+{% for entry in navigaton %}
+  {% if entry.url == "general-configuration-guide" %}
+    {% assign links = entry.pages %}
+  {% endif %}
+{% endfor %}
 
-{% assign links = site.data | where_exp:"nav", "nav.url == 'general-configuration-guide'" | first | map: "pages" %}
 {% include index.html links=links %}

--- a/integrations/index.md
+++ b/integrations/index.md
@@ -5,6 +5,11 @@ title_nav: Integrations
 description: Faster development with integrations of TinyMCE into your favorite framework or CMS.
 type: folder
 ---
+{% assign navigaton = site.data.nav %}
+{% for entry in navigaton %}
+  {% if entry.url == "integrations" %}
+    {% assign links = entry.pages %}
+  {% endif %}
+{% endfor %}
 
-{% assign links = site.data | where_exp:"nav", "nav.url == 'integrations'" | first | map: "pages" %}
 {% include index.html links=links %}

--- a/plugins/index.md
+++ b/plugins/index.md
@@ -6,6 +6,11 @@ description_short: This section will help you configure and extend your editor i
 description: TinyMCE is an incredibly powerful, flexible and customizable rich text editor. This section will help you configure and extend your editor instance.
 type: folder
 ---
+{% assign navigaton = site.data.nav %}
+{% for entry in navigaton %}
+  {% if entry.url == "plugins" %}
+    {% assign links = entry.pages %}
+  {% endif %}
+{% endfor %}
 
-{% assign links = site.data | where_exp:"nav", "nav.url == 'plugins'" | first | map: "pages" %}
 {% include index.html links=links %}

--- a/release-notes/index.md
+++ b/release-notes/index.md
@@ -5,6 +5,11 @@ title_nav: Release notes for TinyMCE 5
 keywords: releasenotes newfeatures deleted technologypreview bugfixes knownissues
 type: folder
 ---
+{% assign navigaton = site.data.nav %}
+{% for entry in navigaton %}
+  {% if entry.url == "release-notes" %}
+    {% assign links = entry.pages %}
+  {% endif %}
+{% endfor %}
 
-{% assign links = site.data | where_exp:"nav", "nav.url == 'release-notes'" | first | map: "pages" %}
 {% include index.html links=links %}

--- a/tinydrive/getting-started/index.md
+++ b/tinydrive/getting-started/index.md
@@ -6,7 +6,15 @@ description: Guide on how to get started with Tiny Drive
 type: folder
 keywords: tinydrive jwt json web token authentication security starter
 ---
+{% assign navigaton = site.data.nav %}
+{% for entry in navigaton %}
+  {% if entry.url == "tinydrive" %}
+    {% for subentry in entry.pages %}
+      {% if subentry.url == "getting-started" %}
+        {% assign links = subentry.pages %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endfor %}
 
-
-{% assign links = site.data | where_exp:"nav", "nav.url == 'getting-started'" | first | map: "pages" %}
 {% include index.html links=links %}

--- a/tinydrive/index.md
+++ b/tinydrive/index.md
@@ -5,6 +5,11 @@ title_nav: Tiny Drive
 description: Tiny Drive
 type: folder
 ---
+{% assign navigaton = site.data.nav %}
+{% for entry in navigaton %}
+  {% if entry.url == "tinydrive" %}
+    {% assign links = entry.pages %}
+  {% endif %}
+{% endfor %}
 
-{% assign links = site.data | where_exp:"nav", "nav.url == 'tinydrive'" | first | map: "pages" %}
 {% include index.html links=links %}

--- a/tinydrive/integrations/index.md
+++ b/tinydrive/integrations/index.md
@@ -6,8 +6,17 @@ description: Third-party integrations to make your Tiny Drive experience smooth 
 type: folder
 keywords: tinydrive storage googledrive dropbox
 ---
+{% assign navigaton = site.data.nav %}
+{% for entry in navigaton %}
+  {% if entry.url == "tinydrive" %}
+    {% for subentry in entry.pages %}
+      {% if subentry.url == "integrations" %}
+        {% assign links = subentry.pages %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endfor %}
 
-{% assign links = site.data | where_exp:"nav", "nav.url == 'integrations'" | first | map: "pages" %}
 {% include index.html links=links %}
 
 

--- a/tinydrive/introduction/index.md
+++ b/tinydrive/introduction/index.md
@@ -6,7 +6,15 @@ description: Overview of Tiny Drive is and its concepts
 type: folder
 keywords: tinydrive overview jwt concepts
 ---
+{% assign navigaton = site.data.nav %}
+{% for entry in navigaton %}
+  {% if entry.url == "tinydrive" %}
+    {% for subentry in entry.pages %}
+      {% if subentry.url == "introduction" %}
+        {% assign links = subentry.pages %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endfor %}
 
-
-{% assign links = site.data | where_exp:"nav", "nav.url == 'introduction'" | first | map: "pages" %}
 {% include index.html links=links %}

--- a/ui-components/index.md
+++ b/ui-components/index.md
@@ -6,7 +6,12 @@ description: The configurable UI components available for customization.
 keywords: toolbar toolbarbuttons buttons toolbarbuttonsapi
 type: folder
 ---
+{% assign navigaton = site.data.nav %}
+{% for entry in navigaton %}
+  {% if entry.url == "ui-components" %}
+    {% assign links = entry.pages %}
+  {% endif %}
+{% endfor %}
 
-{% assign links = site.data | where_exp:"nav", "nav.url == 'ui-components'" | first | map: "pages" %}
 {% include index.html links=links %}
 


### PR DESCRIPTION
**JIRA Ticket Link:** [DOC-307](https://ephocks.atlassian.net/browse/DOC-307)

* Modified TD-209 changes to index.md paths for folders as was not displaying list of entries.
  * **NOTE:** The changes for TD-209 should have worked according to Jekyll/Liquid documentation but weren't.

**Index Page checks:**

* /general-configuration-guide OK
* /cloud-deployment-guide OK
* /demo OK
* /configure OK
* /plugin OK
* /ui-components OK
* /enterprise OK
* /tinydrive OK
* /advanced OK
* /integrations OK
* /release-notes OK

* Changed index cards to use nav_title if present instead of title, or title otherwise.
  * **REF:** S. Nansi requested.