### PR TITLE
Add time and date format reference to template pg

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -491,6 +491,7 @@
     - url: "#Template Plugin Examples"
     - url: "#Making Templates"
     - url: "#Making Snippets"
+    - url: "#Reference Date/Time formats"
     - url: "#Commands"
   - url: "textcolor"
   - url: "textpattern"

--- a/_includes/configuration/ref-time-date-formats.md
+++ b/_includes/configuration/ref-time-date-formats.md
@@ -1,0 +1,20 @@
+### Reference Date/Time formats
+
+| Name | Summary         |
+|------|-----------------|
+| %D   | mm/dd/yy (same as %m/%d/%y) |
+| %r   | 12-hour clock time hh:mm:ss with AM or PM (same as %I:%M:%S %p) |
+| %y   | year as a decimal number without a century (range 00 to 99) |
+| %Y   | year as a decimal number including the century |
+| %m   | month as a decimal number (range 01 to 12) |
+| %B   | full localized month name (e.g. "January") |
+| %b   | abbreviated localized month name (e.g. "Jan") |
+| %d   | day of the month as a decimal number (range 01 to 31) |
+| %A   | full localized weekday name (e.g. "Monday") |
+| %a   | abbreviated localized weekday name (e.g. "Mon") |
+| %H   | hour as a decimal number using a 24-hour clock (range 00 to 23) |
+| %I   | hour as a decimal number using a 12-hour clock (range 01 to 12) |
+| %M   | minute as a decimal number (range 00-59) |
+| %S   | second as a decimal number (range 00-59) |
+| %p   | either "am" or "pm" according to the given time value |
+| %%   | a literal "%" character |

--- a/plugins/insertdatetime.md
+++ b/plugins/insertdatetime.md
@@ -94,26 +94,7 @@ tinymce.init({
 });
 ```
 
-### Reference Date/Time formats
-
-| Name | Summary         |
-|------|-----------------|
-| %D   | mm/dd/yy (same as %m/%d/%y) |
-| %r   | 12-hour clock time hh:mm:ss with AM or PM (same as %I:%M:%S %p) |
-| %y   | year as a decimal number without a century (range 00 to 99) |
-| %Y   | year as a decimal number including the century |
-| %m   | month as a decimal number (range 01 to 12) |
-| %B   | full localized month name (e.g. "January") |
-| %b   | abbreviated localized month name (e.g. "Jan") |
-| %d   | day of the month as a decimal number (range 01 to 31) |
-| %A   | full localized weekday name (e.g. "Monday") |
-| %a   | abbreviated localized weekday name (e.g. "Mon") |
-| %H   | hour as a decimal number using a 24-hour clock (range 00 to 23) |
-| %I   | hour as a decimal number using a 12-hour clock (range 01 to 12) |
-| %M   | minute as a decimal number (range 00-59) |
-| %S   | second as a decimal number (range 00-59) |
-| %p   | either "am" or "pm" according to the given time value |
-| %%   | a literal "%" character |
+{% include configuration/ref-time-date-formats.md %}
 
 ## Commands
 

--- a/plugins/template.md
+++ b/plugins/template.md
@@ -120,6 +120,8 @@ If the creation date is set as 9:00AM on January 15th 2000, then inserting this 
 <p class="cdate">01/15/2000 : 09:00</p>
 ```
 
+For a list of available date and time formats, see: [Reference Date/Time formats](#referencedatetimeformats).
+
 ### `template_mdate_classes`
 
 When HTML elements in a template are assigned this class, the content of the element will be replaced with the 'modified' date (`modifieddate`), formatted according to the `template_mdate_format` option. This option accepts a list of classes (separated by spaces).
@@ -169,6 +171,8 @@ If the date modified is set as 9:00AM on January 15th 2000, then inserting this 
 ```html
 <p class="mdate">01/15/2000 : 09:00</p>
 ```
+
+For a list of available date and time formats, see: [Reference Date/Time formats](#referencedatetimeformats).
 
 ### `template_replace_values`
 
@@ -342,6 +346,8 @@ Snippets are `html` code chunks that can be inserted. Replace variables will onl
 ```html
 This is a simple <strong>snippet</strong>. Will be replaced: {$somevar1}.
 ```
+
+{% include configuration/ref-time-date-formats.md %}
 
 ## Commands
 


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* Add time and date format reference to template plugin page.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)

Review:
- [x] Documentation Team Lead has reviewed
- [ ] Product Manager has reviewed
