### PR TITLE
Update the Open Graph image (og:image)

### DIFF
--- a/_includes/template/head.html
+++ b/_includes/template/head.html
@@ -8,7 +8,7 @@
     <meta property="og:title" content="TinyMCE | {{ page.meta_title | or:page.title }}">
     <meta property="og:type" content="website">
     <meta property="og:description" content="{{ page.meta_description | or:page.description }}">
-    <meta property="og:image" content="https://www.tinymce.com/images/fb-share@2x.png">
+    <meta property="og:image" content="https://www.tiny.cloud/images/tiny-v5-og-image.png">
 
     <title>TinyMCE | {{ page.meta_title | or:page.title }}</title>
 


### PR DESCRIPTION
Update the Open Graph image (og:image) for the Documentation site to match the OG image used for the parent site (tiny.cloud).