### PR TITLE
DOC-692: Document new name property for style_formats

### DIFF
--- a/_includes/configuration/style-formats.md
+++ b/_includes/configuration/style-formats.md
@@ -52,6 +52,23 @@ style_formats: [
 ]
 ```
 
+## Example: Using `style_formats`
+
+This example shows how to append 3 new style formats.
+
+```js
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  style_formats: [
+    {title: 'Bold text', inline: 'b'},
+    {title: 'Red text', inline: 'span', styles: {color: '#ff0000'}},
+    {name: 'my-inline', title: 'My inline', inline: 'span', classes: [ 'my-inline' ]}
+  ],
+  // The following option is used to append style formats rather than overwrite the default style formats.
+  style_formats_merge: true
+});
+```
+
 ## Interactive examples
 
 This example shows you how to:
@@ -59,8 +76,8 @@ This example shows you how to:
 - Override the built-in [formats]({{ site.baseurl }}/configure/content-formatting/#formats).
 - Add some custom styles to the `styleselect` dropdown toolbar button and the `formats` menu item using the [style_formats]({{ site.baseurl }}/configure/editor-appearance/#style_formats) configuration option.
 
-{% include live-demo.html id="format-custom" %}
+{% include live-demo.html id="format-custom" tab="js" %}
 
 This example shows you how to edit HTML5 content such as sections and articles.
 
-{% include live-demo.html id="format-html5" %}
+{% include live-demo.html id="format-html5" tab="js" %}

--- a/_includes/configuration/style-formats.md
+++ b/_includes/configuration/style-formats.md
@@ -13,6 +13,7 @@ There are four types of items the array can contain:
 To merge custom styles with the default `styles_format` values, set [`style_formats_merge`]({{ site.baseurl }}/configure/editor-appearance/#style_formats_merge) to `true`.
 
 **Type:** `Array`
+
 **Default:**
 
 The following is the default value for `style_formats` where it is using references to existing formats:

--- a/_includes/configuration/style-formats.md
+++ b/_includes/configuration/style-formats.md
@@ -5,8 +5,8 @@ This option allows you to define custom items for the `styleselect` dropdown too
 
 There are four types of items the array can contain:
 
-* **Style:** The item must have a `title` and an optional `name` to specify what it will be registered as. Then it needs the other necessary fields to [specify a new format]({{ site.baseurl }}/configure/content-formatting/#formattype). If the name is specified it will be prefixed with `custom-` this is to ensure that it doesn't clash with the default editor formats. The item will be rendered in the UI as a clickable item that applies the given format.
-* **Style reference:** The item must have a `title` and a `format` with refers to a pre-registered editor [format]({{ site.baseurl }}/configure/content-formatting/#formats). The item will be rendered in the UI as a clickable item that applies the given format.
+* **Style:** The item must have a `title` and an optional `name` to specify what it will be registered as. Then it needs the other necessary fields to [specify a new format]({{ site.baseurl }}/configure/content-formatting/#formattype). If the name is specified it will be prefixed with `custom-` this is to ensure that it doesn't clash with the default editor formats, if you give it a unique name you can then refer to it using the formatting api. The item will be rendered in the UI as a clickable item that applies the given format.
+* **Style reference:** The item must have a `title` and a `format` which refers to a pre-registered editor [format]({{ site.baseurl }}/configure/content-formatting/#formats). The item will be rendered in the UI as a clickable item that applies the given format.
 * **Nested menu:** The item must have a `title` and an `items` array that contains other items that will be rendered as a sub-menu.
 * **Group heading:** The item must only have a `title` and will be rendered as a non-clickable heading within the menu. This is useful for grouping items without using nested menus.
 

--- a/_includes/configuration/style-formats.md
+++ b/_includes/configuration/style-formats.md
@@ -15,7 +15,7 @@ To merge custom styles with the default `styles_format` values, set [`style_form
 **Type:** `Array`
 **Default:**
 
