### PR TITLE
update selfhosted docker service to match packs

### DIFF
--- a/_includes/configuration/dockerized-hyperlinking-service.md
+++ b/_includes/configuration/dockerized-hyperlinking-service.md
@@ -29,33 +29,7 @@ The following procedure covers downloading, configuring, building and testing th
     ```sh
     cd tinymce-selfhosted/tinymce-services/
     ```
-e
-{% elsif shbundledockerfiles == false %}
-1. Go to [{{ site.accountpage }}]({{ site.accountpageurl }}) > My Downloads
-and download either:
-* _Tiny Enhanced Media Embed_, or
-* _Tiny Link Checker_.
-2. Open a command line and navigate to the directory containing `ephox-hyperlinking_<version>.zip`. Windows Users should open a Bash command line as the Administrator User.
-3. Extract the contents of `ephox-hyperlinking_<version>.zip`, such as:
 
-    ```sh
-    unzip ephox-hyperlinking_<version>.zip -d tinymce-hyperlinking-service
-    ```
-    The structure of the extracted files will be:
-    ```sh
-    tinymce-hyperlinking-service/
-    ├── ephox-hyperlinking-docker-starter-kit.zip
-    ├── ephox-hyperlinking.war
-    ├── license.txt
-    ├── readme.txt
-    └── version.txt
-    ```
-4. Navigate into the extracted folder.
-
-    ```sh
-    cd tinymce-hyperlinking-service
-    ```
-{% endif %}
 5. Extract the contents of `ephox-hyperlinking-docker-starter-kit.zip`, such as:
 
     ```sh
@@ -83,6 +57,46 @@ and download either:
     ```sh
     cd hyperlinking-service-dockerfile
     ```
+
+{% elsif shbundledockerfiles == false %}
+1. Go to [{{ site.accountpage }}]({{ site.accountpageurl }}) > My Downloads
+and download either:
+* _Tiny Enhanced Media Embed_, or
+* _Tiny Link Checker_.
+2. Open a command line and navigate to the directory containing `ephox-hyperlinking_<version>.zip`. Windows Users should open a Bash command line as the Administrator User.
+3. Extract the contents of `ephox-hyperlinking_<version>.zip`, such as:
+
+    ```sh
+    unzip ephox-hyperlinking_<version>.zip -d tinymce-hyperlinking-service
+    ```
+
+4. Navigate into the extracted folder.
+
+    ```sh
+    cd tinymce-hyperlinking-service
+    ```
+
+5. Extract the contents of `ephox-hyperlinking-docker-starter-kit.zip`, such as:
+
+    ```sh
+    unzip ephox-hyperlinking-docker-starter-kit.zip
+    ```
+    
+    The structure of the current directory (`tinymce-hyperlinking-service/`) will be:
+    ```sh
+    tinymce-hyperlinking-service/
+    ├── config
+    │   └── ephox-hyperlinking-docker-env.conf
+    ├── docker-entrypoint.sh
+    ├── Dockerfile
+    ├── ephox-hyperlinking-docker-starter-kit.zip
+    ├── ephox-hyperlinking.war
+    ├── generate-jetty-start.sh
+    ├── license.txt
+    ├── readme.txt
+    └── version.txt
+    ```
+{% endif %}
 
 5. Set the permissions on the extracted files to executable.
 

--- a/_includes/configuration/dockerized-hyperlinking-service.md
+++ b/_includes/configuration/dockerized-hyperlinking-service.md
@@ -29,24 +29,7 @@ The following procedure covers downloading, configuring, building and testing th
     ```sh
     cd tinymce-selfhosted/tinymce-services/
     ```
-
-5. Extract the contents of `ephox-hyperlinking-docker-starter-kit.zip`, such as:
-
-    ```sh
-    unzip ephox-hyperlinking-docker-starter-kit.zip -d hyperlinking-service-dockerfile
-    ```
-
-6. Copy `ephox-hyperlinking.war` into the directory containing the extracted files, such as:
-
-    ```sh
-    cp ephox-hyperlinking.war hyperlinking-service-dockerfile/
-    ```
-
-4. Navigate into the `hyperlinking-service-dockerfile` folder.
-
-    ```sh
-    cd hyperlinking-service-dockerfile
-    ```
+e
 {% elsif shbundledockerfiles == false %}
 1. Go to [{{ site.accountpage }}]({{ site.accountpageurl }}) > My Downloads
 and download either:
@@ -61,12 +44,11 @@ and download either:
     The structure of the extracted files will be:
     ```sh
     tinymce-hyperlinking-service/
