### PR TITLE
DOC-656: Deprecated premium es_MX lang pack

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -818,6 +818,7 @@
     - url: "#Accompanying Premium Plugin changes"
     - url: "#Minor changes for TinyMCE 5.5"
     - url: "#General bug fixes"
+    - url: "#Deprecated features"
     - url: "#Known issues"
     - url: "#Upgrading to the latest version of TinyMCE 5"
   - url: "release-notes542"

--- a/_includes/configuration/language.md
+++ b/_includes/configuration/language.md
@@ -91,7 +91,7 @@ The available language codes for use with this option are as follows:
 | Slovak                        | sk      | {{ site.tick }}                                                      |
 | Slovenian (Slovenia)          | sl_SI   | {{ site.tick }}                                                      |
 | Spanish                       | es      | {{ site.tick }}                                                      |
-| Spanish (Mexico)              | es_MX   | {{ site.tick }}                                                      |
+| Spanish (Mexico)              | es_MX   | {{ site.tick }} (Premium language pack deprecated in <br>{{site.productname}} 5.5 and newer) |
 | Swedish (Sweden)              | sv_SE   | {{ site.tick }}                                                      |
 | Tajik                         | tg      |                                                                      |
 | Tamil                         | ta      |                                                                      |

--- a/release-notes/release-notes55.md
+++ b/release-notes/release-notes55.md
@@ -128,9 +128,9 @@ The following features have been deprecated with the release of {{site.productna
 
 - [The premium Mexican Spanish language pack has been deprecated](#thepremiummexicanspanishlanguagepackhasbeendeprecated).
 
-### The premium Mexican Spanish language pack has been deprecated
+### The premium Spanish (Mexico) language pack has been deprecated
 
-With the release of {{site.productname}} 5.5, the premium Mexican Spanish language pack (`es_MX`) has been deprecated and will not be updated in the future. The community-translated Mexican Spanish language pack is unaffected.
+With the release of {{site.productname}} 5.5, the premium Spanish (Mexico) language pack (`es_MX`) has been deprecated and will not be updated in the future. The community-translated Spanish (Mexico) language pack is unaffected.
 
 For information on the community maintained language packs, see: [Localization options - `language`]({{site.baseurl}}/configure/localization/#language).
 

--- a/release-notes/release-notes55.md
+++ b/release-notes/release-notes55.md
@@ -124,9 +124,9 @@ For information on the    plugin, see: []().
 
 ## Deprecated features
 
-The following features have been deprecated with the release of {{site.productname}} vnumtxt:
+The following features have been deprecated with the release of {{site.productname}} 5.5:
 
-- [](#).
+- [The premium Mexican Spanish language pack has been deprecated](#thepremiummexicanspanishlanguagepackhasbeendeprecated).
 
 ### The premium Mexican Spanish language pack has been deprecated
 

--- a/release-notes/release-notes55.md
+++ b/release-notes/release-notes55.md
@@ -122,6 +122,18 @@ For information on the    plugin, see: []().
 * Fixed `editor.selection.setCursorLocation` incorrectly placing the cursor outside `pre` elements in some circumstances.
 * Fixed an exception being thrown when pressing the enter key inside pre elements while `br_in_pre` setting is false.
 
+## Deprecated features
+
+The following features have been deprecated with the release of {{site.productname}} vnumtxt:
+
+- [](#).
+
+### The premium Mexican Spanish language pack has been deprecated
+
+With the release of {{site.productname}} 5.5, the premium Mexican Spanish language pack (`es_MX`) has been deprecated and will not be updated in the future. The community-translated Mexican Spanish language pack is unaffected.
+
+For information on the community maintained language packs, see: [Localization options - `language`]({{site.baseurl}}/configure/localization/#language).
+
 ## Known issues
 
 This section describes issues that users of {{site.productname}} 5.5 may encounter, as well as possible workarounds for these issues.

--- a/release-notes/release-notes55.md
+++ b/release-notes/release-notes55.md
@@ -126,7 +126,7 @@ For information on the    plugin, see: []().
 
 The following features have been deprecated with the release of {{site.productname}} 5.5:
 
-- [The premium Mexican Spanish language pack has been deprecated](#thepremiummexicanspanishlanguagepackhasbeendeprecated).
+- [The premium Spanish (Mexico) language pack has been deprecated](#thepremiumspanishmexicolanguagepackhasbeendeprecated).
 
 ### The premium Spanish (Mexico) language pack has been deprecated
 


### PR DESCRIPTION
Related Ticket: DOC-656

Description of Changes:
* Deprecated premium es_MX lang pack

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
