### PR TITLE
Fixed the bootstrap intergration docs using an incorrect selector

### DIFF
--- a/integrations/bootstrap.md
+++ b/integrations/bootstrap.md
@@ -15,7 +15,7 @@ Bootstrap blocks all focus events on contents within the dialog. Add this script
 ```js
 // Prevent Bootstrap dialog from blocking focusin
 $(document).on('focusin', function(e) {
-  if ($(e.target).closest(".mce-window").length) {
+  if ($(e.target).closest(".tox-tinymce-aux, .moxman-window, .tam-assetmanager-root").length) {
     e.stopImmediatePropagation();
   }
 });


### PR DESCRIPTION
Just happened to notice this, this morning when looking around. We fixed the jquery selector a while back, but missed updating the selectors for the bootstrap docs.