### PR TITLE
Update upload-images.md

### DIFF
--- a/general-configuration-guide/upload-images.md
+++ b/general-configuration-guide/upload-images.md
@@ -114,7 +114,7 @@ tinymce.init({
 	  success(json.location);
 	};
 	formData = new FormData();
-	formData.append('file', blobInfo.blob(), fileName(blobInfo));
+	formData.append('file', blobInfo.blob(), blobInfo.filename());
 	xhr.send(formData);
   }
 });


### PR DESCRIPTION
JS sample was referring to a fileName object that didn't exist in the sample code, and yields a "fileName does not exist" error.  This will correct the issue, and ensures the sample fully works.  Sample of complaint:  https://stackoverflow.com/questions/47027982/tinymce-uploadimages-function-not-working