### PR TITLE
DOC-738: Changes to spellchecker_whitelist/ignorelist option

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -870,10 +870,11 @@
   pages:
   - url: "release-notes57"
     pages:
-    - url: "#TinyMCE 5.7 new features and enhancements"
+    - url: "#Overview"
+    - url: "#New features"
+    - url: "#Enhancements"
     - url: "#Accompanying Premium Plugin changes"
     - url: "#Accompanying Premium self-hosted server-side component changes"
-    - url: "#Minor changes for TinyMCE 5.7"
     - url: "#General bug fixes"
     - url: "#Security fixes"
     - url: "#Deprecated features"

--- a/_includes/integrations/webcomponent-tech-ref.md
+++ b/_includes/integrations/webcomponent-tech-ref.md
@@ -470,7 +470,7 @@ window.myConfig = {
     }
   ],
   spellchecker_dialog: true,
-  spellchecker_whitelist: ['Ephox', 'Moxiecode']
+  spellchecker_ignorelist: ['Ephox', 'Moxiecode']
 };
 </script>
 <tinymce-editor

--- a/_includes/integrations/webcomponent-tech-ref.md
+++ b/_includes/integrations/webcomponent-tech-ref.md
@@ -470,7 +470,7 @@ window.myConfig = {
     }
   ],
   spellchecker_dialog: true,
-  spellchecker_ignorelist: ['Ephox', 'Moxiecode']
+  spellchecker_ignore_list: ['Ephox', 'Moxiecode']
 };
 </script>
 <tinymce-editor

