### PR TITLE
TINY-3744: Fixed broken links in docs

### DIFF
--- a/_includes/codepens/annotations/index.html
+++ b/_includes/codepens/annotations/index.html
@@ -7,7 +7,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a href="//www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tinymce.com/forum/">Community Forum</a>.</li>
+    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/">Community Forum</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium subscriptions</a>.</li>
   </ul>
 

--- a/_includes/codepens/basic-example/index.html
+++ b/_includes/codepens/basic-example/index.html
@@ -9,7 +9,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tinymce.com/forum/" target="_blank">Community Forum</a>.</li>
+    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/" target="_blank">Community Forum</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE Enterprise</a>.</li>
   </ul>
 

--- a/_includes/codepens/casechange/index.html
+++ b/_includes/codepens/casechange/index.html
@@ -13,7 +13,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tinymce.com/forum/" target="_blank">Community Forum</a>.</li>
+    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/" target="_blank">Community Forum</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE Enterprise</a>.</li>
   </ul>
 

--- a/_includes/codepens/checklist/index.html
+++ b/_includes/codepens/checklist/index.html
@@ -14,7 +14,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tinymce.com/forum/" target="_blank">Community Forum</a>.</li>
+    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/" target="_blank">Community Forum</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE Enterprise</a>.</li>
   </ul>
 

--- a/_includes/codepens/context-menu/index.html
+++ b/_includes/codepens/context-menu/index.html
@@ -14,7 +14,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tinymce.com/forum/" target="_blank">Community Forum</a>.</li>
+    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/" target="_blank">Community Forum</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE Enterprise</a>.</li>
   </ul>
 

--- a/_includes/codepens/custom-menu-item/index.html
+++ b/_includes/codepens/custom-menu-item/index.html
@@ -8,7 +8,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tinymce.com/forum/">Community Forum</a>.</li>
+    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/">Community Forum</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE Enterprise</a>.</li>
   </ul>
 

--- a/_includes/codepens/custom-toolbar-button/index.html
+++ b/_includes/codepens/custom-toolbar-button/index.html
@@ -7,7 +7,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tinymce.com/forum/">Community Forum</a>.</li>
+    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/">Community Forum</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE Enterprise</a>.</li>
   </ul>
 

--- a/_includes/codepens/custom-toolbar-listbox/index.html
+++ b/_includes/codepens/custom-toolbar-listbox/index.html
@@ -7,7 +7,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tinymce.com/forum/">Community Forum</a>.</li>
+    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/">Community Forum</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="//www.tiny.cloud/pricing">TinyMCE Enterprise</a>.</li>
   </ul>
 

--- a/_includes/codepens/custom-toolbar-split-button/index.html
+++ b/_includes/codepens/custom-toolbar-split-button/index.html
@@ -6,7 +6,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tinymce.com/forum/">Community Forum</a>.</li>
+    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/">Community Forum</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE Enterprise</a>.</li>
   </ul>
 

--- a/_includes/codepens/custom-toolbar-toggle-button/index.html
+++ b/_includes/codepens/custom-toolbar-toggle-button/index.html
@@ -6,7 +6,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tinymce.com/forum/">Community Forum</a>.</li>
+    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/">Community Forum</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE Enterprise</a>.</li>
   </ul>
 

--- a/_includes/codepens/drive-demo-dropbox/index.html
+++ b/_includes/codepens/drive-demo-dropbox/index.html
@@ -6,7 +6,7 @@
   </p>
 
   <p>
-    One of these enhancements is <strong>Tiny Drive</strong>: imagine file management for TinyMCE, in the cloud, made super easy. Learn more at <a href="https://www.tiny.cloud/docs/plugins/drive/#liveexample">our working demo</a>, where you'll find an opportunity to provide feedback to the product team.
+    One of these enhancements is <strong>Tiny Drive</strong>: imagine file management for TinyMCE, in the cloud, made super easy. Learn more at <a href="https://www.tiny.cloud/docs/plugins/tinydrive/#liveexample">our working demo</a>, where you'll find an opportunity to provide feedback to the product team.
   </p>
 
   <h3>An editor for every project</h3>

--- a/_includes/codepens/drive-demo-googledrive/index.html
+++ b/_includes/codepens/drive-demo-googledrive/index.html
@@ -6,7 +6,7 @@
   </p>
 
   <p>
