### PR TITLE
Add note and fix example on spellchecker

### DIFF
--- a/plugins/spellchecker.md
+++ b/plugins/spellchecker.md
@@ -7,6 +7,8 @@ keywords: spellchecker spellchecker_callback spellchecker_language spellchecker_
 controls: toolbar button, menu item
 ---
 
+> **Note**: The Spell Checker plugin is self-hosted _only_. The Spell Checker Pro plugin is provided for some {{site.cloudname}} plans. For information on the Spell Checker Pro plugin, see: [Spell Checker Pro plugin]({{site.baseurl}}/plugins/tinymcespellchecker/).
+
 This plugin enables {{site.productname}}'s spellcheck functionality. It also adds a toolbar button and the menu item `Spellcheck` under the `Tools` menu dropdown.
 
 **Type:** `String`
@@ -18,7 +20,8 @@ tinymce.init({
   selector: "textarea",  // change this value according to your HTML
   plugins: "spellchecker",
   menubar: "tools",
-  toolbar: "spellchecker"
+  toolbar: "spellchecker",
+  spellchecker_rpc_url: 'spellchecker.php'
 });
 ```
 


### PR DESCRIPTION
Related Ticket: DOC-221

Description of Changes:
* Added a note: community spellchecker is not available on cloud
* Added spellchecker_rpc_url: 'spellchecker.php' to the example to reinforce that it requires a self-hosted backend

DOD:
- [x] nav.yml has been updated if applicable
- [x] file has been included where required if applicable
- [x] files removed have been deleted, not just excluded from the build if applicable

Review
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
