### PR TITLE
Added missing referrerpolicy tags to scripts in documents

### DIFF
--- a/_includes/install/cloud.md
+++ b/_includes/install/cloud.md
@@ -3,7 +3,7 @@
 Include this line of code in the `<head>` of your HTML page:
 
 ```html
-<script src="{{ site.cdnurl }}"></script>
+<script src="{{ site.cdnurl }}" referrerpolicy="origin"></script>
 ```
 
 ### Step 2: Initialize TinyMCE as part of a web form
@@ -18,7 +18,7 @@ In this example, let's replace `<textarea id='mytextarea'>` with a TinyMCE edito
 <!DOCTYPE html>
 <html>
 <head>
-  <script src="{{ site.cdnurl }}"></script>
+  <script src="{{ site.cdnurl }}" referrerpolicy="origin"></script>
   <script type="text/javascript">
   tinymce.init({
     selector: '#mytextarea'

--- a/general-configuration-guide/basic-setup.md
+++ b/general-configuration-guide/basic-setup.md
@@ -222,7 +222,7 @@ The following example is a walkthrough of a basic TinyMCE configuration.
 <!DOCTYPE html>
 <html>
 <head>
-  <script type="text/javascript" src='{{ site.cdnurl }}'></script>
+  <script type="text/javascript" src='{{ site.cdnurl }}' referrerpolicy="origin"></script>
   <script type="text/javascript">
   tinymce.init({
     selector: '#myTextarea',

--- a/general-configuration-guide/multiple-editors.md
+++ b/general-configuration-guide/multiple-editors.md
@@ -15,7 +15,7 @@ The following example breaks the page into two separate editable areas. Each are
 <!DOCTYPE html>
 <html>
 <head>
-  <script src="{{ site.cdnurl }}"></script>
+  <script src="{{ site.cdnurl }}" referrerpolicy="origin"></script>
   <script type="text/javascript">
   tinymce.init({
     selector: '.myeditablediv',
@@ -48,7 +48,7 @@ The following example loads each editable area with a unique configuration of Ti
 <!DOCTYPE html>
 <html>
 <head>
-  <script src="{{ site.cdnurl }}"></script>
+  <script src="{{ site.cdnurl }}" referrerpolicy="origin"></script>
   <script type="text/javascript">
   tinymce.init({
     selector: '#myeditable-h1',

--- a/general-configuration-guide/use-tinymce-inline.md
+++ b/general-configuration-guide/use-tinymce-inline.md
@@ -56,7 +56,7 @@ Enabling inline editing mode is simple. Setting the `inline` configuration prope
 <!DOCTYPE html>
 <html>
 <head>
-  <script src="{{ site.cdnurl }}"></script>
+  <script src="{{ site.cdnurl }}" referrerpolicy="origin"></script>
   <script type="text/javascript">
   tinymce.init({
     selector: '#myeditablediv',

--- a/general-configuration-guide/work-with-plugins.md
+++ b/general-configuration-guide/work-with-plugins.md
@@ -21,7 +21,7 @@ Let's start with a simple code snippet you can paste into an empty `html` file (
 <!DOCTYPE html>
 <html>
 <head>
-  <script src="{{ site.cdnurl }}"></script>
+  <script src="{{ site.cdnurl }}" referrerpolicy="origin"></script>
   <script type="text/javascript">
   tinymce.init({
     selector: 'textarea'

--- a/integrations/react.md
+++ b/integrations/react.md
@@ -65,9 +65,6 @@ For more info on the different channels see the [documentation](https://www.tiny
 
 To opt out of using TinyMCE cloud, you have to make TinyMCE globally available yourself. This can be done either by hosting the `tinymce.min.js` file by yourself and adding a script tag to your HTML or, if you are using a module loader, installing TinyMCE with npm. For info on how to get TinyMCE working with module loaders check out [this page in the documentation](https://www.tinymce.com/docs/advanced/usage-with-module-loaders/).
 
-```html
-<script src="{{site.cdnurl}}"></script>
-```
 
 ## 4. Replace the App.js file
 


### PR DESCRIPTION
* Removed code snippet from "Loading TinyMCE by yourself" as it wasn't useful in the context of the content.
* Fixed missing referrer tags in script loads.