### PR TITLE
Added security release note for the ReDoS fix we did in 5.6

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,7 @@ class: changelog
 * Fixed layout issues when empty `tr` elements were incorrectly removed from tables.
 * Fixed image file extensions lost when uploading an image with an alternative extension, such as `.jfif`.
 * Fixed a security issue where URLs in attributes weren't correctly sanitized.
+* Fixed a security issue in the `codesample` plugin by upgrading dependencies.
 * Fixed `DOMUtils.getParents` incorrectly including the shadow root in the array of elements returned.
 * Fixed an issue where the root document could be scrolled while an editor dialog was open inside a shadow root.
 * Fixed `getContent` with text format returning a new line when the editor is empty.

--- a/release-notes/release-notes56.md
+++ b/release-notes/release-notes56.md
@@ -224,6 +224,7 @@ For information on the Spell Checker Pro plugin, see: [Spell Checker Pro plugin]
 {{site.productname}} 5.6 provides fixes for the following security issues:
 
 - Fixed a security issue where URLs in attributes weren't correctly sanitized.
+- Fixed a security issue in the `codesample` plugin by upgrading dependencies.
 
 PowerPaste 5.4.0 provides fixes for the following security issues:
 


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* This adds a changelog/release note entry for the `codesample` ReDoS security issue discovered that we'd fixed in 5.6.0 by upgrading Prism.js.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
