### PR TITLE
DOC-607: block_unsupported_drop option release note

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -738,6 +738,7 @@
     - url: "#Accompanying premium self-hosted server-side component changes"
     - url: "#Minor changes for TinyMCE 5.4"
     - url: "#General bug fixes"
+    - url: "#Deprecated features"
     - url: "#Known issues"
     - url: "#Upgrading to the latest version of TinyMCE 5"
   - url: "release-notes53"

--- a/release-notes/release-notes54.md
+++ b/release-notes/release-notes54.md
@@ -55,6 +55,12 @@ For information on:
 - Creating custom UI components, see: [User interface components]({{site.baseurl}}/ui-components/).
 - Creating and adding a custom icon pack, see: [Create an icon pack for TinyMCE]({{site.baseurl}}/advanced/creating-an-icon-pack/).
 
+### New option for blocking unsupported files from being drag and dropped into the editor
+
+The `block_unsupported_drop` option blocks unsupported images and files from being dropped into the editor. This option is enabled by default. If this option is disabled (`false`), users can drop an unsupported file into the editor, which will cause the browser to navigate away from the page containing the editor.
+
+For information on the `block_unsupported_drop` option, see: [Image & file options - `block_unsupported_drop`]({{site.baseurl}}/configure/file-image-upload/#block_unsupported_drop).
+
 ## Accompanying Premium Plugin changes
 
 The following premium plugin updates were released alongside {{site.productname}} 5.4.


### PR DESCRIPTION
Related Ticket: DOC-607

Description of Changes:
* Add `block_unsupported_drop` option release note

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
