### PR TITLE
removing confusing information from introduction

### DIFF
--- a/plugins/opensource/advlist.md
+++ b/plugins/opensource/advlist.md
@@ -10,8 +10,6 @@ The `advlist` plugin extends the core `bullist` and `numlist` toolbar controls b
 
 > **Important**: The [Lists](../lists) (`lists`) plugin must be activated for the `advlist` plugin to work.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/anchor.md
+++ b/plugins/opensource/anchor.md
@@ -13,8 +13,6 @@ This plugin adds an anchor/bookmark button to the toolbar that inserts an anchor
 
 When a user clicks on the anchor button or menu item they will be prompted via a dialog box to enter a string. The string will be inserted into the HTML as an anchor id at the location of the cursor. For example, a user places their cursor at the beginning of "Hello World" and clicks on the anchor button and enters "start" in the dialog box. The resulting HTML will take the form of `<p><a id="start"></a>Hello, World!</p>`.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/autoresize.md
+++ b/plugins/opensource/autoresize.md
@@ -9,8 +9,6 @@ keywords: height width max_height min_height autoresize_on_init autoresize_overf
 
 This plugin automatically resizes the editor to the content inside it. It is typically used to prevent the editor from expanding infinitely as a user types into the editable area. For example, by giving the `max_height` option a value the editor will stop resizing when the set value is reached.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/bbcode.md
+++ b/plugins/opensource/bbcode.md
@@ -11,8 +11,6 @@ This plugin makes it possible to edit BBCode in a WYSIWYG style by converting ta
 
 > You will need to sacrifice quite a lot of {{site.productname}}'s functionality to use this plugin properly, since BBCode format doesn't support the whole HTML specification.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/charmap.md
+++ b/plugins/opensource/charmap.md
@@ -12,8 +12,6 @@ controls: toolbar button, menu item
 
 This plugin adds a dialog to the editor with a map of special unicode characters, which cannot be added directly from the keyboard. The dialog can be invoked via a toolbar button - `charmap` - or a dedicated menu item added as `Insert > Special character`.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/directionality.md
+++ b/plugins/opensource/directionality.md
@@ -12,10 +12,6 @@ controls: toolbar button
 
 This plugin adds directionality controls to the toolbar, enabling {{site.productname}} to better handle languages written from right to left. It also adds a toolbar button for each of its values, `ltr` for left-to-right text and `rtl` for right-to-left text.
 
-**Type:** `String`
-
-**Possible Values:** `ltr`, `rtl`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/emoticons.md
+++ b/plugins/opensource/emoticons.md
@@ -16,8 +16,6 @@ The emoticons plugin provides an autocompleter for adding emoji without using th
 
 > **Note**: The emoticons plugin does not automatically convert text emoticons into graphical emoji.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/fullpage.md
+++ b/plugins/opensource/fullpage.md
@@ -14,8 +14,6 @@ This plugin allows user to edit certain metadata and document properties such as
 
 The plugin also adds a `Metadata and Document properties` menu under the `File` menu and button to the toolbar.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/hr.md
+++ b/plugins/opensource/hr.md
@@ -12,8 +12,6 @@ controls: toolbar button, menu item
 
 The Horizontal Rule (`hr`) plugin allows a user to insert a horizontal rule on the page at the cursor insertion point. It also adds a toolbar button and a menu item `Horizontal line` under the `Insert` menu.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/image.md
+++ b/plugins/opensource/image.md
@@ -11,8 +11,6 @@ keywords: photo insert edit style format image_caption image_list image_advtab i
 
 This plugin enables the user to insert an image into {{site.productname}}'s editable area. The plugin also adds a toolbar button and an `Insert/edit image` menu item under the `Insert` menu.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/importcss.md
+++ b/plugins/opensource/importcss.md
@@ -10,8 +10,6 @@ The `importcss` plugin adds the ability to automatically import CSS classes from
 
 By default selectors like `".my-class"`, `".my-class1.my-class2"` and `"p.my-class"` get imported as format rules.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/insertdatetime.md
+++ b/plugins/opensource/insertdatetime.md
@@ -12,8 +12,6 @@ controls: toolbar button, menu item
 
 The `insertdatetime` plugin provides a toolbar control and menu item `Insert date/time` (under the `Insert` menu) that lets a user easily insert the current date and/or time into the editable area at the cursor insertion point.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/media.md
+++ b/plugins/opensource/media.md
@@ -12,8 +12,6 @@ controls: toolbar button, menu item
 
 The `media` plugin adds the ability for users to be able to add HTML5 video and audio elements to the editable area. It also adds the item `Insert/edit video` under the `Insert` menu as well as a toolbar button.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/nonbreaking.md
+++ b/plugins/opensource/nonbreaking.md
@@ -12,8 +12,6 @@ controls: toolbar button, menu item
 
 This plugin adds a button for inserting nonbreaking space entities `&nbsp;` at the current caret location (cursor insert point). It also adds a menu item `Nonbreaking space` under the `Insert` menu dropdown and a toolbar button.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/noneditable.md
+++ b/plugins/opensource/noneditable.md
@@ -10,8 +10,6 @@ keywords: noneditable contenteditable editable mceNonEditable noneditable_editab
 
 This plugin enables you to prevent users from being able to edit content within elements assigned the `mceNonEditable` class.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/pagebreak.md
