### PR TITLE
Spell out acronym on first use

### DIFF
--- a/tinydrive/jwt-authentication.md
+++ b/tinydrive/jwt-authentication.md
@@ -8,7 +8,7 @@ keywords: jwt authentication
 
 ## Introduction
 
-{{site.cloudfilemanager}} requires you to setup JWT authentication. This is to ensure that the security of your files remains in your control.
+{{site.cloudfilemanager}} requires you to setup JSON Web Token (JWT) authentication. This is to ensure that the security of your files remains in your control.
 
 JWT is a standard authorization solution for web services and is documented in more detail at the [https://jwt.io/](https://jwt.io/) website. The guide aims to show how to setup JWT authentication for {{site.cloudfilemanager}}.
 


### PR DESCRIPTION
I found knowing JWT stands for JSON Web Token made it slightly less mysterious and more modern. (I think there was some sort of JWT in Java.) It is also best practice to spell out acronyms on first use.

Related Ticket: 

Description of Changes:
* Placeholder text

DOD:
- [ x] nav.yml has been updated if applicable
- [ x] file has been included where required if applicable
- [ x] files removed have been deleted, not just excluded from the build if applicable

Review
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
