### PR TITLE
DOC-723: Add Spell Checker Pro release notes for 5.6

### DIFF
--- a/release-notes/release-notes56.md
+++ b/release-notes/release-notes56.md
@@ -168,10 +168,10 @@ The {{site.productname}} 5.6 release includes an accompanying release of the **S
 
 **Spell Checker Pro** 2.2.0 provides the following improvements:
 
-- Spellchecking dialog now opens faster when checking large documents
-- Spellchecking dialog can now be moved around and does not block access to text
-- Fixed the spellchecker dialog not checking incorrect words outside of the window viewport
-- Fixed the spellchecker as-you-type functionality interfering with the dialog
+- The spellchecker dialog now opens faster when checking large documents.
+- The spellchecker dialog can now be moved around and does not block access to editor content.
+- Fixed the spellchecker dialog not checking incorrect words outside of the window viewport.
+- Fixed the spellchecker as-you-type functionality interfering with the dialog.
   
 For information on the Spell Checker Pro plugin, see: [Spell Checker Pro plugin]({{site.baseurl}}/plugins/premium/tinymcespellchecker/).
 

--- a/release-notes/release-notes56.md
+++ b/release-notes/release-notes56.md
@@ -162,6 +162,19 @@ The {{site.productname}} 5.6 release includes an accompanying release of the **P
 
 For information on the PowerPaste plugin, see: [PowerPaste plugin]({{site.baseurl}}/plugins/premium/powerpaste/).
 
+### Spell Checker Pro 2.2.0
+
+The {{site.productname}} 5.6 release includes an accompanying release of the **Spell Checker Pro** premium plugin.
+
+**Spell Checker Pro** 2.2.0 provides the following improvements:
+
+- Spellchecking dialog now opens faster when checking large documents
+- Spellchecking dialog can now be moved around and does not block access to text
+- Fixed the spellchecker dialog not checking incorrect words outside of the window viewport
+- Fixed the spellchecker as-you-type functionality interfering with the dialog
+  
+For information on the Spell Checker Pro plugin, see: [Spell Checker Pro plugin]({{site.baseurl}}/plugins/premium/tinymcespellchecker/).
+
 ## General bug fixes
 
 {{site.productname}} 5.6 provides fixes for the following bugs:


### PR DESCRIPTION
Related Ticket: DOC-723

Description of Changes:
* Add release notes for upcoming spell checker pro update

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- ~[ ] `_data/nav.yml` has been updated (if applicable)~
- ~[ ] Files has been included where required (if applicable)~
- ~[ ] Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
