### PR TITLE
DOC-601: advcode search and replace

### DIFF
--- a/_includes/codepens/advcode/index.html
+++ b/_includes/codepens/advcode/index.html
@@ -9,8 +9,8 @@
       <tr>
           <td style="width: 50%">
             <textarea class="codedemo">
-              <p>The code (<code>code</code>) plugin provides a dialog for viewing and editing the HTML of the editor content.</p>
-              <p>To open the code dialog:</p>
+              <p>The Code (<code>code</code>) plugin provides a dialog for viewing and editing the HTML of the editor content.</p>
+              <p>To open the Code dialog:</p>
               <ul>
                 <li>On the menu bar, open <strong>View</strong> &gt; <strong>Source code</strong>.</li>
                 <li>On the menu bar, open <strong>Tools</strong> &gt; <strong>Source code</strong>.</li>

--- a/_includes/codepens/advcode/index.html
+++ b/_includes/codepens/advcode/index.html
@@ -1,0 +1,41 @@
+<table>
+  <thead>
+      <tr>
+          <th style="width: 50%"><h2>The Code Plugin</h2></th>
+          <th style="width: 50%"><h2>The Advanced Code Editor Plugin</h2></th>
+      </tr>
+  </thead>
+  <tbody>
+      <tr>
+          <td style="width: 50%">
+            <textarea class="codedemo">
+              <p>The code (<code>code</code>) plugin provides a dialog for viewing and editing the HTML of the editor content.</p>
+              <p>To open the code dialog:</p>
+              <ul>
+                <li>On the menu bar, open <strong>View</strong> &gt; <strong>Source code</strong>.</li>
+                <li>On the menu bar, open <strong>Tools</strong> &gt; <strong>Source code</strong>.</li>
+                <li>Click the <strong>Source code</strong> toolbar button.</li>
+              </ul>
+            </textarea>
+          </td>
+          <td style="width: 50%">
+            <textarea class="advcodedemo">
+              <p>The Advanced Code Editor (<code>advcode</code>) plugin provides the same dialog as the code (<code>code</code>) plugin, but with the following additional features:</p>
+              <ul>
+                <li>Syntax highlighting</li>
+                <li>Element matching and closing</li>
+                <li>Code folding</li>
+                <li>Multiple selections/carets</li>
+                <li>Search and replace</li>
+              </ul>
+              <p>To open the Advanced Code Editor dialog:</p>
+              <ul>
+                <li>On the menu bar, open <strong>View</strong> &gt; <strong>Source code</strong>.</li>
+                <li>On the menu bar, open <strong>Tools</strong> &gt; <strong>Source code</strong>.</li>
+                <li>Click the <strong>Source code</strong> toolbar button.</li>
+              </ul>
+            </textarea>
+          </td>
+      </tr>
+  </tbody>
+</table>

--- a/_includes/codepens/advcode/index.js
+++ b/_includes/codepens/advcode/index.js
@@ -1,0 +1,17 @@
+tinymce.init({
+  selector: 'textarea.advcodedemo',
+  plugins: 'advcode',
+  toolbar: 'code',
+
+  content_css: '//www.tiny.cloud/css/codepen.min.css',
+  height: 600
+});
+
+tinymce.init({
+  selector: 'textarea.codedemo',
+  plugins: 'code',
+  toolbar: 'code',
+
+  content_css: '//www.tiny.cloud/css/codepen.min.css',
+  height: 600
+});

--- a/_includes/misc/advcode-shortcuts.md
+++ b/_includes/misc/advcode-shortcuts.md
@@ -4,10 +4,8 @@ Advanced Code Editor provides the following shortcuts for search and replace wit
 
 | Action | PC | Mac |
 | ---- | ----- | ----- |
