### PR TITLE
DOC-348: readonly option with codepen

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -73,6 +73,7 @@
     - url: "#hidden_input"
     - url: "#init_instance_callback"
     - url: "#plugins"
+    - url: "#readonly"
     - url: "#referrer_policy"
     - url: "#selector"
     - url: "#setup"

--- a/_includes/codepens/readonly-demo/index.html
+++ b/_includes/codepens/readonly-demo/index.html
@@ -1,0 +1,26 @@
+<script type="text/javascript">
+  function getEditorStatus (editorId) {
+    return tinymce.get(editorId).mode.get();
+  };
+  function setEditorStatus (editorId, currentStatus) {
+    if (currentStatus === "design") {
+      tinymce.get(editorId).mode.set("readonly");
+    } else {
+      tinymce.get(editorId).mode.set("design");
+    }
+  };
+  function enableDisable (targetEditor,targetElement) {
+    var status = getEditorStatus (targetEditor);
+    var button = document.getElementById(targetElement);
+    setEditorStatus (targetEditor, status);
+    if (status === "design") {
+      button.innerText="Enable editor";
+    } else {
+      button.innerText="Disable editor";
+    };
+  };
+</script>
+
+<textarea id="readonly-demo">Hello, World!</textarea>
+
+<button id="enableDisableButton" class="btn btn-candy link-sushi" onclick="enableDisable('readonly-demo','enableDisableButton')">Enable editor</button>

--- a/_includes/codepens/readonly-demo/index.html
+++ b/_includes/codepens/readonly-demo/index.html
@@ -2,7 +2,7 @@
   function getEditorStatus (editorId) {
     return tinymce.get(editorId).mode.get();
   };
-  function setEditorStatus (editorId, currentStatus) {
+  function toggleEditorStatus (editorId, currentStatus) {
     if (currentStatus === "design") {
       tinymce.get(editorId).mode.set("readonly");
     } else {
@@ -12,7 +12,7 @@
   function enableDisable (targetEditor, targetElement) {
     var status = getEditorStatus(targetEditor);
     var button = document.getElementById(targetElement);
-    setEditorStatus (targetEditor, status);
+    toggleEditorStatus(targetEditor, status);
     if (status === "design") {
       button.innerText = "Enable editor";
     } else {

--- a/_includes/codepens/readonly-demo/index.html
+++ b/_includes/codepens/readonly-demo/index.html
@@ -9,14 +9,14 @@
       tinymce.get(editorId).mode.set("design");
     }
   };
-  function enableDisable (targetEditor,targetElement) {
-    var status = getEditorStatus (targetEditor);
+  function enableDisable (targetEditor, targetElement) {
+    var status = getEditorStatus(targetEditor);
     var button = document.getElementById(targetElement);
     setEditorStatus (targetEditor, status);
     if (status === "design") {
-      button.innerText="Enable editor";
+      button.innerText = "Enable editor";
     } else {
-      button.innerText="Disable editor";
+      button.innerText = "Disable editor";
     };
   };
 </script>

--- a/_includes/codepens/readonly-demo/index.js
+++ b/_includes/codepens/readonly-demo/index.js
@@ -1,0 +1,4 @@
+tinymce.init({
+  selector: 'textarea#readonly-demo',
+  readonly: true
+});

--- a/_includes/configuration/readonly.md
+++ b/_includes/configuration/readonly.md
@@ -1,0 +1,20 @@
+## readonly
+
+Setting the `readonly` option to `true` will initialize the editor in `"readonly"` mode instead of editing (`"design"`) mode. Once initialized, the editor can be set to editing (`"design"`) mode using the [`tinymce.editor.mode.set` API]({{site.baseurl}}/api/tinymce/tinymce.editormode/#set).
+
+**Type:** `Boolean`
+
+**Default Value:** `false`
+
+**Possible Values:** `true`, `false`
+
+##### Example
+
+```js
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  readonly: true
+});
+```
+
+{% include codepen.html id="readonly-demo" %}

--- a/configure/integration-and-setup.md
+++ b/configure/integration-and-setup.md
@@ -22,6 +22,8 @@ description: Essential editor configuration, including `selector` and `plugins` 
 
 {% include configuration/plugins.md %}
 
+{% include configuration/readonly.md %}
+
 {% include configuration/referrer_policy.md %}
 
 {% include configuration/selector.md %}


### PR DESCRIPTION
Related Ticket: DOC-348

Description of Changes:
* Document `readonly` option
* Add codepen with `readonly` option and APIs to toggle readonly status

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
