### PR TITLE
DOC-751: Added documentation for new bootstrap icon pack

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -874,6 +874,7 @@
     - url: "#New features"
     - url: "#Enhancements"
     - url: "#Accompanying Premium Plugin changes"
+    - url: "#Accompanying Premium Skins and Icon Packs changes"
     - url: "#Accompanying Premium self-hosted server-side component changes"
     - url: "#General bug fixes"
     - url: "#Security fixes"

--- a/_includes/live-demos/premiumskinsandicons-bootstrap/index.js
+++ b/_includes/live-demos/premiumskinsandicons-bootstrap/index.js
@@ -1,20 +1,21 @@
 tinymce.init({
   selector: 'textarea#premiumskinsandicons-bootstrap',
   skin: 'bootstrap',
+  icons: 'bootstrap',
   plugins: 'image lists link anchor charmap',
   toolbar: 'formatselect | bold italic bullist numlist | link image charmap',
   menubar: false,
   setup: function (editor) {
     editor.on('init', function () {
-      editor.getContainer().style.transition='border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out'
+      editor.getContainer().style.transition='border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out';
     });
     editor.on('focus', function () {
-      editor.getContainer().style.boxShadow='0 0 0 .2rem rgba(0, 123, 255, .25)',
-      editor.getContainer().style.borderColor='#80bdff'
+      editor.getContainer().style.boxShadow='0 0 0 .2rem rgba(0, 123, 255, .25)';
+      editor.getContainer().style.borderColor='#80bdff';
     });
     editor.on('blur', function () {
-      editor.getContainer().style.boxShadow='',
-      editor.getContainer().style.borderColor=''
+      editor.getContainer().style.boxShadow='';
+      editor.getContainer().style.borderColor='';
     });
   }
 });

--- a/enterprise/premium-skins-and-icon-packs/bootstrap-demo.md
+++ b/enterprise/premium-skins-and-icon-packs/bootstrap-demo.md
@@ -6,7 +6,7 @@ description: Bootstrap Demo
 keywords: skin skins icon icons bootstrap customize theme
 ---
 
-This demo shows an example form using Bootstrap together with {{site.productname}} with the _Bootstrap_ skin. It's designed to closely matches _colors, forms and buttons_ to the default Bootstrap framework
+This demo shows an example form using Bootstrap together with {{site.productname}} with the _Bootstrap_ skin and _Bootstrap_ icon pack. It's designed to closely matches _colors, forms and buttons_ to the default Bootstrap framework
 
 >The focus outline on the editor is not part of the skin. Take a look in the JS tab below for inspiration on how to add it.
 

--- a/enterprise/premium-skins-and-icon-packs/bootstrap-demo.md
+++ b/enterprise/premium-skins-and-icon-packs/bootstrap-demo.md
@@ -6,9 +6,8 @@ description: Bootstrap Demo
 keywords: skin skins icon icons bootstrap customize theme
 ---
 
-This demo shows an example form using Bootstrap together with {{site.productname}} with the _Bootstrap_ skin and _Bootstrap_ icon pack. It's designed to closely matches _colors, forms and buttons_ to the default Bootstrap framework
+This demo shows an example form using Bootstrap together with {{site.productname}} and the {{site.companyname}} _Bootstrap_ skin and _Bootstrap_ icon pack. It's designed to closely match the _colors, forms, and buttons_ of the default Bootstrap framework UI.
 
 >The focus outline on the editor is not part of the skin. Take a look in the JS tab below for inspiration on how to add it.
 
 {% include live-demo.html id="premiumskinsandicons-bootstrap" %}
-

