### PR TITLE
reenabling spellcheck-as-you-type on ff demo

### DIFF
--- a/_includes/codepens/full-featured/example.js
+++ b/_includes/codepens/full-featured/example.js
@@ -49,7 +49,6 @@ tinymce.init({
   quickbars_selection_toolbar: 'bold italic | quicklink h2 h3 blockquote quickimage quicktable',
   noneditable_noneditable_class: "mceNonEditable",
   toolbar_mode: 'sliding',
-  spellchecker_dialog: true,
   spellchecker_whitelist: ['Ephox', 'Moxiecode'],
   tinycomments_mode: 'embedded',
   content_style: ".mymention{ color: gray; }",

--- a/_includes/codepens/full-featured/index.js
+++ b/_includes/codepens/full-featured/index.js
@@ -271,7 +271,6 @@ tinymce.init({
   quickbars_selection_toolbar: 'bold italic | quicklink h2 h3 blockquote quickimage quicktable',
   noneditable_noneditable_class: "mceNonEditable",
   toolbar_mode: 'sliding',
-  spellchecker_dialog: true,
   spellchecker_whitelist: ['Ephox', 'Moxiecode'],
   tinycomments_mode: 'embedded',
   content_style: ".mymention{ color: gray; }",


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* Re-enable spell-checking-as-you-type on the full-featured demo

DOD:
- [x] nav.yml has been updated if applicable
- [x] file has been included where required if applicable
- [x] files removed have been deleted, not just excluded from the build if applicable

Review
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