-    One of these enhancements is <strong>Tiny Drive</strong>: imagine file management for TinyMCE, in the cloud, made super easy. Learn more at <a href="https://www.tiny.cloud/docs/plugins/drive/#liveexample">our working demo</a>, where you'll find an opportunity to provide feedback to the product team.
+    One of these enhancements is <strong>Tiny Drive</strong>: imagine file management for TinyMCE, in the cloud, made super easy. Learn more at <a href="https://www.tiny.cloud/docs/plugins/tinydrive/#liveexample">our working demo</a>, where you'll find an opportunity to provide feedback to the product team.
   </p>
 
   <h3>An editor for every project</h3>

--- a/_includes/codepens/drive-demo/index.html
+++ b/_includes/codepens/drive-demo/index.html
@@ -6,7 +6,7 @@
   </p>
 
   <p>
-    One of these enhancements is <strong>Tiny Drive</strong>: imagine file management for TinyMCE, in the cloud, made super easy. Learn more at <a href="https://www.tiny.cloud/docs/plugins/drive/#liveexample">our working demo</a>, where you'll find an opportunity to provide feedback to the product team.
+    One of these enhancements is <strong>Tiny Drive</strong>: imagine file management for TinyMCE, in the cloud, made super easy. Learn more at <a href="https://www.tiny.cloud/docs/plugins/tinydrive/#liveexample">our working demo</a>, where you'll find an opportunity to provide feedback to the product team.
   </p>
 
   <h3>An editor for every project</h3>

--- a/_includes/codepens/drive/index.html
+++ b/_includes/codepens/drive/index.html
@@ -14,7 +14,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tinymce.com/forum/" target="_blank">Community Forum</a>.</li>
+    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/" target="_blank">Community Forum</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE Enterprise</a>.</li>
   </ul>
 

--- a/_includes/codepens/format-custom/index.html
+++ b/_includes/codepens/format-custom/index.html
@@ -11,7 +11,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tinymce.com/forum/">Community Forum</a>.</li>
+    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/">Community Forum</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE Enterprise</a>.</li>
   </ul>
 

--- a/_includes/codepens/format-painter/index.html
+++ b/_includes/codepens/format-painter/index.html
@@ -9,7 +9,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tinymce.com/forum/" target="_blank">Community Forum</a>.</li>
+    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/" target="_blank">Community Forum</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE Enterprise</a>.</li>
   </ul>
 

--- a/_includes/codepens/full-featured/index.html
+++ b/_includes/codepens/full-featured/index.html
@@ -7,7 +7,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a href="//www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tinymce.com/forum/">Community Forum</a>.</li>
+    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/">Community Forum</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium subscriptions</a>.</li>
   </ul>
 

--- a/_includes/codepens/image-tools/index.html
+++ b/_includes/codepens/image-tools/index.html
@@ -9,7 +9,7 @@
   
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tinymce.com/forum/">Community Forum</a>.</li>
+    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/">Community Forum</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE Enterprise</a>.</li>
   </ul>
   <h2>A simple table to play with</h2>

--- a/_includes/codepens/page-embed/index.html
+++ b/_includes/codepens/page-embed/index.html
@@ -9,7 +9,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tinymce.com/forum/" target="_blank">Community Forum</a>.</li>
+    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/" target="_blank">Community Forum</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE Enterprise</a>.</li>
   </ul>
 

--- a/_includes/codepens/permanent-pen/index.html
+++ b/_includes/codepens/permanent-pen/index.html
@@ -9,7 +9,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tinymce.com/forum/" target="_blank">Community Forum</a>.</li>
+    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/" target="_blank">Community Forum</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE Enterprise</a>.</li>
   </ul>
 

--- a/_includes/codepens/valid-elements/index.html
+++ b/_includes/codepens/valid-elements/index.html
@@ -11,7 +11,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a href="//www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tinymce.com/forum/">Community Forum</a>.</li>
+    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/">Community Forum</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE Enterprise</a>.</li>
   </ul>
 

--- a/_includes/configuration/mobile.md
+++ b/_includes/configuration/mobile.md
@@ -1,6 +1,6 @@
 ## mobile
 
-This option allows you specify an alternative config that will extend the existing desktop config when the editor is loaded on a mobile device. This gives you the flexibility to override settings specifically for [mobile]({{ site.baseurl }}/docs/mobile) and really customize the mobile experience.
+This option allows you specify an alternative config that will extend the existing desktop config when the editor is loaded on a mobile device. This gives you the flexibility to override settings specifically for [mobile]({{ site.baseurl }}/mobile) and really customize the mobile experience.
 
 **Type:** `Object`
 