-| Find | Ctrl+F | Cmd+F |
-| Find next instance | Ctrl+G | Cmd+G |
-| Find previous instance | Shift+Ctrl+G | Shift+Cmd+G |
-| Replace | Ctrl+H | Cmd+H |
-| Replace All | Shift+Ctrl+R | Shift+Cmd+Option+F |
-
-For a list of shortcuts available in Advanced Code Editor, see: [CodeMirror - Sublime Text bindings demo](https://codemirror.net/demo/sublime.html).
+| Find | Ctrl+F | Command+F |
+| Find next instance | Ctrl+G | Command+G |
+| Find previous instance | Shift+Ctrl+G | Shift+Command+G |
+| Replace | Ctrl+H | Command+Option+F |
+| Replace All | Shift+Ctrl+R | Shift+Command+Option+F |

--- a/_includes/misc/advcode-shortcuts.md
+++ b/_includes/misc/advcode-shortcuts.md
@@ -1,0 +1,13 @@
+## Advanced Code Editor search and replace keyboard shortcuts
+
+Advanced Code Editor provides the following shortcuts for search and replace within the code dialog.
+
+| Action | PC | Mac |
+| ---- | ----- | ----- |
+| Find | Ctrl+F | Cmd+F |
+| Find next instance | Ctrl+G | Cmd+G |
+| Find previous instance | Shift+Ctrl+G | Shift+Cmd+G |
+| Replace | Ctrl+H | Cmd+H |
+| Replace All | Shift+Ctrl+R | Shift+Cmd+Option+F |
+
+For a list of shortcuts available in Advanced Code Editor, see: [CodeMirror - Sublime Text bindings demo](https://codemirror.net/demo/sublime.html).

--- a/advanced/keyboard-shortcuts.md
+++ b/advanced/keyboard-shortcuts.md
@@ -61,6 +61,8 @@ This is a list of available keyboard shortcuts within the editor user interface.
 
 > Note: Browsers and Screen Readers provide additional shortcuts within the editor context.
 
+{% include misc/advcode-shortcuts.md %}
+
 ## Add custom shortcuts to TinyMCE
 
 > **Important**: Adding a custom shortcut with a keyboard combination that conflicts with an existing {{site.productname}} or browser shortcut will override the existing shortcut.

--- a/enterprise/advcode.md
+++ b/enterprise/advcode.md
@@ -13,6 +13,11 @@ The [Advanced Code Editor]({{ site.baseurl }}/plugins/advcode/) plugin (`advcode
 * Bracket matching
 * Code folding
 * Multiple selections/carets
+* Search and Replace
+
+## The difference between the Code and Advanced Code Editor plugins
+
+{% include codepen.html id="advcode" %}
 
 {% assign pluginname = 'Advanced Code Editor' %}
 {% assign pluginminimumplan = 'tiertwo' %}

--- a/plugins/advcode.md
+++ b/plugins/advcode.md
@@ -11,17 +11,23 @@ controls: toolbar button, menu item
 
 This plugin adds a toolbar button that allows a user to edit the HTML code using a more advanced [code editor]({{ site.baseurl }}/enterprise/advcode/) than the default textarea.
 
-If you are using Advanced Code Editor `advcode` plugin, make sure you do not use Code `code` plugin.
+If you are using Advanced Code Editor `advcode` plugin, make sure you do not use Code (`code`) plugin.
 
 ##### Example
 
 ```js
 tinymce.init({
-  selector: "textarea",  // change this value according to your HTML
-  plugins: "advcode",
-  toolbar: "code"
+  selector: 'textarea',  // change this value according to your HTML
+  plugins: 'advcode',
+  toolbar: 'code'
 });
 ```
+
+## The difference between the Code and Advanced Code Editor plugins
+
+{% include codepen.html id="advcode" %}
+
+{% include misc/advcode-shortcuts.md %}
 
 ## Commands
 

--- a/release-notes/release-notes54.md
+++ b/release-notes/release-notes54.md
@@ -10,7 +10,6 @@ These release notes provide an overview of the changes for {{site.productname}} 
 
 - [TinyMCE 5.4 new features and enhancements](#tinymce54newfeaturesandenhancements)
 - [Accompanying Premium Plugin changes](#accompanyingpremiumpluginchanges)
-- [Accompanying premium self-hosted server-side component changes](#accompanyingpremiumself-hostedserver-sidecomponentchanges)
 - [Minor changes for TinyMCE 5.4](#minorchangesfortinymce54)
 - [General bug fixes](#generalbugfixes)
 - [Deprecated features](#deprecatedfeatures)
@@ -56,23 +55,16 @@ For information on:
 
 The following premium plugin updates were released alongside {{site.productname}} 5.4.
 
-### Accessibility Checker 2.x.x
+### Advanced Code Editor 2.1.0
 
-The {{site.productname}} 5.4 release includes an accompanying release of the **Accessibility Checker** premium plugin.
+The {{site.productname}} 5.4 release includes an accompanying release of the **Advanced Code Editor** premium plugin.
 
-**Accessibility Checker** 2.x.x
+**Advanced Code Editor** 2.1.0 provides the following improvements:
 
-For information on the Accessibility Checker plugin, see: [Accessibility Checker plugin]({{site.baseurl}}/plugins/a11ychecker/).
+- Added search/replace support.
+- Fixed the editor `referrer_policy` option not working when loading additional resources.
 
-## Accompanying premium self-hosted server-side component changes
-
-The {{site.productname}} 5.4 release includes accompanying changes affecting the {{site.productname}} **self-hosted** services for the following plugins:
-
--
-
-
-###
-
+For information on the Advanced Code Editor plugin, see: [Advanced Code Editor plugin]({{site.baseurl}}/plugins/advcode/).
 
 ## Minor changes for TinyMCE 5.4
 


### PR DESCRIPTION
Related Ticket: DOC-601

Description of Changes:
* Document new `advcode` search and replace functionality.
* Add `advcode` demo to plugin and enterprise page.
* Add release note for TinyMCE 5.4 release.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
