### PR TITLE
DOC-612: toolbar drawer content determination

### DIFF
--- a/_includes/configuration/toolbar-mode.md
+++ b/_includes/configuration/toolbar-mode.md
@@ -6,6 +6,25 @@
 
 The `toolbar_mode` option is used to extend the toolbar to accommodate the overflowing toolbar buttons. This option is useful for small screens or small editor frames.
 
+The editor will move toolbar buttons to the toolbar drawer based on:
+
+- The defined toolbar groups.
+- The width of the editor.
+
+For example. If the following toolbar configuration is wider than the editor, the toolbar will be split at the group separator (`|`).
+
+```js
+tinymce.init({
+    selector: 'textarea',
+    toolbar: 'undo redo styleselect bold italic alignleft aligncenter alignright alignjustify | bullist numlist outdent indent'
+});
+```
+
+Two situations to consider when organising the toolbar:
+
+- If the first toolbar button group is wider than the editor, the whole toolbar will be shown in the toolbar drawer.
+- If no toolbar button groups are defined, the `toolbar_mode` will default to [the `wrap` toolbar mode](#wrap).
+
 The toolbar modes are not available when using [multiple toolbars]({{site.baseurl}}/configure/editor-appearance/#usingmultipletoolbars) or the [toolbar(n)]({{site.baseurl}}/configure/editor-appearance/#toolbarn) option.
 
 **Type:** `String`

--- a/_includes/configuration/toolbar-mode.md
+++ b/_includes/configuration/toolbar-mode.md
@@ -6,12 +6,12 @@
 
 The `toolbar_mode` option is used to extend the toolbar to accommodate the overflowing toolbar buttons. This option is useful for small screens or small editor frames.
 
-The editor will move toolbar buttons to the toolbar drawer based on:
+When the toolbar_mode is set to `'floating'` or `sliding`, the editor will move toolbar buttons to the toolbar drawer based on:
 
 - The defined toolbar groups.
 - The width of the editor.
 
-For example. If the following toolbar configuration is wider than the editor, the toolbar will be split at the group separator (`|`).
+For example. If the following toolbar configuration is wider than the editor, the items before the separator (`|`) will appear in the main toolbar and the rest will be moved to the toolbar drawer.
 
 ```js
 tinymce.init({
@@ -22,8 +22,8 @@ tinymce.init({
 
 Two situations to consider when organising the toolbar:
 
+- When there is two or more toolbar button groups, the main toolbar will show as many complete, sequential toolbar groups as possible within the width of the editor.
 - If the first toolbar button group is wider than the editor, the whole toolbar will be shown in the toolbar drawer.
-- If no toolbar button groups are defined, the `toolbar_mode` will default to [the `wrap` toolbar mode](#wrap).
 
 The toolbar modes are not available when using [multiple toolbars]({{site.baseurl}}/configure/editor-appearance/#usingmultipletoolbars) or the [toolbar(n)]({{site.baseurl}}/configure/editor-appearance/#toolbarn) option.
 

--- a/_includes/configuration/toolbar-mode.md
+++ b/_includes/configuration/toolbar-mode.md
@@ -22,7 +22,7 @@ tinymce.init({
 
 Two situations to consider when organising the toolbar:
 
-- When there is two or more toolbar button groups, the main toolbar will show as many complete, sequential toolbar groups as possible within the width of the editor.
+- When there are two or more toolbar button groups, the main toolbar will show as many complete, sequential toolbar groups as possible within the width of the editor. Any remaining toolbar button groups will be moved to the toolbar drawer.
 - If the first toolbar button group is wider than the editor, the whole toolbar will be shown in the toolbar drawer.
 
 The toolbar modes are not available when using [multiple toolbars]({{site.baseurl}}/configure/editor-appearance/#usingmultipletoolbars) or the [toolbar(n)]({{site.baseurl}}/configure/editor-appearance/#toolbarn) option.

--- a/_includes/configuration/toolbar.md
+++ b/_includes/configuration/toolbar.md
@@ -17,6 +17,8 @@ tinymce.init({
 });
 ```
 
+> **Note**: The toolbar buttton groups defined in the `toolbar` setting will affect which toolbar buttons will be shown when the toolbar is wider than the editor. For more information, see: [the `toolbar_mode` setting]({{site.baseurl}}/configure/editor-appearance/#toolbar_mode).
+
 ### Adding toolbar group labels
 
 To specify labels to the grouped controls that appear on {{site.productname}}'s toolbar, the `toolbar` option should be provided with an array of objects with `name` and `items` as object properties. The `name` should be a string value that will be set as the `title` attribute on the `div` containing the toolbar group. The `items` should be an array of strings that indicate the controls that should appear within the particular toolbar group.

--- a/_includes/configuration/toolbar.md
+++ b/_includes/configuration/toolbar.md
@@ -17,7 +17,7 @@ tinymce.init({
 });
 ```
 
-> **Note**: The toolbar buttton groups defined in the `toolbar` setting will affect which toolbar buttons will be shown when the toolbar is wider than the editor. For more information, see: [the `toolbar_mode` setting]({{site.baseurl}}/configure/editor-appearance/#toolbar_mode).
+> **Note**: The size of toolbar groups affects the behavior of the toolbar drawer when the `toolbar_mode` is set to `'floating'` (default value) or `'sliding'`. For more information, see: [the `toolbar_mode` setting]({{site.baseurl}}/configure/editor-appearance/#toolbar_mode).
 
 ### Adding toolbar group labels
 


### PR DESCRIPTION
Related Ticket: DOC-612

Description of Changes:
* Add information on how the editor determines which toolbar buttons to move to the more drawer.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
