### PR TITLE
Moving some notes for consistency, create var for RN ent/comm note

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -59,7 +59,7 @@ ctrl_right_click: "> **Note**: When the TinyMCE context menu is _enabled_, users
 notonmobile: "> **Note**: This option is not supported on mobile devices."
 premiumplugin: "> **Note**: This plugin is only available for [paid TinyMCE subscriptions](https://www.tiny.cloud/pricing)."
 differs_for_mobile: "> **Note**: The default option for this setting is different for mobile devices. For information on the default mobile setting, see: [TinyMCE Mobile - Configuration settings with mobile defaults](https://www.tiny.cloud/docs/mobile/#mobiledefaultsforselectedsettings)."
-
+releasenotes_for_stable: "> This is the Tiny Cloud and TinyMCE Enterprise release notes. For information on the latest community version of TinyMCE, see: [TinyMCE Changelog](https://www.tiny.cloud/docs/changelog/)."
 thirdPartyInteg: "> **Important**: This Integration is maintained by a third-party developer. Tiny Technologies, Inc. bears no responsibility for this integration, which is not covered by the Tiny Self-Hosted Software License Agreement. For issues related to the integration, contact the third-party project directly."
 
 moxieMNotOnCloud: "> **Note**: The MoxieManager plugin is _not_ provided on the Tiny Cloud, and is provided as a self-hosted solution only."

--- a/_includes/configuration/block-unsupported-drop.md
+++ b/_includes/configuration/block-unsupported-drop.md
@@ -1,8 +1,8 @@
 ## block_unsupported_drop
 
-When the `block_unsupported_drop` option is set to `true`, the editor blocks unsupported images and files from being dropped into the editor. If the `block_unsupported_drop` option is set to `false`, dropping an unsupported file into the editor will cause the browser to navigate away from the page containing the editor.
-
 {{site.requires_5_4v}}
+
+When the `block_unsupported_drop` option is set to `true`, the editor blocks unsupported images and files from being dropped into the editor. If the `block_unsupported_drop` option is set to `false`, dropping an unsupported file into the editor will cause the browser to navigate away from the page containing the editor.
 
 **Type:** `Boolean`
 

--- a/_includes/configuration/paste-tab-spaces.md
+++ b/_includes/configuration/paste-tab-spaces.md
@@ -7,9 +7,9 @@
 {% endif %}
 ### `paste_tab_spaces`
 
-This option controls how many spaces are used to represent a tab character in HTML when pasting plain text content. By default, the {{pluginname}} plugin will convert each tab character into 4 sequential space characters.
-
 {{site.requires_5_4v}}
+
+This option controls how many spaces are used to represent a tab character in HTML when pasting plain text content. By default, the {{pluginname}} plugin will convert each tab character into 4 sequential space characters.
 
 **Type:** `Number`
 

--- a/_includes/configuration/referrer_policy.md
+++ b/_includes/configuration/referrer_policy.md
@@ -1,11 +1,11 @@
 ## referrer_policy
 
+{{site.requires_5_1v}}
+
 Used for setting the level of referrer information sent when loading plugins and CSS. Referrer policies can be used to:
 
 * Improve the privacy of end-users.
 * Assist with server-side filtering of cross-origin requests for {{site.productname}} resources.
-
-{{site.requires_5_1v}}
 
 **Type:** `String`
 