--- a/_includes/live-demos/classic/index.js
+++ b/_includes/live-demos/classic/index.js
@@ -73,7 +73,7 @@ var demoBaseConfig = {
   toolbar:
     'insertfile a11ycheck undo redo | bold italic | forecolor backcolor | template codesample | alignleft aligncenter alignright alignjustify | bullist numlist | link image tinydrive',
   spellchecker_dialog: true,
-  spellchecker_whitelist: ['Ephox', 'Moxiecode'],
+  spellchecker_ignorelist: ['Ephox', 'Moxiecode'],
   tinydrive_demo_files_url: '{{ site.baseurl }}/demo/tiny-drive-demo/demo_files.json',
   tinydrive_token_provider: function (success, failure) {
     success({ token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJqb2huZG9lIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.Ks_BdfH4CWilyzLNk8S2gDARFhuxIauLa8PwhdEQhEo' });

--- a/_includes/live-demos/classic/index.js
+++ b/_includes/live-demos/classic/index.js
@@ -73,7 +73,7 @@ var demoBaseConfig = {
   toolbar:
     'insertfile a11ycheck undo redo | bold italic | forecolor backcolor | template codesample | alignleft aligncenter alignright alignjustify | bullist numlist | link image tinydrive',
   spellchecker_dialog: true,
-  spellchecker_ignorelist: ['Ephox', 'Moxiecode'],
+  spellchecker_ignore_list: ['Ephox', 'Moxiecode'],
   tinydrive_demo_files_url: '{{ site.baseurl }}/demo/tiny-drive-demo/demo_files.json',
   tinydrive_token_provider: function (success, failure) {
     success({ token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJqb2huZG9lIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.Ks_BdfH4CWilyzLNk8S2gDARFhuxIauLa8PwhdEQhEo' });

--- a/_includes/live-demos/full-featured/example.js
+++ b/_includes/live-demos/full-featured/example.js
@@ -49,7 +49,7 @@ tinymce.init({
   quickbars_selection_toolbar: 'bold italic | quicklink h2 h3 blockquote quickimage quicktable',
   noneditable_noneditable_class: 'mceNonEditable',
   toolbar_mode: 'sliding',
-  spellchecker_ignorelist: ['Ephox', 'Moxiecode'],
+  spellchecker_ignore_list: ['Ephox', 'Moxiecode'],
   tinycomments_mode: 'embedded',
   content_style: '.mymention{ color: gray; }',
   contextmenu: 'link image imagetools table configurepermanentpen',

--- a/_includes/live-demos/full-featured/example.js
+++ b/_includes/live-demos/full-featured/example.js
@@ -49,7 +49,7 @@ tinymce.init({
   quickbars_selection_toolbar: 'bold italic | quicklink h2 h3 blockquote quickimage quicktable',
   noneditable_noneditable_class: 'mceNonEditable',
   toolbar_mode: 'sliding',
-  spellchecker_whitelist: ['Ephox', 'Moxiecode'],
+  spellchecker_ignorelist: ['Ephox', 'Moxiecode'],
   tinycomments_mode: 'embedded',
   content_style: '.mymention{ color: gray; }',
   contextmenu: 'link image imagetools table configurepermanentpen',

--- a/_includes/live-demos/full-featured/index.js
+++ b/_includes/live-demos/full-featured/index.js
@@ -271,7 +271,7 @@ tinymce.init({
   quickbars_selection_toolbar: 'bold italic | quicklink h2 h3 blockquote quickimage quicktable',
   noneditable_noneditable_class: 'mceNonEditable',
   toolbar_mode: 'sliding',
-  spellchecker_ignorelist: ['Ephox', 'Moxiecode'],
+  spellchecker_ignore_list: ['Ephox', 'Moxiecode'],
   tinycomments_mode: 'embedded',
   content_style: '.mymention{ color: gray; }' +
   {{site.liveDemoIframeCSSStyles}},

--- a/_includes/live-demos/full-featured/index.js
+++ b/_includes/live-demos/full-featured/index.js
@@ -271,7 +271,7 @@ tinymce.init({
   quickbars_selection_toolbar: 'bold italic | quicklink h2 h3 blockquote quickimage quicktable',
   noneditable_noneditable_class: 'mceNonEditable',
   toolbar_mode: 'sliding',
-  spellchecker_whitelist: ['Ephox', 'Moxiecode'],
+  spellchecker_ignorelist: ['Ephox', 'Moxiecode'],
   tinycomments_mode: 'embedded',
   content_style: '.mymention{ color: gray; }' +
   {{site.liveDemoIframeCSSStyles}},

--- a/_includes/plugin-apis/tinymcespellchecker-apis.md
+++ b/_includes/plugin-apis/tinymcespellchecker-apis.md
@@ -1,0 +1,15 @@
+{{site.requires_5_7v}}
+
+| Name | Arguments | Description |
+|------| ------| ----------- |
+| addIgnoredWords | words: `string[]`, lang?: `string` | Add an array of words to the `spellchecker_ignore_list` for a specific language. Add the array of words to all languages by omitting the `lang` parameter. |
+
+**Examples**
+
+```js
+// ignore words for all languages
+tinymce.activeEditor.plugins.tinymcespellchecker.addIgnoredWords(['tinymce']);
+
+// ignore words for a specific language
+tinymce.activeEditor.plugins.tinymcespellchecker.addIgnoredWords(['TinyMCE', 'tinymce'], 'en_us');
+```

--- a/plugins/premium/tinymcespellchecker.md
+++ b/plugins/premium/tinymcespellchecker.md
@@ -204,29 +204,32 @@ tinymce.init({
 });
 ```
 
-### `spellchecker_ignorelist`
+<!-- Bookmark for deprecated option name -->
+<a class="anchor" id="spellchecker_whitelist">
 
-This option specifies an array of words to be ignored by the spell checker.
+### `spellchecker_ignore_list`
+
+This option specifies which words should be ignored by the spell checker. If an array of words is provided, the specified words will be ignored for all languages. If an object containing an array of words per language is provided, the specified words will be ignored for the specified languages.
 
 **Type:** `String[]` or `Object`
 
-#### Example: Using `spellchecker_ignorelist`
+#### Example: Using `spellchecker_ignore_list` to ignore words in all languages
 
 ```js
 tinymce.init({
   selector: 'textarea',
   plugins: 'tinymcespellchecker',
-  spellchecker_ignorelist: ['tinymce', 'TinyMCE']
+  spellchecker_ignore_list: ['tinymce', 'TinyMCE']
 });
 ```
 
-#### Example: Using `spellchecker_ignorelist` for specific languages
+#### Example: Using `spellchecker_ignore_list` for specific languages
 
 ```js
 tinymce.init({
   selector: 'textarea',
   plugins: 'tinymcespellchecker',
-  spellchecker_ignorelist: {
+  spellchecker_ignore_list: {
     en_us: ['tinymce', 'TinyMCE'],
     es: ['tinymce']
   }
@@ -336,14 +339,9 @@ tinymce.init({
 });
 ```
 
-## API
 
-| Name | Arguments | Description |
-|------| ------| ----------- |
-| addIgnoredWords | words: `string[]`, lang?: `string` | Add an array of words to the `spellchecker_ignorelist` for a specific language. Add the array of words to all languages by omitting the `lang` parameter. |
+## APIs
 
-### Example: Using `Spell Checker Pro` plugin APIs
+The {{pluginname}} plugin provides the following APIs.
 
-```js
-tinymce.activeEditor.plugins.tinymcespellchecker.addIgnoredWords(['TinyMCE', 'tinymce'], 'en_us');
-```
+{% include plugin-apis/{{plugincode}}-apis.md %}

--- a/plugins/premium/tinymcespellchecker.md
+++ b/plugins/premium/tinymcespellchecker.md
@@ -204,19 +204,32 @@ tinymce.init({
 });
 ```
 
-### `spellchecker_whitelist`
+### `spellchecker_ignorelist`
 
 This option specifies an array of words to be ignored by the spell checker.
 
-**Type:** `String[]`
+**Type:** `String[]` or `Object`
 
-#### Example: Using `spellchecker_whitelist`
+#### Example: Using `spellchecker_ignorelist`
 
 ```js
 tinymce.init({
   selector: 'textarea',
   plugins: 'tinymcespellchecker',
-  spellchecker_whitelist: ['tinymce','TinyMCE']
+  spellchecker_ignorelist: ['tinymce', 'TinyMCE']
+});
+```
+
+#### Example: Using `spellchecker_ignorelist` for specific languages
+
+```js
+tinymce.init({
+  selector: 'textarea',
+  plugins: 'tinymcespellchecker',
+  spellchecker_ignorelist: {
+    en_us: ['tinymce', 'TinyMCE'],
+    es: ['tinymce']
+  }
 });
 ```
 
@@ -321,4 +334,16 @@ tinymce.init({
     });
   }
 });
+```
+
+## API
+
+| Name | Arguments | Description |
+|------| ------| ----------- |
+| addIgnoredWords | words: `string[]`, lang?: `string` | Add an array of words to the `spellchecker_ignorelist` for a specific language. Add the array of words to all languages by omitting the `lang` parameter. |
+
+### Example: Using `Spell Checker Pro` plugin APIs
+
+```js
+tinymce.activeEditor.plugins.tinymcespellchecker.addIgnoredWords(['TinyMCE', 'tinymce'], 'en_us');
 ```

--- a/plugins/premium/tinymcespellchecker.md
+++ b/plugins/premium/tinymcespellchecker.md
@@ -211,6 +211,8 @@ tinymce.init({
 
 This option specifies which words should be ignored by the spell checker. If an array of words is provided, the specified words will be ignored for all languages. If an object containing an array of words per language is provided, the specified words will be ignored for the specified languages.
 
+> **Note:** Languages specified as keys in the `spellchecker_ignore_list` object must match the configured [Spellchecker Languages]({{site.baseurl}}/plugins/premium/tinymcespellchecker/#spellchecker_languages).
+
 **Type:** `String[]` or `Object`
 
 #### Example: Using `spellchecker_ignore_list` to ignore words in all languages

--- a/release-notes/release-notes57.md
+++ b/release-notes/release-notes57.md
@@ -55,7 +55,7 @@ The {{site.productname}} 5.7 release includes an accompanying release of the **S
 
 **Spell Checker Pro** 2.3.0 provides the following enhancements:
 
-### The `spellchecker_ignore_list` option now accepts arrays of words for specific languages
+#### The `spellchecker_ignore_list` option now accepts arrays of words for specific languages
 
 **Spell Checker Pro** 2.3.0 introduces enhancements to the `spellchecker_ignore_list` (formerly `spellchecker_whitelist`, see: [The `spellchecker_whitelist` option has been renamed](#thespellchecker_whitelistoptionhasbeenrenamed)).
 

--- a/release-notes/release-notes57.md
+++ b/release-notes/release-notes57.md
@@ -37,16 +37,16 @@ The following new features were added for the {{site.productname}} 5.7 release.
 
 The following enhancements were made for the {{site.productname}} 5.7 release.
 
-### The `spellchecker_ignorelist` option now accepts arrays of words per language
+### The `spellchecker_ignore_list` option now accepts arrays of words for specific languages
 
-{{site.productname}} 5.7 introduces enhancements to the `spellchecker_ignorelist` (formerly `spellchecker_whitelist`, see: [The `spellchecker_whitelist` option has been renamed](#thespellchecker_whitelistoptionhasbeenrenamed)).
+{{site.productname}} 5.7 introduces enhancements to the `spellchecker_ignore_list` (formerly `spellchecker_whitelist`, see: [The `spellchecker_whitelist` option has been renamed](#thespellchecker_whitelistoptionhasbeenrenamed)).
 
-- It is now possible to specify arrays of words per language to be ignored by Spell Checker Pro plugin using the `spellchecker_ignorelist` option.
+- It is now possible to specify arrays of words for specific languages to be ignored by Spell Checker Pro plugin using the `spellchecker_ignore_list` option.
 - A new `addIgnoredWords` API allows words to be ignored at runtime by the Spell Checker Pro plugin.
 
 For information on:
 
-- The `spellchecker_ignorelist` option, see: [Spell Checker Pro - `spellchecker_ignorelist`]({{ site.baseurl }}/plugins/premium/tinymcespellchecker/#spellchecker_ignorelist).
+- The `spellchecker_ignore_list` option, see: [Spell Checker Pro - `spellchecker_ignore_list`]({{ site.baseurl }}/plugins/premium/tinymcespellchecker/#spellchecker_ignore_list).
 - The `addIgnoredWords` API, see: [Spell Checker Pro - `API`]({{ site.baseurl }}/plugins/premium/tinymcespellchecker/#api).
 
 ### Additional enhancements
@@ -121,9 +121,9 @@ The following features have been deprecated with the release of {{site.productna
 
 ### The `spellchecker_whitelist` option has been renamed
 
-With the release of {{site.productname}} 5.7, the `spellchecker_whitelist` option has been renamed to `spellchecker_ignorelist`.
+With the release of {{site.productname}} 5.7, the `spellchecker_whitelist` option has been renamed to `spellchecker_ignore_list`.
 
-For information on the `spellchecker_ignorelist` option, see: [Spell Checker Pro - `spellchecker_ignorelist`]({{ site.baseurl }}/plugins/premium/tinymcespellchecker/#spellchecker_ignorelist).
+For information on the `spellchecker_ignore_list` option, see: [Spell Checker Pro - `spellchecker_ignore_list`]({{ site.baseurl }}/plugins/premium/tinymcespellchecker/#spellchecker_ignore_list).
 
 ## Known issues
 

--- a/release-notes/release-notes57.md
+++ b/release-notes/release-notes57.md
@@ -6,17 +6,13 @@ description: Release notes for TinyMCE 5.7
 keywords: releasenotes bugfixes
 ---
 
-{% comment %}
-Replace 5.7 with the version number such as: X.Y.Z
-Replace 57 with the version number without points, such as XYZ
-{% endcomment %}
+## Overview
 
-These release notes provide an overview of the changes for {{site.productname}} 5.7, including:
+{{site.productname}} 5.7 was released for {{site.enterpriseversion}} and {{site.cloudname}} on <<`WEEKDAY`, `MMM` `D`<sup>`st|nd|th`</sup>, `YYYY`>>. It includes {{site.productname}} 5.7 and additional changes to premium plugins. These release notes provide an overview of the changes for {{site.productname}} 5.7, including:
 
-- [TinyMCE 5.7 new features and enhancements](#tinymce57newfeaturesandenhancements)
+- [New features](#newfeatures)
+- [Enhancements](#enhancements)
 - [Accompanying Premium Plugin changes](#accompanyingpremiumpluginchanges)
-- [Accompanying Premium self-hosted server-side component changes](#accompanyingpremiumself-hostedserver-sidecomponentchanges)
-- [Minor changes for TinyMCE 5.7](#minorchangesfortinymce57)
 - [General bug fixes](#generalbugfixes)
 - [Security fixes](#securityfixes)
 - [Deprecated features](#deprecatedfeatures)
@@ -25,11 +21,29 @@ These release notes provide an overview of the changes for {{site.productname}} 
 
 {{site.releasenotes_for_stable}}
 
-## TinyMCE 5.7 new features and enhancements
+## New features
 
-The following new features and enhancements were added for the {{site.productname}} 5.7 release.
+The following new features were added for the {{site.productname}} 5.7 release.
 
-### Improvement Name
+### Feature name
+
+### Additional new features
+
+{{site.productname}} 5.7 introduces the following minor new features:
+
+- changelog
+
+## Enhancements
+
+The following enhancements were made for the {{site.productname}} 5.7 release.
+
+### Enhancement name
+
+### Additional enhancements
+
+{{site.productname}} 5.7 introduces the following minor enhancements:
+
+- changelog
 
 ## Accompanying Premium Plugin changes
 
@@ -60,10 +74,10 @@ This version requires Java 8 or higher. For information on the removal of Java 7
 
 For information on:
 
-- The Spell Checker Pro plugin, see: [Spell Checker Pro plugin]({{site.baseurl}}/plugins/tinymcespellchecker/).
-- The Link Checker plugin, see: [Link Checker plugin]({{site.baseurl}}/plugins/linkchecker/).
-- The Image Tools plugin, see: [Image Tools plugin]({{site.baseurl}}/plugins/imagetools/).
-- The Enhanced Media Embed plugin, see: [Enhanced Media Embed plugin]({{site.baseurl}}/plugins/mediaembed/).
+- The Spell Checker Pro plugin, see: [Spell Checker Pro plugin]({{site.baseurl}}/plugins/premium/tinymcespellchecker/).
+- The Link Checker plugin, see: [Link Checker plugin]({{site.baseurl}}/plugins/premium/linkchecker/).
+- The Image Tools plugin, see: [Image Tools plugin]({{site.baseurl}}/plugins/opensource/imagetools/).
+- The Enhanced Media Embed plugin, see: [Enhanced Media Embed plugin]({{site.baseurl}}/plugins/premium/mediaembed/).
 - Deploying the server-side components, see: [Server-side component installation]({{site.baseurl}}/enterprise/server/).
 
 ### Security update for self-hosted server-side components
@@ -76,12 +90,6 @@ For information on:
 
 - Deploying the server-side components, see: [Server-side component installation]({{site.baseurl}}/enterprise/server/).
 - Deploying the server-side components using Docker, see: [Containerized service deployments]({{site.baseurl}}/enterprise/server/dockerservices/).
-
-## Minor changes for TinyMCE 5.7
-
-{{site.productname}} 5.7 introduces the following minor changes:
-
-- changelog
 
 ## General bug fixes
 

--- a/release-notes/release-notes57.md
+++ b/release-notes/release-notes57.md
@@ -37,7 +37,11 @@ The following new features were added for the {{site.productname}} 5.7 release.
 
 The following enhancements were made for the {{site.productname}} 5.7 release.
 
-### Enhancement name
+### The `spellchecker_ignorelist` option now accepts arrays of words per language
+
+It is now possible to specify arrays of words per language to be ignored by Spell Checker Pro using the `spellchecker_ignorelist` option.
+
+For information on the `spellchecker_ignorelist` option, see: [Spell Checker Pro - `spellchecker_ignorelist`]({{site.baseurl}}/plugins/premium/tinymcespellchecker/#spellchecker_ignorelist).
 
 ### Additional enhancements
 
@@ -106,6 +110,14 @@ For information on:
 ## Deprecated features
 
 The following features have been deprecated with the release of {{site.productname}} 5.7:
+
+- [The spellchecker_whitelist option has been renamed](#thespellcheckerwhitelistoptionhasbeenrenamed).
+
+### The spellchecker_whitelist option has been renamed
+
+With the release of {{site.productname}} 5.7, the `spellchecker_whitelist` option has been renamed to `spellchecker_ignorelist`.
+
+For information on the `spellchecker_ignorelist` option, see: [Spell Checker Pro - `spellchecker_ignorelist`]({{site.baseurl}}/plugins/premium/tinymcespellchecker/#spellchecker_ignorelist).
 
 - [](#).
 

--- a/release-notes/release-notes57.md
+++ b/release-notes/release-notes57.md
@@ -67,8 +67,6 @@ For information on:
 - The `spellchecker_ignore_list` option, see: [Spell Checker Pro - `spellchecker_ignore_list`]({{ site.baseurl }}/plugins/premium/tinymcespellchecker/#spellchecker_ignore_list).
 - The `addIgnoredWords` API, see: [Spell Checker Pro - `API`]({{ site.baseurl }}/plugins/premium/tinymcespellchecker/#api).
 
-For information on the Spell Checker Pro plugin, see: [Spell Checker Pro plugin]({{site.baseurl}}/plugins/premium/tinymcespellchecker/).
-
 ## Accompanying Premium self-hosted server-side component changes
 
 The {{site.productname}} 5.7 release includes accompanying changes affecting the {{site.productname}} **self-hosted** services for the following plugins:

--- a/release-notes/release-notes57.md
+++ b/release-notes/release-notes57.md
@@ -37,17 +37,7 @@ The following new features were added for the {{site.productname}} 5.7 release.
 
 The following enhancements were made for the {{site.productname}} 5.7 release.
 
-### The `spellchecker_ignore_list` option now accepts arrays of words for specific languages
-
-{{site.productname}} 5.7 introduces enhancements to the `spellchecker_ignore_list` (formerly `spellchecker_whitelist`, see: [The `spellchecker_whitelist` option has been renamed](#thespellchecker_whitelistoptionhasbeenrenamed)).
-
-- It is now possible to specify arrays of words for specific languages to be ignored by Spell Checker Pro plugin using the `spellchecker_ignore_list` option.
-- A new `addIgnoredWords` API allows words to be ignored at runtime by the Spell Checker Pro plugin.
-
-For information on:
-
-- The `spellchecker_ignore_list` option, see: [Spell Checker Pro - `spellchecker_ignore_list`]({{ site.baseurl }}/plugins/premium/tinymcespellchecker/#spellchecker_ignore_list).
-- The `addIgnoredWords` API, see: [Spell Checker Pro - `API`]({{ site.baseurl }}/plugins/premium/tinymcespellchecker/#api).
+### Enhancement name
 
 ### Additional enhancements
 
@@ -59,15 +49,25 @@ For information on:
 
 The following premium plugin updates were released alongside {{site.productname}} 5.7.
 
-### Premium Plugin Name X.Y.Z
+### Spell Checker Pro 2.3.0
 
-The {{site.productname}} 5.7 release includes an accompanying release of the **<<Premium Plugin Name>>** premium plugin.
+The {{site.productname}} 5.7 release includes an accompanying release of the **Spell Checker Pro** premium plugin.
 
-**<<Premium Plugin Name>>** X.Y.Z provides the following improvements:
+**Spell Checker Pro** 2.3.0 provides the following enhancements:
 
-- <Description>
+### The `spellchecker_ignore_list` option now accepts arrays of words for specific languages
 
-For information on the <<Premium Plugin Name>> plugin, see: [<<Premium Plugin Name>> plugin]({{site.baseurl}}/plugins/<<Premium Plugin Name>>/).
+**Spell Checker Pro** 2.3.0 introduces enhancements to the `spellchecker_ignore_list` (formerly `spellchecker_whitelist`, see: [The `spellchecker_whitelist` option has been renamed](#thespellchecker_whitelistoptionhasbeenrenamed)).
+
+- It is now possible to specify arrays of words for specific languages to be ignored by Spell Checker Pro plugin using the `spellchecker_ignore_list` option.
+- A new `addIgnoredWords` API allows words to be ignored at runtime by the Spell Checker Pro plugin.
+
+For information on:
+
+- The `spellchecker_ignore_list` option, see: [Spell Checker Pro - `spellchecker_ignore_list`]({{ site.baseurl }}/plugins/premium/tinymcespellchecker/#spellchecker_ignore_list).
+- The `addIgnoredWords` API, see: [Spell Checker Pro - `API`]({{ site.baseurl }}/plugins/premium/tinymcespellchecker/#api).
+
+For information on the Spell Checker Pro plugin, see: [Spell Checker Pro plugin]({{site.baseurl}}/plugins/premium/tinymcespellchecker/).
 
 ## Accompanying Premium self-hosted server-side component changes
 

--- a/release-notes/release-notes57.md
+++ b/release-notes/release-notes57.md
@@ -39,9 +39,15 @@ The following enhancements were made for the {{site.productname}} 5.7 release.
 
 ### The `spellchecker_ignorelist` option now accepts arrays of words per language
 
-It is now possible to specify arrays of words per language to be ignored by Spell Checker Pro using the `spellchecker_ignorelist` option.
+{{site.productname}} 5.7 introduces enhancements to the `spellchecker_ignorelist` (formerly `spellchecker_whitelist`, see: [The `spellchecker_whitelist` option has been renamed](#thespellchecker_whitelistoptionhasbeenrenamed)).
 
-For information on the `spellchecker_ignorelist` option, see: [Spell Checker Pro - `spellchecker_ignorelist`]({{site.baseurl}}/plugins/premium/tinymcespellchecker/#spellchecker_ignorelist).
+- It is now possible to specify arrays of words per language to be ignored by Spell Checker Pro plugin using the `spellchecker_ignorelist` option.
+- A new `addIgnoredWords` API allows words to be ignored at runtime by the Spell Checker Pro plugin.
+
+For information on:
+
+- The `spellchecker_ignorelist` option, see: [Spell Checker Pro - `spellchecker_ignorelist`]({{ site.baseurl }}/plugins/premium/tinymcespellchecker/#spellchecker_ignorelist).
+- The `addIgnoredWords` API, see: [Spell Checker Pro - `API`]({{ site.baseurl }}/plugins/premium/tinymcespellchecker/#api).
 
 ### Additional enhancements
 
@@ -111,17 +117,13 @@ For information on:
 
 The following features have been deprecated with the release of {{site.productname}} 5.7:
 
-- [The spellchecker_whitelist option has been renamed](#thespellcheckerwhitelistoptionhasbeenrenamed).
+- [The `spellchecker_whitelist` option has been renamed](#thespellchecker_whitelistoptionhasbeenrenamed).
 
-### The spellchecker_whitelist option has been renamed
+### The `spellchecker_whitelist` option has been renamed
 
 With the release of {{site.productname}} 5.7, the `spellchecker_whitelist` option has been renamed to `spellchecker_ignorelist`.
 
-For information on the `spellchecker_ignorelist` option, see: [Spell Checker Pro - `spellchecker_ignorelist`]({{site.baseurl}}/plugins/premium/tinymcespellchecker/#spellchecker_ignorelist).
-
-- [](#).
-
-### The...
+For information on the `spellchecker_ignorelist` option, see: [Spell Checker Pro - `spellchecker_ignorelist`]({{ site.baseurl }}/plugins/premium/tinymcespellchecker/#spellchecker_ignorelist).
 
 ## Known issues
 


### PR DESCRIPTION
Related Ticket: DOC-738

Description of Changes:
- Rename from `whitelist` to `ignorelist` (backwards compatible)
- Support multiple languages in `ignorelist`
- New `addIgnoredWords` API

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] ~~`_data/nav.yml` has been updated (if applicable)~~
- [x] ~~Files has been included where required (if applicable)~~
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable)~~
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
