### PR TITLE
DOC-739: Added release notes for the media live embed enhancement

### DIFF
--- a/release-notes/release-notes57.md
+++ b/release-notes/release-notes57.md
@@ -39,6 +39,12 @@ The following enhancements were made for the {{site.productname}} 5.7 release.
 
 ### Enhancement name
 
+### Media live embeds now support video and audio elements
+
+The `media_live_embeds` option now supports rendering live embeds of `audio` and `video` elements while editing content. The elements can now also be resized without having to open a dialog to manually change the size.
+
+For information on the `media_live_embeds` option, see: [Media plugin - `media_live_embeds`]({{site.baseurl}}/plugins/opensource/media/#media_live_embeds).
+
 ### Additional enhancements
 
 {{site.productname}} 5.7 introduces the following minor enhancements:


### PR DESCRIPTION
Related Ticket: DOC-739

Description of Changes:
* Adds a release note for the new audio/video live embeds enhancement. I didn't update the option, as it was already vague and never mentioned it only worked for iframes previously.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
