### PR TITLE
TINY-3585: Add documentation for icons_url option

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -82,6 +82,7 @@
     - url: "#fontsize_formats"
     - url: "#height"
     - url: "#icons"
+    - url: "#icons_url"
     - url: "#inline"
     - url: "#max_height"
     - url: "#max_width"

--- a/_includes/configuration/icons_url.md
+++ b/_includes/configuration/icons_url.md
@@ -1,0 +1,15 @@
+## icons_url
+
+If you are using icon packs, this option enables you to specify the location of your icon pack. This is useful if you are loading TinyMCE from one URL, for example a CDN, while loading an icon pack on a local server.
+
+**Type:**  `String`
+
+##### Example
+
+```js
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  icons_url: '/icons/material/icons.js', // load icon pack
+  icons: 'material'      // use icon pack
+});
+```

--- a/configure/editor-appearance.md
+++ b/configure/editor-appearance.md
@@ -30,6 +30,8 @@ description: Configure the editor's appearance, including menu and toolbar contr
 
 {% include configuration/icons.md %}
 
+{% include configuration/icons_url.md %}
+
 {% include configuration/inline.md %}
 
 {% include configuration/max-height.md %}


### PR DESCRIPTION
Added documentation for a new `icons_url` option to Tiny 5.0.6