### PR TITLE
DOC-619: Added docs for the new paste_tab_spaces setting

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -744,7 +744,6 @@
   - url: "release-notes542"
     pages:
     - url: "#Overview"
-    - url: "#TinyMCE 5.4.2 new features and enhancements"
     - url: "#General bug fixes"
     - url: "#Accompanying Premium Plugin changes"
     - url: "#Upgrading to the latest version of TinyMCE 5"

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -411,6 +411,7 @@
     - url: "#paste_webkit_styles"
     - url: "#paste_retain_style_properties"
     - url: "#paste_merge_formats"
+    - url: "#paste_tab_spaces"
     - url: "#paste_convert_word_fake_lists"
     - url: "#paste_remove_styles_if_webkit"
     - url: "#smart_paste"
@@ -426,6 +427,7 @@
     pages:
     - url: "#paste_as_text"
     - url: "#paste_merge_formats"
+    - url: "#paste_tab_spaces"
     - url: "#powerpaste_word_import"
     - url: "#powerpaste_html_import"
     - url: "#powerpaste_allow_local_images"

--- a/_includes/configuration/paste-tab-spaces.md
+++ b/_includes/configuration/paste-tab-spaces.md
@@ -7,7 +7,7 @@
 {% endif %}
 ### `paste_tab_spaces`
 
-This option controls how many spaces are used to represent a tab character in HTML when pasting plain text content. This option by default will cause the {{pluginname}} plugin to convert each tab character into 4 sequential spaces.
+This option controls how many spaces are used to represent a tab character in HTML when pasting plain text content. By default, the {{pluginname}} plugin will convert each tab character into 4 sequential space characters.
 
 {{site.requires_5_4v}}
 

--- a/_includes/configuration/paste-tab-spaces.md
+++ b/_includes/configuration/paste-tab-spaces.md
@@ -1,0 +1,26 @@
+{% if page.title == "Paste plugin" %}
+  {% assign plugin = "paste" %}
+  {% assign pluginname = "Paste" %}
+{% else %}
+  {% assign plugin = "powerpaste" %}
+  {% assign pluginname = "PowerPaste" %}
+{% endif %}
+### `paste_tab_spaces`
+
+This option controls how many spaces are used to represent a tab character in HTML when pasting plain text content. This option by default will cause the {{pluginname}} plugin to convert each tab character into 4 sequential spaces.
+
+{{site.requires_5_4v}}
+
+**Type:** `Number`
+
+**Default Value:** `4`
+
+##### Example: `paste_tab_spaces`
+
+```js
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  plugins: '{{plugin}}',
+  paste_tab_spaces: 2
+});
+```

--- a/plugins/paste.md
+++ b/plugins/paste.md
@@ -224,6 +224,8 @@ tinymce.init({
 
 {% include configuration/paste-merge-formats.md %}
 
+{% include configuration/paste-tab-spaces.md %}
+
 ### `paste_convert_word_fake_lists`
 
 This option lets you disable the logic that converts list like paragraph structures into real semantic HTML lists.

--- a/plugins/powerpaste.md
+++ b/plugins/powerpaste.md
@@ -87,6 +87,8 @@ tinymce.init({
 
 {% include configuration/paste-merge-formats.md %}
 
+{% include configuration/paste-tab-spaces.md %}
+
 ### powerpaste_word_import
 
 This setting controls how content pasted from Microsoft Word is filtered.

--- a/release-notes/release-notes542.md
+++ b/release-notes/release-notes542.md
@@ -10,16 +10,11 @@ keywords: releasenotes bugfixes
 
 These release notes provide an overview of the changes for {{site.productname}} 5.4.2, including:
 
-- [TinyMCE 5.4.2 new feature and enhancements](#tinymce542newfeaturesandenhancements)
 - [General bug fixes](#generalbugfixes)
 - [Accompanying Premium Plugin changes](#accompanyingpremiumpluginchanges)
 - [Upgrading to the latest version of TinyMCE 5](#upgradingtothelatestversionoftinymce5)
 
 > This is the {{site.cloudname}} and {{site.enterpriseversion}} release notes. For information on the latest community version of {{site.productname}}, see: [{{site.productname}} Changelog]({{site.baseurl}}/changelog/).
-
-## TinyMCE 5.4.2 new feature and enhancements
-
-
 
 ## General bug fixes
 
@@ -36,6 +31,7 @@ These release notes provide an overview of the changes for {{site.productname}} 
 * Fixed list toolbar buttons not showing as active when a list is selected.
 * Fixed an issue where the UI would sometimes not be shown or hidden when calling show or hide methods on the editor.
 * Fixed the list type style not retained when copying list items.
+* Fixed tabs in plain text converted to a single space and added new [`paste_tab_spaces`]({{site.baseurl}}/plugins/paste/#paste_tab_spaces) setting to control how many spaces are used to represent a tab.
 
 ## Accompanying Premium Plugin changes
 
@@ -51,6 +47,7 @@ The {{site.productname}} 5.4.2 release includes an accompanying release of the *
 * Fixed an issue where lists would become corrupt on IE 11 due to invalid empty font elements.
 * Fixed multiple new lines collapsing into a single new line when pasting plain text.
 * Fixed cut and copy not working with table selections.
+* Fixed tabs in plain text converted to a single space and added new [`paste_tab_spaces`]({{site.baseurl}}/plugins/powerpaste/#paste_tab_spaces) setting to control how many spaces are used to represent a tab.
 
 {% assign enterprise = true %}
 


### PR DESCRIPTION
Related Ticket: DOC-619

Description of Changes:
* Added the relevant documentation for the new `paste_tab_spaces` setting in TinyMCE 5.4.2.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
