### PR TITLE
DOC-660: Add powerpaste 5.3.3 to release notes

### DIFF
--- a/release-notes/release-notes55.md
+++ b/release-notes/release-notes55.md
@@ -73,6 +73,14 @@ The {{site.productname}} 5.5 release includes an accompanying release of the **A
 
 For information on the    plugin, see: []().
 
+### PowerPaste 5.3.3
+
+The {{site.productname}} 5.5 release includes an accompanying release of the **PowerPaste** premium plugin.
+
+**PowerPaste** 5.3.3 fixes missing `bg_BG`, `eu`, and `id` translations.
+
+For information on the PowerPaste plugin, see: [PowerPaste plugin]({{site.baseurl}}/plugins/powerpaste/).
+
 ## Minor changes for TinyMCE 5.5
 
 {{site.productname}} 5.5 introduces the following minor changes:


### PR DESCRIPTION
Related Ticket: DOC-660

Description of Changes:
* Add powerpaste 5.3.3 to the 5.5 release notes

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
