### PR TITLE
DOC-654: replacing forum links with stackoverflow

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,6 +39,7 @@ productpages: https://apps.tiny.cloud/products
 pricingpage: https://www.tiny.cloud/pricing
 contactpage: https://www.tiny.cloud/contact
 legalpage: https://about.tiny.cloud/legal
+communitysupporturl: https://stackoverflow.com/questions/tagged/tinymce
 # HMTL entities
 tick: '&#10004;'
 cross: '&#10006;'

--- a/_includes/live-demos/annotations/index.html
+++ b/_includes/live-demos/annotations/index.html
@@ -7,7 +7,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a href="//www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/">Community Forum</a>.</li>
+    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium subscriptions</a>.</li>
   </ul>
 

--- a/_includes/live-demos/annotations/index.html
+++ b/_includes/live-demos/annotations/index.html
@@ -7,7 +7,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a href="//www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
+    <li>Have a specific question? Try the <a href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium subscriptions</a>.</li>
   </ul>
 

--- a/_includes/live-demos/basic-example/index.html
+++ b/_includes/live-demos/basic-example/index.html
@@ -9,7 +9,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/" target="_blank">Community Forum</a>.</li>
+    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/basic-example/index.html
+++ b/_includes/live-demos/basic-example/index.html
@@ -9,7 +9,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
+    <li>Have a specific question? Try the <a href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/casechange/index.html
+++ b/_includes/live-demos/casechange/index.html
@@ -13,7 +13,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
+    <li>Have a specific question? Try the <a href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/casechange/index.html
+++ b/_includes/live-demos/casechange/index.html
@@ -13,7 +13,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/" target="_blank">Community Forum</a>.</li>
+    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/context-menu/index.html
+++ b/_includes/live-demos/context-menu/index.html
@@ -14,7 +14,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/" target="_blank">Community Forum</a>.</li>
+    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/context-menu/index.html
+++ b/_includes/live-demos/context-menu/index.html
@@ -14,7 +14,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
+    <li>Have a specific question? Try the <a href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/custom-menu-item/index.html
+++ b/_includes/live-demos/custom-menu-item/index.html
@@ -8,7 +8,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/">Community Forum</a>.</li>
+    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/custom-menu-item/index.html
+++ b/_includes/live-demos/custom-menu-item/index.html
@@ -8,7 +8,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
+    <li>Have a specific question? Try the <a href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/custom-toolbar-button/index.html
+++ b/_includes/live-demos/custom-toolbar-button/index.html
@@ -7,7 +7,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/">Community Forum</a>.</li>
+    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/custom-toolbar-button/index.html
+++ b/_includes/live-demos/custom-toolbar-button/index.html
@@ -7,7 +7,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
+    <li>Have a specific question? Try the <a href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/custom-toolbar-split-button/index.html
+++ b/_includes/live-demos/custom-toolbar-split-button/index.html
@@ -6,7 +6,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/">Community Forum</a>.</li>
+    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/custom-toolbar-split-button/index.html
+++ b/_includes/live-demos/custom-toolbar-split-button/index.html
@@ -6,7 +6,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
+    <li>Have a specific question? Try the <a href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/custom-toolbar-toggle-button/index.html
+++ b/_includes/live-demos/custom-toolbar-toggle-button/index.html
@@ -6,7 +6,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/">Community Forum</a>.</li>
+    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/custom-toolbar-toggle-button/index.html
+++ b/_includes/live-demos/custom-toolbar-toggle-button/index.html
@@ -6,7 +6,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
+    <li>Have a specific question? Try the <a href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/dark-mode/index.html
+++ b/_includes/live-demos/dark-mode/index.html
@@ -9,7 +9,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/" target="_blank">Community Forum</a>.</li>
+    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/dark-mode/index.html
+++ b/_includes/live-demos/dark-mode/index.html
@@ -9,7 +9,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
+    <li>Have a specific question? Try the <a href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/drive/index.html
+++ b/_includes/live-demos/drive/index.html
@@ -14,7 +14,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/" target="_blank">Community Forum</a>.</li>
+    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/drive/index.html
+++ b/_includes/live-demos/drive/index.html
@@ -14,7 +14,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
+    <li>Have a specific question? Try the <a href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/format-custom/index.html
+++ b/_includes/live-demos/format-custom/index.html
@@ -11,7 +11,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
+    <li>Have a specific question? Try the <a href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/format-custom/index.html
+++ b/_includes/live-demos/format-custom/index.html
@@ -11,7 +11,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/">Community Forum</a>.</li>
+    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/format-painter/index.html
+++ b/_includes/live-demos/format-painter/index.html
@@ -9,7 +9,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/" target="_blank">Community Forum</a>.</li>
+    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/format-painter/index.html
+++ b/_includes/live-demos/format-painter/index.html
@@ -9,7 +9,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
+    <li>Have a specific question? Try the <a href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/full-featured/index.html
+++ b/_includes/live-demos/full-featured/index.html
@@ -7,7 +7,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a class="mceNonEditable" href="//www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
+    <li>Have a specific question? Try the <a href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium subscriptions</a>.</li>
   </ul>
 

