### PR TITLE
TINY-3873: Added missing draggable_modal nav menu item

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -77,6 +77,7 @@
     - url: "#contextmenu"
     - url: "#contextmenu_never_use_native"
     - url: "#custom_ui_selector"
+    - url: "#draggable_modal"
     - url: "#elementpath"
     - url: "#event_root"
     - url: "#fixed_toolbar_container"
@@ -654,7 +655,7 @@
     - url: "#New features"
     - url: "#Removed & deprecated features"
     - url: "#Known issues"
-    
+
 - url: "changelog"
   pages:
   - url: "#Version 5.0.11 July 4, 2019"


### PR DESCRIPTION
Noticed that we missed adding the nav menu item in https://github.com/tinymce/tinymce-docs/pull/1140