-    ├── config
-    │   └── ephox-hyperlinking-docker-env.conf
-    ├── docker-entrypoint.sh
-    ├── Dockerfile
+    ├── ephox-hyperlinking-docker-starter-kit.zip
     ├── ephox-hyperlinking.war
-    └── generate-jetty-start.sh
+    ├── license.txt
+    ├── readme.txt
+    └── version.txt
     ```
 4. Navigate into the extracted folder.
 
@@ -74,6 +56,34 @@ and download either:
     cd tinymce-hyperlinking-service
     ```
 {% endif %}
+5. Extract the contents of `ephox-hyperlinking-docker-starter-kit.zip`, such as:
+
+    ```sh
+    unzip ephox-hyperlinking-docker-starter-kit.zip -d hyperlinking-service-dockerfile
+    ```
+    
+    The structure of the extracted files will be:
+    ```sh
+    hyperlinking-service-dockerfile/
+    ├── config
+    │   └── ephox-hyperlinking-docker-env.conf
+    ├── docker-entrypoint.sh
+    ├── Dockerfile
+    └── generate-jetty-start.sh
+    ```
+
+6. Copy `ephox-hyperlinking.war` into the directory containing the extracted files, such as:
+
+    ```sh
+    cp ephox-hyperlinking.war hyperlinking-service-dockerfile/
+    ```
+
+4. Navigate into the `hyperlinking-service-dockerfile` folder.
+
+    ```sh
+    cd hyperlinking-service-dockerfile
+    ```
+
 5. Set the permissions on the extracted files to executable.
 
     ```sh

--- a/_includes/configuration/dockerized-spelling-service.md
+++ b/_includes/configuration/dockerized-spelling-service.md
@@ -36,34 +36,6 @@ The following procedure covers downloading, configuring, building and testing th
     cd tinymce-selfhosted/tinymce-services/
     ```
 
-    {% elsif shbundledockerfiles == false %}
-
-8.  Go to **[{{ site.accountpage }}]({{ site.accountpageurl }}) > My Downloads** and download _Tiny Spell Checker Pro_.
-9.  Open a command line and navigate to the directory containing `ephox-spelling_<version>.zip`. Windows Users should open a Bash command line as the Administrator User.
-10. Extract the contents of `ephox-spelling_<version>.zip`, such as:
-
-    ```sh
-    unzip ephox-spelling_<version>.zip -d tinymce-spelling-service
-    ```
-
-    The structure of the extracted files will be:
-
-    ```sh
-    tinymce-spelling-service/
-    ├── ephox-spelling-docker-starter-kit.zip
-    ├── ephox-spelling.war
-    ├── license.txt
-    ├── readme.txt
-    └── version.txt
-    ```
-
-11. Navigate into the extracted folder.
-
-    ```sh
-    cd tinymce-spelling-service
-    ```
-
-    {% endif %}
 5.  Extract the contents of `ephox-spelling-docker-starter-kit.zip`, such as:
 
     ```sh
@@ -92,6 +64,46 @@ The following procedure covers downloading, configuring, building and testing th
     ```sh
     cd spelling-service-dockerfile
     ```
+
+    {% elsif shbundledockerfiles == false %}
+
+8.  Go to **[{{ site.accountpage }}]({{ site.accountpageurl }}) > My Downloads** and download _Tiny Spell Checker Pro_.
+9.  Open a command line and navigate to the directory containing `ephox-spelling_<version>.zip`. Windows Users should open a Bash command line as the Administrator User.
+10. Extract the contents of `ephox-spelling_<version>.zip`, such as:
+
+    ```sh
+    unzip ephox-spelling_<version>.zip -d tinymce-spelling-service
+    ```
+
+11. Navigate into the extracted folder.
+
+    ```sh
+    cd tinymce-spelling-service
+    ```
+
+5.  Extract the contents of `ephox-spelling-docker-starter-kit.zip`, such as:
+
+    ```sh
+    unzip ephox-spelling-docker-starter-kit.zip
+    ```
+
+    The structure of the current directory (`tinymce-spelling-service/`) will be:
+
+    ```sh
+    tinymce-spelling-service/
+    ├── config
+    │   └── ephox-spelling-docker-env.conf
+    ├── docker-entrypoint.sh
+    ├── Dockerfile
+    ├── ephox-spelling-docker-starter-kit.zip
+    ├── ephox-spelling.war
+    ├── generate-jetty-start.sh
+    ├── license.txt
+    ├── readme.txt
+    └── version.txt
+    ```
+
+    {% endif %}
 
 12. Set the permissions on the extracted files to executable.
 

--- a/_includes/configuration/dockerized-spelling-service.md
+++ b/_includes/configuration/dockerized-spelling-service.md
@@ -36,24 +36,6 @@ The following procedure covers downloading, configuring, building and testing th
     cd tinymce-selfhosted/tinymce-services/
     ```
 
