### PR TITLE
DOC-727: Added missing export details for server-side components

### DIFF
--- a/enterprise/server/index.md
+++ b/enterprise/server/index.md
@@ -15,9 +15,9 @@ The following server-side components are included in the {{site.productname}} Se
 
 |Component                      | File							| Description |
 |:-----------------------------	|:-------						|:----------- |
-| [Spellchecking]({{ site.baseurl }}/enterprise/check-spelling/) 				| ephox-spelling.war		|Spell checking service for {{site.productname}} Enterprise.|
-| [Image Tools Proxy]({{site.baseurl}}/plugins/opensource/imagetools/)				| ephox-image-proxy.war		|Image proxy service for the Image Tools plugin.|
-| [Enhanced Media Embed]({{ site.baseurl }}/enterprise/embed-media/), [Link Checker]({{ site.baseurl }}/enterprise/check-links/)				| ephox-hyperlinking.war		|Link Checker and Enhanced Media Embed service for {{site.productname}} Enterprise.|
+| [Spellchecking]({{site.baseurl}}/enterprise/check-spelling/) 				| ephox-spelling.war		|Spell checking service for {{site.productname}} Enterprise.|
+| [Export]({{site.baseurl}}/plugins/premium/export/), [Image Tools Proxy]({{site.baseurl}}/plugins/opensource/imagetools/)				| ephox-image-proxy.war		|Image proxy service for the Export and Image Tools plugins.|
+| [Enhanced Media Embed]({{site.baseurl}}/enterprise/embed-media/), [Link Checker]({{site.baseurl}}/enterprise/check-links/)				| ephox-hyperlinking.war		|Link Checker and Enhanced Media Embed service for {{site.productname}} Enterprise.|
 
 > **Note:** The "Allowed Origins" service (ephox-allowed-origins.war) has been deprecated. Trusted domains should now be specified directly in the configuration file.
 


### PR DESCRIPTION
Related Ticket: DOC-727

Description of Changes:
* Export was missing in the list of details for what plugins use the image proxy.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
