### PR TITLE
DOC-570: add mcetableapplycellstyle cmd

### DIFF
--- a/_includes/commands/table-cmds.md
+++ b/_includes/commands/table-cmds.md
@@ -4,6 +4,7 @@
 
 | Command                 | Description                                     |
 | ----------------------- | ----------------------------------------------- |
+| mcetableapplycellstyle | Applies the specified styles to the selected cells. The following styles can be changed with this command: `background-color`, `border-color`, `border-style`, and `border-width`. |
 | mceTableSplitCells      | Splits the current merged table cell.           |
 | mceTableMergeCells      | Merges the selected cells.                      |
 | mceTableInsertRowBefore | Inserts a row before the current row.           |
@@ -29,6 +30,7 @@
 **Examples**
 
 ```js
+tinymce.activeEditor.execCommand('mcetableapplycellstyle', false, { backgroundColor: 'red', borderColor: 'blue' });
 tinymce.activeEditor.execCommand('mceTableSplitCells');
 tinymce.activeEditor.execCommand('mceTableMergeCells');
 tinymce.activeEditor.execCommand('mceTableInsertRowBefore');

--- a/_includes/commands/table-cmds.md
+++ b/_includes/commands/table-cmds.md
@@ -4,7 +4,7 @@
 
 | Command                 | Description                                     |
 | ----------------------- | ----------------------------------------------- |
-| mceTableApplyCellStyle | Applies the specified styles to the selected cells. The following styles can be changed with this command: `background-color`, `border-color`, `border-style`, and `border-width`. Providing an empty value for a style will remove the style, such as `{ background-color: '' }`. {{site.requires_5_4v}} |
+| mceTableApplyCellStyle | Applies the specified styles to the selected cells. The following styles can be changed with this command: `background-color`, `border-color`, `border-style`, and `border-width`. Providing an empty value for a style will remove the style, such as `{ 'background-color': '' }`. {{site.requires_5_4v}} |
 | mceTableSplitCells      | Splits the current merged table cell.           |
 | mceTableMergeCells      | Merges the selected cells.                      |
 | mceTableInsertRowBefore | Inserts a row before the current row.           |

--- a/_includes/commands/table-cmds.md
+++ b/_includes/commands/table-cmds.md
@@ -4,7 +4,7 @@
 
 | Command                 | Description                                     |
 | ----------------------- | ----------------------------------------------- |
-| mcetableapplycellstyle | Applies the specified styles to the selected cells. The following styles can be changed with this command: `background-color`, `border-color`, `border-style`, and `border-width`. |
+| mceTableApplyCellStyle | Applies the specified styles to the selected cells. The following styles can be changed with this command: `background-color`, `border-color`, `border-style`, and `border-width`. Providing an empty value for a style will remove the style, such as `{ background-color: '' }`. {{site.requires_5_4v}} |
 | mceTableSplitCells      | Splits the current merged table cell.           |
 | mceTableMergeCells      | Merges the selected cells.                      |
 | mceTableInsertRowBefore | Inserts a row before the current row.           |
@@ -30,7 +30,8 @@
 **Examples**
 
 ```js
-tinymce.activeEditor.execCommand('mcetableapplycellstyle', false, { backgroundColor: 'red', borderColor: 'blue' });
+tinymce.activeEditor.execCommand('mceTableApplyCellStyle', false, { background-color: 'red', border-color: 'blue' });
+tinymce.activeEditor.execCommand('mceTableApplyCellStyle', false, { background-color: '' }); // removes the current background-color
 tinymce.activeEditor.execCommand('mceTableSplitCells');
 tinymce.activeEditor.execCommand('mceTableMergeCells');
 tinymce.activeEditor.execCommand('mceTableInsertRowBefore');

--- a/_includes/commands/table-cmds.md
+++ b/_includes/commands/table-cmds.md
@@ -30,8 +30,8 @@
 **Examples**
 
 ```js
-tinymce.activeEditor.execCommand('mceTableApplyCellStyle', false, { background-color: 'red', border-color: 'blue' });
-tinymce.activeEditor.execCommand('mceTableApplyCellStyle', false, { background-color: '' }); // removes the current background-color
+tinymce.activeEditor.execCommand('mceTableApplyCellStyle', false, { 'background-color': 'red', 'border-color': 'blue' });
+tinymce.activeEditor.execCommand('mceTableApplyCellStyle', false, { 'background-color': '' }); // removes the current background-color
 tinymce.activeEditor.execCommand('mceTableSplitCells');
 tinymce.activeEditor.execCommand('mceTableMergeCells');
 tinymce.activeEditor.execCommand('mceTableInsertRowBefore');

--- a/release-notes/release-notes54.md
+++ b/release-notes/release-notes54.md
@@ -29,6 +29,7 @@ The {{site.productname}} 5.4 release includes the following improvements for the
 
 - Adds: commands, APIs, and icons for; cut, copy, and paste columns.
 - Adds toolbar button icons for the cut, copy, and paste rows.
+- Adds a new `mcetableapplycellstyle`command for applying selected styles to table cells.
 
 For information on the table plugin, see: [Table plugin]({{site.baseurl}}/plugins/table/).
 

--- a/release-notes/release-notes54.md
+++ b/release-notes/release-notes54.md
@@ -29,7 +29,7 @@ The {{site.productname}} 5.4 release includes the following improvements for the
 
 - Adds: commands, APIs, and icons for; cut, copy, and paste columns.
 - Adds toolbar button icons for the cut, copy, and paste rows.
-- Adds a new `mcetableapplycellstyle`command for applying selected styles to table cells.
+- Adds a new `mceTableApplyCellStyle`command for applying selected styles to table cells.
 
 For information on the table plugin, see: [Table plugin]({{site.baseurl}}/plugins/table/).
 


### PR DESCRIPTION
Related Ticket: DOC-570

Description of Changes:
* Add `mcetableapplycellstyle` cmd to table plugin cmds list
* Add 5.4 release note for `mcetableapplycellstyle` cmd

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
