### PR TITLE
TINY-3578: Add examples of new wordcount api

### DIFF
--- a/plugins/wordcount.md
+++ b/plugins/wordcount.md
@@ -6,7 +6,7 @@ description: Show a word count in the TinyMCE status bar.
 keywords: wordcount
 ---
 
-The Word Count plugin adds the functionality for counting words to TinyMCE editor by placing a counter on the right edge of the status bar. Clicking **Word Count** in the status bar switches between counting words and characters. A dialog box with both word and character counts can be opened using the menu item situated in the **Tools** drop-down, or the toolbar button.
+The Word Count plugin adds the functionality for counting words to the TinyMCE editor by placing a counter on the right edge of the status bar. Clicking **Word Count** in the status bar switches between counting words and characters. A dialog box with both word and character counts can be opened using the menu item situated in the **Tools** drop-down, or the toolbar button.
 
 **Type:** `String`
 

--- a/plugins/wordcount.md
+++ b/plugins/wordcount.md
@@ -6,7 +6,7 @@ description: Show a word count in the TinyMCE status bar.
 keywords: wordcount
 ---
 
-This plugin adds word count functionality to TinyMCE by placing a counter on the right edge of the status bar. Clicking the wordcount in the statusbar switches between counting words and characters. Using the menuitem, situated in the Tools dropdown, or the toolbar button you can open a dialog box with both word and character counts. 
+The Word Count plugin adds the functionality for counting words to TinyMCE editor by placing a counter on the right edge of the status bar. Clicking **Word Count** in the status bar switches between counting words and characters. A dialog box with both word and character counts can be opened using the menu item situated in the **Tools** drop-down, or the toolbar button.
 
 **Type:** `String`
 
@@ -22,7 +22,7 @@ tinymce.init({
 
 ## API
 
-The plugin exposes an API for retrieving the word- and character count of either the whole document or the current editor selection. Following is an example of how to retrieve each property.
+The Word Count plugin exposes an API for retrieving the word and character count of either the whole document or the current editor selection. Following is an example of how to retrieve each property.
 
 ##### Example
 

--- a/plugins/wordcount.md
+++ b/plugins/wordcount.md
@@ -19,3 +19,21 @@ tinymce.init({
   toolbar: "wordcount"
 });
 ```
+
+## API
+
+The plugin exposes an API for retrieving the word- and character count of either the whole document or the current editor selection. Following is an example of how to retrieve each property.
+
+##### Example
+
+```js
+var wordcount = tinymce.activeEditor.plugins.wordcount;
+
+console.log(wordcount.body.getWordCount());
+console.log(wordcount.body.getCharacterCount());
+console.log(wordcount.body.getCharacterCountWithoutSpaces());
+
+console.log(wordcount.selection.getWordCount());
+console.log(wordcount.selection.getCharacterCount());
+console.log(wordcount.selection.getCharacterCountWithoutSpaces());
+```


### PR DESCRIPTION
Just some API documentation of the word count plugin for Tiny 5.0.6

/ Simon