### PR TITLE
Use cdn.tiny.cloud domain for codepens, instead of the old cloud.tinymce.com domain

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ baseurl: ""
 shared_baseurl: ""
 syntax_highlight_theme: "tomorrow-night"
 cdnurl: "https://cdn.tiny.cloud/1/no-api-key/tinymce/5/tinymce.min.js"
-codepen_url: "https://cloud.tinymce.com/5/tinymce.min.js?apiKey=qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc"
+codepen_url: "https://cdn.tiny.cloud/1/qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc/tinymce/5/tinymce.min.js"
 default_meta_keywords: tinymce, documentation, docs, plugins, customizable skins, configuration, examples, html, php, java, javascript, image editor, inline editor, distraction-free editor, classic editor
 
 exclude:

--- a/_includes/tinymce-script-tag.html
+++ b/_includes/tinymce-script-tag.html
@@ -1,1 +1,1 @@
-<script src='{{ site.codepen_url }}'></script>
+<script src='{{ site.codepen_url }}' referrerpolicy="origin"></script>


### PR DESCRIPTION
The premium skins/icons demos need dispenser to be able to load, so this updates the codepens to use the new cdn.tiny.cloud domain instead.