### PR TITLE
TINY-6457: Copied over a line from the changelog that wasn't added until after the big changelog-copy-over

### DIFF
--- a/release-notes/release-notes57.md
+++ b/release-notes/release-notes57.md
@@ -162,6 +162,7 @@ It is now possible to specify arrays of words for specific languages to be ignor
 
 - Fixed a bug where it was possible to open multiple instances of the spellchecker dialog.
 - Fixed a regression that caused errors to be thrown if the editor was destroyed while spellchecking.
+- Fixed an issue where the spellchecker would incorrectly check content inside of special elements such as `style`.
 
 For information on the Spell Checker Pro plugin, see: [Spell Checker Pro]({{ site.baseurl }}/plugins/premium/tinymcespellchecker/).
 


### PR DESCRIPTION
…in 5ef7191

Related Ticket: Don't really have a doc ticket, but it's TINY-6457

Description of Changes:
* Copied over a line from the changelog that wasn't added until after the big changelog-copy-over

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- ~[ ] `_data/nav.yml` has been updated (if applicable)~
- ~[ ] Files has been included where required (if applicable)~
- ~[ ] Files removed have been deleted, not just excluded from the build (if applicable)~
- ~[ ] (New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