--- a/_includes/context/priority.md
+++ b/_includes/context/priority.md
@@ -1,5 +1,5 @@
 
-There are two settings that determine determine the priority: `predicate` and `scope`. The priority system mirrors the old [inlite](https://www.tiny.cloud/docs/themes/inlite/#quicklink) theme from TinyMCE 4. The `predicate` is a function that takes in the current context position and returns a boolean. The `scope` is either `node` or `editor`. The whole priority process works as follows:
+There are two settings that determine determine the priority: `predicate` and `scope`. The priority system mirrors the old [inlite](https://www.tiny.cloud/docs-4x/themes/inlite/#quicklink) theme from TinyMCE 4. The `predicate` is a function that takes in the current context position and returns a boolean. The `scope` is either `node` or `editor`. The whole priority process works as follows:
 
 1. The current cursor position is stored to use as the first current context position.
 2. For this current context position, each predicate with `scope: node` in the registered ContextForm is called. Currently, the order they are checked-in cannot be specified. The first predicate that passes will `win` and that ContextForm will be shown.

--- a/_includes/release-notes/deleted.md
+++ b/_includes/release-notes/deleted.md
@@ -5,8 +5,8 @@ In TinyMCE 5.0, some configurations have been removed because they are no longer
 
 | **Setting** | **Description** |
 | ----------- | --------------- |
-| [`fixed_toolbar_container`](https://www.tiny.cloud/docs/configure/editor-appearance/#fixed_toolbar_container) | Owing to the enhancements to the new inline toolbar behaviour, `fixed_toolbar_container` is not required in TinyMCE 5.0. |
-| [`insert_button_items`](https://www.tiny.cloud/docs/configure/editor-appearance/#insert_button_items) | Owing to the changes in the menus and removal of the `context` property, `insert_button_items` is not required in TinyMCE 5.0. Refer to the [Migration guide]({{site.baseurl}}/migration-from-4x/#removedsettings) for a workaround. |
+| [`fixed_toolbar_container`](https://www.tiny.cloud/docs-4x/configure/editor-appearance/#fixed_toolbar_container) | Owing to the enhancements to the new inline toolbar behaviour, `fixed_toolbar_container` is not required in TinyMCE 5.0. |
+| [`insert_button_items`](https://www.tiny.cloud/docs-4x/configure/editor-appearance/#insert_button_items) | Owing to the changes in the menus and removal of the `context` property, `insert_button_items` is not required in TinyMCE 5.0. Refer to the [Migration guide]({{site.baseurl}}/migration-from-4x/#removedsettings) for a workaround. |
 
 ### Removed themes
 
@@ -21,16 +21,16 @@ In TinyMCE 5.0, some configurations have been removed because they are no longer
 
 ### Removed toolbar button types
 
-[Listbox](https://www.tiny.cloud/docs/demo/custom-toolbar-listbox/) is no longer a supported toolbar button type in TinyMCE 5.0. Though listbox has been removed, any functionality provided by custom listbox toolbar buttons can be retained by switching to a different kind of toolbar button using the new methods. The recommended toolbar button type to switch to is the **Split** button.
+[Listbox](https://www.tiny.cloud/docs-4x/demo/custom-toolbar-listbox/) is no longer a supported toolbar button type in TinyMCE 5.0. Though listbox has been removed, any functionality provided by custom listbox toolbar buttons can be retained by switching to a different kind of toolbar button using the new methods. The recommended toolbar button type to switch to is the **Split** button.
 
 ### Removed features
 
 The following plugins from TinyMCE 4.x do not require height or width options to be specified in TinyMCE 5.0:
 
 * [Code]({{site.baseurl}}/plugins/code/)
-* [Codesample]({{site.baseurl}}plugins/codesample/)
-* [Preview]({{site.baseurl}}plugins/preview/)
-* [Template]({{site.baseurl}}plugins/template/)
+* [Codesample]({{site.baseurl}}/plugins/codesample/)
+* [Preview]({{site.baseurl}}/plugins/preview/)
+* [Template]({{site.baseurl}}/plugins/template/)
 
 Refer to the [Migration Guide]({{site.baseurl}}/migration-from-4x/), for more information.
 

--- a/_includes/release-notes/new-features.md
+++ b/_includes/release-notes/new-features.md
@@ -5,7 +5,7 @@ The following new features were added to the TinyMCE 5.0 RC version.
 
 The [Comments 2.0]({{site.baseurl}}/enterprise/tiny-comments/) is a premium plugin built on the [Annotations API]({{site.baseurl}}/advanced/annotations/) to create comment threads (conversations). Comments 2.0 provides the ability to start or join a conversation by adding comments to the content within the TinyMCE editor. 
 
-Refer to the [Comments 2.0]({{site.baseurl}}/plugin/comments/) documentation, for more information.
+Refer to the [Comments 2.0]({{site.baseurl}}/plugins/comments/) documentation, for more information.
 
 ### Context menu
 

--- a/advanced/configuring-comments-callbacks.md
+++ b/advanced/configuring-comments-callbacks.md
@@ -8,7 +8,7 @@ keywords: comments commenting tinycomments callback
 
 ## Introduction
 
-**Callback mode** is the default mode for [Comments 2.0]({{site.baseurl}}/plugins/comments/comments_2.0/). In the callback mode, the user needs to configure storage to be able to save comments on the server. The Comments functions (create, reply, edit, delete comment, delete all conversations, and lookup) are configured differently depending upon the server-side storage configuration.
+**Callback mode** is the default mode for [Comments 2.0]({{site.baseurl}}/plugins/comments/). In the callback mode, the user needs to configure storage to be able to save comments on the server. The Comments functions (create, reply, edit, delete comment, delete all conversations, and lookup) are configured differently depending upon the server-side storage configuration.
 
 ### Required settings
 

--- a/cloud-deployment-guide/editor-and-features.md
+++ b/cloud-deployment-guide/editor-and-features.md
@@ -43,8 +43,8 @@ There are more than 40 open source plugins that enhance the editing experience i
 Extend the [TinyMCE configuration]({{ site.baseurl }}/configure/) to include any additional purchased plugins and associated toolbar and menu items. Refer to the following enablement guides for more information:
 
 * [Mentions]({{ site.baseurl }}/plugins/mentions/)
-* [Tiny Drive]({{ site.baseurl }}/plugins/drive/)
-* [Comments 2.0]({{ site.baseurl }}/plugins//comments/)
+* [Tiny Drive]({{ site.baseurl }}/plugins/tinydrive/)
+* [Comments 2.0]({{ site.baseurl }}/plugins/comments/)
 * [Page Embed]({{ site.baseurl }}/plugins/pageembed/)
 * [Permanent Pen]({{ site.baseurl }}/plugins/permanentpen/)
 * [Format Painter]({{ site.baseurl }}/plugins/formatpainter/)
@@ -104,8 +104,8 @@ Reference [external_plugins]({{ site.baseurl }}/configure/integration-and-setup/
 Extend the [TinyMCE configuration]({{ site.baseurl }}/configure/) to include any additional purchased plugins and associated toolbar and menu items. Refer to the following enablement guides for more information:
 
 * [Mentions]({{ site.baseurl }}/plugins/mentions/)
-* [Tiny Drive]({{ site.baseurl }}/plugins/drive/)
-* [Comments 2.0]({{ site.baseurl }}/plugins//comments/)
+* [Tiny Drive]({{ site.baseurl }}/plugins/tinydrive/)
+* [Comments 2.0]({{ site.baseurl }}/plugins/comments/)
 * [Page Embed]({{ site.baseurl }}/plugins/pageembed/)
 * [Permanent Pen]({{ site.baseurl }}/plugins/permanentpen/)
 * [Format Painter]({{ site.baseurl }}/plugins/formatpainter/)

--- a/cloud-deployment-guide/editor-plugin-version.md
+++ b/cloud-deployment-guide/editor-plugin-version.md
@@ -75,7 +75,7 @@ Use the URL query parameters to specify the version of each premium plugin. This
 
 #### Tiny Drive
 
-* [Developer documentation]({{ site.baseurl }}/plugins/drive/)
+* [Developer documentation]({{ site.baseurl }}/plugins/tinydrive/)
 * [Supported versions](https://plugins.tinymce.com/versions/tinydrive)
 
 ##### Example
@@ -86,7 +86,7 @@ Use the URL query parameters to specify the version of each premium plugin. This
 
 #### Comments 2.0
 
-* [Developer documentation]({{ site.baseurl }}/plugins//comments/)
+* [Developer documentation]({{ site.baseurl }}/plugins/comments/)
 * [Supported versions](https://plugins.tinymce.com/versions/tinycomments)
 
 ##### Example
@@ -214,7 +214,7 @@ The "SDK" version lets the TinyMCE Plugin Manager know that you're not using Tin
 
 #### Tiny Drive
 
-* [Developer documentation]({{ site.baseurl }}/plugins/drive/)
+* [Developer documentation]({{ site.baseurl }}/plugins/tinydrive/)
 
 ##### Example
 
@@ -224,7 +224,7 @@ The "SDK" version lets the TinyMCE Plugin Manager know that you're not using Tin
 
 #### Comments 2.0
 
-* [Developer documentation]({{ site.baseurl }}/plugins//comments/)
+* [Developer documentation]({{ site.baseurl }}/plugins/comments/)
 
 ##### Example
 

--- a/cloud-deployment-guide/features-only.md
+++ b/cloud-deployment-guide/features-only.md
@@ -23,8 +23,8 @@ Add the following script in the webpage once the script tag to load TinyMCE has 
 Extend the [TinyMCE configuration]({{ site.baseurl }}/configure/) to include any additional purchased plugins and associated toolbar and menu items. Refer to the following enablement guides for more information:
 
 * [Mentions]({{ site.baseurl }}/plugins/mentions/)
-* [Tiny Drive]({{ site.baseurl }}/plugins/drive/)
-* [Comments 2.0]({{ site.baseurl }}/plugins//comments/)
+* [Tiny Drive]({{ site.baseurl }}/plugins/tinydrive/)
+* [Comments 2.0]({{ site.baseurl }}/plugins/comments/)
 * [Page Embed]({{ site.baseurl }}/plugins/pageembed/)
 * [Permanent Pen]({{ site.baseurl }}/plugins/permanentpen/)
 * [Format Painter]({{ site.baseurl }}/plugins/formatpainter/)

--- a/cloud-deployment-guide/plugin-editor-version-compatibility.md
+++ b/cloud-deployment-guide/plugin-editor-version-compatibility.md
@@ -33,7 +33,7 @@ to:
 | [Mentions]({{site.baseurl}}/plugins/mentions) | Y | Y |
 | [PowerPaste]({{ site.baseurl }}/plugins/powerpaste/) | Y | Y |
 | [Spell Checker Pro]({{ site.baseurl }}/plugins/tinymcespellchecker/) | Y | Y |
-| [Tiny Drive]({{site.baseurl}}/plugins/drive) | Y | Y |
+| [Tiny Drive]({{site.baseurl}}/plugins/tinydrive) | Y | Y |
 | [Tiny Comments]({{site.baseurl}}/plugins/comments) | Y | Y |
 | [Page Embed]({{site.baseurl}}/plugins/pageembed) | N | Y |
 | [Permanent Pen]({{site.baseurl}}/plugins/permanentpen) | N | Y |

--- a/general-configuration-guide/system-requirements.md
+++ b/general-configuration-guide/system-requirements.md
@@ -7,17 +7,17 @@ keywords: browser compatibility explorer ie safari firefox chrome edge
 ---
 ## Mobile supported platforms
 
-[TinyMCE mobile](https://www.tiny.cloud/docs/mobile/) is available in TinyMCE 5.0
+[TinyMCE mobile]({{site.baseurl}}/mobile/) is available in TinyMCE 5.0
 
 TinyMCE mobile has a streamlined interface with most common touch interactions easily accomplished with one hand. TinyMCE mobile is designed to run on iOS Safari and Android Chrome. TinyMCE mobile is tested on the following platforms:
 
 {% include mobile_platform_compatibility.md %}
 
-Visit the [mobile page](https://www.tiny.cloud/docs/mobile/) to download the self-hosted package. TinyMCE mobile is available on `/dev` branch on Tiny Cloud.
+Visit the [mobile page]({{site.baseurl}}/mobile/) to download the self-hosted package. TinyMCE mobile is available on `/dev` branch on Tiny Cloud.
 
 Please report platform issues and bugs in the [TinyMCE issue tracker](https://github.com/tinymce/tinymce/issues).
 
-Visit [TinyMCE mobile documentation]({{ site.baseurl }}/mobile) for further information on TinyMCE mobile setup and configuration.
+Visit [TinyMCE mobile documentation]({{site.baseurl}}/mobile) for further information on TinyMCE mobile setup and configuration.
 
 ## Browser compatibility
 

--- a/integrations/angular2.md
+++ b/integrations/angular2.md
@@ -161,13 +161,13 @@ Here is a full list of the events available:
 
 ## Loading TinyMCE
 ### Auto-loading from TinyMCE Cloud
-The `Editor` component needs TinyMCE to be globally available to work, but to make it as easy as possible it will automatically load [TinyMCE Cloud](https://www.tiny.cloud/docs/cloud-deployment-guide/) if it can't find TinyMCE available when the component has mounted. To get rid of the `This domain is not registered...` warning, sign up for the cloud and enter the api key like this:
+The `Editor` component needs TinyMCE to be globally available to work, but to make it as easy as possible it will automatically load [TinyMCE Cloud]({{site.baseurl}}/cloud-deployment-guide/) if it can't find TinyMCE available when the component has mounted. To get rid of the `This domain is not registered...` warning, sign up for the cloud and enter the api key like this:
 
 ```html
 <editor apiKey="test" [init]="{/* your settings */}"></editor>
 ```
 
-You can also define what cloud channel you want to use, for more info on the different versions see the [documentation](https://www.tiny.cloud/docs/cloud-deployment-guide/editor-plugin-version/#devtestingandstablereleases).
+You can also define what cloud channel you want to use, for more info on the different versions see the [documentation]({{site.baseurl}}/cloud-deployment-guide/editor-plugin-version/#devtestingandstablereleases).
 
 ### Loading TinyMCE by yourself
 

--- a/integrations/vue.md
+++ b/integrations/vue.md
@@ -161,13 +161,13 @@ Here is a full list of the events available:
 
 ## Loading TinyMCE
 ### Auto-loading from TinyMCE Cloud
-The `Editor` component needs TinyMCE to be globally available to work, but to make it as easy as possible it will automatically load [TinyMCE Cloud](https://www.tiny.cloud/docs/cloud-deployment-guide/) if it can't find TinyMCE available when the component has mounted. To get rid of the `This domain is not registered...` warning, sign up for the cloud and enter the api key like this:
+The `Editor` component needs TinyMCE to be globally available to work, but to make it as easy as possible it will automatically load [TinyMCE Cloud]({{site.baseurl}}/cloud-deployment-guide/) if it can't find TinyMCE available when the component has mounted. To get rid of the `This domain is not registered...` warning, sign up for the cloud and enter the api key like this:
 
 ```html
 <editor api-key='YOUR_API_KEY' :init="{/* your settings */}>"</editor>
 ```
 
-You can also define what cloud channel you want to use, for more info on the different versions see the [documentation](https://www.tiny.cloud/docs/cloud-deployment-guide/editor-plugin-version/#devtestingandstablereleases).
+You can also define what cloud channel you want to use, for more info on the different versions see the [documentation]({{site.baseurl}}/cloud-deployment-guide/editor-plugin-version/#devtestingandstablereleases).
 
 ### Loading TinyMCE by yourself
 

--- a/migration-from-4x.md
+++ b/migration-from-4x.md
@@ -21,7 +21,7 @@ To serve TinyMCE 5 from the cloud, include this in your html page. Substitute 'n
 <script src="{{ site.cdnurl }}" referrerpolicy="origin"></script>
 ```
 
-To serve the latest nightlies and testing builds refer to the [cloud deployment guide](/cloud-deployment-guide/editor-and-features/)
+To serve the latest nightlies and testing builds refer to the [cloud deployment guide]({{site.baseurl}}/cloud-deployment-guide/editor-and-features/)
 
 ```js
 <script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/5-dev/tinymce.min.js" referrerpolicy="origin"></script>
@@ -147,7 +147,7 @@ This will provide a similar but improved [distraction-free]({{site.baseurl}}/gen
 
 #### Modern
 
-The Modern theme is no longer supported in TinyMCE 5.0.  The modern theme's UI library [`tinymce.ui.*`](https://www.tiny.cloud/docs/api/tinymce.ui/) has also been deleted. This change may impact integrations depending upon the [level of customization]({{site.baseurl}}/migration-from-4x/#initialization).
+The Modern theme is no longer supported in TinyMCE 5.0.  The modern theme's UI library [`tinymce.ui.*`](https://www.tiny.cloud/docs-4x/api/tinymce.ui/) has also been deleted. This change may impact integrations depending upon the [level of customization]({{site.baseurl}}/migration-from-4x/#initialization).
 
 > Note: For support related issues such as problems while migrating and a workaround, please contact [support](https://support.tiny.cloud/hc/en-us/requests/new). Alternatively, track developer preview issues on GitHub, [here](https://github.com/tinymce/tinymce/labels/5.x).
 
@@ -226,7 +226,7 @@ For more information on how these methods have changed, see [docs]({{site.baseur
 
 ### Removed toolbar button types
 
-[Listbox](https://www.tiny.cloud/docs/demo/custom-toolbar-listbox/) is no longer a supported toolbar button type in TinyMCE 5.0. Though listbox has been removed, any functionality provided by custom listbox toolbar buttons can be retained by switching to a different kind of toolbar button using the new methods. The recommended toolbar button type to switch to is the **Split** button.
+[Listbox](https://www.tiny.cloud/docs-4x/demo/custom-toolbar-listbox/) is no longer a supported toolbar button type in TinyMCE 5.0. Though listbox has been removed, any functionality provided by custom listbox toolbar buttons can be retained by switching to a different kind of toolbar button using the new methods. The recommended toolbar button type to switch to is the **Split** button.
 
 ### Toolbar configuration differences between TinyMCE 4.x and TinyMCE 5.0:
 
@@ -540,7 +540,7 @@ These features have either changed or have been deleted in TinyMCE 5.0.
 | --------------- |  -------------- |
 | [ContextMenu](https://www.tiny.cloud/docs/plugins/contextmenu/) | New API. See [docs]({{site.baseurl}}/ui-components/contextmenu/). |
 | [ColorPicker](https://www.tiny.cloud/docs/plugins/colorpicker/) | Moved to the core. See [docs]({{site.baseurl}}/configure/content-appearance/#color_picker}}). |
-| [Text Color](https://www.tiny.cloud/docs/plugins/textcolor/#textcolor_rows) | The `textcolor` plugin was removed and this setting is not required in TinyMCE 5.0. |
+| [Text Color](https://www.tiny.cloud/docs/plugins/textcolor/) | The `textcolor` plugin was removed and this setting is not required in TinyMCE 5.0. |
 
 ### Table
 
@@ -568,5 +568,5 @@ The table below shows UI configurations that have been removed. They are general
 | pack | Emulates flex pack | Use CSS stylesheets for custom styling |
 | no-wrap | Emulates CSS no line wrap | Use CSS stylesheet for custom styling |
 
-Please see the [TinyMCE 4.x docs](https://www.tiny.cloud/docs/) for more information on the above settings.
+Please see the [TinyMCE 4.x docs](https://www.tiny.cloud/docs-4x/) for more information on the above settings.
 

--- a/plugins/checklist.md
+++ b/plugins/checklist.md
@@ -17,7 +17,7 @@ The **Checklist** plugin helps the user keep track of all required actions by cr
 
 In the TinyMCE 5 editor, checklists are presented as lists with small checkboxes on the left hand side of the list items. After the item has been completed, a small tick or check mark is drawn in the box by clicking on it.
 
-**Checklist** is a premium plugin from Tiny. Please see the [Premium features](https://www.tiny.cloud/docs/enterprise/tiny-comments/) section for all the buying options.
+**Checklist** is a premium plugin from Tiny. Please see the [Premium features]({{site.baseurl}}/enterprise/tiny-comments/) section for all the buying options.
 
 There is also a demo provided to explore the **Checklist** capabilities [here]({{site.baseurl}}/demo/checklist/).
 
@@ -25,7 +25,7 @@ Once you have obtained the **Checklist** plugin, refer to the following instruct
 
 ### Configuring the Checklist toolbar button
 
-Use the following script to add the **Checklist** [toolbar button](https://www.tiny.cloud/docs/ui-components/toolbarbuttons/):
+Use the following script to add the **Checklist** [toolbar button]({{site.baseurl}}/ui-components/toolbarbuttons/):
 
 ```js
 tinymce.init({

--- a/plugins/permanentpen.md
+++ b/plugins/permanentpen.md
@@ -68,7 +68,7 @@ There are two ways to access the Permanent Pen properties:
 
 #### From the menubar
 
-Add the Permanent pen properties option to the menu bar with the [menu]({{site.baseurl}}/docs/configure/editor-appearance/#menu) configuration.
+Add the Permanent pen properties option to the menu bar with the [menu]({{site.baseurl}}/configure/editor-appearance/#menu) configuration.
 
 ```js
 tinymce.init({

--- a/plugins/quickbars.md
+++ b/plugins/quickbars.md
@@ -115,4 +115,4 @@ tinymce.init({
 ### Related configuration options
 
 * [quickbars_insert_toolbar]({{ site.baseurl }}/configure/editor-appearance/#quickbars_insert_toolbar)
-* [quickbars_selection_toolbar]({{ site.baseurl }}configure/editor-appearance/#quickbars_selection_toolbar)
+* [quickbars_selection_toolbar]({{ site.baseurl }}/configure/editor-appearance/#quickbars_selection_toolbar)

--- a/release-notes/release-notes502.md
+++ b/release-notes/release-notes502.md
@@ -24,7 +24,7 @@ The new TinyMCE 5.0.2 editor has the ability to add checklists to the content. T
 
 For more information on **Checklist** refer to the full [documentation]({{site.baseurl}}/plugins/checklist/).
 
-There is also a demo provided to explore the **Checklist** capabilities [here](https://www.tiny.cloud/docs/demo/checklist/).
+There is also a demo provided to explore the **Checklist** capabilities [here]({{site.baseurl}}/demo/checklist/).
 
 ## Updates and enhancements
 

--- a/release-notes/release-notes505.md
+++ b/release-notes/release-notes505.md
@@ -39,7 +39,7 @@ To try out **Tiny Drive** start with this [dedicated product page](https://www.t
 
 For more information on **Tiny Drive** refer to the full [documentation]({{site.baseurl}}/tinydrive/).
 
-There is also a demo provided to explore the **Tiny Drive** capabilities [here]({{site.baseurl}}/tinydrive/introduction/demo/).
+There is also a demo provided to explore the **Tiny Drive** capabilities [here]({{site.baseurl}}/tinydrive/introduction/#demo).
 
 ### Link Checker
 

--- a/release-notes/release-notes506.md
+++ b/release-notes/release-notes506.md
@@ -23,7 +23,7 @@ TinyMCE 5.0.6 adds a new configuration option `image_uploadtab` that can be used
 
 For more information on `image_uploadtab`, refer to the [documentation]({{site.baseurl}}/plugins/image/#image_uploadtab).
 
-### Wordcount plugin api
+### Word Count plugin api
 
 TinyMCE 5.0.6 adds a new API for the Word Count plugin. The API exposes the functionality used by the Word Count dialog and allows developers to retrieve details about how many words or characters are used inside the editor content.
 

--- a/tinydrive/integrations/dropbox-integration.md
+++ b/tinydrive/integrations/dropbox-integration.md
@@ -20,7 +20,7 @@ You can get Dropbox integration up and running by following the steps below.
 
 ### 1. Create the application
 
-1. Open the [https://www.dropbox.com/developers/apps/create](Create app) page.
+1. Open the [Create app](https://www.dropbox.com/developers/apps/create) page.
 2. Select the `Dropbox API` from `Choose an API`.
 3. Select `Full Dropbox` from the `Choose the type of access you need`.
 4. Name your app with something company unique `acmeinc-tinydrive` for example.

--- a/ui-components/contextform.md
+++ b/ui-components/contextform.md
@@ -7,7 +7,7 @@ keywords: contextforms context forms contextformsbarapi
 ---
 
 A context form consists of an input field, and a series of related buttons. Context forms can be shown wherever a context toolbar can be shown. Also, when a context form is registered containing a `launch` configuration, a special context toolbar button with name `form:${name}` is registered which will launch that particular context form.
-Context forms are a generalisation of the `Insert Link` form that existed in the original [inlite](https://www.tiny.cloud/docs/themes/inlite/#quicklink) theme from TinyMCE 4.
+Context forms are a generalisation of the `Insert Link` form that existed in the original [inlite](https://www.tiny.cloud/docs-4x/themes/inlite/#quicklink) theme from TinyMCE 4.
 
 ### Registering a context form
 


### PR DESCRIPTION
I've also updated https://community.tinymce.com/ to https://community.tiny.cloud/ as suggested by Alex.