### PR TITLE
#1660: fixing media callback examples

### DIFF
--- a/plugins/media.md
+++ b/plugins/media.md
@@ -44,7 +44,7 @@ tinymce.init({
   menubar: 'insert',
   toolbar: 'media',
   audio_template_callback: function(data) {
-   return '<audio controls>' + '\n<source src="' + data.source1 + '"' + (data.source1mime ? ' type="' + data.source1mime + '"' : '') + ' />\n' + '</audio>';
+   return '<audio controls>' + '\n<source src="' + data.source + '"' + (data.sourcemime ? ' type="' + data.sourcemime + '"' : '') + ' />\n' + (data.altsource ? '<source src="' + data.altsource + '"' + (data.altsourcemime ? ' type="' + data.altsourcemime + '"' : '') + ' />\n' : '') + '</audio>';
  }
 });
 ```
@@ -230,7 +230,7 @@ tinymce.init({
   menubar: 'insert',
   toolbar: 'media',
   video_template_callback: function(data) {
-   return '<video width="' + data.width + '" height="' + data.height + '"' + (data.poster ? ' poster="' + data.poster + '"' : '') + ' controls="controls">\n' + '<source src="' + data.source1 + '"' + (data.source1mime ? ' type="' + data.source1mime + '"' : '') + ' />\n' + (data.source2 ? '<source src="' + data.source2 + '"' + (data.source2mime ? ' type="' + data.source2mime + '"' : '') + ' />\n' : '') + '</video>';
+   return '<video width="' + data.width + '" height="' + data.height + '"' + (data.poster ? ' poster="' + data.poster + '"' : '') + ' controls="controls">\n' + '<source src="' + data.source + '"' + (data.sourcemime ? ' type="' + data.sourcemime + '"' : '') + ' />\n' + (data.altsource ? '<source src="' + data.altsource + '"' + (data.altsourcemime ? ' type="' + data.altsourcemime + '"' : '') + ' />\n' : '') + '</video>';
  }
 });
 ```

--- a/plugins/table.md
+++ b/plugins/table.md
@@ -271,7 +271,7 @@ tinymce.init({
 });
 ```
 
-{% include configuration/table-column-resizing.md %}
+#{% include configuration/table-column-resizing.md %}
 
 ### `table_class_list`
 


### PR DESCRIPTION
Related Ticket: #1660 

Description of Changes:
* Fixes #1660 
* Fixes media template callback examples
* Quick fix regarding table plugin heading

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
