### PR TITLE
DOC-741: Added IPv6 support release note

### DIFF
--- a/release-notes/release-notes57.md
+++ b/release-notes/release-notes57.md
@@ -61,6 +61,12 @@ The `TableModified` event now contains additional data which specifies whether t
 
 For information on the `TableModified` event, see: [Table plugin - Events]({{ site.baseurl }}/plugins/opensource/table/#events).
 
+### Added IPv6 URI parsing support
+
+The {{site.productname}} `URI` API now supports parsing IPv6 URLs. This enhancement was a community contribution by dev7355608.
+
+For information on the `URI` API, see: [URI]({{site.baseurl}}/api/tinymce.util/tinymce.util.uri/).
+
 ### Additional enhancements
 
 {{site.productname}} 5.7 introduces the following minor enhancements:


### PR DESCRIPTION
Related Ticket: DOC-741

Description of Changes:
* Added release note for IPv6 parsing support

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
