### PR TITLE
Fix minor syntax issues in integration code examples

### DIFF
--- a/_includes/integrations/angular-quick-start.md
+++ b/_includes/integrations/angular-quick-start.md
@@ -63,22 +63,20 @@ This procedure requires:
     ```html
     <h1>{{site.productname}} {{site.productmajorversion}} Angular Demo</h1>
     <editor
-      initialValue="<p>This is the initial content of the editor</p>"
       [init]="{
-           height: 500,
-           menubar: false,
-           plugins: [
-             'advlist autolink lists link image charmap print preview anchor',
-             'searchreplace visualblocks code fullscreen',
-             'insertdatetime media table paste code help wordcount'
-           ],
-           toolbar:
-             'undo redo | formatselect | bold italic backcolor | \
-             alignleft aligncenter alignright alignjustify | \
-             bullist numlist outdent indent | removeformat | help'
-         }"
-      >
-    </editor>
+        height: 500,
+        menubar: false,
+        plugins: [
+          'advlist autolink lists link image charmap print preview anchor',
+          'searchreplace visualblocks code fullscreen',
+          'insertdatetime media table paste code help wordcount'
+        ],
+        toolbar:
+          'undo redo | formatselect | bold italic backcolor | \
+          alignleft aligncenter alignright alignjustify | \
+          bullist numlist outdent indent | removeformat | help'
+      }"
+    ></editor>
     ```
     This {{site.productname}} editor configuration should replicate the example on the [Basic example page]({{site.baseurl}}/demo/basic-example/).
 7. Provide access to {{site.productname}} using {{site.cloudname}} or by self-hosting {{site.productname}}.
@@ -90,7 +88,7 @@ This procedure requires:
         Such as:
 
         ```js
-        <Editor apiKey="your-api-key" [init]={% raw %}{{% endraw %} /* your other settings */ {% raw %}}{% endraw %} />
+        <editor apiKey="your-api-key" [init]={% raw %}{{% endraw %} /* your other settings */ {% raw %}}{% endraw %} ></editor>
         ```
 
     * **{{site.productname}} Self-hosted**