--- a/_includes/live-demos/full-featured/index.html
+++ b/_includes/live-demos/full-featured/index.html
@@ -7,7 +7,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a class="mceNonEditable" href="//www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a class="mceNonEditable" href="https://community.tiny.cloud/forum/">Community Forum</a>.</li>
+    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium subscriptions</a>.</li>
   </ul>
 

--- a/_includes/live-demos/image-tools/index.html
+++ b/_includes/live-demos/image-tools/index.html
@@ -9,7 +9,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
+    <li>Have a specific question? Try the <a href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
   <h2>A simple table to play with</h2>

--- a/_includes/live-demos/image-tools/index.html
+++ b/_includes/live-demos/image-tools/index.html
@@ -9,7 +9,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/">Community Forum</a>.</li>
+    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
   <h2>A simple table to play with</h2>

--- a/_includes/live-demos/open-source-plugins/index.html
+++ b/_includes/live-demos/open-source-plugins/index.html
@@ -6,7 +6,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a class="mceNonEditable" href="//www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a class="mceNonEditable" href="https://community.tiny.cloud/forum/">Community Forum</a>.</li>
+    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/open-source-plugins/index.html
+++ b/_includes/live-demos/open-source-plugins/index.html
@@ -6,7 +6,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a class="mceNonEditable" href="//www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
+    <li>Have a specific question? Try the <a href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/page-embed/index.html
+++ b/_includes/live-demos/page-embed/index.html
@@ -9,7 +9,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/" target="_blank">Community Forum</a>.</li>
+    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/page-embed/index.html
+++ b/_includes/live-demos/page-embed/index.html
@@ -9,7 +9,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
+    <li>Have a specific question? Try the <a href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/paste-from-word/index.html
+++ b/_includes/live-demos/paste-from-word/index.html
@@ -19,7 +19,7 @@
 <h2>Got questions or need help?</h2>
 <ul>
 <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-<li>Have a specific question? Visit the <a href="https://community.tiny.cloud/" target="_blank" rel="noopener">Community Forum</a>.</li>
+<li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
 <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
 </ul>
 <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br />All the best from the TinyMCE team.</p>

--- a/_includes/live-demos/paste-from-word/index.html
+++ b/_includes/live-demos/paste-from-word/index.html
@@ -19,7 +19,7 @@
 <h2>Got questions or need help?</h2>
 <ul>
 <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-<li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
+<li>Have a specific question? Try the <a href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
 <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
 </ul>
 <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br />All the best from the TinyMCE team.</p>

--- a/_includes/live-demos/permanent-pen/index.html
+++ b/_includes/live-demos/permanent-pen/index.html
@@ -9,7 +9,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/" target="_blank">Community Forum</a>.</li>
+    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/permanent-pen/index.html
+++ b/_includes/live-demos/permanent-pen/index.html
@@ -9,7 +9,7 @@
 
   <ul>
     <li>Our <a href="https://www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
+    <li>Have a specific question? Try the <a href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/valid-elements/index.html
+++ b/_includes/live-demos/valid-elements/index.html
@@ -6,7 +6,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a href="//www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Visit the <a href="https://community.tiny.cloud/forum/">Community Forum</a>.</li>
+    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_includes/live-demos/valid-elements/index.html
+++ b/_includes/live-demos/valid-elements/index.html
@@ -6,7 +6,7 @@
   <h2>Got questions or need help?</h2>
   <ul>
     <li>Our <a href="//www.tiny.cloud/docs/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-    <li>Have a specific question? Try the <a class="mceNonEditable" href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
