### PR TITLE
add example for lists_indent_on_tab

### DIFF
--- a/plugins/lists.md
+++ b/plugins/lists.md
@@ -28,6 +28,17 @@ These settings affect the execution of the `lists` plugin.
 
 This boolean option allows to disable the indent on tab key functionality. Its default value is set to `true`.
 
+For example:
+
+```js
+tinymce.init({
+  selector: "textarea",  // change this value according to your HTML
+  plugins: "lists",
+  toolbar: "numlist bullist",
+  lists_indent_on_tab: false
+});
+```
+
 ## Commands
 
 The Lists plugin provides the following JavaScript commands.


### PR DESCRIPTION
Related Ticket: DOC-99

Description of Changes:
* Adding simple example for lists plugin `lists_indent_on_tab` option.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
