### PR TITLE
"advanced install options" to "installing TinyMCE"

### DIFF
--- a/_includes/integrations/angular-quick-start.md
+++ b/_includes/integrations/angular-quick-start.md
@@ -12,7 +12,7 @@ This procedure requires:
 * Access to `tinymce.min.js` on either:
 
     * [{{site.cloudname}}]({{site.baseurl}}/cloud-deployment-guide/editor-and-features/).
-    * {{site.productname}} Self-hosted. See [Advanced installation choices]({{site.baseurl}}/general-configuration-guide/advanced-install/) for details on self-hosting {{site.productname}}.
+    * {{site.productname}} Self-hosted. See [Installing {{ site.productname }}]({{site.baseurl}}/general-configuration-guide/advanced-install/) for details on self-hosting {{site.productname}}.
 
 ### Procedure
 
@@ -144,7 +144,7 @@ This procedure requires:
 
         To use an independent deployment of {{site.productname}} with the create a Angular application, add the script to `/path/to/tinymce-angular-demo/src/app/app.component.html`.
 
-        For information on self-hosting {{site.productname}}, see: [Advanced installation choices]({{site.baseurl}}/general-configuration-guide/advanced-install/).
+        For information on self-hosting {{site.productname}}, see: [Installing {{ site.productname }}]({{site.baseurl}}/general-configuration-guide/advanced-install/).
 
       * **Bundling {{site.productname}} with the Angular application using a module loader**
 

--- a/_includes/integrations/react-quick-start.md
+++ b/_includes/integrations/react-quick-start.md
@@ -12,7 +12,7 @@ This procedure requires:
 * Access to `tinymce.min.js` on either:
 
     * [{{site.cloudname}}]({{site.baseurl}}/cloud-deployment-guide/editor-and-features/).
-    * {{site.productname}} Self-hosted. See [Advanced installation choices]({{site.baseurl}}/general-configuration-guide/advanced-install/) for details on self-hosting {{site.productname}}.
+    * {{site.productname}} Self-hosted. See [Installing {{ site.productname }}]({{site.baseurl}}/general-configuration-guide/advanced-install/) for details on self-hosting {{site.productname}}.
 
 ### Procedure
 
@@ -98,7 +98,7 @@ This procedure requires:
 
         To use an independent deployment of {{site.productname}} with the create a React application, add the script to `/path/to/tinymce-react-demo/public/index.html`.
 
-        For information on self-hosting {{site.productname}}, see: [Advanced installation choices]({{site.baseurl}}/general-configuration-guide/advanced-install/).
+        For information on self-hosting {{site.productname}}, see: [Installing {{ site.productname }}]({{site.baseurl}}/general-configuration-guide/advanced-install/).
 
       * **Bundling {{site.productname}} with the React application using a module loader**
 

--- a/_includes/integrations/vue-quick-start.md
+++ b/_includes/integrations/vue-quick-start.md
@@ -12,7 +12,7 @@ This procedure requires:
 * Access to `tinymce.min.js` on either:
 
     * [{{site.cloudname}}]({{site.baseurl}}/cloud-deployment-guide/editor-and-features/).
-    * {{site.productname}} Self-hosted. See [Advanced installation choices]({{site.baseurl}}/general-configuration-guide/advanced-install/) for details on self-hosting {{site.productname}}.
+    * {{site.productname}} Self-hosted. See [Installing {{ site.productname }}]({{site.baseurl}}/general-configuration-guide/advanced-install/) for details on self-hosting {{site.productname}}.
 
 ### Procedure
 
@@ -105,7 +105,7 @@ This procedure requires:
 
         To use an independent deployment of {{site.productname}} with the create a Vue.js application, add the script to `/path/to/tinymce-vue-demo/public/index.html`.
 
-        For information on self-hosting {{site.productname}}, see: [Advanced installation choices]({{site.baseurl}}/general-configuration-guide/advanced-install/).
+        For information on self-hosting {{site.productname}}, see: [Installing {{ site.productname }}]({{site.baseurl}}/general-configuration-guide/advanced-install/).
 
       * **Bundling {{site.productname}} with the Vue.js application using a module loader**
 

--- a/general-configuration-guide/advanced-install.md
+++ b/general-configuration-guide/advanced-install.md
@@ -1,7 +1,7 @@
 ---
 layout: default
-title: Advanced installation choices
-title_nav: More installation choices
+title: Installing TinyMCE
+title_nav: Options for installing TinyMCE
 description_short: Cloud, package managers, Self-hosted, jQuery and custom builds.
 description: Learn how to install TinyMCE via TinyMCE Cloud, package manager options, Self-hosted, jQuery and custom build options.
 keywords: npm bower composer nuget

