### PR TITLE
Added toggle menu item example to the toolbar menu button demo

### DIFF
--- a/_includes/live-demos/custom-toolbar-menu-button/index.js
+++ b/_includes/live-demos/custom-toolbar-menu-button/index.js
@@ -4,6 +4,9 @@ tinymce.init({
   toolbar: 'mybutton',
 
   setup: function (editor) {
+    /* Menu items are recreated when the menu is closed and opened, so we need
+       a variable to store the toggle menu item state. */
+    var toggleState = false;
 
     /* example, adding a toolbar menu button */
     editor.ui.registry.addMenuButton('mybutton', {
@@ -40,6 +43,18 @@ tinymce.init({
                   }
                 }
               ];
+            }
+          },
+          {
+            type: 'togglemenuitem',
+            text: 'Toggle menu item',
+            onAction: function () {
+              toggleState = !toggleState;
+              editor.insertContent('&nbsp;<em>You toggled a menuitem ' + (toggleState ? 'on' : 'off') + '</em>');
+            },
+            onSetup: function (api) {
+              api.setActive(toggleState);
+              return function() {};
             }
           }
         ];


### PR DESCRIPTION
Related Ticket: DOC-629 

Description of Changes:
* Added a toggle menu item type to the menu button demo. The demo is the currently the only place where we let people know which types of menuitems are available.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] ~~`_data/nav.yml` has been updated (if applicable)~~
- [x] ~~Files has been included where required (if applicable)~~
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable)~~
- [x] ~~(New product features only) Release Note added~~

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
