### PR TITLE
Doc fallback-to-get for linkcheck and consolidate

### DIFF
--- a/enterprise/check-links.md
+++ b/enterprise/check-links.md
@@ -12,29 +12,11 @@ Think of Link Checker as "spell-checking for URLs". But instead of checking spel
 
 Your have two deployment options. One is super easy with {{site.cloudname}}, the other is to go the more traditional Self-hosted route, requiring an additional [server-side component]({{ site.baseurl }}/enterprise/server/) to be installed and configured.
 
-## Link Checker self-hosted quick setup
+## Link Checker self-hosted setup
 
-Once you have the [server-side component]({{ site.baseurl }}/enterprise/server/) installed, additional configuration to your `application.conf` file is required. (Don't forget to restart the Java application server after updating the configuration.)
+Once you have the server-side component installed, additional configuration to your `application.conf` file is required. (Don't forget to restart the Java application server after updating the configuration.)
 
-This element configures the Link Checker service's built-in cache. When a hyperlink is checked and confirmed valid, the result is cached to save unnecessary network traffic in the future.
-
-Default settings are automatically configured, meaning these settings are optional.
-
-- `capacity` - sets the capacity of the cache. The default setting is 500.
-- `timeToLiveInSeconds` - sets the time-to-live of elements of the cache, measured in seconds. This is the maximum total amount of time that an element is allowed to remain in the cache. The default setting is 86400 seconds, which is one day.
-- `timeToIdleInSeconds` - sets the time-to-idle of elements of the cache, measured in seconds. This is the maximum amount of time that an element will remain in the cache if it is not being accessed. The default setting is 3600 seconds, which is one hour.
-
-Example:
-
-```
-ephox {
-  link-checking.cache {
-    capacity = 500
-    timeToLiveInSeconds = 86400
-    timeToIdleInSeconds = 3600
-  }
-}
-```
+For information on configuring the server-side component, see: [Configure server-side components]({{ site.baseurl }}/enterprise/server/).
 
 You will also find more Self-hosted setup information on the [Link Checker plugin page]({{ site.baseurl }}/plugins/linkchecker/).
 

--- a/enterprise/server/configure.md
+++ b/enterprise/server/configure.md
@@ -14,10 +14,7 @@ This configuration file will require you to enter *at least* the following  info
 
 - `allowed-origins` - the domains allowed to communicate with the server-side editor features. This is required by all server-side components.
 
-Some server-side components require additional configuration which can be found in their individual documentation:
-
-- [Enhanced Media Embed]({{ site.baseurl }}/enterprise/embed-media/mediaembed-server-config/)
-- [Link Checker]({{ site.baseurl }}/enterprise/check-links/#linkcheckersdkquicksetup)
+The Enhanced Media Embed server-side component require additional configuration, which can be found on the [Enhanced Media Embed page]({{ site.baseurl }}/enterprise/embed-media/mediaembed-server-config/).
 
 ### `allowed-origins` (required)
 
@@ -213,6 +210,66 @@ ephox {
     }
 }
 ````
+
+### `link-checking` (optional)
+
+The Link checker has three configurable settings:
+
+- `enabled`
+- `fallback-to-get`
+- `link-checking.cache`
+
+#### `enabled` (optional)
+
+Used to enable (`true`) or disable (`false`) the Link-checking service. This setting is `true` by default.
+
+For example:
+
+```
+ephox {
+  link-checking {
+    enabled = true
+  }
+}
+```
+
+#### `fallback-to-get` (optional)
+
+The Link-checker normally relies on the `HEAD` response. If this setting is `true`, the link-checker will fall-back to `GET` responses. When `true`, the Link checker can correctly identify working URLs that return non-standard `HEAD` replies. This setting can lead to performance issues when enabled (`true`) and is set to `false` by default.
+
+For example:
+
+```
+ephox {
+  link-checking {
+    fallback-to-get = true
+  }
+}
+```
+
+#### `cache` (optional)
+
+This element configures the Link Checker service's built-in cache. When a hyperlink is checked and confirmed valid, the result is cached to save unnecessary network traffic in the future.
+
+Default settings are automatically configured, meaning these settings are optional.
+
+- `capacity` - sets the capacity of the cache. The default setting is 500.
+- `timeToLiveInSeconds` - sets the time-to-live of elements of the cache, measured in seconds. This is the maximum total amount of time that an element is allowed to remain in the cache. The default setting is 86400 seconds, which is one day.
+- `timeToIdleInSeconds` - sets the time-to-idle of elements of the cache, measured in seconds. This is the maximum amount of time that an element will remain in the cache if it is not being accessed. The default setting is 3600 seconds, which is one hour.
+
+Example:
+
+```
+ephox {
+  link-checking {
+    cache {
+      capacity = 500
+      timeToLiveInSeconds = 86400
+      timeToIdleInSeconds = 3600
+    }
+  }
+}
+```
 
 ## Logging
 

--- a/enterprise/server/configure.md
+++ b/enterprise/server/configure.md
@@ -237,6 +237,8 @@ ephox {
 
 #### `fallback-to-get` (optional)
 
+{{site.requires_jsscwar_230v}}
+
 The Link-checker normally relies on the `HEAD` response. If this setting is `true`, the link-checker will fall-back to `GET` responses. When `true`, the Link checker can correctly identify working URLs that return non-standard `HEAD` replies. This setting can lead to performance issues when enabled (`true`) and is set to `false` by default.
 
 For example:

--- a/enterprise/server/configure.md
+++ b/enterprise/server/configure.md
@@ -239,7 +239,7 @@ ephox {
 
 {{site.requires_jsscwar_230v}}
 
-The Link-checker normally relies on the `HEAD` response. If this setting is `true`, the link-checker will fall-back to `GET` responses. When `true`, the Link checker can correctly identify working URLs that return non-standard `HEAD` replies. This setting can lead to performance issues when enabled (`true`) and is set to `false` by default.
+The Link-checker normally relies on the `HEAD` response. If `fallback-to-get` is `true`, the link-checker may issue a `GET` request in addition to the `HEAD` request to verify a link. When `true`, the Link checker can correctly identify working URLs that return non-standard `HEAD` replies. Enabling the `fallback-to-get` setting can lead to server performance issues and is set to `false` by default.
 
 For example:
 

--- a/enterprise/server/configure.md
+++ b/enterprise/server/configure.md
@@ -239,7 +239,7 @@ ephox {
 
 {{site.requires_jsscwar_230v}}
 
-The Link-checker normally relies on the `HEAD` response. If `fallback-to-get` is `true`, the link-checker may issue a `GET` request after the receiving a non-standard `HEAD` response to verify a link. When `true`, the Link checker can correctly identify working URLs that return non-standard `HEAD` replies. Enabling the `fallback-to-get` setting can lead to server performance issues and is set to `false` by default.
+The Link-checker normally relies on the `HEAD` response. If `fallback-to-get` is `true`, the link-checker may issue a `GET` request after receiving a non-standard `HEAD` response to verify a link. When `true`, the Link checker can correctly identify working URLs that return non-standard `HEAD` replies. Enabling the `fallback-to-get` setting can lead to server performance issues and is set to `false` by default.
 
 For example:
 

--- a/enterprise/server/configure.md
+++ b/enterprise/server/configure.md
@@ -239,7 +239,7 @@ ephox {
 
 {{site.requires_jsscwar_230v}}
 
-The Link-checker normally relies on the `HEAD` response. If `fallback-to-get` is `true`, the link-checker may issue a `GET` request in addition to the `HEAD` request to verify a link. When `true`, the Link checker can correctly identify working URLs that return non-standard `HEAD` replies. Enabling the `fallback-to-get` setting can lead to server performance issues and is set to `false` by default.
+The Link-checker normally relies on the `HEAD` response. If `fallback-to-get` is `true`, the link-checker may issue a `GET` request after the receiving a non-standard `HEAD` response to verify a link. When `true`, the Link checker can correctly identify working URLs that return non-standard `HEAD` replies. Enabling the `fallback-to-get` setting can lead to server performance issues and is set to `false` by default.
 
 For example:
 

--- a/release-notes/release-notes53.md
+++ b/release-notes/release-notes53.md
@@ -63,15 +63,15 @@ For a list of valid menu items, see: [Editor control identifiers - Menu controls
 
 ### Enhanced Media Embed
 
-
+The {{site.productname}} 5.3 release includes accompanying changes affecting the {{site.productname}} **self-hosted** **Enhanced Media Embed** service. {{site.cloudname}} users are unaffected. For details, see: [Accompanying premium self-hosted server-side component changes](#accompanyingpremiumself-hostedserver-sidecomponentchanges).
 
 ### Image Tools Proxy
 
-
+The {{site.productname}} 5.3 release includes accompanying changes affecting the {{site.productname}} **self-hosted** **Image Tools Proxy** service. {{site.cloudname}} users are unaffected. For details, see: [Accompanying premium self-hosted server-side component changes](#accompanyingpremiumself-hostedserver-sidecomponentchanges).
 
 ### Link Checker
 
-
+The {{site.productname}} 5.3 release includes accompanying changes affecting the {{site.productname}} **self-hosted** **Link Checker** service. {{site.cloudname}} users are unaffected. For details, see: [Accompanying premium self-hosted server-side component changes](#accompanyingpremiumself-hostedserver-sidecomponentchanges).
 
 ### PowerPaste 5.3.0
 
@@ -96,6 +96,8 @@ The {{site.productname}} 5.3 release includes an accompanying release of the **S
 - Spellchecking performance issues when using the `autoresize` plugin.
 - Missing `spell-check` icons on Spell Checker Pro menu items.
 - Spellchecking incorrectly moving the editor selection into non-editable elements.
+
+The {{site.productname}} **self-hosted** **Spell Checker Pro** service has also been updated. {{site.cloudname}} users are unaffected. For details, see: [Accompanying premium self-hosted server-side component changes](#accompanyingpremiumself-hostedserver-sidecomponentchanges).
 
 For information on Spell Checker Pro plugin, see: [Spell Checker Pro plugin]({{site.baseurl}}/plugins/tinymcespellchecker/).
 
@@ -140,6 +142,12 @@ For information on deploying the server-side components using Docker, see: [Cont
 The new `same-origin` option allows all cross-origin requests to be blocked by the server while allowing all same-origin requests.
 
 For information on configuring the same-origin option, see: [Configure server-side components - allowed-origins.same-origin (optional)]({{site.baseurl}}/enterprise/server/configure/#allowed-originssame-originoptional).
+
+### New `fallback-to-get` setting for the Link Checker service
+
+The new `fallback-to-get` configuration setting allows the Link checker can correctly identify working URLs that return non-standard `HEAD` replies.
+
+For information on configuring the Link Checker service, see: [Configure server-side components - `link-checking`]({{site.baseurl}}/enterprise/server/configure/#link-checkingoptional)
 
 ## Minor changes for TinyMCE 5.3
 


### PR DESCRIPTION
Related Ticket: DOC-521

Description of Changes:
* Document new linkchecker server-side setting `fallback-to-get`
* Add release note and cross-ref premium plugin release notes to server-side changes
* Move linkchecker config setting to server-side component page and document undocumented `enabled` setting.
* Additional minor fixes.

DOD:
- [x] nav.yml has been updated if applicable
- [x] file has been included where required if applicable
- [x] files removed have been deleted, not just excluded from the build if applicable

Review
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
