### PR TITLE
improve clarity about menubar on mobile

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -49,7 +49,7 @@ requires_5_2v: "> **Note**: This feature is only available for TinyMCE 5.2 and l
 
 notonmobile: "> **Note**: This option is not supported on mobile devices."
 premiumplugin: "> **Note**: This plugin is only available for [paid TinyMCE subscriptions](https://www.tiny.cloud/pricing)."
-differs_for_mobile: "> **Note**: The default option for this setting is different for mobile devices. For information on the default mobile setting, see: [TinyMCE Mobile - Configuration settings with mobile defaults](https://www.tiny.cloud/docs/mobile/#configurationsettingswithmobiledefaults/)."
+differs_for_mobile: "> **Note**: The default option for this setting is different for mobile devices. For information on the default mobile setting, see: [TinyMCE Mobile - Configuration settings with mobile defaults](https://www.tiny.cloud/docs/mobile/#mobiledefaultsforselectedsettings)."
 
 thirdPartyInteg: "> **Important**: This Integration is maintained by a third-party developer. Tiny Technologies, Inc. bears no responsibility for this integration, which is not covered by the Tiny Self-Hosted Software License Agreement. For issues related to the integration, contact the third-party project directly."
 

--- a/_includes/configuration/menu.md
+++ b/_includes/configuration/menu.md
@@ -14,4 +14,6 @@ If you would like to group these menu items, please insert a `|` pipe character 
 
 {% include configuration/defaultmenuitems.md %}
 
+{{site.differs_for_mobile}}
+
 If all you need is to control which menus are available and/or in what order, see the [menubar parameter](#menubar).

--- a/_includes/configuration/mobile.md
+++ b/_includes/configuration/mobile.md
@@ -13,6 +13,7 @@ tinymce.init({
   selector: 'textarea',
   plugins: [ 'code', 'lists' ]
   mobile: {
+    menubar: true,
     plugins: [ 'autosave', 'lists', 'autolink' ],
     toolbar: [ 'undo', 'bold', 'italic', 'styleselect' ]
   }


### PR DESCRIPTION
Related Ticket: DOC-465

Description of Changes:
* add menubar reference to mobile option
* add mobile differences note to menu option
* fix broken link in differs_for_mobile note

DOD:
- [x] nav.yml has been updated if applicable
- [x] file has been included where required if applicable
- [x] files removed have been deleted, not just excluded from the build if applicable

Review
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
