### PR TITLE
DOC-606: Spellchecker deprecation notices

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -50,7 +50,7 @@ requires_5_3v: "> **Note**: This feature is only available for TinyMCE 5.3 and l
 requires_5_4v: "> **Note**: This feature is only available for TinyMCE 5.4 and later."
 
 requires_jsscwar_230v: "> **Note**: This feature is only available for TinyMCE self-hosted server-side components, version 2.3.0 and later. To check the version of a running service, visit _&#60;domain&#62;_/_&#60;service&#62;_/version. Such as `http://localhost:8080/ephox-hyperlinking/version`."
-deprecate_spellchecker: "> **Important**: The TinyMCE **core** Spell Checker plugin (`spellchecker`) was deprecated with the release of TinyMCE 5.4. For details, see [the TinyMCE core Spell Checker plugin deprecation notice](https://www.tiny.cloud/docs/release-notes/release-notes54/#thetinymcecorespellcheckerplugin)."
+deprecate_spellchecker: "> **Important**: The TinyMCE **free** Spell Checker plugin (`spellchecker`) was deprecated with the release of TinyMCE 5.4. For details, see [the TinyMCE core Spell Checker plugin deprecation notice](https://www.tiny.cloud/docs/release-notes/release-notes54/#thetinymcecorespellcheckerplugin)."
 ctrl_right_click: "> **Note**: When the TinyMCE context menu is _enabled_, users can still access the browser context menu, including the browser spellchecker, using the `Ctrl+Right click` shortcut. However if the `contextmenu_never_use_native` option is enabled, holding the `Ctrl` key will have no effect."
 notonmobile: "> **Note**: This option is not supported on mobile devices."
 premiumplugin: "> **Note**: This plugin is only available for [paid TinyMCE subscriptions](https://www.tiny.cloud/pricing)."

--- a/_config.yml
+++ b/_config.yml
@@ -50,7 +50,8 @@ requires_5_3v: "> **Note**: This feature is only available for TinyMCE 5.3 and l
 requires_5_4v: "> **Note**: This feature is only available for TinyMCE 5.4 and later."
 
 requires_jsscwar_230v: "> **Note**: This feature is only available for TinyMCE self-hosted server-side components, version 2.3.0 and later. To check the version of a running service, visit _&#60;domain&#62;_/_&#60;service&#62;_/version. Such as `http://localhost:8080/ephox-hyperlinking/version`."
-
+deprecate_spellchecker: "> **Important**: The TinyMCE **core** Spell Checker plugin (`spellchecker`) was deprecated with the release of TinyMCE 5.4. For details, see [the TinyMCE core Spell Checker plugin deprecation notice](https://www.tiny.cloud/docs/release-notes/release-notes54/#thetinymcecorespellcheckerplugin)."
+ctrl_right_click: "> **Note**: When the TinyMCE context menu is _enabled_, users can still access the browser context menu, including the browser spellchecker, using the `Ctrl+Right click` shortcut. However if the `contextmenu_never_use_native` option is enabled, holding the `Ctrl` key will have no effect."
 notonmobile: "> **Note**: This option is not supported on mobile devices."
 premiumplugin: "> **Note**: This plugin is only available for [paid TinyMCE subscriptions](https://www.tiny.cloud/pricing)."
 differs_for_mobile: "> **Note**: The default option for this setting is different for mobile devices. For information on the default mobile setting, see: [TinyMCE Mobile - Configuration settings with mobile defaults](https://www.tiny.cloud/docs/mobile/#mobiledefaultsforselectedsettings)."

--- a/_config.yml
+++ b/_config.yml
@@ -50,7 +50,7 @@ requires_5_3v: "> **Note**: This feature is only available for TinyMCE 5.3 and l
 requires_5_4v: "> **Note**: This feature is only available for TinyMCE 5.4 and later."
 
 requires_jsscwar_230v: "> **Note**: This feature is only available for TinyMCE self-hosted server-side components, version 2.3.0 and later. To check the version of a running service, visit _&#60;domain&#62;_/_&#60;service&#62;_/version. Such as `http://localhost:8080/ephox-hyperlinking/version`."
