### PR TITLE
DOC-721: Added PowerPaste 5.4.0 release notes

### DIFF
--- a/release-notes/release-notes56.md
+++ b/release-notes/release-notes56.md
@@ -111,7 +111,7 @@ The {{site.productname}} 5.6 release includes an accompanying release of the **P
 
 **PowerPaste** 5.4.0 provides the following improvements:
 
-- Added a new `image_file_types` option to determine which image file types will automatically be converted into `img` tags by the `smart_paste` feature.
+- Added a new `images_file_types` option to determine which image file types will automatically be converted into `img` tags by the `smart_paste` feature.
 - Fixed the `Cut` menu item not working in the latest version of Firefox.
 - Fixed two Cross-Site Scripting (XSS) vulnerability issues. For more information, see: [Security fixes](#security-fixes).
 

--- a/release-notes/release-notes56.md
+++ b/release-notes/release-notes56.md
@@ -99,6 +99,18 @@ The {{site.productname}} 5.6 release includes an accompanying release of the **C
 
 For information on the Comments plugin, see: [Comments plugin]({{site.baseurl}}/plugins/comments/).
 
+### PowerPaste 5.4.0
+
+The {{site.productname}} 5.6 release includes an accompanying release of the **PowerPaste** premium plugin.
+
+**PowerPaste** 5.4.0 provides the following improvements:
+
+- Added a new `image_file_types` option to determine which image file types will automatically be converted into `img` tags by the `smart_paste` feature.
+- Fixed the `Cut` menu item not working in the latest version of Firefox.
+- Fixed two Cross-Site Scripting (XSS) vulnerability issues. For more information, see: [Security fixes](#security-fixes).
+
+For information on the PowerPaste plugin, see: [PowerPaste plugin]({{site.baseurl}}/plugins/powerpaste/).
+
 ## Accompanying Premium self-hosted server-side component changes
 
 The {{site.productname}} 5.6 release includes accompanying changes affecting the {{site.productname}} **self-hosted** services for the following plugins:
@@ -148,6 +160,11 @@ For information on:
 {{site.productname}} 5.6 provides fixes for the following security issues:
 
 - changelog
+
+PowerPaste 5.4.0 provides fixes for the following security issues:
+
+* Fixed a Cross-Site Scripting (XSS) vulnerability where internal HTML content wasn't sanitized in some cases.
+* Fixed a Cross-Site Scripting (XSS) vulnerability where specific HTML comments weren't sanitized in some cases.
 
 ## Deprecated features
 


### PR DESCRIPTION
Related Ticket: DOC-721

Description of Changes:
* Added release notes for PowerPaste 5.4.0

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
