### PR TITLE
reducing ambiguity about location of origins.env

### DIFF
--- a/_includes/configuration/dockerized-hyperlinking-service.md
+++ b/_includes/configuration/dockerized-hyperlinking-service.md
@@ -99,7 +99,7 @@ and download either:
 1. _Optional_: Configure the Enhanced Media Embed Service, as described in [Configure Enhanced Media Embed Server]({{site.baseurl}}/enterprise/embed-media/mediaembed-server-config/).
 1. _Optional_: Configure the service to use a HTTP proxy by updating `config/ephox-hyperlinking-docker-env.conf`. See:
 [Configure server-side components - proxy]({{site.baseurl}}/enterprise/server/configure/#proxyoptional).
-1. Create an `origins.env` file and specify the Hypertext Transfer Protocol (HTTP) and domain name of sites hosting the TinyMCE editor (`allowed-origins`). Up to 99 origins can be added without editing `config/ephox-hyperlinking-docker-env.conf`.
+1. Create an `origins.env` file in the same directory as the `Dockerfile`, and specify the Hypertext Transfer Protocol (HTTP) and domain name of sites hosting the TinyMCE editor (`allowed-origins`). Up to 99 origins can be added without editing `config/ephox-hyperlinking-docker-env.conf`.
 
     For example:
 

--- a/_includes/configuration/dockerized-image-proxy.md
+++ b/_includes/configuration/dockerized-image-proxy.md
@@ -64,7 +64,7 @@ The following procedure covers downloading, configuring, building and testing th
     For information on the `http` configuration setting, see: [Configure server-side components - `http`]({{site.baseurl}}/enterprise/server/configure/#httpoptional).
 1. _Optional_: Configure the service to use a HTTP proxy by updating `config/ephox-image-proxy-docker-env.conf`. See:
 [Configure server-side components]({{site.baseurl}}/enterprise/server/configure/).
-7. Create an `origins.env` file and specify the Hypertext Transfer Protocol (HTTP) and domain name of sites hosting the TinyMCE editor (`allowed-origins`). Up to 99 origins can be added without editing `config/ephox-image-proxy-docker-env.conf`.
+7. Create an `origins.env` file in the same directory as the `Dockerfile`, and specify the Hypertext Transfer Protocol (HTTP) and domain name of sites hosting the TinyMCE editor (`allowed-origins`). Up to 99 origins can be added without editing `config/ephox-image-proxy-docker-env.conf`.
 
     For example:
 

--- a/_includes/configuration/dockerized-spelling-service.md
+++ b/_includes/configuration/dockerized-spelling-service.md
@@ -111,7 +111,7 @@ The following procedure covers downloading, configuring, building and testing th
 14. _Optional_: Configure the service to use a HTTP proxy by updating `config/ephox-spelling-docker-env.conf`. See:
     [Configure server-side components]({{site.baseurl}}/enterprise/server/configure/).
 15. _Optional_: Add a custom dictionary, as described in [Adding custom dictionaries]({{site.baseurl}}/enterprise/check-spelling/custom/).
-16. Create an `origins.env` file and specify the Hypertext Transfer Protocol (HTTP) and domain name of sites hosting the TinyMCE editor (`allowed-origins`). Up to 99 origins can be added without editing `config/ephox-spelling-docker-env.conf`.
+16. Create an `origins.env` file in the same directory as the `Dockerfile`, and specify the Hypertext Transfer Protocol (HTTP) and domain name of sites hosting the TinyMCE editor (`allowed-origins`). Up to 99 origins can be added without editing `config/ephox-spelling-docker-env.conf`.
 
     For example:
 


### PR DESCRIPTION
Related Ticket: DOC-416

Description of Changes:
* reducing ambiguity about location of the origins.env file for docker deployments of the server-side components.

DOD:
- [x] nav.yml has been updated if applicable
- [x] file has been included where required if applicable
- [x] files removed have been deleted, not just excluded from the build if applicable

Review
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