--- a/release-notes/release-notes51.md
+++ b/release-notes/release-notes51.md
@@ -14,7 +14,7 @@ These release notes provide a high-level coverage of the changes for {{site.prod
 - [Known issues](#knownissues)
 - [Upgrading to the latest version of TinyMCE 5](#upgradingtothelatestversionoftinymce5)
 
-> This is the {{site.cloudname}} and {{site.enterpriseversion}} release notes. For information on the latest community version of {{site.productname}}, see: [{{site.productname}} Changelog]({{site.baseurl}}/changelog/).
+{{site.releasenotes_for_stable}}
 
 ## New features and enhancements
 

--- a/release-notes/release-notes514.md
+++ b/release-notes/release-notes514.md
@@ -11,7 +11,7 @@ These release notes provide an overview of the changes for {{site.productname}} 
 - [General bug fixes](#generalbugfixes)
 - [Security fixes](#securityfixes)
 
-> This is the {{site.cloudname}} and {{site.enterpriseversion}} release notes. For information on the latest community version of {{site.productname}}, see: [{{site.productname}} Changelog]({{site.baseurl}}/changelog/).
+{{site.releasenotes_for_stable}}
 
 ## General bug fixes
 

--- a/release-notes/release-notes515.md
+++ b/release-notes/release-notes515.md
@@ -10,7 +10,7 @@ These release notes provide an overview of the changes for {{site.productname}} 
 
 - [General bug fixes](#generalbugfixes)
 
-> This is the {{site.cloudname}} and {{site.enterpriseversion}} release notes. For information on the latest community version of {{site.productname}}, see: [{{site.productname}} Changelog]({{site.baseurl}}/changelog/).
+{{site.releasenotes_for_stable}}
 
 ## General bug fixes
 

--- a/release-notes/release-notes516.md
+++ b/release-notes/release-notes516.md
@@ -12,7 +12,7 @@ These release notes provide an overview of the changes for {{site.productname}} 
 - [Security fixes](#securityfixes)
 - [Premium Plugin changes](#premiumpluginchanges)
 
-> This is the {{site.cloudname}} and {{site.enterpriseversion}} release notes. For information on the latest community version of {{site.productname}}, see: [{{site.productname}} Changelog]({{site.baseurl}}/changelog/).
+{{site.releasenotes_for_stable}}
 
 ## General bug fixes
 

--- a/release-notes/release-notes52.md
+++ b/release-notes/release-notes52.md
@@ -16,7 +16,7 @@ These release notes provide an overview of the changes for {{site.productname}} 
 - [Known issues](#knownissues)
 - [Upgrading to the latest version of TinyMCE 5](#upgradingtothelatestversionoftinymce5)
 
-> This is the {{site.cloudname}} and {{site.enterpriseversion}} release notes. For information on the latest community version of {{site.productname}}, see: [{{site.productname}} Changelog]({{site.baseurl}}/changelog/).
+{{site.releasenotes_for_stable}}
 
 ## TinyMCE 5.2 new features and enhancements
 
@@ -64,7 +64,7 @@ The `a11y_advanced_options` setting adds an option to set an image as decorative
 - The _Insert/Edit Image_ dialog.
 - The _Accessibility Checker error_ dialog for images without alternative text or the `role="presentation"` attribute.
 
-For information on the `a11y_advanced_options`, including the impact on the `a11ychecker_allow_decorative_images` setting, see: 
+For information on the `a11y_advanced_options`, including the impact on the `a11ychecker_allow_decorative_images` setting, see:
 
 - [The Accessibility Checker plugin - `a11y_advanced_options`]({{site.baseurl}}/plugins/a11ychecker/#a11y_advanced_options).
 - [The Image plugin - `a11y_advanced_options`]({{site.baseurl}}/plugins/image/#a11y_advanced_options).

--- a/release-notes/release-notes521.md
+++ b/release-notes/release-notes521.md
@@ -14,7 +14,7 @@ These release notes provide an overview of the changes for {{site.productname}} 
 - [Accompanying Premium Plugin changes](#accompanyingpremiumpluginchanges)
 - [Upgrading to the latest version of TinyMCE 5](#upgradingtothelatestversionoftinymce5)
 
-> This is the {{site.cloudname}} and {{site.enterpriseversion}} release notes. For information on the latest community version of {{site.productname}}, see: [{{site.productname}} Changelog]({{site.baseurl}}/changelog/).
+{{site.releasenotes_for_stable}}
 
 ## General bug fixes
 

--- a/release-notes/release-notes522.md
+++ b/release-notes/release-notes522.md
@@ -15,7 +15,7 @@ These release notes provide an overview of the changes for {{site.productname}} 
 - [Accompanying Premium Plugin changes](#accompanyingpremiumpluginchanges)
 - [Upgrading to the latest version of TinyMCE 5](#upgradingtothelatestversionoftinymce5)
 
-> This is the {{site.cloudname}} and {{site.enterpriseversion}} release notes. For information on the latest community version of {{site.productname}}, see: [{{site.productname}} Changelog]({{site.baseurl}}/changelog/).
+{{site.releasenotes_for_stable}}
 
 ## General bug fixes
 
@@ -46,7 +46,7 @@ The {{site.productname}} 5.2.2 release includes an accompanying release of the *
 
 The {{site.productname}} 5.2.2 release includes an accompanying release of the **SpellChecker Pro** premium plugin.
 
-**SpellChecker Pro** 2.0.1 provides a fixes for: 
+**SpellChecker Pro** 2.0.1 provides a fixes for:
 
 * The context menu being incorrectly positioned on a scrolled page in TinyMCE 4.
 * An unhandled exception thrown when enabling spellchecking in inline mode for TinyMCE 4.

--- a/release-notes/release-notes53.md
+++ b/release-notes/release-notes53.md
@@ -17,7 +17,7 @@ These release notes provide an overview of the changes for {{site.productname}} 
 - [Known issues](#knownissues)
 - [Upgrading to the latest version of TinyMCE 5](#upgradingtothelatestversionoftinymce5)
 
-> This is the {{site.cloudname}} and {{site.enterpriseversion}} release notes. For information on the latest community version of {{site.productname}}, see: [{{site.productname}} Changelog]({{site.baseurl}}/changelog/).
+{{site.releasenotes_for_stable}}
 
 ## TinyMCE 5.3 new features and enhancements
 

--- a/release-notes/release-notes54.md
+++ b/release-notes/release-notes54.md
@@ -18,7 +18,7 @@ These release notes provide an overview of the changes for {{site.productname}} 
 - [Known issues](#knownissues)
 - [Upgrading to the latest version of TinyMCE 5](#upgradingtothelatestversionoftinymce5)
 
-> This is the {{site.cloudname}} and {{site.enterpriseversion}} release notes. For information on the latest community version of {{site.productname}}, see: [{{site.productname}} Changelog]({{site.baseurl}}/changelog/).
+{{site.releasenotes_for_stable}}
 
 ## TinyMCE 5.4 new features and enhancements
 

--- a/release-notes/release-notes542.md
+++ b/release-notes/release-notes542.md
@@ -14,7 +14,7 @@ These release notes provide an overview of the changes for {{site.productname}} 
 - [Accompanying Premium Plugin changes](#accompanyingpremiumpluginchanges)
 - [Upgrading to the latest version of TinyMCE 5](#upgradingtothelatestversionoftinymce5)
 
-> This is the {{site.cloudname}} and {{site.enterpriseversion}} release notes. For information on the latest community version of {{site.productname}}, see: [{{site.productname}} Changelog]({{site.baseurl}}/changelog/).
+{{site.releasenotes_for_stable}}
 
 ## General bug fixes
 


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* Moving "requires version" notes to above setting descriptions for consistency
* Created variable for note indicating that release notes reflect the enterprise release, not community

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
