### PR TITLE
DOC-605: Add svgs unsupported note to docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -64,6 +64,8 @@ thirdPartyInteg: "> **Important**: This Integration is maintained by a third-par
 
 moxieMNotOnCloud: "> **Note**: The MoxieManager plugin is _not_ provided on the Tiny Cloud, and is provided as a self-hosted solution only."
 
+svgsNotSupported: "> **Note**: SVGs (Scalable Vector Graphics) are not supported in TinyMCE to protect our users and their end-users. SVGs can be used to perform both client-side and server-side attacks."
+
 predefinedIconsOnly: "Name of the icon to be displayed. Must correspond to an icon: in the [icon pack](https://www.tiny.cloud/docs/advanced/editor-icon-identifiers/), in a [custom icon pack](https://www.tiny.cloud/docs/advanced/creating-an-icon-pack/), or added using the [`addIcon` API](https://www.tiny.cloud/docs/api/tinymce.editor.ui/tinymce.editor.ui.registry/#addicon)."
 
 exclude:

--- a/advanced/security.md
+++ b/advanced/security.md
@@ -42,6 +42,8 @@ To protect {{site.productname}} users, {{site.companyname}}:
 
 {{site.productname}} filters content such as scripts from the editor content, however, client-side applications can be by-passed by attackers. {{site.companyname}} recommends processing received editor content through server-side filters.
 
+SVGs (Scalable Vector Graphics) are not supported in {{site.productname}} to protect our users and their end-users. SVGs can be used to perform both client-side and server-side attacks.
+
 From the 1st of January 2020, Security Advisories for patched XSS vulnerabilities will be published on the [{{site.productname}} GitHub repository Security page](https://github.com/tinymce/tinymce/security/advisories?state=published).
 
 ### Keeping dependencies up-to-date

--- a/general-configuration-guide/upload-images.md
+++ b/general-configuration-guide/upload-images.md
@@ -38,6 +38,8 @@ tinymce.activeEditor.uploadImages(function(success) {
 });
 ```
 
+{{site.svgsNotSupported}}
+
 ## Image Uploader requirements
 
 A server-side upload handler script uploads local images to a remote server. The script must:

--- a/plugins/image.md
+++ b/plugins/image.md
@@ -26,7 +26,9 @@ tinymce.init({
 
 ```
 
-> Note that this is not drag-drop functionality and the user is required to enter the path to the image. Optionally the user can also enter the image description, dimensions, and whether image proportions should be constrained (selected via a checkbox). Some of these settings can be preset using the plugin's configuration options.
+> **Note**: This is not drag-drop functionality and the user is required to enter the path to the image. Optionally the user can also enter the image description, dimensions, and whether image proportions should be constrained (selected via a checkbox). Some of these settings can be preset using the plugin's configuration options.
+
+{{site.svgsNotSupported}}
 
 ## Options
 

--- a/plugins/imagetools.md
+++ b/plugins/imagetools.md
@@ -8,7 +8,9 @@ keywords: imagetools rotate rotateleft rotateright flip flipv fliph editimage im
 
 Image Tools (`imagetools`) plugin adds a contextual editing toolbar to the images in the editor. If toolbar is not appearing on image click, it might be that you need to enable `imagetools_cors_hosts` or `imagetools_proxy` (see below).
 
-> *Warning:* This feature requires at least Internet Explorer 10, since it makes use of `HTML5 File API`.
+{{site.svgsNotSupported}}
+
+> **Note**: This feature requires at least Internet Explorer 10, since it makes use of `HTML5 File API`.
 
 ## Cloud Installation
 The Image Tools plugin is provided with all subscriptions to [{{site.cloudname}}]({{ site.baseurl }}/cloud-deployment-guide/editor-and-features/), including an automatically configured image proxy.

--- a/plugins/imagetools.md
+++ b/plugins/imagetools.md
@@ -10,8 +10,6 @@ Image Tools (`imagetools`) plugin adds a contextual editing toolbar to the image
 
 {{site.svgsNotSupported}}
 
-> **Note**: This feature requires at least Internet Explorer 10, since it makes use of `HTML5 File API`.
-
 ## Cloud Installation
 The Image Tools plugin is provided with all subscriptions to [{{site.cloudname}}]({{ site.baseurl }}/cloud-deployment-guide/editor-and-features/), including an automatically configured image proxy.
 Simply add `image` to the `toolbar` list and `image imagetools` to the `plugins` list.


### PR DESCRIPTION
Related Ticket: DOC-605

Description of Changes:
* Add a note indicating that SVGs are not supported for security purposes.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
