### PR TITLE
Cleaned up template example that had removed settings

### DIFF
--- a/plugins/template.md
+++ b/plugins/template.md
@@ -285,8 +285,6 @@ tinymce.init({
     username : "Jack Black",
     staffid : "991234"
   },
-  template_popup_height: "400",
-  template_popup_width: "320",
   templates : [
     {
       title: "Editor Details",


### PR DESCRIPTION
These settings were removed in TinyMCE 5 and while the setting descriptions themselves were removed, they weren't removed from the other examples.

Fixes #1465