### PR TITLE
TINY-3652: Cloud languages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,6 +35,7 @@ tick: '&#10004;'
 cross: '&#10006;'
 nbsp: '&#160;'
 tab: '&#160;&#160;'
+newline: '<br>'
 virt_ellps: '&#8942;'
 ellps: '&#133;'
 

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -103,6 +103,7 @@
     - url: "#min_width"
     - url: "#mobile"
     - url: "#preview_styles"
+    - url: "#quickbars_image_toolbar"
     - url: "#quickbars_insert_toolbar"
     - url: "#quickbars_selection_toolbar"
     - url: "#removed_menuitems"

--- a/_includes/configuration/image_toolbar.md
+++ b/_includes/configuration/image_toolbar.md
@@ -1,0 +1,29 @@
+## quickbars_insert_toolbar
+
+The **quickbars_image_toolbar** option enables configuration of the Quick Image toolbar enabled by the [quickbars]({{ site.baseurl }}/plugins/quickbars) plugin. The toolbar can be disabled by setting `quickbars_image_toolbar` to `false`. The toolbar can also be configured to display non-default buttons using a space-separated string of toolbar button names. The Quick Image toolbar is intended for image-related buttons but any [{{site.productname}} toolbar buttons]({{ site.baseurl }}/advanced/editor-control-identifiers/#toolbarcontrols) or [custom toolbar buttons]({{ site.baseurl }}/ui-components/toolbarbuttons) are allowed.
+
+**Type:** `String` or `false`
+
+**Defaults:** `alignleft aligncenter alignright`
+
+##### Example customizing the Quick Image toolbar
+
+```js
+tinymce.init({
+  selector: 'div.tinymce',
+  plugins: 'quickbars',
+  inline: true,
+  quickbars_image_toolbar: 'alignleft aligncenter alignright'
+});
+```
+
+##### Example disabling the Quick Image toolbar
+
+```js
+tinymce.init({
+  selector: 'div.tinymce',
+  plugins: 'quickbars',
+  inline: true,
+  quickbars_image_toolbar: false
+});
+```

--- a/_includes/configuration/image_toolbar.md
+++ b/_includes/configuration/image_toolbar.md
@@ -1,4 +1,4 @@
-## quickbars_insert_toolbar
+## quickbars_image_toolbar
 
 The **quickbars_image_toolbar** option enables configuration of the Quick Image toolbar enabled by the [quickbars]({{ site.baseurl }}/plugins/quickbars) plugin. The toolbar can be disabled by setting `quickbars_image_toolbar` to `false`. The toolbar can also be configured to display non-default buttons using a space-separated string of toolbar button names. The Quick Image toolbar is intended for image-related buttons but any [{{site.productname}} toolbar buttons]({{ site.baseurl }}/advanced/editor-control-identifiers/#toolbarcontrols) or [custom toolbar buttons]({{ site.baseurl }}/ui-components/toolbarbuttons) are allowed.
 

--- a/_includes/configuration/language.md
+++ b/_includes/configuration/language.md
@@ -28,83 +28,83 @@ tinymce.init({
 
 The available language codes for use with this option are as follows:
 
-| Language                      |  Code   |
-| :-----------------------------| :-------|
-| Arabic                        | ar      |
-| Arabic (Saudi Arabia)         | ar_SA   |
-| Armenian                      | hy      |
-| Azerbaijani                   | az      |
-| Basque                        | eu      |
-| Belarusian                    | be      |
-| Bengali (Bangladesh)          | bn_BD   |
-| Bosnian                       | bs      |
-| Bulgarian (Bulgaria)          | bg_BG   |
-| Catalan                       | ca      |
-| Chinese (China)               | zh_CN   |
-| Chinese (Taiwan)              | zh_TW   |
-| Croatian                      | hr      |
-| Czech                         | cs      |
-| Danish                        | da      |
-| Divehi                        | dv      |
-| Dutch                         | nl      |
-| English (Canada)              | en_CA   |
-| English (United Kingdom)      | en_GB   |
-| Estonian                      | et      |
-| Faroese                       | fo      |
-| Finnish                       | fi      |
-| French (France)               | fr_FR   |
-| Gaelic, Scottish              | gd      |
-| Galician                      | gl      |
-| Georgian (Georgia)            | ka_GE   |
-| German                        | de      |
-| German (Austria)              | de_AT   |
-| Greek                         | el      |
-| Hebrew (Israel)               | he_IL   |
-| Hindi (India)                 | hi_IN   |
-| Hungarian (Hungary)           | hu_HU   |
-| Icelandic (Iceland)           | is_IS   |
-| Indonesian                    | id      |
-| Italian                       | it      |
-| Japanese                      | ja      |
-| Kabyle                        | kab     |
-| Kazakh                        | kk      |
-| Khmer (Cambodia)              | km_KH   |
-| Korean (Korea)                | ko_KR   |
-| Kurdish                       | ku      |
-| Kurdish (Iraq)                | ku_IQ   |
-| Latvian                       | lv      |
-| Lithuanian                    | lt      |
-| Luxembourgish                 | lb      |
-| Malayalam                     | ml      |
-| Malayalam (India)             | ml_IN   |
-| Mongolian (Mongolia)          | mn_MN   |
-| Norwegian Bokmål (Norway)     | nb_NO   |
-| Persian                       | fa      |
-| Persian (Iran)                | fa_IR   |
-| Polish                        | pl      |
-| Portuguese (Brazil)           | pt_BR   |
-| Portuguese (Portugal)         | pt_PT   |
-| Romanian                      | ro      |
-| Russian                       | ru      |
-| Serbian                       | sr      |
-| Sinhala (Sri Lanka)           | si_LK   |
-| Slovak                        | sk      |
-| Slovenian (Slovenia)          | sl_SI   |
-| Spanish                       | es      |
-| Spanish (Mexico)              | es_MX   |
-| Swedish (Sweden)              | sv_SE   |
-| Tajik                         | tg      |
-| Tamil                         | ta      |
-| Tamil (India)                 | ta_IN   |
-| Tatar                         | tt      |
-| Thai (Thailand)               | th_TH   |
-| Turkish                       | tr      |
-| Turkish (Turkey)              | tr_TR   |
-| Uighur                        | ug      |
-| Ukrainian                     | uk      |
-| Ukrainian (Ukraine)           | uk_UA   |
-| Vietnamese                    | vi      |
-| Vietnamese (Viet Nam)         | vi_VN   |
-| Welsh                         | cy      |
+| Language                      |  Code   | {{ site.cloudname }} /{{ site.newline }}Enterprise |
+| :-----------------------------| :-----: | :------------------------------------------------: |
+| Arabic                        | ar      | {{ site.tick }}                                    |
+| Arabic (Saudi Arabia)         | ar_SA   |                                                    |
+| Armenian                      | hy      |                                                    |
+| Azerbaijani                   | az      |                                                    |
+| Basque                        | eu      | {{ site.tick }}                                    |
+| Belarusian                    | be      |                                                    |
+| Bengali (Bangladesh)          | bn_BD   |                                                    |
+| Bosnian                       | bs      |                                                    |
+| Bulgarian (Bulgaria)          | bg_BG   | {{ site.tick }}                                    |
+| Catalan                       | ca      | {{ site.tick }}                                    |
+| Chinese (China)               | zh_CN   | {{ site.tick }}                                    |
+| Chinese (Taiwan)              | zh_TW   | {{ site.tick }}                                    |
+| Croatian                      | hr      | {{ site.tick }}                                    |
+| Czech                         | cs      | {{ site.tick }}                                    |
+| Danish                        | da      | {{ site.tick }}                                    |
+| Divehi                        | dv      |                                                    |
+| Dutch                         | nl      | {{ site.tick }}                                    |
+| English (Canada)              | en_CA   |                                                    |
+| English (United Kingdom)      | en_GB   |                                                    |
+| Estonian                      | et      |                                                    |
+| Faroese                       | fo      |                                                    |
+| Finnish                       | fi      | {{ site.tick }}                                    |
+| French (France)               | fr_FR   | {{ site.tick }}                                    |
+| Gaelic, Scottish              | gd      |                                                    |
+| Galician                      | gl      |                                                    |
+| Georgian (Georgia)            | ka_GE   |                                                    |
+| German                        | de      | {{ site.tick }}                                    |
+| German (Austria)              | de_AT   |                                                    |
+| Greek                         | el      |                                                    |
+| Hebrew (Israel)               | he_IL   | {{ site.tick }}                                    |
+| Hindi (India)                 | hi_IN   |                                                    |
+| Hungarian (Hungary)           | hu_HU   | {{ site.tick }}                                    |
+| Icelandic (Iceland)           | is_IS   |                                                    |
+| Indonesian                    | id      | {{ site.tick }}                                    |
+| Italian                       | it      | {{ site.tick }}                                    |
+| Japanese                      | ja      | {{ site.tick }}                                    |
+| Kabyle                        | kab     |                                                    |
+| Kazakh                        | kk      | {{ site.tick }}                                    |
+| Khmer (Cambodia)              | km_KH   |                                                    |
+| Korean (Korea)                | ko_KR   | {{ site.tick }}                                    |
+| Kurdish                       | ku      |                                                    |
+| Kurdish (Iraq)                | ku_IQ   |                                                    |
+| Latvian                       | lv      |                                                    |
+| Lithuanian                    | lt      |                                                    |
+| Luxembourgish                 | lb      |                                                    |
+| Malayalam                     | ml      |                                                    |
+| Malayalam (India)             | ml_IN   |                                                    |
+| Mongolian (Mongolia)          | mn_MN   |                                                    |
+| Norwegian Bokmål (Norway)     | nb_NO   | {{ site.tick }}                                    |
+| Persian                       | fa      | {{ site.tick }}                                    |
+| Persian (Iran)                | fa_IR   |                                                    |
+| Polish                        | pl      | {{ site.tick }}                                    |
+| Portuguese (Brazil)           | pt_BR   | {{ site.tick }}                                    |
+| Portuguese (Portugal)         | pt_PT   | {{ site.tick }}                                    |
+| Romanian                      | ro      | {{ site.tick }}                                    |
+| Russian                       | ru      | {{ site.tick }}                                    |
+| Serbian                       | sr      |                                                    |
+| Sinhala (Sri Lanka)           | si_LK   |                                                    |
+| Slovak                        | sk      | {{ site.tick }}                                    |
+| Slovenian (Slovenia)          | sl_SI   | {{ site.tick }}                                    |
+| Spanish                       | es      | {{ site.tick }}                                    |
+| Spanish (Mexico)              | es_MX   | {{ site.tick }}                                    |
+| Swedish (Sweden)              | sv_SE   | {{ site.tick }}                                    |
+| Tajik                         | tg      |                                                    |
+| Tamil                         | ta      |                                                    |
+| Tamil (India)                 | ta_IN   |                                                    |
+| Tatar                         | tt      |                                                    |
+| Thai (Thailand)               | th_TH   | {{ site.tick }}                                    |
+| Turkish                       | tr      | {{ site.tick }}                                    |
+| Turkish (Turkey)              | tr_TR   |                                                    |
+| Uighur                        | ug      |                                                    |
+| Ukrainian                     | uk      | {{ site.tick }}                                    |
+| Ukrainian (Ukraine)           | uk_UA   |                                                    |
+| Vietnamese                    | vi      |                                                    |
+| Vietnamese (Viet Nam)         | vi_VN   |                                                    |
+| Welsh                         | cy      |                                                    |
 
 If a language you need is not available, you may wish to translate it yourself. To contribute to translating {{site.productname}}, go to our [Transifex translation](https://www.transifex.com/projects/p/tinymce/) page and sign up, then request to join a team or create a new team if your language are not listed.

--- a/_includes/configuration/language.md
+++ b/_includes/configuration/language.md
@@ -28,83 +28,83 @@ tinymce.init({
 
 The available language codes for use with this option are as follows:
 
-| Language                      |  Code   | {{ site.cloudname }} /{{ site.newline }}Enterprise |
-| :-----------------------------| :-----: | :------------------------------------------------: |
-| Arabic                        | ar      | {{ site.tick }}                                    |
-| Arabic (Saudi Arabia)         | ar_SA   |                                                    |
-| Armenian                      | hy      |                                                    |
-| Azerbaijani                   | az      |                                                    |
-| Basque                        | eu      | {{ site.tick }}                                    |
-| Belarusian                    | be      |                                                    |
-| Bengali (Bangladesh)          | bn_BD   |                                                    |
-| Bosnian                       | bs      |                                                    |
-| Bulgarian (Bulgaria)          | bg_BG   | {{ site.tick }}                                    |
-| Catalan                       | ca      | {{ site.tick }}                                    |
-| Chinese (China)               | zh_CN   | {{ site.tick }}                                    |
-| Chinese (Taiwan)              | zh_TW   | {{ site.tick }}                                    |
-| Croatian                      | hr      | {{ site.tick }}                                    |
-| Czech                         | cs      | {{ site.tick }}                                    |
-| Danish                        | da      | {{ site.tick }}                                    |
-| Divehi                        | dv      |                                                    |
-| Dutch                         | nl      | {{ site.tick }}                                    |
-| English (Canada)              | en_CA   |                                                    |
-| English (United Kingdom)      | en_GB   |                                                    |
-| Estonian                      | et      |                                                    |
-| Faroese                       | fo      |                                                    |
-| Finnish                       | fi      | {{ site.tick }}                                    |
-| French (France)               | fr_FR   | {{ site.tick }}                                    |
-| Gaelic, Scottish              | gd      |                                                    |
-| Galician                      | gl      |                                                    |
-| Georgian (Georgia)            | ka_GE   |                                                    |
-| German                        | de      | {{ site.tick }}                                    |
-| German (Austria)              | de_AT   |                                                    |
-| Greek                         | el      |                                                    |
-| Hebrew (Israel)               | he_IL   | {{ site.tick }}                                    |
-| Hindi (India)                 | hi_IN   |                                                    |
-| Hungarian (Hungary)           | hu_HU   | {{ site.tick }}                                    |
-| Icelandic (Iceland)           | is_IS   |                                                    |
-| Indonesian                    | id      | {{ site.tick }}                                    |
-| Italian                       | it      | {{ site.tick }}                                    |
-| Japanese                      | ja      | {{ site.tick }}                                    |
-| Kabyle                        | kab     |                                                    |
-| Kazakh                        | kk      | {{ site.tick }}                                    |
-| Khmer (Cambodia)              | km_KH   |                                                    |
-| Korean (Korea)                | ko_KR   | {{ site.tick }}                                    |
-| Kurdish                       | ku      |                                                    |
-| Kurdish (Iraq)                | ku_IQ   |                                                    |
-| Latvian                       | lv      |                                                    |
-| Lithuanian                    | lt      |                                                    |
-| Luxembourgish                 | lb      |                                                    |
-| Malayalam                     | ml      |                                                    |
-| Malayalam (India)             | ml_IN   |                                                    |
-| Mongolian (Mongolia)          | mn_MN   |                                                    |
-| Norwegian Bokmål (Norway)     | nb_NO   | {{ site.tick }}                                    |
-| Persian                       | fa      | {{ site.tick }}                                    |
-| Persian (Iran)                | fa_IR   |                                                    |
-| Polish                        | pl      | {{ site.tick }}                                    |
-| Portuguese (Brazil)           | pt_BR   | {{ site.tick }}                                    |
-| Portuguese (Portugal)         | pt_PT   | {{ site.tick }}                                    |
-| Romanian                      | ro      | {{ site.tick }}                                    |
-| Russian                       | ru      | {{ site.tick }}                                    |
-| Serbian                       | sr      |                                                    |
-| Sinhala (Sri Lanka)           | si_LK   |                                                    |
-| Slovak                        | sk      | {{ site.tick }}                                    |
-| Slovenian (Slovenia)          | sl_SI   | {{ site.tick }}                                    |
-| Spanish                       | es      | {{ site.tick }}                                    |
-| Spanish (Mexico)              | es_MX   | {{ site.tick }}                                    |
-| Swedish (Sweden)              | sv_SE   | {{ site.tick }}                                    |
-| Tajik                         | tg      |                                                    |
-| Tamil                         | ta      |                                                    |
-| Tamil (India)                 | ta_IN   |                                                    |
-| Tatar                         | tt      |                                                    |
-| Thai (Thailand)               | th_TH   | {{ site.tick }}                                    |
-| Turkish                       | tr      | {{ site.tick }}                                    |
-| Turkish (Turkey)              | tr_TR   |                                                    |
-| Uighur                        | ug      |                                                    |
-| Ukrainian                     | uk      | {{ site.tick }}                                    |
-| Ukrainian (Ukraine)           | uk_UA   |                                                    |
-| Vietnamese                    | vi      |                                                    |
-| Vietnamese (Viet Nam)         | vi_VN   |                                                    |
-| Welsh                         | cy      |                                                    |
+| Language                      |  Code   | {{ site.cloudname }} /{{ site.newline }}{{ site.enterpriseversion }} |
+| :-----------------------------| :-----: | :------------------------------------------------------------------: |
+| Arabic                        | ar      | {{ site.tick }}                                                      |
+| Arabic (Saudi Arabia)         | ar_SA   |                                                                      |
+| Armenian                      | hy      |                                                                      |
+| Azerbaijani                   | az      |                                                                      |
+| Basque                        | eu      | {{ site.tick }}                                                      |
+| Belarusian                    | be      |                                                                      |
+| Bengali (Bangladesh)          | bn_BD   |                                                                      |
+| Bosnian                       | bs      |                                                                      |
+| Bulgarian (Bulgaria)          | bg_BG   | {{ site.tick }}                                                      |
+| Catalan                       | ca      | {{ site.tick }}                                                      |
+| Chinese (China)               | zh_CN   | {{ site.tick }}                                                      |
+| Chinese (Taiwan)              | zh_TW   | {{ site.tick }}                                                      |
+| Croatian                      | hr      | {{ site.tick }}                                                      |
+| Czech                         | cs      | {{ site.tick }}                                                      |
+| Danish                        | da      | {{ site.tick }}                                                      |
+| Divehi                        | dv      |                                                                      |
+| Dutch                         | nl      | {{ site.tick }}                                                      |
+| English (Canada)              | en_CA   |                                                                      |
+| English (United Kingdom)      | en_GB   |                                                                      |
+| Estonian                      | et      |                                                                      |
+| Faroese                       | fo      |                                                                      |
+| Finnish                       | fi      | {{ site.tick }}                                                      |
+| French (France)               | fr_FR   | {{ site.tick }}                                                      |
+| Gaelic, Scottish              | gd      |                                                                      |
+| Galician                      | gl      |                                                                      |
+| Georgian (Georgia)            | ka_GE   |                                                                      |
+| German                        | de      | {{ site.tick }}                                                      |
+| German (Austria)              | de_AT   |                                                                      |
+| Greek                         | el      |                                                                      |
+| Hebrew (Israel)               | he_IL   | {{ site.tick }}                                                      |
+| Hindi (India)                 | hi_IN   |                                                                      |
+| Hungarian (Hungary)           | hu_HU   | {{ site.tick }}                                                      |
+| Icelandic (Iceland)           | is_IS   |                                                                      |
+| Indonesian                    | id      | {{ site.tick }}                                                      |
+| Italian                       | it      | {{ site.tick }}                                                      |
+| Japanese                      | ja      | {{ site.tick }}                                                      |
+| Kabyle                        | kab     |                                                                      |
+| Kazakh                        | kk      | {{ site.tick }}                                                      |
+| Khmer (Cambodia)              | km_KH   |                                                                      |
+| Korean (Korea)                | ko_KR   | {{ site.tick }}                                                      |
+| Kurdish                       | ku      |                                                                      |
+| Kurdish (Iraq)                | ku_IQ   |                                                                      |
+| Latvian                       | lv      |                                                                      |
+| Lithuanian                    | lt      |                                                                      |
+| Luxembourgish                 | lb      |                                                                      |
+| Malayalam                     | ml      |                                                                      |
+| Malayalam (India)             | ml_IN   |                                                                      |
+| Mongolian (Mongolia)          | mn_MN   |                                                                      |
+| Norwegian Bokmål (Norway)     | nb_NO   | {{ site.tick }}                                                      |
+| Persian                       | fa      | {{ site.tick }}                                                      |
+| Persian (Iran)                | fa_IR   |                                                                      |
+| Polish                        | pl      | {{ site.tick }}                                                      |
+| Portuguese (Brazil)           | pt_BR   | {{ site.tick }}                                                      |
+| Portuguese (Portugal)         | pt_PT   | {{ site.tick }}                                                      |
+| Romanian                      | ro      | {{ site.tick }}                                                      |
+| Russian                       | ru      | {{ site.tick }}                                                      |
+| Serbian                       | sr      |                                                                      |
+| Sinhala (Sri Lanka)           | si_LK   |                                                                      |
+| Slovak                        | sk      | {{ site.tick }}                                                      |
+| Slovenian (Slovenia)          | sl_SI   | {{ site.tick }}                                                      |
+| Spanish                       | es      | {{ site.tick }}                                                      |
+| Spanish (Mexico)              | es_MX   | {{ site.tick }}                                                      |
+| Swedish (Sweden)              | sv_SE   | {{ site.tick }}                                                      |
+| Tajik                         | tg      |                                                                      |
+| Tamil                         | ta      |                                                                      |
+| Tamil (India)                 | ta_IN   |                                                                      |
+| Tatar                         | tt      |                                                                      |
+| Thai (Thailand)               | th_TH   | {{ site.tick }}                                                      |
+| Turkish                       | tr      | {{ site.tick }}                                                      |
+| Turkish (Turkey)              | tr_TR   |                                                                      |
+| Uighur                        | ug      |                                                                      |
+| Ukrainian                     | uk      | {{ site.tick }}                                                      |
+| Ukrainian (Ukraine)           | uk_UA   |                                                                      |
+| Vietnamese                    | vi      |                                                                      |
+| Vietnamese (Viet Nam)         | vi_VN   |                                                                      |
+| Welsh                         | cy      |                                                                      |
 
 If a language you need is not available, you may wish to translate it yourself. To contribute to translating {{site.productname}}, go to our [Transifex translation](https://www.transifex.com/projects/p/tinymce/) page and sign up, then request to join a team or create a new team if your language are not listed.

--- a/cloud-deployment-guide/editor-and-features.md
+++ b/cloud-deployment-guide/editor-and-features.md
@@ -78,7 +78,7 @@ Ensure the `tiny-api-key` and `tinymce-api-key` headers are retained while reque
 
 ### Step 5: Specifying a translation
 
-Extend the TinyMCE configuration to specify the [translation language]({{ site.baseurl }}/configure/localization/#language) with the `language` configuration option.
+To change the user interface language with a language pack, use the [language configuration option]({{ site.baseurl }}/configure/localization/#language).
 
 Alternatively, [download a language pack]({{site.gettiny}}/language-packages/) to enable a language other than English (US). [Specify its location]({{ site.baseurl }}/configure/localization/#language_url) with the `language_url` configuration option.
 

--- a/cloud-deployment-guide/editor-and-features.md
+++ b/cloud-deployment-guide/editor-and-features.md
@@ -77,7 +77,10 @@ Ensure that the following URLs are accessible via this proxy if the network has 
 Ensure the `tiny-api-key` and `tinymce-api-key` headers are retained while requesting the list of above URLs.
 
 ### Step 5: Specifying a translation
-[Download a language pack]({{site.gettiny}}/language-packages/) to enable a language other than English (US). [Specify its location]({{ site.baseurl }}/configure/localization/#language_url) with the `language_url` configuration option.
+
+Extend the TinyMCE configuration to specify the [translation language]({{ site.baseurl }}/configure/localization/#language) with the `language` configuration option.
+
+Alternatively, [download a language pack]({{site.gettiny}}/language-packages/) to enable a language other than English (US). [Specify its location]({{ site.baseurl }}/configure/localization/#language_url) with the `language_url` configuration option.
 
 ## Migrating from a self-hosted environment to Tiny Cloud
 

--- a/configure/editor-appearance.md
+++ b/configure/editor-appearance.md
@@ -52,6 +52,8 @@ description: Configure the editor's appearance, including menu and toolbar contr
 
 {% include configuration/preview-styles.md %}
 
+{% include configuration/image-toolbar.md %}
+
 {% include configuration/insert-toolbar.md %}
 
 {% include configuration/selection-toolbar.md %}

--- a/plugins/quickbars.md
+++ b/plugins/quickbars.md
@@ -18,7 +18,7 @@ The Quick Toolbar plugin enables three new context toolbars:
 
 It also enables three new toolbar buttons:
 
-* _Quick Link_ - an inline dialog for creating and editing links without a dialog.
+* _Quick Link_ - an inline form for creating and editing links without a dialog.
 * _Quick Image_ - immediately prompts a user to select a local image to upload.
 * _Quick Table_ - immediately inserts a 2x2 table without prompting the user to select the number of rows and columns.
 
@@ -79,7 +79,7 @@ tinymce.init({
 
 The Quick Link (`quicklink`) toolbar button lets the user quickly insert/edit links inline. It is included in the Quick Selection context toolbar by default and can be used in other context toolbars.
 
-##### Example:
+##### Example using quicklink in a custom context toolbar:
 
 ```js
 tinymce.init({
@@ -103,7 +103,7 @@ The Quick Image (`quickimage`) toolbar button helps you quickly insert images fr
 
 > Note: To enable automatic upload of images on insertion, [image upload]({{ site.baseurl }}/advanced/handle-async-image-uploads/) must be configured.
 
-##### Example using quickimage in the editor toolbar
+##### Example using quickimage in the editor toolbar:
 
 ```js
 tinymce.init({
@@ -117,7 +117,7 @@ tinymce.init({
 
 The Quick Table (`quicktable`) toolbar button inserts a 2x2 table with 100% width. It is included in the Quick Insert context toolbar by default and can be used in other toolbars.
 
-##### Example using quicktable in the editor toolbar
+##### Example using quicktable in the editor toolbar:
 
 ```js
 tinymce.init({

--- a/plugins/quickbars.md
+++ b/plugins/quickbars.md
@@ -10,19 +10,20 @@ The Quick Toolbar plugin (`quickbars`) enables new user interface components to 
 
 It replaces the capabilities of the `inlite` theme in TinyMCE 4 or earlier.
 
-The Quick Toolbar plugin enables two new context toolbars:
+The Quick Toolbar plugin enables three new context toolbars:
 
-* _Quick Selection_ - shown when text is selected for quick access to formatting commands such as bold, italic and link.
+* _Quick Selection_ - shown when text is selected for quick access to formatting buttons such as bold, italic and link.
 * _Quick Insert_ - shown when a new line is created for the quick insertion of objects such as tables and images.
+* _Quick Image_ - shown when an image or figure is selected for quick access to image formatting buttons such as alignment.
 
-It also enables three new toolbar controls:
+It also enables three new toolbar buttons:
 
-* _Quick Link_ - an inline experience for creating and editing links without a dialog
-* _Quick Image_ - immediately prompts a user to select a local image to upload
-* _Quick Table_ - immediately inserts a 2x2 table without prompting the user to select the number of rows and columns
+* _Quick Link_ - an inline dialog for creating and editing links without a dialog.
+* _Quick Image_ - immediately prompts a user to select a local image to upload.
+* _Quick Table_ - immediately inserts a 2x2 table without prompting the user to select the number of rows and columns.
 
 
-##### Example enabling both context toolbars with their default controls:
+##### Example enabling all context toolbars with their default toolbar buttons:
 
 ```js
 tinymce.init({
@@ -33,7 +34,7 @@ tinymce.init({
     inline: true
 });
 ```
-#### Example disabling the Quick Insert toolbar:
+#### Example disabling the Quick Insert context toolbar:
 
 ```js
 tinymce.init({
@@ -46,7 +47,7 @@ tinymce.init({
 });
 ```
 
-#### Example disabling the Quick Selection minibar:
+#### Example disabling the Quick Selection context toolbar:
 
 ```js
 tinymce.init({
@@ -59,13 +60,7 @@ tinymce.init({
 });
 ```
 
-### Plugin-specific controls
-
-#### Quick Link
-
-The Quick Link (`quicklink`) control lets the user quickly insert/edit links inline. It can only be used in the Quick Selection toolbar.
-
-##### Example:
+#### Example disabling the Quick Image context toolbar:
 
 ```js
 tinymce.init({
@@ -74,45 +69,67 @@ tinymce.init({
     toolbar: false,
     menubar: false,
     inline: true,
-    quickbars_selection_toolbar: 'bold italic | quicklink h2 h3 blockquote'
+    quickbars_image_toolbar: false
+});
+```
+
+### Plugin-specific toolbar buttons
+
+#### Quick Link
+
+The Quick Link (`quicklink`) toolbar button lets the user quickly insert/edit links inline. It is included in the Quick Selection context toolbar by default and can be used in other context toolbars.
+
+##### Example:
+
+```js
+tinymce.init({
+    selector: "div.tinymce",
+    plugins: [ 'quickbars' ],
+    setup: function(editor) {
+        editor.ui.registry.addContextToolbar('imageselection', {
+            predicate: function(node) {
+                return node.nodeName === 'P';
+            },
+            items: 'quicklink',
+            position: 'node'
+        });
+    }
 });
 ```
 
 #### Quick Image
 
-The Quick Image (`quickimage`) control lets you quickly insert images from the local computer into the editor. These can then be automatically uploaded if you configure [image uploading]({{ site.baseurl }}/advanced/handle-async-image-uploads/). It can be used in both the Quick Insert toolbar and other toolbars.
+The Quick Image (`quickimage`) toolbar button helps you quickly insert images from your computer into the editor. It is included in the Quick Insert context toolbar by default and can be used in other toolbars.
 
-##### Example:
+> Note: To enable automatic upload of images on insertion, [image upload]({{ site.baseurl }}/advanced/handle-async-image-uploads/) must be configured.
+
+##### Example using quickimage in the editor toolbar
 
 ```js
 tinymce.init({
     selector: "div.tinymce",
     plugins: [ 'quickbars' ],
-    toolbar: false,
-    menubar: false,
-    inline: true,
-    quickbars_insert_toolbar: 'quickimage quicktable'
+    toolbar: 'quickimage'
 });
 ```
 
 #### Quick Table
 
-The Quick Table (`quicktable`) control lets you quickly insert a 2x2 table with 100% width. It can be used in both the Quick Insert toolbar and other toolbars.
+The Quick Table (`quicktable`) toolbar button inserts a 2x2 table with 100% width. It is included in the Quick Insert context toolbar by default and can be used in other toolbars.
 
-##### Example:
+##### Example using quicktable in the editor toolbar
 
 ```js
 tinymce.init({
     selector: "div.tinymce",
     plugins: [ 'quickbars' ],
-    toolbar: false,
-    menubar: false,
-    inline: true,
-    quickbars_insert_toolbar: 'quickimage quicktable'
+    toolbar: 'quicktable'
 });
 ```
 
 ### Configuration options
+
+##{% include configuration/image-toolbar.md %}
 
 ##{% include configuration/insert-toolbar.md %}
 


### PR DESCRIPTION
Updated the cloud setup docs to mention that the languages can be loaded directly from the cloud now.

I wasn't sure if we should mention that only enterprise language packs are available? As the list available is really a subset of the community languages, so I figured if we did mention it, then we'd need to include a list which might be confusing or a bit too much for this page. So @tylerkelly13 (and anyone else who has an opinion) I wanted to get your take on what you think would be best?