### PR TITLE
RN powerpaste imagedrop source for pre/postprocess

### DIFF
--- a/release-notes/release-notes53.md
+++ b/release-notes/release-notes53.md
@@ -33,9 +33,13 @@ The following premium plugins updates were released alongside {{site.productname
 
 The {{site.productname}} 5.3 release includes an accompanying release of the **PowerPaste** premium plugin.
 
-**PowerPaste** 5.3.0 
+**PowerPaste** 5.3.0 adds a new `imagedrop` `source` which fires an event when dropping an image file into the editor. This `source` can be used with the PowerPaste `paste_preprocess` and `paste_postprocess` options.
 
-For information on the PowerPaste plugin, see: [PowerPaste plugin]({{site.baseurl}}/plugins/powerpaste/).
+For information on:
+
+- The PowerPaste plugin, see: [PowerPaste plugin]({{site.baseurl}}/plugins/powerpaste/).
+- The PowerPaste `paste_preprocess` option, see: [PowerPaste plugin - `paste_preprocess`]({{site.baseurl}}/plugins/powerpaste/#paste_preprocess).
+- The PowerPaste `paste_postprocess` option, see: [PowerPaste plugin - `paste_postprocess`]({{site.baseurl}}/plugins/powerpaste/#paste_postprocess).
 
 ### Spellchecker Pro 2.0.2
 


### PR DESCRIPTION
Related Ticket: DOC-542

Description of Changes:
* Add a release note for the new `imagedrop` `source` for the PowerPaste `paste_preprocess` and `paste_postprocess` options.

DOD:
- [x] nav.yml has been updated if applicable
- [x] file has been included where required if applicable
- [x] files removed have been deleted, not just excluded from the build if applicable

Review
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