+    <li>Have a specific question? Try the <a href="{{site.communitysupporturl}}" target="_blank" rel="noopener"><code>{{site.prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium plans</a>.</li>
   </ul>
 

--- a/_scripts/check-links-staging.sh
+++ b/_scripts/check-links-staging.sh
@@ -4,4 +4,4 @@
 # https://www.notion.so/tinycloud/Check-for-broken-links-4876019acee44cc88c5082e447c85519
 
 mkdir -p ./_report/report
-linkchecker -r 2 -t 10 https://staging.tiny.cloud/docs/ --check-extern --output=html --ignore-url=https://community.tiny.cloud/.* > _report/report/index.html || true
+linkchecker -r 2 -t 10 https://staging.tiny.cloud/docs/ --check-extern --output=html --ignore-url=https://github.com/tinymce/tinymce-docs/tree/* --ignore-url=https://github.com/tinymce/tinymce-docs/issues/* > _report/report/index.html || true

--- a/general-configuration-guide/get-support.md
+++ b/general-configuration-guide/get-support.md
@@ -10,9 +10,8 @@ keywords: forum forums url absolute relative security xss
 Paid premium support is available as part of [{{site.enterpriseversion}} and {{site.cloudname}} subscriptions]({{site.pricingpage}}). {{site.productname}} Enterprise customers can [submit a case support request]({{ site.baseurl }}/enterprise/support/).
 
 
-## Forums
-Open Source Community Edition users can get free access to the [{{site.productname}} Forum](https://community.tiny.cloud/). Sign up [here](https://community.tiny.cloud/).
-
+## Community support
+Open Source Community Edition users can get free help from Stack Overflow using the [`{{site.prodnamecode}}` tag]({{site.communitysupporturl}}).
 
 ## FAQ & troubleshooting
 

--- a/integrations/bootstrap.md
+++ b/integrations/bootstrap.md
@@ -75,4 +75,4 @@ This code is required because Bootstrap blocks all `focusin` calls from elements
 
 #### A note about integrations
 
-> Note: We are pleased to provide integrations/code guidance to help you build great products with {{site.productname}}. If you have queries about this integration, please join the [{{site.productname}} Community](https://community.tiny.cloud/).
+> Note: We are pleased to provide integrations/code guidance to help you build great products with {{site.productname}}. If you have queries about this integration, post your question on Stack Overflow using the [`{{site.prodnamecode}}` tag]({{site.communitysupporturl}}).

--- a/integrations/jquery.md
+++ b/integrations/jquery.md
@@ -106,4 +106,4 @@ This code is required because jQuery blocks all `focusin` calls from elements ou
 
 #### A note about integrations
 
-> Note: We are pleased to provide integrations/code guidance to help you build great products with {{site.productname}}. If you have queries about this integration, please join the [{{site.productname}} Community](https://community.tiny.cloud/).
+> Note: We are pleased to provide integrations/code guidance to help you build great products with {{site.productname}}. If you have queries about this integration, post your question on Stack Overflow using the [`{{site.prodnamecode}}` tag]({{site.communitysupporturl}}).

--- a/integrations/swing.md
+++ b/integrations/swing.md
@@ -36,7 +36,7 @@ The Swing integration allows the user to select the origin of the {{site.product
 
   ```java
   final Config myTinyConfiguration = Config.cloud("<my_api_key>", "{{site.productmajorversion}}-stable");
-  ``` 
+  ```
 
 * External deployments allow to use a local version of {{site.productname}} by giving the address of the location where {{site.productname}} is being served.
 
@@ -128,4 +128,4 @@ For more examples check the [GitHub repository](https://github.com/tinymce/tinym
 
 #### A note about integrations
 
-> Note: {{site.companyname}} references to third-party integrations/code to help users build great products with the {{site.productname}} editor. For support related issues such as queries about this integration, please contact [{{site.supportname}}]({{site.supporturl}}) or join the [{{site.productname}} Community](https://community.tiny.cloud/).
+> Note: {{site.companyname}} references to third-party integrations/code to help users build great products with the {{site.productname}} editor. For support related issues such as queries about this integration, please contact [{{site.supportname}}]({{site.supporturl}}) or post your question on Stack Overflow using the [`{{site.prodnamecode}}` tag]({{site.communitysupporturl}}).


### PR DESCRIPTION
Related Ticket: DOC-654

Description of Changes:
* replacing forum links with stackoverflow

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