-deprecate_spellchecker: "> **Important**: The TinyMCE **free** Spell Checker plugin (`spellchecker`) was deprecated with the release of TinyMCE 5.4. For details, see [the TinyMCE core Spell Checker plugin deprecation notice](https://www.tiny.cloud/docs/release-notes/release-notes54/#thetinymcecorespellcheckerplugin)."
+deprecate_spellchecker: "> **Important**: The **free** TinyMCE Spell Checker plugin (`spellchecker`) was deprecated with the release of TinyMCE 5.4. For details, see [the free TinyMCE Spell Checker plugin deprecation notice](https://www.tiny.cloud/docs/release-notes/release-notes54/#thefreetinymcespellcheckerplugin)."
 ctrl_right_click: "> **Note**: When the TinyMCE context menu is _enabled_, users can still access the browser context menu, including the browser spellchecker, using the `Ctrl+Right click` shortcut. However if the `contextmenu_never_use_native` option is enabled, holding the `Ctrl` key will have no effect."
 notonmobile: "> **Note**: This option is not supported on mobile devices."
 premiumplugin: "> **Note**: This plugin is only available for [paid TinyMCE subscriptions](https://www.tiny.cloud/pricing)."

--- a/_includes/codepens/basic-conf/index.js
+++ b/_includes/codepens/basic-conf/index.js
@@ -4,7 +4,7 @@ tinymce.init({
   width: 600,
   height: 300,
   plugins: [
-    'advlist autolink link image lists charmap print preview hr anchor pagebreak spellchecker',
+    'advlist autolink link image lists charmap print preview hr anchor pagebreak',
     'searchreplace wordcount visualblocks visualchars code fullscreen insertdatetime media nonbreaking',
     'table emoticons template paste help'
   ],
@@ -12,7 +12,7 @@ tinymce.init({
     'bullist numlist outdent indent | link image | print preview media fullpage | ' +
     'forecolor backcolor emoticons | help',
   menu: {
-    favs: {title: 'My Favorites', items: 'code visualaid | searchreplace | spellchecker | emoticons'}
+    favs: {title: 'My Favorites', items: 'code visualaid | searchreplace | emoticons'}
   },
   menubar: 'favs file edit view insert format tools table help'
 });

--- a/_includes/configuration/contextmenu.md
+++ b/_includes/configuration/contextmenu.md
@@ -17,8 +17,7 @@ To disable the editor's context menu, set this option to `false`.
 
 **Default Value:** `'link linkchecker image imagetools table spellchecker configurepermanentpen'`
 
-> **Note**: The browsers native context menu can still be accessed by holding the `Ctrl` key while right clicking with the mouse.
-> However if the `contextmenu_never_use_native` option is enabled, holding the `Ctrl` key will have no effect.
+{{site.ctrl_right_click}}
 
 ### Example: contextmenu
 

--- a/_includes/configuration/contextmenu_never_use_native.md
+++ b/_includes/configuration/contextmenu_never_use_native.md
@@ -1,12 +1,12 @@
 ## `contextmenu_never_use_native`
 
-The `contextmenu_never_use_native` option allows you to disable the browser's native context menu from appearing within the editor.
+The `contextmenu_never_use_native` option allows you to prevent the browser context menu from appearing within the editor.
 
-> Caution: Using this option may result into unexpected behavior when right-clicking in text areas. We advise you to consider all your options carefully before using this feature.
+> **Caution**: Using this option may result into unexpected behavior when right-clicking in text areas. We advise you to consider all your options carefully before using this feature.
 
-Type: `Boolean`
+**Type**: `Boolean`
 
-Default Value: `false`
+**Default Value**: `false`
 
 #### Example
 

--- a/_includes/configuration/contextmenu_never_use_native.md
+++ b/_includes/configuration/contextmenu_never_use_native.md
@@ -2,7 +2,7 @@
 
 The `contextmenu_never_use_native` option allows you to prevent the browser context menu from appearing within the editor.
 
-> **Caution**: Using this option may result into unexpected behavior when right-clicking in text areas. We advise you to consider all your options carefully before using this feature.
+> **Caution**: Using this option may result in unexpected behavior when right-clicking in text areas. We advise you to consider all your options carefully before using this feature.
 
 **Type**: `Boolean`
 

--- a/advanced/editor-command-identifiers.md
+++ b/advanced/editor-command-identifiers.md
@@ -354,6 +354,8 @@ The following command requires the [Search and Replace (`searchreplace`)]({{ sit
 
 The following command requires the [Spell Checker (`spellchecker`)]({{ site.baseurl }}/plugins/spellchecker/) plugin.
 
+{{site.deprecate_spellchecker}}
+
 {% include commands/spellchecker-cmds.md %}
 
 ### Table

--- a/advanced/events.md
+++ b/advanced/events.md
@@ -281,6 +281,8 @@ The following events are provided by the [PowerPaste plugin]({{ site.baseurl }}/
 
 The following events are provided by the [Spell Checker plugin]({{ site.baseurl }}/plugins/spellchecker/).
 
+{{site.deprecate_spellchecker}}
+
 | Name            | Data | Description                           |
 | --------------- | ---- | ------------------------------------- |
 | SpellcheckStart | N/A  | Fired when spellchecking is enabled.  |

--- a/general-configuration-guide/basic-setup.md
+++ b/general-configuration-guide/basic-setup.md
@@ -203,7 +203,7 @@ The following example is a basic {{site.productname}} configuration.
     width: 600,
     height: 300,
     plugins: [
-      'advlist autolink link image lists charmap print preview hr anchor pagebreak spellchecker',
+      'advlist autolink link image lists charmap print preview hr anchor pagebreak',
       'searchreplace wordcount visualblocks visualchars code fullscreen insertdatetime media nonbreaking',
       'table emoticons template paste help'
     ],
@@ -211,7 +211,7 @@ The following example is a basic {{site.productname}} configuration.
       'bullist numlist outdent indent | link image | print preview media fullpage | ' +
       'forecolor backcolor emoticons | help',
     menu: {
-      favs: {title: 'My Favorites', items: 'code visualaid | searchreplace | spellchecker | emoticons'}
+      favs: {title: 'My Favorites', items: 'code visualaid | searchreplace | emoticons'}
     },
     menubar: 'favs file edit view insert format tools table help',
     content_css: 'css/content.css'
@@ -246,7 +246,7 @@ Selects the plugins to be included on load.
 
 ```js
 plugins: [
-  'advlist autolink link image lists charmap print preview hr anchor pagebreak spellchecker',
+  'advlist autolink link image lists charmap print preview hr anchor pagebreak',
   'searchreplace wordcount visualblocks visualchars code fullscreen insertdatetime media nonbreaking',
   'table emoticons template paste help'
 ],
@@ -262,7 +262,7 @@ Adds an additonal menu named "My Favorites" with `menu`, then adds it to the men
 
 ```js
 menu: {
-  favs: {title: 'My Favorites', items: 'code visualaid | searchreplace | spellchecker | emoticons'}
+  favs: {title: 'My Favorites', items: 'code visualaid | searchreplace | emoticons'}
 },
 menubar: 'favs file edit view insert format tools table help',
 ```

--- a/general-configuration-guide/spell-checking.md
+++ b/general-configuration-guide/spell-checking.md
@@ -8,7 +8,7 @@ keywords: spell checker spelling browser_spellcheck gecko_spellcheck
 
 ## Browser-based spell checking
 
-Assign the [`browser_spellcheck`]({{ site.baseurl }}/configure/spelling/#browser_spellcheck) configuration option the value of `true` to utilize the browser's native spell check functionality. Enabling the [`contextmenu`]({{ site.baseurl }}/configure/editor-appearance/#contextmenu) option _may_ be required depending on the right-click or context usability requirement.
+Assign the [`browser_spellcheck`]({{ site.baseurl }}/configure/spelling/#browser_spellcheck) configuration option the value of `true` to utilize the browser's native spell check functionality. Disabling the [`contextmenu`]({{ site.baseurl }}/configure/editor-appearance/#contextmenu) option _may_ be required depending on the right-click or context usability requirement.
 
 ```js
 tinymce.init({
@@ -18,7 +18,11 @@ tinymce.init({
 });
 ```
 
+{{site.ctrl_right_click}}
+
 ## PHP Spellchecker component
+
+{{site.deprecate_spellchecker}}
 
 You can also use {{site.productname}}'s PHP _Spellchecker_ component, that you can [download here](http://download.moxiecode.com/spellcheckers/tinymce_spellchecker_php_4.0.zip). To view the complete changelog history, view this [`txt`](http://archive.tinymce.com/develop/changelog/?type=phpspell) file. The {{site.productname}}'s PHP Spellchecker component requires a little more work than the browser-based option, being a server-side script.
 

--- a/migration-from-4x.md
+++ b/migration-from-4x.md
@@ -653,6 +653,8 @@ For information on Context Menus, see [UI components - Context menu]({{site.base
 
 ### Spellchecker plugin
 
+{{site.deprecate_spellchecker}}
+
 [`spellchecker_callback`]({{site.baseurl}}/plugins/spellchecker/#spellchecker_callback) has been updated to remove a legacy format for the `success` callback, which accepted a mapping object of misspelled words to suggestions. For example:
 
 ```js

--- a/plugins/spellchecker.md
+++ b/plugins/spellchecker.md
@@ -7,6 +7,8 @@ keywords: spellchecker spellchecker_callback spellchecker_language spellchecker_
 controls: toolbar button, menu item
 ---
 
+{{site.deprecate_spellchecker}}
+
 > **Note**: The Spell Checker plugin is self-hosted _only_. The Spell Checker Pro plugin is provided for some {{site.cloudname}} plans. For information on the Spell Checker Pro plugin, see: [Spell Checker Pro plugin]({{site.baseurl}}/plugins/tinymcespellchecker/).
 
 This plugin enables {{site.productname}}'s spellcheck functionality. It also adds a toolbar button and the menu item `Spellcheck` under the `Tools` menu dropdown.

--- a/release-notes/release-notes54.md
+++ b/release-notes/release-notes54.md
@@ -103,6 +103,27 @@ For information on the Advanced Code Editor plugin, see: [Advanced Code Editor p
 
 ## Deprecated features
 
+The following features have been deprecated with the release of {{site.productname}} 5.4:
+
+- [The TinyMCE core Spell Checker plugin](#thetinymcecorespellcheckerplugin).
+- [The `table_responsive_width` option in the Table plugin](#thetable_responsive_widthoption).
+
+### The TinyMCE core Spell Checker plugin
+
+The {{site.productname}} core Spell Checker plugin (`spellchecker`) has been deprecated and will be removed in a future major release of {{site.productname}}. This includes both the editor plugin and the PHP backend program.
+
+This change **_does not_** affect:
+
+- [The Spellchecker Pro premium plugin]({{site.baseurl}}/plugins/tinymcespellchecker/).
+- [Browser-based spell checking in {{site.productname}}]({{site.baseurl}}/general-configuration-guide/spell-checking/#browser-basedspellchecking).
+
+To develop and maintain a new spellchecking plugin based on the {{site.productname}} core Spell Checker plugin:
+
+- Fork the PHP backend program from the [_tinymce/tinymce_spellchecker_php_ GitHub repository](https://github.com/tinymce/tinymce_spellchecker_php).
+- Extract the Spell Checker user interface from the [Spellchecker plugin directory in the _tinymce/tinymce_ GitHub repository](https://github.com/tinymce/tinymce/tree/develop/modules/tinymce/src/plugins/spellchecker).
+
+### The `table_responsive_width` option
+
 The `table_responsive_width` option has been deprecated with the release of {{site.productname}} 5.4. This option has been replaced by [`table_sizing_mode`]({{site.baseurl}}/plugins/table/#table_sizing_mode).
 
 ## Known issues

--- a/release-notes/release-notes54.md
+++ b/release-notes/release-notes54.md
@@ -105,19 +105,19 @@ For information on the Advanced Code Editor plugin, see: [Advanced Code Editor p
 
 The following features have been deprecated with the release of {{site.productname}} 5.4:
 
-- [The TinyMCE core Spell Checker plugin](#thetinymcecorespellcheckerplugin).
+- [The TinyMCE free Spell Checker plugin](#thetinymcefreespellcheckerplugin).
 - [The `table_responsive_width` option in the Table plugin](#thetable_responsive_widthoption).
 
-### The TinyMCE core Spell Checker plugin
+### The TinyMCE free Spell Checker plugin
 
-The {{site.productname}} core Spell Checker plugin (`spellchecker`) has been deprecated and will be removed in a future major release of {{site.productname}}. This includes both the editor plugin and the PHP backend program.
+The {{site.productname}} free Spell Checker plugin (`spellchecker`) has been deprecated and will be removed in a future major release of {{site.productname}}. This includes both the editor plugin and the PHP backend program.
 
 This change **_does not_** affect:
 
 - [The Spellchecker Pro premium plugin]({{site.baseurl}}/plugins/tinymcespellchecker/).
 - [Browser-based spell checking in {{site.productname}}]({{site.baseurl}}/general-configuration-guide/spell-checking/#browser-basedspellchecking).
 
-To develop and maintain a new spellchecking plugin based on the {{site.productname}} core Spell Checker plugin:
+To develop and maintain a new spellchecking plugin based on the {{site.productname}} free Spell Checker plugin:
 
 - Fork the PHP backend program from the [_tinymce/tinymce_spellchecker_php_ GitHub repository](https://github.com/tinymce/tinymce_spellchecker_php).
 - Extract the Spell Checker user interface from the [Spellchecker plugin directory in the _tinymce/tinymce_ GitHub repository](https://github.com/tinymce/tinymce/tree/develop/modules/tinymce/src/plugins/spellchecker).

--- a/release-notes/release-notes54.md
+++ b/release-notes/release-notes54.md
@@ -105,19 +105,19 @@ For information on the Advanced Code Editor plugin, see: [Advanced Code Editor p
 
 The following features have been deprecated with the release of {{site.productname}} 5.4:
 
-- [The TinyMCE free Spell Checker plugin](#thetinymcefreespellcheckerplugin).
+- [The free TinyMCE Spell Checker plugin](#thefreetinymcespellcheckerplugin).
 - [The `table_responsive_width` option in the Table plugin](#thetable_responsive_widthoption).
 
-### The TinyMCE free Spell Checker plugin
+### The free TinyMCE Spell Checker plugin
 
-The {{site.productname}} free Spell Checker plugin (`spellchecker`) has been deprecated and will be removed in a future major release of {{site.productname}}. This includes both the editor plugin and the PHP backend program.
+The **free** {{site.productname}} Spell Checker plugin (`spellchecker`) has been deprecated and will be removed in a future major release of {{site.productname}}. This includes both the editor plugin and the PHP backend program.
 
 This change **_does not_** affect:
 
 - [The Spellchecker Pro premium plugin]({{site.baseurl}}/plugins/tinymcespellchecker/).
 - [Browser-based spell checking in {{site.productname}}]({{site.baseurl}}/general-configuration-guide/spell-checking/#browser-basedspellchecking).
 
-To develop and maintain a new spellchecking plugin based on the {{site.productname}} free Spell Checker plugin:
+To develop and maintain a new spellchecking plugin based on the free {{site.productname}} Spell Checker plugin:
 
 - Fork the PHP backend program from the [_tinymce/tinymce_spellchecker_php_ GitHub repository](https://github.com/tinymce/tinymce_spellchecker_php).
 - Extract the Spell Checker user interface from the [Spellchecker plugin directory in the _tinymce/tinymce_ GitHub repository](https://github.com/tinymce/tinymce/tree/develop/modules/tinymce/src/plugins/spellchecker).


### PR DESCRIPTION
Related Ticket: DOC-606

Description of Changes:
* Add a deprecation notice to 5.4 release notes for the community spellchecker
* Add admonitions to docs about deprecation of the the spellchecker
* Tidy-up some misleading demos
* Fix some language around context menus

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
