### PR TITLE
TINY-3658: Added docs for new imagetools_fetch_image function

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -269,6 +269,7 @@
     pages:
     - url: "#imagetools_cors_hosts"
     - url: "#imagetools_credentials_hosts"
+    - url: "#imagetools_fetch_image"
     - url: "#imagetools_proxy"
     - url: "#imagetools_toolbar"
   - url: "importcss"

--- a/plugins/imagetools.md
+++ b/plugins/imagetools.md
@@ -88,7 +88,7 @@ tinymce.init({
 
 ### `imagetools_fetch_image`
 
-This option can be used to define a custom fetch function, which provides another way to access images in complex situations. The function will be passed the HTML element of the image to be fetched and should return a `Blob` containing the content.
+This option can be used to define a custom fetch function, which provides another way to access images in complex situations. The function will be passed the HTML element of the image to be fetched and should return a `Promise` containing a `Blob` representation of the image.
 
 **Type:** `Function`
 
@@ -100,9 +100,11 @@ tinymce.init({
   toolbar: "image",
   plugins: "image imagetools",
   imagetools_fetch_image: function (img) {
-    // Fetch the image and return a blob containing the image content
-    ...
-    return new Blob(...);
+    return new tinymce.util.Promise(function (resolve) {
+      // Fetch the image and return a blob containing the image content
+      ...
+      resolve(new Blob(...));
+    });
   }
 });
 ```

--- a/plugins/imagetools.md
+++ b/plugins/imagetools.md
@@ -86,6 +86,27 @@ tinymce.init({
 });
 ```
 
+### `imagetools_fetch_image`
+
+This option can be used to define a custom fetch function, which provides another way to access images in complex situations. The function will be passed the HTML element of the image to be fetched and should return a `Blob` containing the content.
+
+**Type:** `Function`
+
+##### Example
+
+```js
+tinymce.init({
+  selector: "textarea",  // change this value according to your HTML
+  toolbar: "image",
+  plugins: "image imagetools",
+  imagetools_fetch_image: function (img) {
+    // Fetch the image and return a blob containing the image content
+    ...
+    return new Blob(...);
+  }
+});
+```
+
 ### `imagetools_proxy`
 
 Another way of getting images across domains is using local server-side proxy. Proxy is basically a script, that will retrieve remote image and pipe it back to TinyMCE, as if it was local. Example of such proxy (written in PHP) can be found below.


### PR DESCRIPTION
Added this as I noticed it was missing when writing up the internal R10 release notes for Bart. @spocke feel free to change anything if I've got it wrong or if you want to word things differently.