### PR TITLE
DOC-752: Remove inline references from quickbars page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -77,6 +77,7 @@ svgsNotSupported: "> **Note**: SVGs (Scalable Vector Graphics) are not supported
 predefinedIconsOnly: "Name of the icon to be displayed. Must correspond to an icon: in the [icon pack](https://www.tiny.cloud/docs/advanced/editor-icon-identifiers/), in a [custom icon pack](https://www.tiny.cloud/docs/advanced/creating-an-icon-pack/), or added using the [`addIcon` API](https://www.tiny.cloud/docs/api/tinymce.editor.ui/tinymce.editor.ui.registry/#addicon)."
 
 liveDemoIframeCSSStyles: "'body { font-family:Helvetica,Arial,sans-serif; font-size:14px }'"
+liveDemoPrimaryColor: "#1976D2"
 
 exclude:
   - Dockerfile

--- a/_includes/configuration/image_toolbar.md
+++ b/_includes/configuration/image_toolbar.md
@@ -16,7 +16,6 @@ To disable the Quick Image toolbar, set `quickbars_image_toolbar` to `false`.
 tinymce.init({
   selector: 'div.tinymce',
   plugins: 'quickbars image imagetools',
-  inline: true,
   quickbars_image_toolbar: 'alignleft aligncenter alignright | rotateleft rotateright | imageoptions'
 });
 ```
@@ -29,7 +28,6 @@ To disable the Quick Image toolbar, set `quickbars_image_toolbar` to `false`.
 tinymce.init({
   selector: 'div.tinymce',
   plugins: 'quickbars',
-  inline: true,
   quickbars_image_toolbar: false
 });
 ```

--- a/_includes/configuration/insert-toolbar.md
+++ b/_includes/configuration/insert-toolbar.md
@@ -14,7 +14,6 @@ To disable the Quick Insert toolbar, set `quickbars_insert_toolbar` to `false`.
 tinymce.init({
   selector: 'div.tinymce',
   plugins: 'quickbars hr pagebreak',
-  inline: true,
   quickbars_insert_toolbar: 'quickimage quicktable | hr pagebreak'
 });
 ```
@@ -28,7 +27,6 @@ To disable the Quick Insert toolbar, set `quickbars_insert_toolbar` to `false`.
 tinymce.init({
   selector: 'div.tinymce',
   plugins: 'quickbars',
-  inline: true,
   quickbars_insert_toolbar: false
 });
 ```

--- a/_includes/configuration/selection-toolbar.md
+++ b/_includes/configuration/selection-toolbar.md
@@ -14,7 +14,6 @@ To disable the Quick Selection toolbar, set `quickbars_selection_toolbar` to `fa
 tinymce.init({
   selector: 'div.tinymce',
   plugins: 'quickbars',
-  inline: true,
   quickbars_selection_toolbar: 'bold italic | formatselect | quicklink blockquote'
 });
 ```
@@ -27,7 +26,6 @@ To disable the Quick Selection toolbar, set `quickbars_selection_toolbar` to `fa
 tinymce.init({
   selector: 'div.tinymce',
   plugins: 'quickbars',
-  inline: true,
   quickbars_selection_toolbar: false
 });
 ```

--- a/_includes/live-demos/autocompleter/index.js
+++ b/_includes/live-demos/autocompleter/index.js
@@ -8,7 +8,6 @@ var specialChars = [
   { text: 'ampersand', value: '&' },
   { text: 'asterisk', value: '*' }
 ];
