### PR TITLE
add note: moxiemanager not on cloud

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -54,6 +54,8 @@ differs_for_mobile: "> **Note**: The default option for this setting is differen
 
 thirdPartyInteg: "> **Important**: This Integration is maintained by a third-party developer. Tiny Technologies, Inc. bears no responsibility for this integration, which is not covered by the Tiny Self-Hosted Software License Agreement. For issues related to the integration, contact the third-party project directly."
 
+moxieMNotOnCloud: "> **Note**: The MoxieManager plugin is _not_ provided on the Tiny Cloud, and is provided as a self-hosted solution only."
+
 exclude:
   - Dockerfile
   - Gemfile

--- a/enterprise/moxiemanager.md
+++ b/enterprise/moxiemanager.md
@@ -5,6 +5,8 @@ description: MoxieManager is a premium plugin to manage files & images.
 keywords: moxiemanager .net php relative_urls
 ---
 
+{{site.moxieMNotOnCloud}}
+
 ## File and Image Management Using Moxie Manager
 
 MoxieManager is a premium {{site.productname}} plugin and server system that enables users to insert files located externally to the editor (e.g. on their client desktop) into their document.

--- a/plugins/moxiemanager.md
+++ b/plugins/moxiemanager.md
@@ -6,6 +6,8 @@ description: File and image management plugin and service
 keywords: amazon azure premium pro enterprise tiny relative_urls
 ---
 
+{{site.moxieMNotOnCloud}}
+
 MoxieManager is a premium {{site.productname}} plugin and server system that enables users to insert files located externally to the editor (e.g. on their client desktop) into their document.
 
 MoxieManager is an application separate from {{site.productname}} that includes .NET or PHP server components. Being built by the team behind {{site.productname}} it has tight integration with the editor via a toolbar control. It is designed to work with {{site.productname}} configuration settings such as `relative_urls`.


### PR DESCRIPTION
Related Ticket: DOC-539

Description of Changes:
* add a note to emphasize that moxiemanager not provided by Tiny Cloud

DOD:
- [x] nav.yml has been updated if applicable
- [x] file has been included where required if applicable
- [x] files removed have been deleted, not just excluded from the build if applicable

Review
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
