### PR TITLE
add context menu ids page

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -667,6 +667,7 @@
       - url: "#Editor Management Commands"
   - url: "editor-control-identifiers"
   - url: "editor-icon-identifiers"
+  - url: "editor-context-menu-identifiers"
   - url: "events"
     pages:
       - url: "#Handling Editor events"

--- a/advanced/editor-context-menu-identifiers.md
+++ b/advanced/editor-context-menu-identifiers.md
@@ -1,0 +1,12 @@
+---
+layout: default
+title: Editor context menu section identifiers
+title_nav: Editor context menu section identifiers
+description_short: Complete list of available context menu sections.
+description: Complete list of available context menu sections.
+keywords: contextmenu
+---
+
+{% include configuration/available-context-menu-sections.md %}
+
+For information on customizing the context menu and adding custom context menu sections, see: [Context menu]({{site.baseurl}}/ui-components/contextmenu/#availablecontextmenusections).

--- a/advanced/editor-context-menu-identifiers.md
+++ b/advanced/editor-context-menu-identifiers.md
@@ -1,7 +1,7 @@
 ---
 layout: default
-title: Editor context menu section identifiers
-title_nav: Editor context menu section identifiers
+title: Editor context menu identifiers
+title_nav: Editor context menu identifiers
 description_short: Complete list of available context menu sections.
 description: Complete list of available context menu sections.
 keywords: contextmenu


### PR DESCRIPTION
Related Ticket: DOC-563

Description of Changes:
* Add a context menu id's page alongside other id pages

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