--- a/integrations/bootstrap.md
+++ b/integrations/bootstrap.md
@@ -38,7 +38,7 @@ This procedure creates a basic Bootstrap integration containing a {{site.product
         <script src="/path/to/tinymce.min.js"></script>
         ```
 
-        For information on self-hosting {{site.productname}}, see: [Advanced installation choices]({{site.baseurl}}/general-configuration-guide/advanced-install/).
+        For information on self-hosting {{site.productname}}, see: [Installing {{ site.productname }}]({{site.baseurl}}/general-configuration-guide/advanced-install/).
 
 
 3. Add an initialization point for {{site.productname}}, such as:

--- a/integrations/jquery.md
+++ b/integrations/jquery.md
@@ -37,7 +37,7 @@ This procedure creates a basic jQuery integration containing a {{site.productnam
 <script src="/path/to/jquery.tinymce.min.js"></script>
         ```
 
-        For information on self-hosting {{site.productname}}, see: [Advanced installation choices]({{site.baseurl}}/general-configuration-guide/advanced-install/).
+        For information on self-hosting {{site.productname}}, see: [Installing {{ site.productname }}]({{site.baseurl}}/general-configuration-guide/advanced-install/).
 
 
 3. Add an initialization point for {{site.productname}}, such as:

--- a/integrations/knockout.md
+++ b/integrations/knockout.md
@@ -38,7 +38,7 @@ Michael Papworth developed the Knockout binding for TinyMCE. For details, see: [
         <script src="/path/to/jquery.tinymce.min.js"></script>
         ```
 
-        For information on self-hosting {{site.productname}}, see: [Advanced installation choices]({{site.baseurl}}/general-configuration-guide/advanced-install/).
+        For information on self-hosting {{site.productname}}, see: [Installing {{ site.productname }}]({{site.baseurl}}/general-configuration-guide/advanced-install/).
 
 1. Source `tinymce-knockout-binding` (`wysiwyg.js`) on the page.
 

--- a/integrations/rails.md
+++ b/integrations/rails.md
@@ -95,7 +95,7 @@ This procedure creates a [basic Ruby on Rails application](https://guides.rubyon
     ```
 The page containing the {{site.productname}} will be accessible at `http://localhost:<port>/` (default: [http://localhost:3000/](http://localhost:3000/)).
 
-For information on self-hosting {{site.productname}}, see: [Advanced installation choices]({{site.baseurl}}/general-configuration-guide/advanced-install/).
+For information on self-hosting {{site.productname}}, see: [Installing {{ site.productname }}]({{site.baseurl}}/general-configuration-guide/advanced-install/).
 
 ### The third-party TinyMCE Ruby on Rails gem
 

--- a/migration-from-froala.md
+++ b/migration-from-froala.md
@@ -46,7 +46,7 @@ Replace `your-api-key` with your [{{site.cloudname}} API key]({{site.accountpage
 ```
 Replace `/path/to/tinymce/base/directory` with the relative path of the `tinymce/` directory containing `tinymce.min.js`.
 
-For information on {{site.productname}} deployment types, see: [Advanced installation choices]({{site.baseurl}}/general-configuration-guide/advanced-install/).
+For information on {{site.productname}} deployment types, see: [Installing {{ site.productname }}]({{site.baseurl}}/general-configuration-guide/advanced-install/).
 
 ### Replace the Froala editor variable assignment with the tinymce.init function
 To insert an editor in the body of the page for a `<textarea>` element such as:
@@ -121,7 +121,7 @@ The following examples show an initial Froala configuration and the migrated {{s
 
 For information on:
 * Getting started with {{site.productname}}, see: [{{site.productname}} Quick Start]({{site.baseurl}}/quick-start).
-* Installing {{site.productname}}, see: [Advanced installation choices]({{site.baseurl}}/general-configuration-guide/advanced-install/).
+* Installing {{site.productname}}, see: [Installing {{ site.productname }}]({{site.baseurl}}/general-configuration-guide/advanced-install/).
 
 ## Updating the list of Plugins
 

--- a/quick-start.md
+++ b/quick-start.md
@@ -80,4 +80,4 @@ For information on:
     * [{{site.productname}} distraction-free editing mode]({{site.baseurl}}/general-configuration-guide/use-tinymce-distraction-free/).
   * Adding {{site.productname}} plugins, see: [Work with plugins to extend TinyMCE]({{site.baseurl}}/general-configuration-guide/work-with-plugins/).
   * Localizing the {{site.productname}} editor, see: [Localize {{site.productname}}]({{site.baseurl}}/general-configuration-guide/localize-your-language/).
-  * Self-hosting {{site.productname}}, see: [Advanced installation choices]({{site.baseurl}}/general-configuration-guide/advanced-install/).
+  * Self-hosting {{site.productname}}, see: [Installing {{ site.productname }}]({{site.baseurl}}/general-configuration-guide/advanced-install/).


### PR DESCRIPTION
Renaming the "Advanced installation choices" to "Installing TinyMCE"