-5.  Extract the contents of `ephox-spelling-docker-starter-kit.zip`, such as:
-
-    ```sh
-    unzip ephox-spelling-docker-starter-kit.zip -d spelling-service-dockerfile
-    ```
-
-6.  Copy `ephox-spelling.war` into the directory containing the extracted files, such as:
-
-    ```sh
-    cp ephox-spelling.war spelling-service-dockerfile/
-    ```
-
-7.  Navigate into the `spelling-service-dockerfile` folder.
-
-    ```sh
-    cd spelling-service-dockerfile
-    ```
-
     {% elsif shbundledockerfiles == false %}
 
 8.  Go to **[{{ site.accountpage }}]({{ site.accountpageurl }}) > My Downloads** and download _Tiny Spell Checker Pro_.
@@ -68,12 +50,11 @@ The following procedure covers downloading, configuring, building and testing th
 
     ```sh
     tinymce-spelling-service/
-    ├── config
-    │   └── ephox-spelling-docker-env.conf
-    ├── docker-entrypoint.sh
-    ├── Dockerfile
+    ├── ephox-spelling-docker-starter-kit.zip
     ├── ephox-spelling.war
-    └── generate-jetty-start.sh
+    ├── license.txt
+    ├── readme.txt
+    └── version.txt
     ```
 
 11. Navigate into the extracted folder.
@@ -83,6 +64,34 @@ The following procedure covers downloading, configuring, building and testing th
     ```
 
     {% endif %}
+5.  Extract the contents of `ephox-spelling-docker-starter-kit.zip`, such as:
+
+    ```sh
+    unzip ephox-spelling-docker-starter-kit.zip -d spelling-service-dockerfile
+    ```
+
+    The structure of the extracted files will be:
+
+    ```sh
+    spelling-service-dockerfile/
+    ├── config
+    │   └── ephox-spelling-docker-env.conf
+    ├── docker-entrypoint.sh
+    ├── Dockerfile
+    └── generate-jetty-start.sh
+    ```
+
+6.  Copy `ephox-spelling.war` into the directory containing the extracted files, such as:
+
+    ```sh
+    cp ephox-spelling.war spelling-service-dockerfile/
+    ```
+
+7.  Navigate into the `spelling-service-dockerfile` folder.
+
+    ```sh
+    cd spelling-service-dockerfile
+    ```
 
 12. Set the permissions on the extracted files to executable.
 


### PR DESCRIPTION
Related Ticket: DOC-543

Description of Changes:
* Update dockerized self-hosted services docs for individually licensed services to match the final file structure.

DOD:
- [x] nav.yml has been updated if applicable
- [x] file has been included where required if applicable
- [x] files removed have been deleted, not just excluded from the build if applicable

Review
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