--- a/enterprise/premium-skins-and-icon-packs/index.md
+++ b/enterprise/premium-skins-and-icon-packs/index.md
@@ -47,6 +47,7 @@ Use the [icons]({{site.baseurl}}/configure/editor-appearance/#icons) option with
 
 Available values for [icon]({{site.baseurl}}/configure/editor-appearance/#icons) packs:
 
+- bootstrap
 - material
 - small
 - jam
@@ -69,14 +70,14 @@ Due to different toolbar button sizes, some icon packs fit better with some skin
 
 | Skin | Compatible Icon pack |
 | --- | --- |
-| material-classic | material, jam, small, thin |
-| material-outline | material, jam, small, thin |
-| bootstrap | material, jam, small, thin |
-| fabric | material, jam, small, thin |
-| borderless | material, jam, small, thin |
-| naked | material, jam, small, thin |
-| outside | material, jam, small, thin |
-| snow | material, jam, small, thin |
+| material-classic | bootstrap, material, jam, small, thin |
+| material-outline | bootstrap, material, jam, small, thin |
+| bootstrap | bootstrap, material, jam, small, thin |
+| fabric | bootstrap, material, jam, small, thin |
+| borderless | bootstrap, material, jam, small, thin |
+| naked | bootstrap, material, jam, small, thin |
+| outside | bootstrap, material, jam, small, thin |
+| snow | bootstrap, material, jam, small, thin |
 | small | jam, small |
 | jam | jam, small |
 

--- a/release-notes/release-notes57.md
+++ b/release-notes/release-notes57.md
@@ -86,7 +86,7 @@ For information on:
 
 ## Accompanying Premium Skins and Icon Packs changes
 
-The {{site.productname}} 5.7 release includes an accompanying release of the **Premium Skins and Icon Packs** premium content. Included is a new `bootstrap` icon pack that provides [Bootstrap icons](https://icons.getbootstrap.com/) for {{site.productname}}.
+The {{site.productname}} 5.7 release includes an accompanying release of the **Premium Skins and Icon Packs**. Included is a new `bootstrap` icon pack that provides [Bootstrap icons](https://icons.getbootstrap.com/) for {{site.productname}}.
 
 For information on using premium skins and icon packs, see: [Premium Skins and Icon Packs]({{site.baseurl}}/enterprise/premium-skins-and-icon-packs/).
 

--- a/release-notes/release-notes57.md
+++ b/release-notes/release-notes57.md
@@ -13,6 +13,7 @@ keywords: releasenotes bugfixes
 - [New features](#newfeatures)
 - [Enhancements](#enhancements)
 - [Accompanying Premium Plugin changes](#accompanyingpremiumpluginchanges)
+- [Accompanying Premium Skins and Icon Packs changes](#accompanyingpremiumskinsandiconpackschanges)
 - [General bug fixes](#generalbugfixes)
 - [Security fixes](#securityfixes)
 - [Deprecated features](#deprecatedfeatures)
@@ -82,6 +83,12 @@ For information on:
 
 - The `spellchecker_ignore_list` option, see: [Spell Checker Pro - `spellchecker_ignore_list`]({{ site.baseurl }}/plugins/premium/tinymcespellchecker/#spellchecker_ignore_list).
 - The `addIgnoredWords` API, see: [Spell Checker Pro - `API`]({{ site.baseurl }}/plugins/premium/tinymcespellchecker/#api).
+
+## Accompanying Premium Skins and Icon Packs changes
+
+The {{site.productname}} 5.7 release includes an accompanying release of the **Premium Skins and Icon Packs** premium content. Included is a new `bootstrap` icon pack that provides [Bootstrap icons](https://icons.getbootstrap.com/) for {{site.productname}}.
+
+For information on using premium skins and icon packs, see: [Premium Skins and Icon Packs]({{site.baseurl}}/enterprise/premium-skins-and-icon-packs/).
 
 ## Accompanying Premium self-hosted server-side component changes
 


### PR DESCRIPTION
Related Ticket: DOC-751

Description of Changes:
* Adds a release note for the new bootstrap icon pack.
* Updates the skin/icon compatibility matrix.
* Updates the bootstrap demo to use the bootstrap icon pack (won't work until it's on cloud though). Also fixed some mino syntax issues in the demo.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
