### PR TITLE
DOC-696: Added `jif` to image_file_types default extensions list

### DIFF
--- a/_includes/configuration/image-file-types.md
+++ b/_includes/configuration/image-file-types.md
@@ -4,7 +4,7 @@ This option configures which image file formats will be recognized and placed in
 
 **Type:** `String`
 
-**Default Value:** `'jpeg,jpg,jpe,jfi,jfif,png,gif,bmp,webp'`
+**Default Value:** `'jpeg,jpg,jpe,jfi,jif,jfif,png,gif,bmp,webp'`
 
 **Possible Values:** A list of valid web image file extensions. For a list of possible values see: [MDN Web Docs - Image file type and format guide](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types).
 

--- a/_includes/configuration/image-file-types.md
+++ b/_includes/configuration/image-file-types.md
@@ -1,5 +1,7 @@
 ### `image_file_types`
 
+{{site.requires_5_6v}}
+
 This option configures which image file formats will be recognized and placed in an `img` element by the [`smart_paste`](#smart_paste) functionality when content is pasted into the editor.
 
 **Type:** `String`


### PR DESCRIPTION
Related Ticket: DOC-696

Description of Changes:
* We missed `jif` in the original list, so we've added it now and this is just a minor update to reflect that.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
