### PR TITLE
DOC-549: Update module loader examples to include importing default icons

### DIFF
--- a/advanced/usage-with-module-loaders.md
+++ b/advanced/usage-with-module-loaders.md
@@ -19,6 +19,9 @@ If you are using ES2015 modules, a simple example could look something like this
 // Import {{site.productname}}
 import tinymce from 'tinymce/tinymce';
 
+// Default icons are required for TinyMCE 5.3 or above
+import 'tinymce/icons/default';
+
 // A theme is also required
 import 'tinymce/themes/silver';
 
@@ -40,6 +43,9 @@ The example is nearly the same if you are using CommonJS modules. However, a dif
 ```javascript
 // Import {{site.productname}}
 var tinymce = require('tinymce/tinymce');
+
+// Default icons are required for TinyMCE 5.3 or above
+require('tinymce/icons/default');
 
 // A theme is also required
 require('tinymce/themes/silver');


### PR DESCRIPTION
Related Ticket: DOC-549

Description of Changes:
* Updated the module loader examples to include importing the default icon pack since it was split from core in 5.3.0.

DOD:
- [X] nav.yml has been updated if applicable
- [X] file has been included where required if applicable
- [X] files removed have been deleted, not just excluded from the build if applicable

Review
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
