### PR TITLE
TINY-6510: Added missing security fixes section to 5.5 release notes

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -836,6 +836,7 @@
     - url: "#Accompanying Premium Plugin changes"
     - url: "#Minor changes for TinyMCE 5.5"
     - url: "#General bug fixes"
+    - url: "#Security fixes"
     - url: "#Deprecated features"
     - url: "#Known issues"
     - url: "#Upgrading to the latest version of TinyMCE 5"

--- a/release-notes/release-notes55.md
+++ b/release-notes/release-notes55.md
@@ -12,6 +12,8 @@ These release notes provide an overview of the changes for {{site.productname}} 
 - [Accompanying Premium Plugin changes](#accompanyingpremiumpluginchanges)
 - [Minor changes for TinyMCE 5.5](#minorchangesfortinymce54)
 - [General bug fixes](#generalbugfixes)
+- [Security fixes](#securityfixes)
+- [Deprecated features](#deprecatedfeatures)
 - [Known issues](#knownissues)
 - [Upgrading to the latest version of TinyMCE 5](#upgradingtothelatestversionoftinymce5)
 
@@ -338,6 +340,12 @@ For information on using the {{site.productname}} premium icon packs, see: [Tiny
 * Fixed the `dirty` flag not being correctly set during an `AddUndo` event.
 * Fixed `editor.selection.setCursorLocation` incorrectly placing the cursor outside `pre` elements in some circumstances.
 * Fixed an exception being thrown when pressing the enter key inside pre elements while `br_in_pre` setting is false.
+
+## Security fixes
+
+Accessibility Checker 2.3.0 provides fixes for the following security issues:
+
+* Fixed a Cross-Site Scripting (XSS) vulnerability in the accessibility issue repair function.
 
 ## Deprecated features
 


### PR DESCRIPTION
Related Ticket: TINY-6510

Description of Changes:
* Added a note about the `a11ychecker` security fix released in 5.5
* Added missing "Deprecated features" in the release notes ToC

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