-The following is the default value for `style_formats`:
+The following is the default value for `style_formats` where it is using references to existing formats:
 
 ```js
 style_formats: [

--- a/_includes/configuration/style-formats.md
+++ b/_includes/configuration/style-formats.md
@@ -3,9 +3,10 @@
 
 This option allows you to define custom items for the `styleselect` dropdown toolbar button and the `formats` menu item.
 
-There are three types of items the array can contain:
+There are four types of items the array can contain:
 
-* **Style:** The item must have a `title` and either a `format` with refers to a pre-registered editor [format]({{ site.baseurl }}/configure/content-formatting/#formats) or the necessary fields to [specify a new format]({{ site.baseurl }}/configure/content-formatting/#formattype). The item will be rendered in the UI as a clickable item that applies the given format.
+* **Style:** The item must have a `title` and an optional `name` to specify what it will be registered as. Then it needs the other necessary fields to [specify a new format]({{ site.baseurl }}/configure/content-formatting/#formattype). If the name is specified it will be prefixed with `custom-` this is to ensure that it doesn't clash with the default editor formats. The item will be rendered in the UI as a clickable item that applies the given format.
+* **Style reference:** The item must have a `title` and a `format` with refers to a pre-registered editor [format]({{ site.baseurl }}/configure/content-formatting/#formats). The item will be rendered in the UI as a clickable item that applies the given format.
 * **Nested menu:** The item must have a `title` and an `items` array that contains other items that will be rendered as a sub-menu.
 * **Group heading:** The item must only have a `title` and will be rendered as a non-clickable heading within the menu. This is useful for grouping items without using nested menus.
 

--- a/_includes/configuration/style-formats.md
+++ b/_includes/configuration/style-formats.md
@@ -5,7 +5,7 @@ This option allows you to define custom items for the `styleselect` dropdown too
 
 There are four types of items the array can contain:
 
-* **Style:** The item must have a `title` and an optional `name` to specify what it will be registered as. Then it needs the other necessary fields to [specify a new format]({{ site.baseurl }}/configure/content-formatting/#formattype). If the name is specified it will be prefixed with `custom-` this is to ensure that it doesn't clash with the default editor formats, if you give it a unique name you can then refer to it using the formatting api. The item will be rendered in the UI as a clickable item that applies the given format.
+* **Style:** The item must have a `title` and the necessary fields to [specify a new format]({{ site.baseurl }}/configure/content-formatting/#formattype). An optional `name` can be provided for the style, which will be prefixed with `custom-` to ensure that it does not override the default editor formats. If given a unique `name`, the style can be used with the formatting API. The item will be rendered in the UI as a clickable item that applies the given format.
 * **Style reference:** The item must have a `title` and a `format` which refers to a pre-registered editor [format]({{ site.baseurl }}/configure/content-formatting/#formats). The item will be rendered in the UI as a clickable item that applies the given format.
 * **Nested menu:** The item must have a `title` and an `items` array that contains other items that will be rendered as a sub-menu.
 * **Group heading:** The item must only have a `title` and will be rendered as a non-clickable heading within the menu. This is useful for grouping items without using nested menus.

--- a/release-notes/release-notes56.md
+++ b/release-notes/release-notes56.md
@@ -30,9 +30,9 @@ A new `format_empty_lines` option allows empty lines to be formatted for multi-l
 
 For information on the `format_empty_lines` option, see: [Content Formatting - `format_empty_lines`]({{ site.baseurl }}/configure/content-formatting/#format_empty_lines).
 
-### New optional `name` field for the style_formats setting
+### New optional `name` field for the `style_formats` option
 
-A new optional `name` field that enables you to set a specific name to the format when it's being registered.
+A new optional `name` field that sets a specific name to the format when it's being registered using the `style_formats` option.
 
 For information on the `name` field, see: [User interface - `style_formats`]({{ site.baseurl }}/configure/editor-appearance/#style_formats).
 

--- a/release-notes/release-notes56.md
+++ b/release-notes/release-notes56.md
@@ -30,6 +30,12 @@ A new `format_empty_lines` option allows empty lines to be formatted for multi-l
 
 For information on the `format_empty_lines` option, see: [Content Formatting - `format_empty_lines`]({{ site.baseurl }}/configure/content-formatting/#format_empty_lines).
 
+### New optional `name` field for the style_formats setting
+
+A new optional `name` field that enables you to set a specific name to the format when it's being registered.
+
+For information on the `name` field, see: [User interface - `style_formats`]({{ site.baseurl }}/configure/editor-appearance/#style_formats).
+
 ## Accompanying Premium Plugin changes
 
 The following premium plugin updates were released alongside {{site.productname}} 5.6.


### PR DESCRIPTION
Related Ticket: DOC-692

Description of Changes:
* New feature to add fixed named to style formats separate form the title that is currently used to generate a format name.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
