### PR TITLE
fixing migration 4.x guide

### DIFF
--- a/_includes/release-notes/new-features.md
+++ b/_includes/release-notes/new-features.md
@@ -3,13 +3,13 @@ The following new features were added to the TinyMCE 5.0 RC version.
 
 ### Comments 2.0
 
-The [Comments 2.0]({{site.baseurl}}/enterprise/tiny-comments/) is a premium plugin built on the [Annotations API]({{site.baseurl}}/advanced/annotations/) to create comment threads (conversations). Comments 2.0 provides the ability to start or join a conversation by adding comments to the content within the TinyMCE editor. 
+The [Comments 2.0]({{site.baseurl}}/enterprise/tiny-comments/) is a premium plugin built on the [Annotations API]({{site.baseurl}}/advanced/annotations/) to create comment threads (conversations). Comments 2.0 provides the ability to start or join a conversation by adding comments to the content within the TinyMCE editor.
 
 Refer to the [Comments 2.0]({{site.baseurl}}/plugins/comments/) documentation, for more information.
 
 ### Context menu
 
-The [Context menu](https://www.tiny.cloud/docs/plugins/contextmenu/) is no longer a plugin, it is part of the core and always enabled. Where TinyMCE 4.x only supported adding registered menu items, the new context menu also allows plugins to register "sections" of the context menu. These sections are dynamic and may show or hide depending on the cursor position when the context menu is opened. For example, the default context menu config is now `'link image editimage table spelling'` which are all plugin section references, not menu items. 
+The [Context menu](https://www.tiny.cloud/docs/plugins/contextmenu/) is no longer a plugin, it is part of the core and always enabled. Where TinyMCE 4.x only supported adding registered menu items, the new context menu also allows plugins to register "sections" of the context menu. These sections are dynamic and may show or hide depending on the cursor position when the context menu is opened. For example, the default context menu config is now `'link image editimage table spelling'` which are all plugin section references, not menu items.
 
 The context menu supports both individual menu items and dynamic context menu sections. Refer to the [context menu]({{site.baseurl}}/ui-components/contextmenu/) documentation, for more information.
 
@@ -25,7 +25,7 @@ The Custom Menu items configurations options have changed in TinyMCE 5.0. The `a
 
 ### Custom sidebars
 
-Custom sidebars allow developers to add custom tools and widgets to a sidebar within the editor. In TinyMCE 5.0 the configuration has changed slightly. The method for registering custom sidebars is now `editor.ui.registry.addSidebar()` and `onrender` is now `onSetup`. 
+Custom sidebars allow developers to add custom tools and widgets to a sidebar within the editor. In TinyMCE 5.0 the configuration has changed slightly. The method for registering custom sidebars is now `editor.ui.registry.addSidebar()` and `onrender` is now `onSetup`.
 
 Refer to the [Custom sidebars]({{site.baseurl}}/ui-components/customsidebar/) documentation for more information.
 
@@ -47,11 +47,9 @@ TinyMCE is up-to-date with the latest accessibility standards. This includes the
 
 A new experimental feature has been added that allows using the tab across all TinyMCE toolbars, sidebars, content, and footer bar. This allows more granular control to quickly jump to the appropriate editor control and then navigate down to its specific feature sets.
 
-> TinyMCE is the only editor to have this feature!
-
 ### Mentions
 
-The [Mentions]({{site.baseurl}}/enterprise/mentions/) plugin makes it possible for users to send notifications using **@username** in the document. 
+The [Mentions]({{site.baseurl}}/enterprise/mentions/) plugin makes it possible for users to send notifications using **@username** in the document.
 
 Mentions is available for download through [TinyMCE Cloud]({{site.baseurl}}/cloud-deployment-guide/editor-and-features/). Include the mentions parameter in the tinymce.init script. Refer to the [Mentions]({{site.baseurl}}/plugins/mentions/) documentation, for more information on setup and configuration.
 
@@ -101,7 +99,7 @@ Refer to the [Permanent Pen]({{site.baseurl}}/plugins/permanentpen/) documentati
 
 ### Tables
 
-Tables are better in TinyMCE 5.0 editor. Creating and configuring tables in TinyMCE 5.0 is simpler.
+Creating and configuring tables in TinyMCE 5.0 is simpler.
 
 This feature has been enhanced by modifying the code to ensure the styles are correct and consistent. The **Styles** text field has been removed from the advanced table properties dialogs. The dialog configuration is now much less confronting and confusing for non-developers.
 

--- a/_includes/release-notes/new-features.md
+++ b/_includes/release-notes/new-features.md
@@ -9,7 +9,7 @@ Refer to the [Comments 2.0]({{site.baseurl}}/plugins/comments/) documentation, f
 
 ### Context menu
 
-The [Context menu](https://www.tiny.cloud/docs/plugins/contextmenu/) is no longer a plugin, it is part of the core and always enabled. Where TinyMCE 4.x only supported adding registered menu items, the new context menu also allows plugins to register "sections" of the context menu. These sections are dynamic and may show or hide depending on the cursor position when the context menu is opened. For example, the default context menu config is now `'link image editimage table spelling'` which are all plugin section references, not menu items.
+The [Context menu]({{site.url}}/docs-4x/plugins/contextmenu/) is no longer a plugin, it is part of the core and always enabled. Where TinyMCE 4.x only supported adding registered menu items, the new context menu also allows plugins to register "sections" of the context menu. These sections are dynamic and may show or hide depending on the cursor position when the context menu is opened. For example, the default context menu config is now `'link image editimage table spelling'` which are all plugin section references, not menu items.
 
 The context menu supports both individual menu items and dynamic context menu sections. Refer to the [context menu]({{site.baseurl}}/ui-components/contextmenu/) documentation, for more information.
 

--- a/migration-from-4x.md
+++ b/migration-from-4x.md
@@ -16,12 +16,12 @@ This chapter describes the migration process and workarounds for customers using
 
 ### Cloud Delivery
 
-To serve TinyMCE 5 from the cloud, include this in your html page. Substitute 'no-api-key' with your api key.
+To use TinyMCE 5 from the Tiny Cloud, include this in your HTML page. Replace 'no-api-key' with your api key.
 ```js
 <script src="{{ site.cdnurl }}" referrerpolicy="origin"></script>
 ```
 
-To serve the latest nightlies and testing builds refer to the [cloud deployment guide]({{site.baseurl}}/cloud-deployment-guide/editor-and-features/)
+To use the latest development and testing builds, refer to the [cloud deployment guide]({{site.baseurl}}/cloud-deployment-guide/editor-and-features/).
 
 ```js
 <script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/5-dev/tinymce.min.js" referrerpolicy="origin"></script>
@@ -58,9 +58,9 @@ In TinyMCE 5.0, some configurations have been removed because they are no longer
 
 #### Removed settings
 
-* [`file_browser_callback`](https://www.tiny.cloud/docs/configure/file-image-upload/#file_browser_callback) - Previously, the `file_browser_callback` option was used to add a file or image browser to TinyMCE. This feature was deprecated in version 4.1.0 and replaced by [`file_picker_callback`]({{site.baseurl}}/configure/file-image-upload/#file_picker_callback). `file_browser_callback` option has been removed from TinyMCE 5.0 owing to the configuration changes in the dialog component.
+* [`file_browser_callback`]({{site.baseurl}}/configure/file-image-upload/#file_browser_callback) - Previously, the `file_browser_callback` option was used to add a file or image browser to TinyMCE. This feature was deprecated in version 4.1.0 and replaced by [`file_picker_callback`]({{site.baseurl}}/configure/file-image-upload/#file_picker_callback). `file_browser_callback` option has been removed from TinyMCE 5.0 owing to the configuration changes in the dialog component.
 
-* [`insert_button_items`](https://www.tiny.cloud/docs/configure/editor-appearance/#insert_button_items) - Previously, the `insert_button_items` option was used to specify what to display in the `insert` toolbar button's menu in a space-separated list of menu items control identifiers or `|` for a menu separator. This toolbar button has been removed from TinyMCE 5.0 owing to the changes in the menus and removal of the `context` property. For a workaround, configure a custom toolbar button using the following configurations in the `tinymce.init`:
+* [`insert_button_items`]({{site.baseurl}}/configure/editor-appearance/#insert_button_items) - Previously, the `insert_button_items` option was used to specify what to display in the `insert` toolbar button's menu in a space-separated list of menu items control identifiers or `|` for a menu separator. This toolbar button has been removed from TinyMCE 5.0 owing to the changes in the menus and removal of the `context` property. For a workaround, configure a custom toolbar button using the following configurations in the `tinymce.init`:
 
 ```js
 tinymce.init({
@@ -128,10 +128,10 @@ In TinyMCE 5.0, some themes have been removed and are now combined in a new sing
 
 | **Removed Theme** | **Replaced by** |
 | ----------------- | --------------  |
-| [Modern](https://www.tiny.cloud/docs-4x/themes/modern/) | Silver |
-| [Modern inline](https://www.tiny.cloud/docs-4x/general-configuration-guide/use-tinymce-inline/) | Silver Inline |
-| [Inlite(Distraction-free Editor)](https://www.tiny.cloud/docs-4x/themes/inlite/) | Silver (distraction free configuration) |
-| [Mobile](https://www.tiny.cloud/docs-4x/themes/mobile/) | Silver (responsive to small screen touch devices)  |
+| [Modern]({{site.url}}/docs-4x/themes/modern/) | Silver |
+| [Modern inline]({{site.url}}/docs-4x/general-configuration-guide/use-tinymce-inline/) | Silver Inline |
+| [Inlite(Distraction-free Editor)]({{site.url}}/docs-4x/themes/inlite/) | Silver (distraction free configuration) |
+| [Mobile]({{site.url}}/docs-4x/themes/mobile/) | Silver (responsive to small screen touch devices)  |
 
 ### Removed themes
 
@@ -151,7 +151,7 @@ This will provide a similar but improved [distraction-free]({{site.baseurl}}/gen
 
 #### Modern
 
-The Modern theme is no longer supported in TinyMCE 5.0.  The modern theme's UI library [`tinymce.ui.*`](https://www.tiny.cloud/docs-4x/api/tinymce.ui/) has also been deleted. This change may impact integrations depending upon the [level of customization]({{site.baseurl}}/migration-from-4x/#initialization).
+The Modern theme is no longer supported in TinyMCE 5.0.  The modern theme's UI library [`tinymce.ui.*`]({{site.url}}/docs-4x/api/tinymce.ui/) has also been deleted. This change may impact integrations depending upon the [level of customization](#initialization).
 
 > Note: For support related issues such as problems while migrating and a workaround, please contact [support](https://support.tiny.cloud/hc/en-us/requests/new). Alternatively, track developer preview issues on GitHub, [here](https://github.com/tinymce/tinymce/labels/5.x).
 
@@ -230,7 +230,7 @@ For more information on how these methods have changed, see [docs]({{site.baseur
 
 ### Removed toolbar button types
 
-[Listbox](https://www.tiny.cloud/docs-4x/demo/custom-toolbar-listbox/) is no longer a supported toolbar button type in TinyMCE 5.0. Though listbox has been removed, any functionality provided by custom listbox toolbar buttons can be retained by switching to a different kind of toolbar button using the new methods. The recommended toolbar button type to switch to is the **Split** button.
+[Listbox]({{site.url}}/docs-4x/demo/custom-toolbar-listbox/) is no longer a supported toolbar button type in TinyMCE 5.0. Though listbox has been removed, any functionality provided by custom listbox toolbar buttons can be retained by switching to a different kind of toolbar button using the new methods. The recommended toolbar button type to switch to is the **Split** button.
 
 ### Toolbar configuration differences between TinyMCE 4.x and TinyMCE 5.0:
 
@@ -286,7 +286,7 @@ editor.ui.registry.addButton('myButton', {
 
 `onpostrender` has been removed and replaced with `onSetup` for menu and toolbar components. There are 3 major changes:
 
-* While [`onpostrender`](https://www.tiny.cloud/docs/advanced/creating-a-custom-button/#togglebutton) only ran once, when the editor was created, [`onSetup`]({{site.baseurl}}/ui-components/typesoftoolbarbuttons/#basicbuttonexampleandexplanation) runs every time a component is rendered, e.g. for a menu item, every time its menu becomes visible.
+* While [`onpostrender`]({{site.baseurl}}/advanced/creating-a-custom-button/#togglebutton) only ran once, when the editor was created, [`onSetup`]({{site.baseurl}}/ui-components/typesoftoolbarbuttons/#basicbuttonexampleandexplanation) runs every time a component is rendered, e.g. for a menu item, every time its menu becomes visible.
 * `onSetup` now has an API containing some helper functions. Each type of toolbar button has a different API.
 * `onSetup` can be configured to return a function, which will be automatically be called on the teardown of the component, e.g., when a menu item's menu is closed.
     * If some functionality only runs when the editor is first initialized, it should be passed to `editor.on('init', callback)` as the callback function.
@@ -487,27 +487,9 @@ For more information about the new URL dialog configuration, see the [`URL dialo
 
 Docs are coming soon! -->
 
-### Custom context toolbars
-
-The Context Toolbar accepts toolbar buttons that were previously added to the editor using the editor's `addButton`, `addToggleButton`, `addSplitButton` or a`ddMenuButton` functions. The method for creating custom context toolbars in TinyMCE 5.0 has also been changed from `editor.addContextToolbar()` to `editor.ui.registry.addContextToolbar()`.
-
-For more information on Context Toolbars, see [docs]({{site.baseurl}}/ui-components/contexttoolbar).
-
-### Custom context menus
-
-The [Context menu](https://www.tiny.cloud/docs/plugins/contextmenu/) is no longer a plugin, it is part of the core and always enabled. Where TinyMCE 4.x only supported adding registered menu items, the new context menu also allows plugins to register "sections" of the context menu. These sections are dynamic and may show or hide depending on the cursor position when the context menu is opened. For example, the default context menu config is now `'link image editimage table spelling'` which are all plugin section references, not menu items. See [docs]({{site.baseurl}}/ui-components/contextmenu/)
-
-##### New methods:
-
-| **New method** | **Description** |
-| ----------- | -------------- |
-| editor.ui.registry.addContextMenu() | Adds a custom context menu. |
-
-For more information on Context Menus, see the [docs]({{site.baseurl}}/ui-components/contextmenu).
-
 ### Custom context forms
 
-ContextForm consists of an input field and a series of related buttons. Context forms can be shown wherever a context toolbar can be displayed. Also, when a context form is registered containing a `launch` configuration, a special context toolbar button with name **\`form:${name}\`** is registered which will launch that particular context form. ContextForms are a generalization of the `Insert Link` form that existed in the original [inlite](https://www.tiny.cloud/docs-4x/themes/inlite/#quicklink) theme from TinyMCE 4.
+ContextForm consists of an input field and a series of related buttons. Context forms can be shown wherever a context toolbar can be displayed. Also, when a context form is registered containing a `launch` configuration, a special context toolbar button with name **\`form:${name}\`** is registered which will launch that particular context form. ContextForms are a generalization of the `Insert Link` form that existed in the original [inlite]({{site.url}}/docs-4x/themes/inlite/#quicklink) theme from TinyMCE 4.
 
 ## Plugins
 
@@ -542,9 +524,27 @@ These features have either changed or have been deleted in TinyMCE 5.0.
 
 | **Plugin name** | **Description** |
 | --------------- |  -------------- |
-| [ContextMenu](https://www.tiny.cloud/docs/plugins/contextmenu/) | New API. See [docs]({{site.baseurl}}/ui-components/contextmenu/). |
-| [ColorPicker](https://www.tiny.cloud/docs/plugins/colorpicker/) | Moved to the core. See [docs]({{site.baseurl}}/configure/content-appearance/#color_picker}}). |
-| [Text Color](https://www.tiny.cloud/docs/plugins/textcolor/) | The `textcolor` plugin was removed and this setting is not required in TinyMCE 5.0. |
+| [ContextMenu]({{site.baseurl}}/plugins/contextmenu/) | New API. See [docs]({{site.baseurl}}/ui-components/contextmenu/). |
+| [ColorPicker]({{site.baseurl}}/plugins/colorpicker/) | Moved to the core. See [docs]({{site.baseurl}}/configure/content-appearance/#color_picker}}). |
+| [Text Color]({{site.baseurl}}/plugins/textcolor/) | The `textcolor` plugin was removed and this setting is not required in TinyMCE 5.0. |
+
+#### Custom context toolbars
+
+The Context Toolbar accepts toolbar buttons that were previously added to the editor using the editor's `addButton`, `addToggleButton`, `addSplitButton` or a`ddMenuButton` functions. The method for creating custom context toolbars in TinyMCE 5.0 has also been changed from `editor.addContextToolbar()` to `editor.ui.registry.addContextToolbar()`.
+
+For information on Context Toolbars, see the [docs]({{site.baseurl}}/ui-components/contexttoolbar).
+
+#### Custom context menus
+
+The [Context menu]({{site.baseurl}}/plugins/contextmenu/) is no longer a plugin, it is part of the core and always enabled. Where TinyMCE 4.x only supported adding registered menu items, the new context menu also allows plugins to register "sections" of the context menu. These sections are dynamic and may show or hide depending on the cursor position when the context menu is opened. For example, the default context menu config is now `'link image editimage table spelling'` which are all plugin section references, not menu items. For information on using context menus, see: [UI components - Context menu]({{site.baseurl}}/ui-components/contextmenu/).
+
+##### New methods:
+
+| **New method** | **Description** |
+| ----------- | -------------- |
+| editor.ui.registry.addContextMenu() | Adds a custom context menu. |
+
+For more information on Context Menus, see the [docs]({{site.baseurl}}/ui-components/contextmenu).
 
 ### Table
 
@@ -572,5 +572,5 @@ The table below shows UI configurations that have been removed. They are general
 | pack | Emulates flex pack | Use CSS stylesheets for custom styling |
 | no-wrap | Emulates CSS no line wrap | Use CSS stylesheet for custom styling |
 
-Please see the [TinyMCE 4.x docs](https://www.tiny.cloud/docs-4x/) for more information on the above settings.
+Please see the [TinyMCE 4.x docs]({{site.url}}/docs-4x/) for more information on the above settings.
 

--- a/migration-from-4x.md
+++ b/migration-from-4x.md
@@ -524,9 +524,9 @@ These features have either changed or have been deleted in TinyMCE 5.0.
 
 | **Plugin name** | **Description** |
 | --------------- |  -------------- |
-| [ContextMenu]({{site.baseurl}}/plugins/contextmenu/) | New API. See [docs]({{site.baseurl}}/ui-components/contextmenu/). |
-| [ColorPicker]({{site.baseurl}}/plugins/colorpicker/) | Moved to the core. See [docs]({{site.baseurl}}/configure/content-appearance/#color_picker}}). |
-| [Text Color]({{site.baseurl}}/plugins/textcolor/) | The `textcolor` plugin was removed and this setting is not required in TinyMCE 5.0. |
+| [ContextMenu]({{site.url}}/docs-4x/plugins/contextmenu/) | New API. See the [docs]({{site.baseurl}}/ui-components/contextmenu/). |
+| [ColorPicker]({{site.url}}/docs-4x/plugins/colorpicker/) | Moved to the core. See the [docs]({{site.baseurl}}/configure/content-appearance/#color_picker}}). |
+| [Text Color]({{site.url}}/docs-4x/plugins/textcolor/) | The `textcolor` plugin was removed and this setting is not required in TinyMCE 5.0. |
 
 #### Custom context toolbars
 
@@ -536,7 +536,7 @@ For information on Context Toolbars, see the [docs]({{site.baseurl}}/ui-componen
 
 #### Custom context menus
 
-The [Context menu]({{site.baseurl}}/plugins/contextmenu/) is no longer a plugin, it is part of the core and always enabled. Where TinyMCE 4.x only supported adding registered menu items, the new context menu also allows plugins to register "sections" of the context menu. These sections are dynamic and may show or hide depending on the cursor position when the context menu is opened. For example, the default context menu config is now `'link image editimage table spelling'` which are all plugin section references, not menu items. For information on using context menus, see: [UI components - Context menu]({{site.baseurl}}/ui-components/contextmenu/).
+The [Context menu]({{site.url}}/docs-4x/plugins/contextmenu/) is no longer a plugin, it is part of the core and always enabled. Where TinyMCE 4.x only supported adding registered menu items, the new context menu also allows plugins to register "sections" of the context menu. These sections are dynamic and may show or hide depending on the cursor position when the context menu is opened. For example, the default context menu config is now `'link image editimage table spelling'` which are all plugin section references, not menu items. For information on using context menus, see: [UI components - Context menu]({{site.baseurl}}/ui-components/contextmenu/).
 
 ##### New methods:
 


### PR DESCRIPTION
Fixing the migration from 4.x guide using bug info in the 5.0 release notes and fixing the 5.0 release notes