### PR TITLE
DOC-638: Added documentation for new contextmenu_avoid_overlap setting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -52,6 +52,7 @@ requires_5_1v: "> **Note**: This feature is only available for TinyMCE 5.1 and l
 requires_5_2v: "> **Note**: This feature is only available for TinyMCE 5.2 and later."
 requires_5_3v: "> **Note**: This feature is only available for TinyMCE 5.3 and later."
 requires_5_4v: "> **Note**: This feature is only available for TinyMCE 5.4 and later."
+requires_5_5v: "> **Note**: This feature is only available for TinyMCE 5.5 and later."
 
 requires_jsscwar_230v: "> **Note**: This feature is only available for TinyMCE self-hosted server-side components, version 2.3.0 and later. To check the version of a running service, visit _&#60;domain&#62;_/_&#60;service&#62;_/version. Such as `http://localhost:8080/ephox-hyperlinking/version`."
 deprecate_spellchecker: "> **Important**: The **free** TinyMCE Spell Checker plugin (`spellchecker`) was deprecated with the release of TinyMCE 5.4. For details, see [the free TinyMCE Spell Checker plugin deprecation notice](https://www.tiny.cloud/docs/release-notes/release-notes54/#thefreetinymcespellcheckerplugin)."

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -85,6 +85,7 @@
     - url: "#block_formats"
     - url: "#branding"
     - url: "#contextmenu"
+    - url: "#contextmenu_avoid_overlap"
     - url: "#contextmenu_never_use_native"
     - url: "#custom_ui_selector"
     - url: "#draggable_modal"

--- a/_includes/configuration/contextmenu_avoid_overlap.md
+++ b/_includes/configuration/contextmenu_avoid_overlap.md
@@ -1,0 +1,18 @@
+## `contextmenu_avoid_overlap`
+
+{{site.requires_5_5v}}
+
+The `contextmenu_avoid_overlap` option prevents the context menu from covering (or overlapping) specific nodes within the editor. This option accepts a [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors). When the context menu is opened on a node that matches the specified selector, the context menu will render below the node, instead of where the click occurred.
+
+**Type**: `String`
+
+**Default Value**: `''`
+
+#### Example
+
+```js
+tinymce.init({
+  selector: 'textarea',
+  contextmenu_avoid_overlap: '.mce-spelling-word'
+});
+```

--- a/_includes/configuration/contextmenu_avoid_overlap.md
+++ b/_includes/configuration/contextmenu_avoid_overlap.md
@@ -2,7 +2,7 @@
 
 {{site.requires_5_5v}}
 
-The `contextmenu_avoid_overlap` option prevents the context menu from covering (or overlapping) specific nodes within the editor. This option accepts a [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors). When the context menu is opened on a node that matches the specified selector, the context menu will render below the node, instead of where the click occurred.
+The `contextmenu_avoid_overlap` option prevents the context menu from covering (or overlapping) specific nodes within the editor. This option accepts a [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors). When the context menu is opened on a node that matches the specified selector, the context menu will render below the node, instead of where the click occurred. If there is not enough room in the browser window below the node, the context menu will be shown above the node.
 
 **Type**: `String`
 

--- a/configure/editor-appearance.md
+++ b/configure/editor-appearance.md
@@ -12,6 +12,8 @@ description: Configure the editor's appearance, including menu and toolbar contr
 
 {% include configuration/contextmenu.md %}
 
+{% include configuration/contextmenu_avoid_overlap.md %}
+
 {% include configuration/contextmenu_never_use_native.md %}
 
 {% include configuration/custom-ui-selector.md %}

--- a/release-notes/release-notes55.md
+++ b/release-notes/release-notes55.md
@@ -23,6 +23,12 @@ These release notes provide an overview of the changes for {{site.productname}} 
 
 The following new features and enhancements were added for the {{site.productname}} 5.5 release.
 
+### New `contextmenu_avoid_overlap` option for controlling the placement of content menus
+
+The new `contextmenu_avoid_overlap` option can be used to prevent context menus from covering the selected node if the node has a specified class.
+
+For information on the `contextmenu_avoid_overlap` option, see: [User interface options - `contextmenu_avoid_overlap`]({{site.baseurl}}/configure/editor-appearance/#contextmenu_avoid_overlap).
+
 ###
 
 

--- a/release-notes/release-notes55.md
+++ b/release-notes/release-notes55.md
@@ -23,9 +23,9 @@ These release notes provide an overview of the changes for {{site.productname}} 
 
 The following new features and enhancements were added for the {{site.productname}} 5.5 release.
 
-### New `contextmenu_avoid_overlap` option for controlling the placement of content menus
+### New `contextmenu_avoid_overlap` option for controlling the placement of context menus
 
-The new `contextmenu_avoid_overlap` option can be used to prevent context menus from covering the selected node if the node has a specified class.
+The new `contextmenu_avoid_overlap` option can be used to prevent context menus from covering the selected node if the node matches the specified [CSS selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors).
 
 For information on the `contextmenu_avoid_overlap` option, see: [User interface options - `contextmenu_avoid_overlap`]({{site.baseurl}}/configure/editor-appearance/#contextmenu_avoid_overlap).
 


### PR DESCRIPTION
Related Ticket: DOC-638

Description of Changes:
* Adds documentation for the new `contextmenu_avoid_overlap` setting.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
