### PR TITLE
remove duplicate item from built-in formats list

### DIFF
--- a/_includes/configuration/formats.md
+++ b/_includes/configuration/formats.md
@@ -47,7 +47,6 @@ TinyMCE has some built in formats that can be overridden. These are:
 * div
 * address
 * pre
-* div
 * code
 * dt, dd
 * samp


### PR DESCRIPTION
remove duplicate `div` from built-in formats list