--- a/_includes/integrations/angular-tech-ref.md
+++ b/_includes/integrations/angular-tech-ref.md
@@ -95,9 +95,9 @@ To register for a {{site.cloudname}} API key, visit the [sign-up page]({{site.ac
 ##### Example: `apiKey`
 
 ```xml
-<Editor
+<editor
   apiKey="your-api-key"
-/>
+></editor>
 ```
 
 #### `cloudChannel`
@@ -115,7 +115,10 @@ Changes the {{site.productname}} build used for the editor to one of the followi
 Such as:
 
 ```js
-<Editor apiKey="your-api-key" cloudChannel="{{site.productmajorversion}}-dev" [init]={% raw %}{{% endraw %} /* your other settings */ {% raw %}}{% endraw %} />
+<editor
+  apiKey="your-api-key"
+  cloudChannel="{{site.productmajorversion}}-dev"
+></editor>
 ```
 For information {{site.productname}} development channels, see: [Specifying the {{site.productname}} editor version deployed from Cloud - dev, testing, and stable releases]({{site.baseurl}}/cloud-deployment-guide/editor-plugin-version/#devtestingandstablereleases).
 
@@ -130,9 +133,9 @@ The `disabled` property can dynamically switch the editor between a "disabled" (
 ##### Example: `disabled`
 
 ```html
-<Editor
+<editor
   [disabled]="true"
-/>
+></editor>
 ```
 
 #### `id`
@@ -145,9 +148,9 @@ An id for the editor. Used for retrieving the editor instance using the `tinymce
 ##### Example: `id`
 
 ```xml
-<Editor
+<editor
   id="uuid"
-/>
+></editor>
 ```
 
 #### `init`
@@ -162,14 +165,14 @@ For information on the {{site.productname}} selector (`tinymce.init`), see: [Bas
 ##### Example: `init`
 
 ```html
-<Editor
+<editor
   [init]="{% raw %}{{% endraw %}
     plugins: [
      'lists link image paste help wordcount'
     ],
     toolbar: 'undo redo | formatselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | help'
   {% raw %}}{% endraw %}"
-/>
+></editor>
 ```
 
 #### `initialValue`
@@ -182,9 +185,9 @@ Initial content of the editor when the editor is initialized.
 ##### Example: `initialValue`
 
 ```xml
-<Editor
-  initialValue='Once upon a time...'
-/>
+<editor
+  initialValue="Once upon a time..."
+></editor>
 ```
 
 #### `inline`
@@ -199,9 +202,9 @@ For information on inline mode, see: [User interface options - `inline`]({{site.
 ##### Example: `inline`
 
 ```html
-<Editor
+<editor
   [inline]="true"
-/>
+></editor>
 ```
 
 #### `plugins`
@@ -214,9 +217,9 @@ For information on adding plugins to {{site.productname}}, see: [Add plugins to 
 ##### Example: `plugins`
 
 ```xml
-<Editor
+<editor
   plugins="lists code"
-/>
+></editor>
 ```
 
 #### `tagName`
@@ -229,18 +232,16 @@ Only valid when [`<editor [inline]="true"></editor>`](#inline). Used to define t
 ##### Example: `tagName`
 
 ```html
-<Editor
+<editor
   [inline]="true"
-  tagName="myTextArea"
-/>
+  tagName="my-custom-tag"
+></editor>
 ```
 
 #### `toolbar`
 Used to set the toolbar for the editor. Using `<editor toolbar="bold italic"></editor>` is the same as setting `{toolbar: 'bold italic'}` in the {{site.productname}} selector (`tinymce.init`).
 
 For information setting the toolbar for {{site.productname}}, see: [User interface options - toolbar]({{site.baseurl}}/configure/editor-appearance/#toolbar).
-
-**Default value:** `' '`
 
 **Possible values:**  See [Editor control identifiers - Toolbar controls]({{site.baseurl}}/advanced/editor-control-identifiers/).
 
@@ -249,10 +250,10 @@ For information setting the toolbar for {{site.productname}}, see: [User interfa
 ##### Example: `toolbar`
 
 ```xml
-<Editor
+<editor
   plugins="code"
   toolbar="bold italic underline code"
-/>
+></editor>
 ```
 
 ### Using the `ngModel` directive
@@ -285,9 +286,9 @@ Functions can be bound to editor events, such as:
 <editor (onSelectionChange)="handleEvent($event)"></editor>
 ```
 
-When the handler is called (`handleEvent` in this example), it is called with two arguments:
+When the handler is called (`handleEvent` in this example), it is called with an event containing two properties:
 
-* `event` - The event object.
+* `event` - The TinyMCE event object.
 * `editor` - A reference to the editor.
 
 The following events are available:

--- a/_includes/integrations/react-quick-start.md
+++ b/_includes/integrations/react-quick-start.md
@@ -43,8 +43,8 @@ This procedure requires:
     import { Editor } from '@tinymce/tinymce-react';
 
     class App extends React.Component {
-      handleEditorChange = (e) => {
-        console.log('Content was updated:', e.target.getContent());
+      handleEditorChange = (content, editor) => {
+        console.log('Content was updated:', content);
       }
 
       render() {
@@ -64,7 +64,7 @@ This procedure requires:
                 alignleft aligncenter alignright alignjustify | \
                 bullist numlist outdent indent | removeformat | help'
             {% raw %}}}{% endraw %}
-            onChange={this.handleEditorChange}
+            onEditorChange={this.handleEditorChange}
           />
         );
       }

--- a/_includes/integrations/react-tech-ref.md
+++ b/_includes/integrations/react-tech-ref.md
@@ -26,9 +26,9 @@
 
 To install the `tinymce-react` package and save it to your `package.json`.
 
-    ```
-    $ npm install --save @tinymce/tinymce-react
-    ```
+```sh
+$ npm install --save @tinymce/tinymce-react
+```
 
 ### Configuring the editor
 
@@ -86,7 +86,11 @@ Changes the {{site.productname}} build used for the editor to one of the followi
 Such as:
 
 ```js
-<Editor apiKey='your-api-key' cloudChannel='{{site.productmajorversion}}-dev' init={% raw %}{{{% endraw %} /* your other settings */ {% raw %}}}{% endraw %} />
+<Editor
+  apiKey='your-api-key'
+  cloudChannel='{{site.productmajorversion}}-dev'
+  init={% raw %}{{{% endraw %} /* your other settings */ {% raw %}}}{% endraw %}
+/>
 ```
 For information {{site.productname}} development channels, see: [Specifying the {{site.productname}} editor version deployed from Cloud - dev, testing, and stable releases]({{site.baseurl}}/cloud-deployment-guide/editor-plugin-version/#devtestingandstablereleases).
 
@@ -209,7 +213,7 @@ Only valid when [`<Editor inline={true} />`](#inline). Used to define the HTML e
 ```xml
 <Editor
   inline={true}
-  tagName='myTextArea'
+  tagName='my-custom-tag'
 />
 ```
 
@@ -224,9 +228,6 @@ Sets the `name` attribute for the `textarea` element used for the editor in form
 
 ```xml
 <Editor
-  init={% raw %}{{{% endraw %}
-    selector: 'textarea'
-  {% raw %}}}{% endraw %}
   textareaName='myTextArea'
 />
 ```
@@ -235,8 +236,6 @@ Sets the `name` attribute for the `textarea` element used for the editor in form
 Used to set the toolbar for the editor. Using `<Editor toolbar='bold' />` is the same as setting `{toolbar: 'bold'}` in the {{site.productname}} selector (`tinymce.init`).
 
 For information setting the toolbar for {{site.productname}}, see: [User interface options - toolbar]({{site.baseurl}}/configure/editor-appearance/#toolbar).
-
-**Default value:** `' '`
 
 **Possible values:**  See [Editor control identifiers - Toolbar controls]({{site.baseurl}}/advanced/editor-control-identifiers/).
 
@@ -277,7 +276,10 @@ class MyComponent extends React.Component {
 
   render() {
     return (
-      <Editor value={this.state.content} onEditorChange={this.handleEditorChange} />
+      <Editor
+        value={this.state.content}
+        onEditorChange={this.handleEditorChange}
+      />
     )
   }
 }
@@ -293,7 +295,10 @@ Functions can be bound to editor events, such as:
 <Editor onSelectionChange={this.handlerFunction} />
 ```
 
-Where the `handlerFunction` is triggered with the event, in this case `onSelectionChange`.
+When the handler is called (**handlerFunction** in this example), it is called with two arguments:
+
+* `event` - The TinyMCE event object.
+* `editor` - A reference to the editor.
 
 The following events are available:
 

--- a/_includes/integrations/vue-quick-start.md
+++ b/_includes/integrations/vue-quick-start.md
@@ -50,7 +50,6 @@ This procedure requires:
         <img alt="Vue logo" src="./assets/logo.png">
         <editor
           api-key="no-api-key"
-          initialValue="<p>This is the initial content of the editor</p>"
           :init="{% raw %}{{% endraw %}
             height: 500,
             menubar: false,
@@ -64,7 +63,7 @@ This procedure requires:
               alignleft aligncenter alignright alignjustify | \
               bullist numlist outdent indent | removeformat | help'
           {% raw %}}{% endraw %}"
-          ></editor>
+        />
       </div>
     </template>
 

--- a/_includes/integrations/vue-tech-ref.md
+++ b/_includes/integrations/vue-tech-ref.md
@@ -63,7 +63,7 @@ $ npm install --save @tinymce/tinymce-vue
 3. Add the `<editor>` tag to the `template`
 
     ```html
-    <editor api-key="API_KEY" :init="{plugins: 'wordcount'}"></editor>
+    <editor api-key="API_KEY" :init="{plugins: 'wordcount'}" />
     ```
 
 ### Configuring the editor
@@ -121,7 +121,11 @@ Changes the {{site.productname}} build used for the editor to one of the followi
 Such as:
 
 ```js
-<editor api-key="your-api-key" cloud-channel="{{site.productmajorversion}}-dev" :init="{% raw %}{{% endraw %} /* your other settings */ {% raw %}}{% endraw %}" />
+<editor
+  api-key="your-api-key"
+  cloud-channel="{{site.productmajorversion}}-dev"
+  :init="{% raw %}{{% endraw %} /* your other settings */ {% raw %}}{% endraw %}"
+/>
 ```
 For information {{site.productname}} development channels, see: [Specifying the {{site.productname}} editor version deployed from Cloud - dev, testing, and stable releases]({{site.baseurl}}/cloud-deployment-guide/editor-plugin-version/#devtestingandstablereleases).
 
@@ -254,7 +258,7 @@ Only valid when [`<editor :inline=true />`](#inline). Used to define the HTML el
 ```xml
 <editor
   :inline=true
-  tag-name='myTextArea'
+  tag-name='my-custom-tag'
 />
 ```
 
@@ -262,8 +266,6 @@ Only valid when [`<editor :inline=true />`](#inline). Used to define the HTML el
 Used to set the toolbar for the editor. Using `<editor toolbar="bold italic" />` is the same as setting `{toolbar: 'bold italic'}` in the {{site.productname}} selector (`tinymce.init`).
 
 For information setting the toolbar for {{site.productname}}, see: [User interface options - toolbar]({{site.baseurl}}/configure/editor-appearance/#toolbar).
-
-**Default value:** `" "`
 
 **Possible values:**  See [Editor control identifiers - Toolbar controls]({{site.baseurl}}/advanced/editor-control-identifiers/).
 
@@ -283,7 +285,7 @@ For information setting the toolbar for {{site.productname}}, see: [User interfa
 The `v-model` directive can be used to create a two-way data binding. For example:
 
 ```html
-<editor v-model="content"></editor>
+<editor v-model="content" />
 ```
 
 For information on `v-model` and form input bindings, see: [Vue.js documentation - Form Input Bindings](https://vuejs.org/v2/guide/forms.html).
@@ -293,12 +295,12 @@ For information on `v-model` and form input bindings, see: [Vue.js documentation
 Functions can be bound to editor events, such as:
 
 ```html
-<editor @onSelectionChange="handlerFunction"></editor>
+<editor @onSelectionChange="handlerFunction" />
 ```
 
-Where the `handlerFunction` is triggered with the event and is called with two arguments:
+When the handler is called (**handlerFunction** in this example), it is called with two arguments:
 
-* `event` - The event object.
+* `event` - The TinyMCE event object.
 * `editor` - A reference to the editor.
 
 The following events are available:


### PR DESCRIPTION
Mostly various minor syntax fixes for the code examples for the React, Angular and Vue integrations