### PR TITLE
Fix a broken link on color picker plugin

### DIFF
--- a/plugins/colorpicker.md
+++ b/plugins/colorpicker.md
@@ -6,4 +6,4 @@ description: Select a color from a pallete.
 keywords: colorpicker color color_picker_callback
 ---
 
-With the release {{site.productname}} 5 the color picker plugin has been combined into the editor core. For information on adding the color picker, see: [`custom_colors`]({{site.baseurl}}/configure/content-appearance/#custom_colors).
+With the release of {{site.productname}} 5, the color picker plugin has been merged into the editor core. For information on adding the color picker to {{site.productname}}, see: [`custom_colors`]({{site.baseurl}}/configure/content-appearance/#custom_colors).

--- a/plugins/colorpicker.md
+++ b/plugins/colorpicker.md
@@ -6,4 +6,4 @@ description: Select a color from a pallete.
 keywords: colorpicker color color_picker_callback
 ---
 
-With the release TinyMCE 5 the color picker plugin has been combined into the editor core. Accordingly, the [Color Picker documentation]({{site.baseurl}}/configure/content-appearance/#color_picker) has been moved into the core as well.
+With the release {{site.productname}} 5 the color picker plugin has been combined into the editor core. For information on adding the color picker, see: [`custom_colors`]({{site.baseurl}}/configure/content-appearance/#custom_colors).


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* Fixed a broken link on the color picker plugin page and updated the text.

DOD:
- [x] nav.yml has been updated if applicable
- [x] file has been included where required if applicable
- [x] files removed have been deleted, not just excluded from the build if applicable

Review
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
