### PR TITLE
#1654: Show and Hide the live demos based on current tab

### DIFF
--- a/_includes/live-demo.html
+++ b/_includes/live-demo.html
@@ -222,17 +222,26 @@ When the example.js file is present, the link to the external codepen site is di
     /* TODO: */
     var tabs = tabNames.map(function(t) {
       return {
+        name: t,
         tab: document.getElementById("live_demo_tab_" + t + "_" + id),
         pane: document.getElementById("live_demo_pane_" + t + "_" + id)
       };
     });
-
+    var lastTabName = '{{ initialTab }}';
     tabs.forEach(function(t) {
       t.tab.onclick = function(e) {
         tabs.forEach(function(tt) {
           tt.pane.style.display = t === tt ? 'block' : 'none';
           tt.tab.className = t === tt ? 'live_demo_tab_selected' : 'live_demo_tab_deselected';
         });
+        if (lastTabName !== t.name) {
+          if (t.name === 'run') {
+            tinymce.activeEditor.show();
+          } else if (lastTabName === 'run') {
+            tinymce.activeEditor.hide();
+          }
+          lastTabName = t.name;
+        }
         e.preventDefault();
       };
     });

--- a/_includes/live-demo.html
+++ b/_includes/live-demo.html
@@ -227,19 +227,27 @@ When the example.js file is present, the link to the external codepen site is di
         pane: document.getElementById("live_demo_pane_" + t + "_" + id)
       };
     });
+
     var lastTabName = '{{ initialTab }}';
     tabs.forEach(function(t) {
       t.tab.onclick = function(e) {
-        tabs.forEach(function(tt) {
-          tt.pane.style.display = t === tt ? 'block' : 'none';
-          tt.tab.className = t === tt ? 'live_demo_tab_selected' : 'live_demo_tab_deselected';
-        });
         if (lastTabName !== t.name) {
-          if (t.name === 'run') {
-            tinymce.activeEditor.show();
-          } else if (lastTabName === 'run') {
-            tinymce.activeEditor.hide();
+          tabs.forEach(function(tt) {
+            tt.pane.style.display = t === tt ? 'block' : 'none';
+            tt.tab.className = t === tt ? 'live_demo_tab_selected' : 'live_demo_tab_deselected';
+          });
+
+          {% if include.type != 'tinydrive' %}
+          var editor = tinymce.get('{{ include.id }}');
+          if (editor) {
+            if (t.name === 'run') {
+              editor.show();
+            } else if (lastTabName === 'run') {
+              editor.hide();
+            }
           }
+          {% endif %}
+
           lastTabName = t.name;
         }
         e.preventDefault();


### PR DESCRIPTION
Related Ticket: https://github.com/tinymce/tinymce-docs/issues/1654

Description of Changes:
* Show or hide live demos based on currently visible tab
Fixes #1654 

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
