### PR TITLE
feature/TINY-3873: Added information about the draggable_modal config option

### DIFF
--- a/_includes/configuration/draggable-modal.md
+++ b/_includes/configuration/draggable-modal.md
@@ -1,0 +1,18 @@
+## draggable_modal
+
+Use the `draggable_modal` option to enable dragging for [modal dialogs]({{site.baseurl}}/ui-components/dialog/).
+
+**Type:** `Boolean`
+
+**Default Value:** `false`
+
+**Possible Values:** `true`, `false`
+
+##### Example
+
+```js
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  draggable_modal: true
+});
+```

--- a/configure/editor-appearance.md
+++ b/configure/editor-appearance.md
@@ -16,6 +16,8 @@ description: Configure the editor's appearance, including menu and toolbar contr
 
 {% include configuration/custom-ui-selector.md %}
 
+{% include configuration/draggable-modal.md %}
+
 {% include configuration/elementpath.md %}
 
 {% include configuration/event-root.md %}


### PR DESCRIPTION
Documented the `draggable_modal` config option that can be used to enable or disable dragging of modal dialogs.