### PR TITLE
DOC-607: Re-labeled "Image/File upload options" page and added "block_unsupported_drop" setting

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -174,6 +174,7 @@
   - url: "file-image-upload"
     pages:
     - url: "#automatic_uploads"
+    - url: "#block_unsupported_drop"
     - url: "#file_picker_callback"
     - url: "#file_picker_types"
     - url: "#images_dataimg_filter"

--- a/_includes/configuration/block-unsupported-drop.md
+++ b/_includes/configuration/block-unsupported-drop.md
@@ -1,0 +1,20 @@
+## block_unsupported_drop
+
+Enable or disable blocking unsupported images or files being dropped within the editor. An unsupported file is any image or file that is not handled by a plugin and would cause the browser to navigate away from the editor.
+
+{{site.requires_5_4v}}
+
+**Type:** `Boolean`
+
+**Default Value:** `true`
+
+**Possible Values:** `true`, `false`
+
+##### Example
+
+```js
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  block_unsupported_drop: false
+});
+```

--- a/_includes/configuration/block-unsupported-drop.md
+++ b/_includes/configuration/block-unsupported-drop.md
@@ -1,6 +1,6 @@
 ## block_unsupported_drop
 
-Enable or disable blocking unsupported images or files being dropped within the editor. An unsupported file is any image or file that is not handled by a plugin and would cause the browser to navigate away from the editor.
+When the `block_unsupported_drop` option is set to `true`, the editor blocks unsupported images and files from being dropped into the editor. If the `block_unsupported_drop` option is set to `false`, dropping an unsupported file into the editor will cause the browser to navigate away from the page containing the editor.
 
 {{site.requires_5_4v}}
 

--- a/configure/file-image-upload.md
+++ b/configure/file-image-upload.md
@@ -1,12 +1,14 @@
 ---
 layout: default
-title: Image &amp; file upload options
-title_nav: Image &amp; file upload options
+title: Image &amp; file options
+title_nav: Image &amp; file options
 description_short:
-description: These settings affect TinyMCE's image and file upload capabilities.
+description: These settings affect TinyMCE's image and file handling capabilities.
 ---
 
 {% include configuration/automatic-uploads.md %}
+
+{% include configuration/block-unsupported-drop.md %}
 
 {% include configuration/file-picker-callback.md %}
 

--- a/release-notes/release-notes53.md
+++ b/release-notes/release-notes53.md
@@ -239,7 +239,7 @@ The `images_dataimg_filter` option has been deprecated with the release of {{sit
 
 For information on:
 
-- The `images_dataimg_filter` option, see: [Image & file upload options - images_dataimg_filter]({{site.baseurl}}/configure/file-image-upload/#images_dataimg_filter).
+- The `images_dataimg_filter` option, see: [Image & file options - images_dataimg_filter]({{site.baseurl}}/configure/file-image-upload/#images_dataimg_filter).
 - The future introduction of real-time collaboration, see: [Tiny Blueprint - Collaboration needs a clean Slate]({{site.url}}/blog/real-time-collaborative-editing-slate-js/).
 
 


### PR DESCRIPTION
Related Ticket: DOC-607

Description of Changes:
* Adds the new `block_unsuuported_drop` setting.
* This renames the `Image & File upload options" page to "Image & File options" so it's more generic. I haven't changed the URL/filename though as that'd break existing links (as discussed with Tyler).

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
