### PR TITLE
DOC-609: Fixed broken linkchecker_preprocess example

### DIFF
--- a/plugins/linkchecker.md
+++ b/plugins/linkchecker.md
@@ -75,7 +75,7 @@ tinymce.init({
   linkchecker_preprocess: function (data) {
     /* This example will encode or double encode the url */
     var newUrl = encodeURIComponent(data.url);
-    return { url: newUrl };]
+    return { url: newUrl };
   }
 });
 ```


### PR DESCRIPTION
Related Ticket: DOC-609

Description of Changes:
* The example for the `linkchecker_preprocess` had an additional `]` that shouldn't have been there.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
