### PR TITLE
Add documentation for the pastetext toolbar button for the Paste plugin

### DIFF
--- a/plugins/paste.md
+++ b/plugins/paste.md
@@ -24,7 +24,7 @@ tinymce.init({
   selector: "textarea",  // change this value according to your HTML
   plugins: "paste",
   menubar: "edit",
-  toolbar: "paste pastetext" // paste corresponds to the `Paste` menu button, pastetext corresponds to the `Paste as text` menu button
+  toolbar: "paste pastetext"
 });
 ```
 

--- a/plugins/paste.md
+++ b/plugins/paste.md
@@ -24,7 +24,7 @@ tinymce.init({
   selector: "textarea",  // change this value according to your HTML
   plugins: "paste",
   menubar: "edit",
-  toolbar: "paste"
+  toolbar: "paste pastetext" // paste corresponds to the `Paste` menu button, pastetext corresponds to the `Paste as text` menu button
 });
 ```
 


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
Add documentation for the pastetext toolbar button for the Paste plugin

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
