### PR TITLE
DOC-690: Document new format_empty_lines option

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -170,6 +170,7 @@
   - url: "content-formatting"
     pages:
       - url: "#formats"
+      - url: "#format_empty_lines"
       - url: "#indentation"
       - url: "#indent_use_margin"
   - url: "spelling"

--- a/_includes/configuration/format-empty-lines.md
+++ b/_includes/configuration/format-empty-lines.md
@@ -1,0 +1,18 @@
+## `format_empty_lines`
+
+{{ site.requires_5_6v }}
+
+This option allows `inline` formats to be applied to empty lines for multi-line selections.
+
+**Type:** `Boolean`
+
+**Default Value:** `false`
+
+### Example: Using `format_empty_lines`
+
+```js
+tinymce.init({
+  selector: 'textarea',  // change this value according to your html
+  format_empty_lines: true
+});
+```

--- a/_includes/configuration/format-empty-lines.md
+++ b/_includes/configuration/format-empty-lines.md
@@ -2,7 +2,7 @@
 
 {{ site.requires_5_6v }}
 
-This option allows "inline" formats to be applied to empty lines for multi-line selections. Inline formats include bold (`<strong>`) and underline (`<span style="text-decoration: underline;">`).
+This option allows "inline" formats to be applied to empty lines for multi-line selections. Examples of inline formats include bold (`<strong>`) and underline (`<span style="text-decoration: underline;">`).
 
 **Type:** `Boolean`
 

--- a/_includes/configuration/format-empty-lines.md
+++ b/_includes/configuration/format-empty-lines.md
@@ -2,7 +2,7 @@
 
 {{ site.requires_5_6v }}
 
-This option allows `inline` formats to be applied to empty lines for multi-line selections.
+This option allows "inline" formats to be applied to empty lines for multi-line selections. Inline formats include bold (`<strong>`) and underline (`<span style="text-decoration: underline;">`).
 
 **Type:** `Boolean`
 

--- a/configure/content-formatting.md
+++ b/configure/content-formatting.md
@@ -8,4 +8,6 @@ description: These settings change the way the editor handles the input and outp
 
 {% include configuration/formats.md %}
 
+{% include configuration/format-empty-lines.md %}
+
 {% include configuration/indentation.md %}

--- a/release-notes/release-notes56.md
+++ b/release-notes/release-notes56.md
@@ -11,7 +11,7 @@ These release notes provide an overview of the changes for {{site.productname}} 
 - [TinyMCE 5.6 new features and enhancements](#tinymce56newfeaturesandenhancements)
 - [Accompanying Premium Plugin changes](#accompanyingpremiumpluginchanges)
 - [Accompanying Premium self-hosted server-side component changes](#accompanyingpremiumself-hostedserver-sidecomponentchanges)
-- [Minor changes for TinyMCE 5.6](#minorchangesfortinymce55)
+- [Minor changes for TinyMCE 5.6](#minorchangesfortinymce56)
 - [General bug fixes](#generalbugfixes)
 - [Security fixes](#securityfixes)
 - [Deprecated features](#deprecatedfeatures)
@@ -26,7 +26,7 @@ The following new features and enhancements were added for the {{site.productnam
 
 ### New `format_empty_lines` option for content formatting
 
-A new `format_empty_lines` option allows empty lines to be formatted for mult-line selections when applying an `inline` format such as `bold`.
+A new `format_empty_lines` option allows empty lines to be formatted for mult-line selections when applying an "inline" format such as bold (`<strong>`).
 
 For information on the `format_empty_lines` option, see: [Content Formatting - `format_empty_lines`]({{ site.baseurl }}/configure/content-formatting/#format_empty_lines).
 

--- a/release-notes/release-notes56.md
+++ b/release-notes/release-notes56.md
@@ -8,7 +8,7 @@ keywords: releasenotes bugfixes
 
 These release notes provide an overview of the changes for {{site.productname}} 5.6, including:
 
-- [TinyMCE 5.6 new features and enhancements](#tinymce55newfeaturesandenhancements)
+- [TinyMCE 5.6 new features and enhancements](#tinymce56newfeaturesandenhancements)
 - [Accompanying Premium Plugin changes](#accompanyingpremiumpluginchanges)
 - [Accompanying Premium self-hosted server-side component changes](#accompanyingpremiumself-hostedserver-sidecomponentchanges)
 - [Minor changes for TinyMCE 5.6](#minorchangesfortinymce55)
@@ -24,7 +24,11 @@ These release notes provide an overview of the changes for {{site.productname}} 
 
 The following new features and enhancements were added for the {{site.productname}} 5.6 release.
 
-### Improvement Name
+### New `format_empty_lines` option for content formatting
+
+A new `format_empty_lines` option allows empty lines to be formatted for mult-line selections when applying an `inline` format such as `bold`.
+
+For information on the `format_empty_lines` option, see: [Content Formatting - `format_empty_lines`]({{ site.baseurl }}/configure/content-formatting/#format_empty_lines).
 
 ## Accompanying Premium Plugin changes
 

--- a/release-notes/release-notes56.md
+++ b/release-notes/release-notes56.md
@@ -26,7 +26,7 @@ The following new features and enhancements were added for the {{site.productnam
 
 ### New `format_empty_lines` option for content formatting
 
-A new `format_empty_lines` option allows empty lines to be formatted for mult-line selections when applying an "inline" format such as bold (`<strong>`).
+A new `format_empty_lines` option allows empty lines to be formatted for multi-line selections when applying an "inline" format such as bold (`<strong>`).
 
 For information on the `format_empty_lines` option, see: [Content Formatting - `format_empty_lines`]({{ site.baseurl }}/configure/content-formatting/#format_empty_lines).
 


### PR DESCRIPTION
Related Ticket: DOC-690, TINY-6483

Description of Changes:
* Document new `format_empty_lines` setting

Pre-checks:
- [X] Branch prefixed with `feature/` or `hotfix/`
- [X] `_data/nav.yml` has been updated (if applicable)
- [X] Files has been included where required (if applicable)
- [X] Files removed have been deleted, not just excluded from the build (if applicable)
- [X] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