-
 tinymce.init({
   selector: 'textarea#autocompleter',
   height: 250,
@@ -17,13 +16,13 @@ tinymce.init({
       editor.selection.setRng(rng);
       editor.insertContent(value);
       autocompleteApi.hide();
-    }
+    };
 
     var getMatchedChars = function (pattern) {
       return specialChars.filter(function (char) {
         return char.text.indexOf(pattern) !== -1;
       });
-    }
+    };
 
     /* An autocompleter that allows you to insert special characters */
     editor.ui.registry.addAutocompleter('specialchars', {

--- a/_includes/live-demos/quickbars/index.html
+++ b/_includes/live-demos/quickbars/index.html
@@ -1,0 +1,29 @@
+<h3>The Quickbars plugin in the Classic (iframe) editor</h3>
+
+<textarea id="iframe">
+  <p style="text-align: center; font-size: 15px;">
+    <img title="TinyMCE Logo" src="//www.tiny.cloud/images/glyph-tinymce@2x.png" alt="TinyMCE Logo" width="110" height="97" />
+  </p>
+  <h4 style="text-align: center;">Welcome to the Quickbars demo for TinyMCE Classic (iframe) mode</h4>
+  <p>To see:</p>
+  <ul>
+    <li>The <strong>Quick Insert Toolbar</strong>, place the cursor at the start of an empty line in the editor.</li>
+    <li>The <strong>Quick Selection Toolbar</strong>, select (highlight) any text in the editor.</li>
+    <li>The <strong>Quick Image Toolbar</strong>, select (highlight) any text in the editor.</li>
+  </ul>
+</textarea>
+
+<h3>The Quickbars plugin in an inline editor</h3>
+
+<div id="inline-distraction-free" class="my-inline-editor" contenteditable="true" style="position: relative;">
+  <p style="text-align: center; font-size: 15px;">
+    <img title="TinyMCE Logo" src="//www.tiny.cloud/images/glyph-tinymce@2x.png" alt="TinyMCE Logo" width="110" height="97" />
+  </p>
+  <h4 style="text-align: center;">Welcome to the Quickbars demo for TinyMCE Classic (iframe) mode</h4>
+  <p>To see:</p>
+  <ul>
+    <li>The <strong>Quick Insert Toolbar</strong>, place the cursor at the start of an empty line in the editor.</li>
+    <li>The <strong>Quick Selection Toolbar</strong>, select (highlight) any text in the editor.</li>
+    <li>The <strong>Quick Image Toolbar</strong>, select (highlight) any text in the editor.</li>
+  </ul>
+</div>

--- a/_includes/live-demos/quickbars/index.html
+++ b/_includes/live-demos/quickbars/index.html
@@ -9,7 +9,7 @@
   <ul>
     <li>The <strong>Quick Insert Toolbar</strong>, place the cursor at the start of an empty line in the editor.</li>
     <li>The <strong>Quick Selection Toolbar</strong>, select (highlight) any text in the editor.</li>
-    <li>The <strong>Quick Image Toolbar</strong>, select (highlight) any text in the editor.</li>
+    <li>The <strong>Quick Image Toolbar</strong>, select any image in the editor.</li>
   </ul>
 </textarea>
 
@@ -24,6 +24,6 @@
   <ul>
     <li>The <strong>Quick Insert Toolbar</strong>, place the cursor at the start of an empty line in the editor.</li>
     <li>The <strong>Quick Selection Toolbar</strong>, select (highlight) any text in the editor.</li>
-    <li>The <strong>Quick Image Toolbar</strong>, select (highlight) any text in the editor.</li>
+    <li>The <strong>Quick Image Toolbar</strong>, select any image in the editor.</li>
   </ul>
 </div>

--- a/_includes/live-demos/quickbars/index.html
+++ b/_includes/live-demos/quickbars/index.html
@@ -15,7 +15,7 @@
 
 <h3>The Quickbars plugin in an inline editor</h3>
 
-<div id="inline-distraction-free" class="my-inline-editor" contenteditable="true" style="position: relative;">
+<div id="inline-distraction-free" class="my-inline-editor">
   <p style="text-align: center; font-size: 15px;">
     <img title="TinyMCE Logo" src="//www.tiny.cloud/images/glyph-tinymce@2x.png" alt="TinyMCE Logo" width="110" height="97" />
   </p>

--- a/_includes/live-demos/quickbars/index.js
+++ b/_includes/live-demos/quickbars/index.js
@@ -1,0 +1,32 @@
+tinymce.init({
+  selector: 'textarea#iframe',
+  plugins: 'quickbars table image link lists media autoresize help',
+  toolbar: 'undo redo | formatselect | bold italic | alignleft aligncentre alignright alignjustify | indent outdent | bullist numlist',
+  content_style: {{site.liveDemoIframeCSSStyles}}
+});
+
+tinymce.init({
+  selector: 'div#inline-distraction-free',
+  menubar: false,
+  inline: true,
+  plugins: [
+    'autolink',
+    'autoresize',
+    'codesample',
+    'link',
+    'lists',
+    'media',
+    'powerpaste',
+    'table',
+    'image',
+    'quickbars',
+    'codesample',
+    'help'
+  ],
+  toolbar: false,
+  quickbars_insert_toolbar: 'quicktable image media codesample',
+  quickbars_selection_toolbar: 'bold italic underline | formatselect | bullist numlist | blockquote quicklink',
+  contextmenu: 'undo redo | inserttable | cell row column deletetable | help',
+  powerpaste_word_import: 'clean',
+  powerpaste_html_import: 'clean',
+});

--- a/_includes/live-demos/quickbars/style.css
+++ b/_includes/live-demos/quickbars/style.css
@@ -1,0 +1,11 @@
+.my-inline-editor:hover {
+  box-shadow: 0 0 4px #1976D2;
+  border-radius: 4px;
+}
+.my-inline-editor:focus {
+  box-shadow: 0 0 4px #1976D2;
+  border-radius: 4px;
+}
+.my-inline-editor {
+  padding: 12px;
+}

--- a/plugins/opensource/quickbars.md
+++ b/plugins/opensource/quickbars.md
@@ -28,10 +28,7 @@ This plugin also adds three new toolbar buttons:
 ```js
 tinymce.init({
   selector: 'div.tinymce',
-  plugins: [ 'quickbars' ],
-  toolbar: false,
-  menubar: false,
-  inline: true
+  plugins: [ 'quickbars' ]
 });
 ```
 
@@ -45,9 +42,6 @@ The following examples show how to disable specific quick toolbars for editors w
 tinymce.init({
   selector: 'div.tinymce',
   plugins: [ 'quickbars' ],
-  toolbar: false,
-  menubar: false,
-  inline: true,
   quickbars_insert_toolbar: false
 });
 ```
@@ -58,9 +52,6 @@ tinymce.init({
 tinymce.init({
   selector: 'div.tinymce',
   plugins: [ 'quickbars' ],
-  toolbar: false,
-  menubar: false,
-  inline: true,
   quickbars_selection_toolbar: false
 });
 ```
@@ -73,9 +64,6 @@ tinymce.init({
 tinymce.init({
   selector: 'div.tinymce',
   plugins: [ 'quickbars' ],
-  toolbar: false,
-  menubar: false,
-  inline: true,
   quickbars_image_toolbar: false
 });
 ```

--- a/plugins/opensource/quickbars.md
+++ b/plugins/opensource/quickbars.md
@@ -23,6 +23,10 @@ This plugin also adds three new toolbar buttons:
 
 > **Note**: The Quick Toolbars plugin provides the contextual toolbars found in the `inlite` theme from TinyMCE 4 and earlier.
 
+## Interactive example
+
+{% include live-demo.html id="quickbars" %}
+
 ## Basic setup
 
 ```js


### PR DESCRIPTION
Related Ticket: DOC-752

Description of Changes:
* Remove inline references from quickbars page to reduce confusion about quickbars working in iframe and inline mode

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
