### PR TITLE
DOC-232: Added missing context menu details

### DIFF
--- a/_includes/configuration/contextmenu.md
+++ b/_includes/configuration/contextmenu.md
@@ -11,7 +11,12 @@ If the same name is registered as both a context menu section and a menu item, t
 
 The default configuration includes all plugins that provide a context menu; `link`, `image`, `imagetools`, `table`, and `spellchecker`.
 
-**Type:** `String`
+Alternatively the editors context menu can be disabled by setting this option to `false`.
+
+**Type:** `String` or `false`
+
+> Note: The browsers native context menu can still be accessed by holding the `Ctrl` key while right clicking with the mouse.
+However if the `contextmenu_never_use_native` option is enabled, holding the `Ctrl` key will have no effect.
 
 #### Default configuration example
 


### PR DESCRIPTION
This adds details about disabling the context menu and using the CTRL key to bypass the editors context menu.

Note: Setting the context menu to false wasn't an offical way to disable it, but it just so happened to have worked since 5.0.0. I've also seen it mentioned elsewhere (eg [StackOverflow](https://stackoverflow.com/a/56168371) and [browser spellchecker docs](https://www.tiny.cloud/docs/general-configuration-guide/spell-checking/#browser-basedspellchecking)) so thought it'd be good to document it here and make the code actually respect it properly (which I've done as part of TINY-3392).