### PR TITLE
DOC-327: Changed links back to using "drive" to reflect changes in DOC-319

### DIFF
--- a/_includes/codepens/drive-demo-dropbox/index.html
+++ b/_includes/codepens/drive-demo-dropbox/index.html
@@ -6,7 +6,7 @@
   </p>
 
   <p>
-    One of these enhancements is <strong>Tiny Drive</strong>: imagine file management for TinyMCE, in the cloud, made super easy. Learn more at <a href="https://www.tiny.cloud/docs/plugins/tinydrive/#liveexample">our working demo</a>, where you'll find an opportunity to provide feedback to the product team.
+    One of these enhancements is <strong>Tiny Drive</strong>: imagine file management for TinyMCE, in the cloud, made super easy. Learn more at <a href="https://www.tiny.cloud/docs/plugins/drive/#liveexample">our working demo</a>, where you'll find an opportunity to provide feedback to the product team.
   </p>
 
   <h3>An editor for every project</h3>

--- a/_includes/codepens/drive-demo-googledrive/index.html
+++ b/_includes/codepens/drive-demo-googledrive/index.html
@@ -6,7 +6,7 @@
   </p>
 
   <p>
-    One of these enhancements is <strong>Tiny Drive</strong>: imagine file management for TinyMCE, in the cloud, made super easy. Learn more at <a href="https://www.tiny.cloud/docs/plugins/tinydrive/#liveexample">our working demo</a>, where you'll find an opportunity to provide feedback to the product team.
+    One of these enhancements is <strong>Tiny Drive</strong>: imagine file management for TinyMCE, in the cloud, made super easy. Learn more at <a href="https://www.tiny.cloud/docs/plugins/drive/#liveexample">our working demo</a>, where you'll find an opportunity to provide feedback to the product team.
   </p>
 
   <h3>An editor for every project</h3>

--- a/_includes/codepens/drive-demo/index.html
+++ b/_includes/codepens/drive-demo/index.html
@@ -6,7 +6,7 @@
   </p>
 
   <p>
-    One of these enhancements is <strong>Tiny Drive</strong>: imagine file management for TinyMCE, in the cloud, made super easy. Learn more at <a href="https://www.tiny.cloud/docs/plugins/tinydrive/#liveexample">our working demo</a>, where you'll find an opportunity to provide feedback to the product team.
+    One of these enhancements is <strong>Tiny Drive</strong>: imagine file management for TinyMCE, in the cloud, made super easy. Learn more at <a href="https://www.tiny.cloud/docs/plugins/drive/#liveexample">our working demo</a>, where you'll find an opportunity to provide feedback to the product team.
   </p>
 
   <h3>An editor for every project</h3>

--- a/cloud-deployment-guide/editor-and-features.md
+++ b/cloud-deployment-guide/editor-and-features.md
@@ -43,7 +43,7 @@ There are more than 40 open source plugins that enhance the editing experience i
 Extend the [TinyMCE configuration]({{ site.baseurl }}/configure/) to include any additional purchased plugins and associated toolbar and menu items. Refer to the following enablement guides for more information:
 
 * [Mentions]({{ site.baseurl }}/plugins/mentions/)
-* [Tiny Drive]({{ site.baseurl }}/plugins/tinydrive/)
+* [Tiny Drive]({{ site.baseurl }}/plugins/drive/)
 * [Comments 2.0]({{ site.baseurl }}/plugins/comments/)
 * [Page Embed]({{ site.baseurl }}/plugins/pageembed/)
 * [Permanent Pen]({{ site.baseurl }}/plugins/permanentpen/)
@@ -104,7 +104,7 @@ Reference [external_plugins]({{ site.baseurl }}/configure/integration-and-setup/
 Extend the [TinyMCE configuration]({{ site.baseurl }}/configure/) to include any additional purchased plugins and associated toolbar and menu items. Refer to the following enablement guides for more information:
 
 * [Mentions]({{ site.baseurl }}/plugins/mentions/)
-* [Tiny Drive]({{ site.baseurl }}/plugins/tinydrive/)
+* [Tiny Drive]({{ site.baseurl }}/plugins/drive/)
 * [Comments 2.0]({{ site.baseurl }}/plugins/comments/)
 * [Page Embed]({{ site.baseurl }}/plugins/pageembed/)
 * [Permanent Pen]({{ site.baseurl }}/plugins/permanentpen/)

--- a/cloud-deployment-guide/editor-plugin-version.md
+++ b/cloud-deployment-guide/editor-plugin-version.md
@@ -75,7 +75,7 @@ Use the URL query parameters to specify the version of each premium plugin. This
 
 #### Tiny Drive
 
-* [Developer documentation]({{ site.baseurl }}/plugins/tinydrive/)
+* [Developer documentation]({{ site.baseurl }}/plugins/drive/)
 * [Supported versions](https://plugins.tinymce.com/versions/tinydrive)
 
 ##### Example
@@ -214,7 +214,7 @@ The "SDK" version lets the TinyMCE Plugin Manager know that you're not using Tin
 
 #### Tiny Drive
 
-* [Developer documentation]({{ site.baseurl }}/plugins/tinydrive/)
+* [Developer documentation]({{ site.baseurl }}/plugins/drive/)
 
 ##### Example
 

--- a/cloud-deployment-guide/features-only.md
+++ b/cloud-deployment-guide/features-only.md
@@ -23,7 +23,7 @@ Add the following script in the webpage once the script tag to load TinyMCE has 
 Extend the [TinyMCE configuration]({{ site.baseurl }}/configure/) to include any additional purchased plugins and associated toolbar and menu items. Refer to the following enablement guides for more information:
 
 * [Mentions]({{ site.baseurl }}/plugins/mentions/)
-* [Tiny Drive]({{ site.baseurl }}/plugins/tinydrive/)
+* [Tiny Drive]({{ site.baseurl }}/plugins/drive/)
 * [Comments 2.0]({{ site.baseurl }}/plugins/comments/)
 * [Page Embed]({{ site.baseurl }}/plugins/pageembed/)
 * [Permanent Pen]({{ site.baseurl }}/plugins/permanentpen/)

--- a/cloud-deployment-guide/plugin-editor-version-compatibility.md
+++ b/cloud-deployment-guide/plugin-editor-version-compatibility.md
@@ -33,7 +33,7 @@ to:
 | [Mentions]({{site.baseurl}}/plugins/mentions) | Y | Y |
 | [PowerPaste]({{ site.baseurl }}/plugins/powerpaste/) | Y | Y |
 | [Spell Checker Pro]({{ site.baseurl }}/plugins/tinymcespellchecker/) | Y | Y |
-| [Tiny Drive]({{site.baseurl}}/plugins/tinydrive) | Y | Y |
+| [Tiny Drive]({{site.baseurl}}/plugins/drive) | Y | Y |
 | [Tiny Comments]({{site.baseurl}}/plugins/comments) | Y | Y |
 | [Page Embed]({{site.baseurl}}/plugins/pageembed) | N | Y |
 | [Permanent Pen]({{site.baseurl}}/plugins/permanentpen) | N | Y |


### PR DESCRIPTION
This fixes the links broken by changes made for DOC-319, since it changed back to using `drive` as the url instead of `tinydrive`.