+++ b/plugins/opensource/pagebreak.md
@@ -14,10 +14,6 @@ This plugin adds page break support and enables a user to insert page breaks in 
 
 It also adds a toolbar button and a menu item `Page break` under the `Insert` menu dropdown.
 
-**Type:** `String`
-
-**Default Value:** `"<!-- pagebreak -->"`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/pagebreak.md
+++ b/plugins/opensource/pagebreak.md
@@ -33,6 +33,8 @@ These settings affect the execution of the `pagebreak` plugin. They enable you t
 
 **Type:** `String`
 
+**Default Value:** `"<!-- pagebreak -->"`
+
 #### Example: Using `pagebreak_separator`
 
 ```js

--- a/plugins/opensource/paste.md
+++ b/plugins/opensource/paste.md
@@ -18,8 +18,6 @@ The plugin also adds a menu item `Paste as text` under the `Edit` menu dropdown 
 
 > **Note:** The toolbar button won't work in browsers that don't support direct access to the clipboard. In such cases the user will be presented with a modal/dialog box advising them of this along with a reminder of standard keyboard shortcuts.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/preview.md
+++ b/plugins/opensource/preview.md
@@ -12,8 +12,6 @@ controls: toolbar button, menu item
 
 This plugin adds a preview button to the toolbar. Pressing the button opens a dialog box showing the current content in a preview mode. It also adds a menu item `Preview` under the `File` and `View` menu dropdowns.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/print.md
+++ b/plugins/opensource/print.md
@@ -12,8 +12,6 @@ controls: toolbar button, menu item
 
 This plugin adds a print button to the toolbar. It also adds a `Print` item to the `File` menu dropdown.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/save.md
+++ b/plugins/opensource/save.md
@@ -12,8 +12,6 @@ controls: toolbar button
 
 This plugin adds a save button to the {{site.productname}} toolbar, which will submit the form that the editor is within.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/searchreplace.md
+++ b/plugins/opensource/searchreplace.md
@@ -12,8 +12,6 @@ controls: toolbar button, menu item
 
 This plugin adds search/replace dialogs to {{site.productname}}. It also adds a toolbar button and the menu item `Find and replace` under the `Edit` menu dropdown.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/spellchecker.md
+++ b/plugins/opensource/spellchecker.md
@@ -16,8 +16,6 @@ controls: toolbar button, menu item
 
 This plugin enables {{site.productname}}'s spellcheck functionality. It also adds a toolbar button and the menu item `Spellcheck` under the `Tools` menu dropdown.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/tabfocus.md
+++ b/plugins/opensource/tabfocus.md
@@ -8,8 +8,6 @@ keywords: tabfocus tabfocus_elements prev next
 
 This plugin adds the possibility to tab in/out of {{site.productname}}.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/table.md
+++ b/plugins/opensource/table.md
@@ -12,8 +12,6 @@ controls: toolbar button, menu item
 
 The `table` plugin adds table management functionality to {{site.productname}}. It also adds a new menubar item `Table` with various options in its dropdown including `Insert table` and options to modify cells, rows and columns, and a toolbar button with the same functionality.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/template.md
+++ b/plugins/opensource/template.md
@@ -12,8 +12,6 @@ controls: toolbar button, menu item
 
 The `template` plugin adds support for custom templates. It also adds a menu item `Insert template` under the `Insert` menu and a toolbar button.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/textpattern.md
+++ b/plugins/opensource/textpattern.md
@@ -10,8 +10,6 @@ The Text Pattern plugin matches special patterns in the text and applies formats
 
 The default pattern is similar to markdown syntax, so the user can type `# text` to produce a header or `**text**` to make text **bold**.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/toc.md
+++ b/plugins/opensource/toc.md
@@ -12,8 +12,6 @@ controls: toolbar button, menu item
 
 The `toc` plugin will generate basic *Table of Contents* and insert it into the editor at the current cursor position. Items for the table will be taken from the headers found in the content.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/visualblocks.md
+++ b/plugins/opensource/visualblocks.md
@@ -12,8 +12,6 @@ controls: toolbar button, menu item
 
 This plugin allows a user to see block level elements in the editable area. It is similar to WYSIWYG hidden character functionality, but at block level. It also adds a toolbar button and a menu item `Show blocks` under the `View` menu dropdown.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/visualchars.md
+++ b/plugins/opensource/visualchars.md
@@ -12,8 +12,6 @@ controls: toolbar button, menu item
 
 This plugin adds the ability to see invisible characters like `&nbsp;` displayed in the editable area. It also adds a toolbar control and a menu item `Show invisible characters` under the `View` menu.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js

--- a/plugins/opensource/wordcount.md
+++ b/plugins/opensource/wordcount.md
@@ -11,8 +11,6 @@ keywords: wordcount
 
 The Word Count plugin adds the functionality for counting words to the {{site.productname}} editor by placing a counter on the right edge of the status bar. Clicking **Word Count** in the status bar switches between counting words and characters. A dialog box with both word and character counts can be opened using the menu item situated in the **Tools** drop-down, or the toolbar button.
 
-**Type:** `String`
-
 ## Basic setup
 
 ```js


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* removing confusing information from introduction on plugin pages

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
