### PR TITLE
regex allowed-origins docs and RN

### DIFF
--- a/enterprise/server/configure.md
+++ b/enterprise/server/configure.md
@@ -107,6 +107,24 @@ ephox {
 }
 ````
 
+#### Regular Expressions support
+
+{{site.requires_jsscwar_230v}}
+
+Regular expressions can be used alongside [wildcards](#wildcardsupport) for specifying `allowed-origins.origins`. To use a regular expression, start and end the expression with the forward-slash `'/'` character.
+
+For example:
+
+```
+ephox {
+  allowed-origins {
+    origins = [ "https?://myserver", "/(myserver|myotherserver\.)?example\.com/", "http://myserver:8080" ]
+  }
+}
+```
+
+For a list of valid constructs, see: [Java 8: `java.util.regex` - Summary of regular-expression constructs](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#sum).
+
 #### `allowed-origins.same-origin` (optional)
 
 {{site.requires_jsscwar_230v}}

--- a/release-notes/release-notes53.md
+++ b/release-notes/release-notes53.md
@@ -135,6 +135,10 @@ From {{site.productname}} 5.3, premium self-hosted bundles include the files req
 
 For information on deploying the server-side components using Docker, see: [Containerized service deployments]({{site.baseurl}}/enterprise/server/dockerservices/).
 
+### Regular Expression support for allowed-origins
+
+Version 2.3.0 of the {{site.productname}} server-side components adds support for using regular expressions to specify `allowed-origins`. For information on using regular expressions for specifying allowed origins, see: [Configure server-side components - Regular Expressions support]({{site.baseurl}}/enterprise/server/configure/#regularexpressionssupport).
+
 ### New configuration option for simplifying same-origin deployments
 
 The new `same-origin` option allows all cross-origin requests to be blocked by the server while allowing all same-origin requests.


### PR DESCRIPTION
Related Ticket: DOC-522

Description of Changes:
* Added docs on using  regex for specifying allowed-origins for server-side components
* Added release note for regex allowed-origins support

DOD:
- [x] nav.yml has been updated if applicable
- [x] file has been included where required if applicable
- [x] files removed have been deleted, not just excluded from the build if applicable

Review
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
