### PR TITLE
hotfix/DOC-331: Added tinycomments_can_delete, can_delete_comment, and ...

### DIFF
--- a/plugins/comments.md
+++ b/plugins/comments.md
@@ -75,7 +75,7 @@ tinymce.init({
 
 > Available in Tiny Comments version 2.1 onwards.
 
-Optional - This option sets the author's display name to be used when creating or replying to comments. If this option is omitted, then the author id is used instead.
+_Optional_ - This option sets the author's display name to be used when creating or replying to comments. If this option is omitted, then the author id is used instead.
 
 **Type:** `String`
 
@@ -90,7 +90,105 @@ tinymce.init({
 })
 ```
 
-#### Embedded mode options
+##### tinycomments_can_delete
+
+_Optional_ - This option sets the author permissions for _deleting comment conversations_. If the `tinycomments_can_delete` option is not included, the current author (`currentAuthor`) cannot delete comment conversations created by other authors.
+
+**Type:** `Function`
+
+**Default Function**
+```js
+function (req, done, fail) {
+  var allowed = req.comments.length > 0 && req.comments[0].author === currentAuthor;
+  done({
+    canDelete: allowed
+  });
+}
+```
+
+The following example extends the default behavior to allow the author `<Admin user>` to delete other author's comment conversations by adding `|| currentAuthor === "<Admin user>"`.
+
+###### Example
+
+```js
+tinymce.init({
+  selector: "#textarea",
+  tinycomments_author: 'embedded_journalist',
+  tinycomments_can_delete: function (req, done, fail) {
+    var allowed = req.comments.length > 0 && req.comments[0].author === currentAuthor;
+    done({
+      canDelete: allowed || currentAuthor === "<Admin user>"
+    });
+  }
+});
+```
+
+##### tinycomments_can_delete_comment
+
+
+_Optional_ - This option sets the author permissions for _deleting comments_. If the `tinycomments_can_delete_comment` option is not included, the current author (`currentAuthor`) cannot delete comments added by other authors.
+
+**Type:** `Function`
+
+**Default Function**
+```js
+function (req, done, fail) {
+  var allowed = req.comment.author === currentAuthor;
+  done({
+    canDelete: allowed
+  });
+}
+```
+
+The following example extends the default behavior to allow the author `<Admin user>` to delete other author's comments by adding `|| currentAuthor === "<Admin user>"`.
+
+###### Example
+
+```js
+tinymce.init({
+  selector: "#textarea",
+  tinycomments_author: 'embedded_journalist',
+  tinycomments_can_delete_comment: function (req, done, fail) {
+    var allowed = req.comment.author === currentAuthor;
+    done({
+      canDelete: allowed || currentAuthor === "<Admin user>"
+    });
+  }
+});
+```
+
+##### tinycomments_can_edit_comment
+
+_Optional_ - This option sets the author permissions for _editing comments_. If the `tinycomments_can_edit_comment` option is not included, the current author (`currentAuthor`) cannot edit comments added by other authors.
+
+**Type:** `Function`
+
+**Default Function**
+```js
+function (req, done, fail) {
+  var allowed = req.comment.author === currentAuthor;
+  done({
+    canEdit: allowed
+  });
+}
+```
+
+The following example extends the default behavior to allow the author `<Admin user>` to edit other author's comments by adding `|| currentAuthor === "<Admin user>"`.
+
+###### Example
+
+```js
+tinymce.init({
+  selector: "#textarea",
+  tinycomments_author: 'embedded_journalist',
+  tinycomments_can_edit_comment: function (req, done, fail) {
+    var allowed = req.comment.author === currentAuthor;
+    done({
+      canEdit: allowed || currentAuthor === "<Admin user>"
+    });
+  }
+});
+```
 
 ### Configuring the Comments 2.0 addcomment toolbar button
 
@@ -142,9 +240,9 @@ Currently, there are three menu items available:
 
 The highlight styles are now a part of the overall content skin and are changed through customizing the skin.
 
-TinyMCE open source project [oxide](https://github.com/tinymce/oxide/blob/master/src/less/theme/content/comments/comments.less) (default skin), defines the variables used for changing the annotation colours. 
+TinyMCE open source project [oxide](https://github.com/tinymce/oxide/blob/master/src/less/theme/content/comments/comments.less) (default skin), defines the variables used for changing the annotation colours.
 
-Refer to the [documentation]({{site.baseurl}}/advanced/creating-a-skin/#creatingaskin) for building a skin using this repo. 
+Refer to the [documentation]({{site.baseurl}}/advanced/creating-a-skin/#creatingaskin) for building a skin using this repo.
 
 For more information on configuring TinyMCE formats, refer to the [formats]({{site.baseurl}}/configure/content-formatting/#formats) section.
 
@@ -159,6 +257,7 @@ For more information on configuring TinyMCE formats, refer to the [formats]({{si
 1. Press **Clear** to delete or **Save** to store the input comment.
 
 **Result**: The selected text will be highlighted as per the configured options. The following screen with the option for editing, deleting, and replying to the comment, will appear.
+
 ![**Delete Conversation**]({{site.baseurl}}/images/commentedit.png)
 
 Note: The above procedure can be followed for adding multiple comments to the document.
@@ -176,7 +275,7 @@ Follow this procedure to delete a comment. This option is not available for the 
 
 1. Click on this ![**3dots**]({{site.baseurl}}/images/3dots.png) icon above the comments box to expand the menu.
 1. Select **Delete** from the menu items.
-1. The following options appear in the comments sidebar:
+1. The following options appear in the comments sidebar:<br/>
 ![**delete comment**]({{site.baseurl}}/images/delete.png)
 1. Click **Cancel** to save or **Delete** to remove the comment from the conversation.
 
@@ -186,7 +285,7 @@ This option is only available for the first comment in a conversation. Once the 
 
 1. Click on this ![**3dots**]({{site.baseurl}}/images/3dots.png) icon above the comments box to expand the menu.
 1. Select **Delete conversation** from the menu items.
-1. The following decision dialog box will appear:
+1. The following decision dialog box will appear:<br/>
 ![**delete conversation**]({{site.baseurl}}/images/decision.png)
 1. Click **Cancel** to save or **Delete** to remove the conversation.
 
@@ -205,7 +304,7 @@ Follow this procedure to display the comments sidebar:
 Follow this procedure to delete all conversations in the document:
 
 1. From the navigation menu, choose **File** -> **Delete all conversations** option to delete all the comments in a document.
-1. The following decision dialog box will appear:
+1. The following decision dialog box will appear:<br />
 ![**Delete all conversations**]({{site.baseurl}}/images/decision2.png)
 1. Click **Ok** to remove the all the comments or **Cancel** to dismiss the action.
 
@@ -219,7 +318,7 @@ Users have to be cautious when deciding the order in which the plugins are added
 
 Comments can cause an issue if the [Full Page]({{site.baseurl}}/plugins/fullpage/) plugin `fullpage` appears before Comments 2.0 plugin `tinycomments` in the plugin list, and `tinycomments` is configured to use `embedded mode`.
 
-The order that the plugins appear affects the order that the `getContent` hooks are processed in. This creates an issue with `tinycomments` working as expected since the `fullpage` plugin adds outer `<html>` elements before `tinycomments` adds its comment data. This leads to the comment data being in the wrong place. The consequence of this situation is that when a saved document is re-opened, the comment data is lost (but the highlights are still there). 
+The order that the plugins appear affects the order that the `getContent` hooks are processed in. This creates an issue with `tinycomments` working as expected since the `fullpage` plugin adds outer `<html>` elements before `tinycomments` adds its comment data. This leads to the comment data being in the wrong place. The consequence of this situation is that when a saved document is re-opened, the comment data is lost (but the highlights are still there).
 
 For a workaround, please ensure that `tinycomments` is listed before `fullpage` in the plugins list. This should result in `tinycomments` working properly.
 

--- a/plugins/comments.md
+++ b/plugins/comments.md
@@ -92,14 +92,15 @@ tinymce.init({
 
 ##### tinycomments_can_delete
 
-_Optional_ - This option sets the author permissions for _deleting comment conversations_. If the `tinycomments_can_delete` option is not included, the current author (`currentAuthor`) cannot delete comment conversations created by other authors.
+_Optional_ - This option sets the author permissions for _deleting comment conversations_. If the `tinycomments_can_delete` option is not included, the current author (`tinycomments_author`) cannot delete comment conversations created by other authors.
 
 **Type:** `Function`
 
 **Default Function**
 ```js
 function (req, done, fail) {
-  var allowed = req.comments.length > 0 && req.comments[0].author === currentAuthor;
+  var allowed = req.comments.length > 0 &&
+                req.comments[0].author === <Current_tinycomments_author>;
   done({
     canDelete: allowed
   });
@@ -111,11 +112,14 @@ The following example extends the default behavior to allow the author `<Admin u
 ###### Example
 
 ```js
+var currentAuthor = 'embedded_journalist';
+
 tinymce.init({
   selector: "#textarea",
-  tinycomments_author: 'embedded_journalist',
+  tinycomments_author: currentAuthor,
   tinycomments_can_delete: function (req, done, fail) {
-    var allowed = req.comments.length > 0 && req.comments[0].author === currentAuthor;
+    var allowed = req.comments.length > 0 &&
+                  req.comments[0].author === currentAuthor;
     done({
       canDelete: allowed || currentAuthor === "<Admin user>"
     });
@@ -126,14 +130,14 @@ tinymce.init({
 ##### tinycomments_can_delete_comment
 
 
-_Optional_ - This option sets the author permissions for _deleting comments_. If the `tinycomments_can_delete_comment` option is not included, the current author (`currentAuthor`) cannot delete comments added by other authors.
+_Optional_ - This option sets the author permissions for _deleting comments_. If the `tinycomments_can_delete_comment` option is not included, the current author (`tinycomments_author`) cannot delete comments added by other authors.
 
 **Type:** `Function`
 
 **Default Function**
 ```js
 function (req, done, fail) {
-  var allowed = req.comment.author === currentAuthor;
+  var allowed = req.comment.author === <Current_tinycomments_author>;
   done({
     canDelete: allowed
   });
@@ -145,9 +149,11 @@ The following example extends the default behavior to allow the author `<Admin u
 ###### Example
 
 ```js
+var currentAuthor = 'embedded_journalist';
+
 tinymce.init({
   selector: "#textarea",
-  tinycomments_author: 'embedded_journalist',
+  tinycomments_author: currentAuthor,
   tinycomments_can_delete_comment: function (req, done, fail) {
     var allowed = req.comment.author === currentAuthor;
     done({
@@ -159,14 +165,14 @@ tinymce.init({
 
 ##### tinycomments_can_edit_comment
 
-_Optional_ - This option sets the author permissions for _editing comments_. If the `tinycomments_can_edit_comment` option is not included, the current author (`currentAuthor`) cannot edit comments added by other authors.
+_Optional_ - This option sets the author permissions for _editing comments_. If the `tinycomments_can_edit_comment` option is not included, the current author (`tinycomments_author`) cannot edit comments added by other authors.
 
 **Type:** `Function`
 
 **Default Function**
 ```js
 function (req, done, fail) {
-  var allowed = req.comment.author === currentAuthor;
+  var allowed = req.comment.author === <Current_tinycomments_author>;
   done({
     canEdit: allowed
   });
@@ -178,9 +184,11 @@ The following example extends the default behavior to allow the author `<Admin u
 ###### Example
 
 ```js
+var currentAuthor = 'embedded_journalist';
+
 tinymce.init({
   selector: "#textarea",
-  tinycomments_author: 'embedded_journalist',
+  tinycomments_author: currentAuthor,
   tinycomments_can_edit_comment: function (req, done, fail) {
     var allowed = req.comment.author === currentAuthor;
     done({


### PR DESCRIPTION
Added:
- `tinycomments_can_delete`
- `tinycomments_can_delete_comment`
- `tinycomments_can_edit_comment`
options to the comment plugin page.