### PR TITLE
DOC-726: Clarify autocompleter trigger character documentation

### DIFF
--- a/ui-components/autocompleter.md
+++ b/ui-components/autocompleter.md
@@ -8,7 +8,7 @@ keywords: autcomplete
 
 ## Overview
 
-An `autocompleter` enables users to quickly find and select from a pre-populated list of values as they type, leveraging searching and filtering. It provides suggestions to insert while the user is typing into the content. For example, with the [charmap]({{site.baseurl}}/plugins/charmap/) plugin enabled, typing **:amp** should show the ampersand item in the menu. To activate the `autocompleter` the user must precede the trigger character (colon in this case) with some separator such as space or newline. Pressing `esc` should close the autocomplete menu.
+An `autocompleter` enables users to quickly find and select from a pre-populated list of values as they type, leveraging searching and filtering. It provides suggestions to insert while the user is typing into the content. For example, with the [charmap]({{site.baseurl}}/plugins/charmap/) plugin enabled, typing **:amp** should show the ampersand item in the menu. To activate the `autocompleter`, the user must precede the trigger character (colon in this case) with a separator character, such as a space or a newline. Pressing `esc` should close the autocomplete menu.
 
 ## How to create custom autocompleters
 
@@ -54,4 +54,3 @@ The `fetch` results should be a list of objects with the following details:
 This example shows how the charmap plugin adds the standard autocompleter. The autocompleter will show whenever a `:` character is typed plus at least one additional character.
 
 {% include live-demo.html id="autocompleter" height="300" tab="js" %}
-

--- a/ui-components/autocompleter.md
+++ b/ui-components/autocompleter.md
@@ -8,7 +8,7 @@ keywords: autcomplete
 
 ## Overview
 
-An `autocompleter` enables users to quickly find and select from a pre-populated list of values as they type, leveraging searching and filtering. It provides suggestions to insert while the user is typing into the content. For example, with the [charmap]({{site.baseurl}}/plugins/charmap/) plugin enabled, typing **:amp** should show the ampersand item in the menu. To activate the `autocompleter`, the user must precede the trigger character (colon in this case) with a separator character, such as a space or a newline. Pressing `esc` should close the autocomplete menu.
+An `autocompleter` enables users to quickly find and select from a pre-populated list of values as they type, leveraging searching and filtering. It provides suggestions to insert while the user is typing into the content. For example, with the [charmap]({{site.baseurl}}/plugins/charmap/) plugin enabled, typing **:amp** should show the ampersand item in the menu. To activate the `autocompleter` the user must precede the trigger character (colon in this case) with some separator such as space or newline. Pressing `esc` should close the autocomplete menu.
 
 ## How to create custom autocompleters
 
@@ -54,3 +54,4 @@ The `fetch` results should be a list of objects with the following details:
 This example shows how the charmap plugin adds the standard autocompleter. The autocompleter will show whenever a `:` character is typed plus at least one additional character.
 
 {% include live-demo.html id="autocompleter" height="300" tab="js" %}
+

--- a/ui-components/autocompleter.md
+++ b/ui-components/autocompleter.md
@@ -8,7 +8,7 @@ keywords: autcomplete
 
 ## Overview
 
-An `autocompleter` enables users to quickly find and select from a pre-populated list of values as they type, leveraging searching and filtering. It provides suggestions to insert while the user is typing into the content. For example, with the [charmap]({{site.baseurl}}/plugins/charmap/) plugin enabled, typing **:amp** should show the ampersand item in the menu. Pressing `esc` should close the autocomplete menu.
+An `autocompleter` enables users to quickly find and select from a pre-populated list of values as they type, leveraging searching and filtering. It provides suggestions to insert while the user is typing into the content. For example, with the [charmap]({{site.baseurl}}/plugins/charmap/) plugin enabled, typing **:amp** should show the ampersand item in the menu. To activate the `autocompleter` the user must precede the trigger character (colon in this case) with some separator such as space or newline. Pressing `esc` should close the autocomplete menu.
 
 ## How to create custom autocompleters
 
@@ -25,7 +25,7 @@ The two arguments this method take are:
 
 | Name | Value | Requirement | Description |
 | ---- | ----- | ----------- | ----------- |
-| ch | string | Required | The character to trigger the autocompleter. |
+| ch | string (of one character) | Required | The character to trigger the autocompleter. |
 | fetch | `(pattern: string, maxResults: number, fetchOptions: Record<string, any>) => Promise<AutocompleterItem[]>` | Required | A function that is passed the current matched text pattern, the maximum number of expected results and any additional fetch options. The function should return a promise containing matching results. |
 | onAction | `(api, rng: Range, value: string) => void` | Required | A function invoked when a fetched item is selected. |
 | columns | number or 'auto' | Optional | default: auto - The number of columns to show. If set to `1` column, then icons and text are displayed, otherwise only icons are displayed. |


### PR DESCRIPTION
Related Ticket: DOC-726

Description of Changes:
1. In order to activate the Autocompleter the user must precede the trigger character with some separator (tab, space, newline). This need some clarification in documentation.
2. Improve typing for trigger character. Now we have: String. Better it to be: String(of one character). Because TinyMCE currently doesn't  support multicharacter trigger

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
