### PR TITLE
Update inline syntax for webpack loaders

### DIFF
--- a/advanced/usage-with-module-loaders.md
+++ b/advanced/usage-with-module-loaders.md
@@ -78,7 +78,7 @@ Another option when using Webpack is to use the [file loader](https://github.com
 
 ```javascript
 require.context(
-  'file?name=[path][name].[ext]&context=node_modules/tinymce!tinymce/skins',
+  'file-loader?name=[path][name].[ext]&context=node_modules/tinymce!tinymce/skins',
   true,
   /.*/
 );


### PR DESCRIPTION
According to the updated documentation for [inline](https://webpack.js.org/concepts/loaders/#inline) syntax of loaders, you now need to append `-loader` to the end of the desired webpack loader.