### PR TITLE
DOC-742: Document changes to lists plugin with multiple text blocks selected

### DIFF
--- a/release-notes/release-notes57.md
+++ b/release-notes/release-notes57.md
@@ -43,7 +43,7 @@ The following enhancements were made for the {{site.productname}} 5.7 release.
 
 {{site.productname}} 5.7 introduces the following minor enhancements:
 
-- changelog
+- The `lists` plugin will now apply list styles to all text blocks within a selection.
 
 ## Accompanying Premium Plugin changes
 

--- a/release-notes/release-notes57.md
+++ b/release-notes/release-notes57.md
@@ -39,10 +39,10 @@ The following enhancements were made for the {{site.productname}} 5.7 release.
 
 ### Improved behavior when using `lists` plugin on mixed content
 
-The `lists` plugin has been updated to improve the handling of content containing:
+The `lists` plugin has been updated to improve toggling lists on content containing:
 
-- Multiple text blocks.
-- Combinations of existing lists and text blocks.
+- Multiple blocks of text.
+- Combinations of existing lists and blocks of text.
 
 ### Additional enhancements
 

--- a/release-notes/release-notes57.md
+++ b/release-notes/release-notes57.md
@@ -39,7 +39,7 @@ The following enhancements were made for the {{site.productname}} 5.7 release.
 
 ### Improved behavior when using `lists` plugin on mixed content
 
-Improved behavior when using the `lists` plugin to add lists to selections containing:
+The `lists` plugin has been updated to improve the handling of content containing:
 
 - Multiple text blocks.
 - Combinations of existing lists and text blocks.

--- a/release-notes/release-notes57.md
+++ b/release-notes/release-notes57.md
@@ -42,7 +42,7 @@ The following enhancements were made for the {{site.productname}} 5.7 release.
 Improved behavior when using the `lists` plugin to add lists to selections containing:
 
 - Multiple text blocks.
-- Mixes of existing lists and text blocks.
+- Combinations of existing lists and text blocks.
 
 ### Additional enhancements
 

--- a/release-notes/release-notes57.md
+++ b/release-notes/release-notes57.md
@@ -37,13 +37,18 @@ The following new features were added for the {{site.productname}} 5.7 release.
 
 The following enhancements were made for the {{site.productname}} 5.7 release.
 
-### Enhancement name
+### Improved behavior when using `lists` plugin on mixed content
+
+Improved behavior when using the `lists` plugin to add lists to selections containing:
+
+- Multiple text blocks.
+- Mixes of existing lists and text blocks.
 
 ### Additional enhancements
 
 {{site.productname}} 5.7 introduces the following minor enhancements:
 
-- The `lists` plugin will now apply list styles to all text blocks within a selection.
+- changelog
 
 ## Accompanying Premium Plugin changes
 


### PR DESCRIPTION
Related Ticket: DOC-742

Description of Changes:

Minor enhancement note for changes to `lists` plugin behaviour on selections across multiple text blocks.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] ~~`_data/nav.yml` has been updated (if applicable)~~
- [x] ~~Files has been included where required (if applicable)~~
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable)~~
- [x] ~~(New product features only) Release Note added~~

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
