### PR TITLE
DOC-756: Document series column feature for the advtable plugin

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -234,6 +234,8 @@
       - url: "#API"
     - url: "advcode"
     - url: "advtable"
+      pages:
+      - url: "#advtable_value_series"
     - url: "casechange"
     - url: "checklist"
     - url: "comments"

--- a/_includes/commands/advtable-cmds.md
+++ b/_includes/commands/advtable-cmds.md
@@ -5,8 +5,9 @@
 | mceSortTableAdvanced     | Performs an Advanced Table Sort. See below for details.                                         |
 | mceSortTableByColumnAsc  | Sorts the current table ascending by column based on the current cursor position or selection.  |
 | mceSortTableByColumnDesc | Sorts the current table descending by column based on the current cursor position or selection. |
-| mceSortTableByRowAsc    | Sorts the current table ascending by row based on the current cursor position or selection.     |
-| mceSortTableByRowDesc     | Sorts the current table descending by row based on the current cursor position or selection.    |
+| mceSortTableByRowAsc     | Sorts the current table ascending by row based on the current cursor position or selection.     |
+| mceSortTableByRowDesc    | Sorts the current table descending by row based on the current cursor position or selection.    |
+| mceTableToggleSeries     | Toggles a series column on the selected table. See below for more details. |
 
 `mceSortTableAdvanced` accepts an object with the following value pairs:
 
@@ -14,6 +15,11 @@
 - `roworcol` - a zero-indexed integer in a string representing the row from the top of the table or column from the left of the table.
 - `sort` - `'row'`, `'column'`, `'selection'`, or `'table'`
 - `order` - `'ascending'` or `'descending'`
+
+`mceTableToggleSeries` accepts an object with the following key-value pairs:
+
+- `name` - a string indicating the series to toggle. Series and their associated names are configured using the [advtable_value_series]({{site.baseurl}}/plugins/premium/advtable/#advtable_value_series) option. If a different series name is provided than what is present on the table, the series column will be updated to use the new series.
+- `location` - `'left'`
 
 **Examples**
 
@@ -24,4 +30,5 @@ tinymce.activeEditor.execCommand('mceSortTableByColumnAsc')
 tinymce.activeEditor.execCommand('mceSortTableByColumnDesc')
 tinymce.activeEditor.execCommand('mceSortTableByRowAsc')
 tinymce.activeEditor.execCommand('mceSortTableByRowDesc')
+tinymce.activeEditor.execCommand('mceTableToggleSeries', false, { name: 'numbers', location: 'left' })
 ```

--- a/_includes/commands/advtable-cmds.md
+++ b/_includes/commands/advtable-cmds.md
@@ -2,24 +2,12 @@
 | Command                  | Description                                                                                     |
 | ------------------------ | ----------------------------------------------------------------------------------------------- |
 | mceAdvancedTableSort     | Opens the Advanced Table Sort Dialog for the current selection or cursor location.              |
-| mceSortTableAdvanced     | Performs an Advanced Table Sort. See below for details.                                         |
+| mceSortTableAdvanced     | Performs an Advanced Table Sort. For details, see [mceSortTableAdvanced](#mcesorttableadvanced).                                         |
 | mceSortTableByColumnAsc  | Sorts the current table ascending by column based on the current cursor position or selection.  |
 | mceSortTableByColumnDesc | Sorts the current table descending by column based on the current cursor position or selection. |
 | mceSortTableByRowAsc     | Sorts the current table ascending by row based on the current cursor position or selection.     |
 | mceSortTableByRowDesc    | Sorts the current table descending by row based on the current cursor position or selection.    |
-| mceTableToggleSeries     | Toggles a series column on the selected table. See below for more details. |
-
-`mceSortTableAdvanced` accepts an object with the following value pairs:
-
-- `sortby` - `'row'` or `'column'`
-- `roworcol` - a zero-indexed integer in a string representing the row from the top of the table or column from the left of the table.
-- `sort` - `'row'`, `'column'`, `'selection'`, or `'table'`
-- `order` - `'ascending'` or `'descending'`
-
-`mceTableToggleSeries` accepts an object with the following key-value pairs:
-
-- `name` - a string indicating the series to toggle. Series and their associated names are configured using the [advtable_value_series]({{site.baseurl}}/plugins/premium/advtable/#advtable_value_series) option. If a different series name is provided than what is present on the table, the series column will be updated to use the new series.
-- `location` - `'left'`
+| mceTableToggleSeries     | Toggles a series column on the selected table. For details, see [mceTableToggleSeries](#mcetabletoggleseries). {{ site.requires_5_7v }} |
 
 **Examples**
 
@@ -32,3 +20,20 @@ tinymce.activeEditor.execCommand('mceSortTableByRowAsc')
 tinymce.activeEditor.execCommand('mceSortTableByRowDesc')
 tinymce.activeEditor.execCommand('mceTableToggleSeries', false, { name: 'numbers', location: 'left' })
 ```
+
+### `mceSortTableAdvanced`
+
+`mceSortTableAdvanced` accepts an object with the following value pairs:
+
+- `sortby` - `'row'` or `'column'`
+- `roworcol` - a zero-indexed integer in a string representing the row from the top of the table or column from the left of the table.
+- `sort` - `'row'`, `'column'`, `'selection'`, or `'table'`
+- `order` - `'ascending'` or `'descending'`
+
+### `mceTableToggleSeries`
+
+`mceTableToggleSeries` accepts an object with the following key-value pairs:
+
+- `name` - a string indicating the series to toggle. Series and their associated names are configured using the [advtable_value_series]({{site.baseurl}}/plugins/premium/advtable/#advtable_value_series) option. If the provided series name is different to the name currently present on the table, the series column will be updated to use the new series.
+{% comment %} Need to elaborate on this more {% endcomment %}
+- `location` - `'left'`

--- a/_includes/commands/advtable-cmds.md
+++ b/_includes/commands/advtable-cmds.md
@@ -36,5 +36,5 @@ tinymce.activeEditor.execCommand('mceTableToggleSeries', false, { name: 'numbers
 
 | Name | Value | Requirement | Description |
 | ---- | ----- | ----------- | ----------- |
-| name | `string` | Required |  Specifies the series to toggle. Series and their associated names are configured using the [advtable_value_series option]({{site.baseurl}}/plugins/premium/advtable/#advtable_value_series). If the provided series name is different to the name currently present on the table, the series column will be updated to use the new series. |
+| name | `string` | Required |  Specifies the series to toggle. Series and their associated names are configured using the [advtable_value_series option]({{site.baseurl}}/plugins/premium/advtable/#advtable_value_series). If the series name provided is not present on the table, a series column will be inserted or an existing series will be replaced by the new series. |
 | location | `'left'` | Required | Specifies the location of where the series is toggled in the table. For example, a location of `left` will toggle a series column on the left side of the table.  |

--- a/_includes/commands/advtable-cmds.md
+++ b/_includes/commands/advtable-cmds.md
@@ -36,5 +36,5 @@ tinymce.activeEditor.execCommand('mceTableToggleSeries', false, { name: 'numbers
 
 | Name | Value | Requirement | Description |
 | ---- | ----- | ----------- | ----------- |
-| name | `string` | Required |  Specifies the series to toggle. Series and their associated names are configured using the [advtable_value_series]({{site.baseurl}}/plugins/premium/advtable/#advtable_value_series) option. If the provided series name is different to the name currently present on the table, the series column will be updated to use the new series. |
-| location | `'left'` | Required | Specifies the location of where the series should be toggled in the table. |
+| name | `string` | Required |  Specifies the series to toggle. Series and their associated names are configured using the [advtable_value_series option]({{site.baseurl}}/plugins/premium/advtable/#advtable_value_series). If the provided series name is different to the name currently present on the table, the series column will be updated to use the new series. |
+| location | `'left'` | Required | Specifies the location of where the series is toggled in the table. For example, a location of `left` will toggle a series column on the left side of the table.  |

--- a/_includes/commands/advtable-cmds.md
+++ b/_includes/commands/advtable-cmds.md
@@ -23,7 +23,7 @@ tinymce.activeEditor.execCommand('mceTableToggleSeries', false, { name: 'numbers
 
 ### `mceSortTableAdvanced`
 
-`mceSortTableAdvanced` accepts an object with the following value pairs:
+`mceSortTableAdvanced` accepts an object with the following key-value pairs:
 
 - `sortby` - `'row'` or `'column'`
 - `roworcol` - a zero-indexed integer in a string representing the row from the top of the table or column from the left of the table.

--- a/_includes/commands/advtable-cmds.md
+++ b/_includes/commands/advtable-cmds.md
@@ -34,6 +34,7 @@ tinymce.activeEditor.execCommand('mceTableToggleSeries', false, { name: 'numbers
 
 `mceTableToggleSeries` accepts an object with the following key-value pairs:
 
-- `name` - a string indicating the series to toggle. Series and their associated names are configured using the [advtable_value_series]({{site.baseurl}}/plugins/premium/advtable/#advtable_value_series) option. If the provided series name is different to the name currently present on the table, the series column will be updated to use the new series.
-{% comment %} Need to elaborate on this more {% endcomment %}
-- `location` - `'left'`
+| Name | Value | Requirement | Description |
+| ---- | ----- | ----------- | ----------- |
+| name | `string` | Required |  Specifies the series to toggle. Series and their associated names are configured using the [advtable_value_series]({{site.baseurl}}/plugins/premium/advtable/#advtable_value_series) option. If the provided series name is different to the name currently present on the table, the series column will be updated to use the new series. |
+| location | `'left'` | Required | Specifies the location of where the series should be toggled in the table. |

--- a/_includes/configuration/advtable-value-series.md
+++ b/_includes/configuration/advtable-value-series.md
@@ -1,0 +1,82 @@
+## `advtable_value_series`
+{{ site.requires_5_8 }}
+
+{% if pluginname != "Advanced Tables" %}
+> **Note**: The `advtable_value_series` option requires the Advanced Tables plugin.
+{% endif %}
+
+The `advtable_value_series` option allows values series to be configured that can be used to populate cells in a table.
+
+**Type:** `Object`
+
+**Default Value:**
+ - `numbers` - a natural number series.
+ - `alpha` - a base26 letter series.
+
+```js
+{
+  numbers: {
+    update: true,
+    resizable: false,
+    generator: ...
+  },
+  alpha: {
+    update: true,
+    resizable: false,
+    generator: ...
+  },
+}
+```
+
+### Series configuration
+
+| Name | Value | Requirement | Description |
+| ---- | ----- | ----------- | ----------- |
+| update | `boolean` | Optional | default: `false` - Specifies whether the table cells that are part of the series should update after changes are made to the table. |
+| resizable | `boolean` | Optional | default: `true` - Specifies whether the table cells that are part of the series are resizable when using the resize bars. |
+| generator | `(info: GeneratorInfo, rowIndex: number, columnIndex: number) => GeneratorResult` | Required | [Usage of generator](#usageofgenerator). |
+
+#### Usage of generator
+
+The `generator` is a callback function that is used to specify how a table cell that is part of the series should be updated. The callback is passed information relating to the generator and table cell, the row index and column index of the table cell. For more details, see: [GeneratorInfo](#generatorinfo).
+The callback should return an object containing the value and optionally, the classes and attributes that should be applied on the table cell. For more details, see: [GeneratorResult](#generatorresult).
+
+##### GeneratorInfo
+
+| Name | Value | Description |
+| ---- | ----- | ----------- |
+| rowType | `'thead'`, `'tbody'` or '`tfoot'` | The section of the table cell. |
+| cellType | `'td'` or `'th'` | The type of the table cell. |
+| direction | `'row'` or `'column'` | The direction of the generator. |
+| prevSeriesValue | `string` or `undefined` | The previous value calculated from the generator. |
+
+##### GeneratorResult
+
+| Name | Value | Requirement | Description |
+| ---- | ----- | ----------- | ----------- |
+| classes | `string[]` | Optional | The classes that should be applied on the table cell. |
+| attributes | `Record<string, string, boolean, number or null>` | Optional | The attributes that should be applied or removed on the table cell. |
+| value | `string`, `number` or `undefined` | Optional | The value of the table cell. If the given value is `undefined`, it will attempt to use the previous value of the table cell. |
+
+### Example: Using `advtable_value_series`
+
+```js
+tinymce.init({
+  selector: 'textarea',  // change this value according to your html
+  plugins: 'table advtable',
+  menubar: 'table',
+  advtable_value_series: {
+    numbers: {
+      update: true,
+      resizable: false,
+      generator: function (info, rowIndex, columnIndex) {
+        return {
+          value: rowIndex + 1
+        };
+      }
+    },
+  }
+});
+```
+
+{% comment %} TODO: Do I need to make a note that this option is used in conjuction with the mceTableToggleSeries command? {% endcomment %}

--- a/_includes/configuration/advtable-value-series.md
+++ b/_includes/configuration/advtable-value-series.md
@@ -19,13 +19,13 @@ The `advtable_value_series` option configures value series for populating cells 
   numbers: { 
     update: true,
     resizable: false,
-    generator: `GeneratorFunction` // For details, see: 'Usage of generator'
+    generator: `GeneratorFunction` // For details, see: 'Creating a value series generator'
   },
   // English alphabetic series
   alpha: {
     update: true,
     resizable: false,
-    generator: `GeneratorFunction` // For details, see: 'Usage of generator'
+    generator: `GeneratorFunction` // For details, see: 'Creating a value series generator'
   },
 }
 ```

--- a/_includes/configuration/advtable-value-series.md
+++ b/_includes/configuration/advtable-value-series.md
@@ -5,9 +5,9 @@
 > **Note**: The `advtable_value_series` option requires the Advanced Tables plugin.
 {% endif %}
 
-The `advtable_value_series` option is used in conjuction with the [mceTableToggleSeries]({{site.baseurl}}/plugins/premium/advtable/#commands) command.
+The `advtable_value_series` option is used in conjunction with the [mceTableToggleSeries]({{site.baseurl}}/plugins/premium/advtable/#commands) command.
 
-The `advtable_value_series` option allows values series to be configured that can be used to populate cells in a table.
+The `advtable_value_series` option allows value series to be configured that can be used to populate cells in a table.
 
 **Type:** `Object`
 

--- a/_includes/configuration/advtable-value-series.md
+++ b/_includes/configuration/advtable-value-series.md
@@ -36,13 +36,13 @@ Both default series are configured to update on table changes and not resize whe
 
 | Name | Value | Requirement | Description |
 | ---- | ----- | ----------- | ----------- |
-| update | `boolean` | Optional | default: `false` - Specifies whether the table cells that are part of the series should update after changes are made to the table. |
-| resizable | `boolean` | Optional | default: `true` - Specifies whether the table cells that are part of the series are resizable when using the resize bars. |
+| update | `boolean` | Optional | default: `false` - When `true`, the series values will be updated when changes are made to the table. |
+| resizable | `boolean` | Optional | default: `true` - When `true`, table cells containing the series values can be resized using a mouse or touch device. |
 | generator | `(info: GeneratorInfo, rowIndex: number, columnIndex: number) => GeneratorResult` | Required | [Usage of generator](#usageofgenerator). |
 
 #### Usage of generator
 
-The `generator` is a callback function that is used to specify how a table cell that is part of the series should be updated. The callback is passed information relating to the generator and table cell, the row index and column index of the table cell. For more details, see: [GeneratorInfo](#generatorinfo). The callback should return an object containing the value and optionally, the classes and attributes that should be applied on the table cell. For more details, see: [GeneratorResult](#generatorresult).
+The `generator` is a callback function for specifying how to update a table cell of a value series. The callback is passed information relating to the generator and table cell, the row index, and column index of the table cell. For details, see: [GeneratorInfo](#generatorinfo). The callback should return an object containing the value and optionally, any classes and attributes to be applied to the table cell. For details, see: [GeneratorResult](#generatorresult).
 
 ##### GeneratorInfo
 
@@ -51,15 +51,15 @@ The `generator` is a callback function that is used to specify how a table cell 
 | rowType | `'thead'`, `'tbody'` or `'tfoot'` | The section of the table cell. |
 | cellType | `'td'` or `'th'` | The type of the table cell. |
 | direction | `'row'` or `'column'` | The direction of the generator. |
-| prevSeriesValue | `string` or `undefined` | The previous value calculated from the generator. |
+| prevSeriesValue | `string` or `undefined` | The previous value calculated by the generator. |
 
 ##### GeneratorResult
 
 | Name | Value | Requirement | Description |
 | ---- | ----- | ----------- | ----------- |
-| classes | `string[]` | Optional | The classes that should be applied on the table cell. |
-| attributes | `Object` | Optional | The attributes that should be applied on the table cell. `attributes` should be specified as an object where each key is an attribute and each value is of type `string`, `boolean`, `number` or `null`. If `null` is given as the value for an attribute, the attribute is removed from the table cell. |
-| value | `string`, `number` or `undefined` | Optional | The value of the table cell. If the given value is `undefined`, it will attempt to use the previous value of the table cell. |
+| classes | `string[]` | Optional | The classes to be applied to the table cell. |
+| attributes | `Object` | Optional | The attributes to be applied to the table cell. The `attributes` should be provided as an object where each key is an attribute and each value is of type `string`, `boolean`, `number` or `null`. A value of `null` for an attribute will remove the attribute from the table cell. |
+| value | `string`, `number` or `undefined` | Optional | The value of the table cell. If the value is `undefined`, the editor will use the previous value of the table cell. |
 
 ### Example: Using `advtable_value_series`
 

--- a/_includes/configuration/advtable-value-series.md
+++ b/_includes/configuration/advtable-value-series.md
@@ -19,7 +19,7 @@ The `advtable_value_series` option allows values series to be configured that ca
   numbers: { 
     update: true,
     resizable: false,
-    generator: `GeneratorFunction` // For deatils, see: 'Usage of generator'
+    generator: `GeneratorFunction` // For details, see: 'Usage of generator'
   },
   // English alphabetic series
   alpha: {

--- a/_includes/configuration/advtable-value-series.md
+++ b/_includes/configuration/advtable-value-series.md
@@ -25,7 +25,7 @@ The `advtable_value_series` option allows values series to be configured that ca
   alpha: {
     update: true,
     resizable: false,
-    generator: `GeneratorFunction` // For deatils, see: 'Usage of generator'
+    generator: `GeneratorFunction` // For details, see: 'Usage of generator'
   },
 }
 ```

--- a/_includes/configuration/advtable-value-series.md
+++ b/_includes/configuration/advtable-value-series.md
@@ -1,32 +1,36 @@
 ## `advtable_value_series`
-{{ site.requires_5_8 }}
+{{ site.requires_5_7 }}
 
 {% if pluginname != "Advanced Tables" %}
 > **Note**: The `advtable_value_series` option requires the Advanced Tables plugin.
 {% endif %}
+
+The `advtable_value_series` option is used in conjuction with the [mceTableToggleSeries]({{site.baseurl}}/plugins/premium/advtable/#commands) command.
 
 The `advtable_value_series` option allows values series to be configured that can be used to populate cells in a table.
 
 **Type:** `Object`
 
 **Default Value:**
- - `numbers` - a natural number series.
- - `alpha` - a base26 letter series.
 
 ```js
 {
-  numbers: {
+  // Natural number series
+  numbers: { 
     update: true,
     resizable: false,
-    generator: ...
+    generator: `GeneratorFunction` // For deatils, see: 'Usage of generator'
   },
+  // English alphabetic series
   alpha: {
     update: true,
     resizable: false,
-    generator: ...
+    generator: `GeneratorFunction` // For deatils, see: 'Usage of generator'
   },
 }
 ```
+
+Both default series are configured to update on table changes and not resize when using the resize bars.
 
 ### Series configuration
 
@@ -38,14 +42,13 @@ The `advtable_value_series` option allows values series to be configured that ca
 
 #### Usage of generator
 
-The `generator` is a callback function that is used to specify how a table cell that is part of the series should be updated. The callback is passed information relating to the generator and table cell, the row index and column index of the table cell. For more details, see: [GeneratorInfo](#generatorinfo).
-The callback should return an object containing the value and optionally, the classes and attributes that should be applied on the table cell. For more details, see: [GeneratorResult](#generatorresult).
+The `generator` is a callback function that is used to specify how a table cell that is part of the series should be updated. The callback is passed information relating to the generator and table cell, the row index and column index of the table cell. For more details, see: [GeneratorInfo](#generatorinfo). The callback should return an object containing the value and optionally, the classes and attributes that should be applied on the table cell. For more details, see: [GeneratorResult](#generatorresult).
 
 ##### GeneratorInfo
 
 | Name | Value | Description |
 | ---- | ----- | ----------- |
-| rowType | `'thead'`, `'tbody'` or '`tfoot'` | The section of the table cell. |
+| rowType | `'thead'`, `'tbody'` or `'tfoot'` | The section of the table cell. |
 | cellType | `'td'` or `'th'` | The type of the table cell. |
 | direction | `'row'` or `'column'` | The direction of the generator. |
 | prevSeriesValue | `string` or `undefined` | The previous value calculated from the generator. |
@@ -55,7 +58,7 @@ The callback should return an object containing the value and optionally, the cl
 | Name | Value | Requirement | Description |
 | ---- | ----- | ----------- | ----------- |
 | classes | `string[]` | Optional | The classes that should be applied on the table cell. |
-| attributes | `Record<string, string, boolean, number or null>` | Optional | The attributes that should be applied or removed on the table cell. |
+| attributes | `Object` | Optional | The attributes that should be applied on the table cell. `attributes` should be specified as an object where each key is an attribute and each value is of type `string`, `boolean`, `number` or `null`. If `null` is given as the value for an attribute, the attribute is removed from the table cell. |
 | value | `string`, `number` or `undefined` | Optional | The value of the table cell. If the given value is `undefined`, it will attempt to use the previous value of the table cell. |
 
 ### Example: Using `advtable_value_series`
@@ -78,5 +81,3 @@ tinymce.init({
   }
 });
 ```
-
-{% comment %} TODO: Do I need to make a note that this option is used in conjuction with the mceTableToggleSeries command? {% endcomment %}

--- a/_includes/configuration/advtable-value-series.md
+++ b/_includes/configuration/advtable-value-series.md
@@ -5,9 +5,9 @@
 > **Note**: The `advtable_value_series` option requires the Advanced Tables plugin.
 {% endif %}
 
-The `advtable_value_series` option is used in conjunction with the [mceTableToggleSeries]({{site.baseurl}}/plugins/premium/advtable/#commands) command.
+The `advtable_value_series` option is used in conjunction with the [mceTableToggleSeries command]({{site.baseurl}}/plugins/premium/advtable/#commands).
 
-The `advtable_value_series` option allows value series to be configured that can be used to populate cells in a table.
+The `advtable_value_series` option configures value series for populating cells in a table. This option can be used to create row identifiers.
 
 **Type:** `Object`
 
@@ -38,9 +38,9 @@ Both default series are configured to update on table changes and not resize whe
 | ---- | ----- | ----------- | ----------- |
 | update | `boolean` | Optional | default: `false` - When `true`, the series values will be updated when changes are made to the table. |
 | resizable | `boolean` | Optional | default: `true` - When `true`, table cells containing the series values can be resized using a mouse or touch device. |
-| generator | `(info: GeneratorInfo, rowIndex: number, columnIndex: number) => GeneratorResult` | Required | [Usage of generator](#usageofgenerator). |
+| generator | `(info: GeneratorInfo, rowIndex: number, columnIndex: number) => GeneratorResult` | Required | For details on creating a value series generator, see: [Creating a value series generator](#creatingavalueseriesgenerator).  |
 
-#### Usage of generator
+#### Creating a value series generator
 
 The `generator` is a callback function for specifying how to update a table cell of a value series. The callback is passed information relating to the generator and table cell, the row index, and column index of the table cell. For details, see: [GeneratorInfo](#generatorinfo). The callback should return an object containing the value and optionally, any classes and attributes to be applied to the table cell. For details, see: [GeneratorResult](#generatorresult).
 

--- a/plugins/premium/advtable.md
+++ b/plugins/premium/advtable.md
@@ -8,6 +8,7 @@ keywords: sort tables advanced advtable premium
 
 {% assign pluginname = "Advanced Tables" %}
 {% assign plugincode = "advtable" %}
+{% assign plugincategory = "premium" %}
 {{site.requires_5_1v}}<br/>
 {{site.premiumplugin}}
 
@@ -41,6 +42,12 @@ tinymce.init({
   menubar: 'table'
 });
 ```
+
+## Configuration options
+
+The following configuration options affect the behavior of the {{pluginname}} plugin.
+
+{% include configuration/advtable-value-series.md %}
 
 {% include misc/plugin-menu-item-id-boilerplate.md %}
 

--- a/release-notes/release-notes58.md
+++ b/release-notes/release-notes58.md
@@ -57,7 +57,18 @@ The {{site.productname}} 5.8 release includes an accompanying release of the **<
 
 - <Description>
 
-For information on the <<Premium Plugin Name>> plugin, see: [<<Premium Plugin Name>> plugin]({{site.baseurl}}/plugins/<<Premium Plugin Name>>/).
+For information on the <<Premium Plugin Name>> plugin, see: [<<Premium Plugin Name>> plugin]({{site.baseurl}}/plugins/premium/advtable/).
+
+### Advanced Tables 1.1.0
+
+The {{site.productname}} 5.8 release includes an accompanying release of the **Advanced Tables** premium plugin.
+
+**Advanced Tables** 1.1.0 provides the following new features:
+
+- Added a new `advtable_value_series` option that allows value series to be configured. For details, see: [Advanced Tables plugin - advtable_value_series]({{site.baseurl}}/plugins/premium/advtable/#advtable_value_series).
+- Added a new `mceTableToggleSeries` command that toggles a series column on the selected table. For details, see: [Advanced Tables plugin - Commands]({{site.baseurl}}/plugins/premium/advtable/#commands).
+
+For information on the Advanced Tables plugin, see: [Advanced Tables plugin]({{site.baseurl}}/plugins/premium/advtable/).
 
 ## Accompanying Premium self-hosted server-side component changes
 


### PR DESCRIPTION
Related Ticket: TINY-6005

Description of Changes:
* Documentation for the current work that has been done for the (table row numbering)/(series column) feature in Advanced Tables. 

Pre-checks:
- [X] Branch prefixed with `feature/` or `hotfix/`
- [X] `_data/nav.yml` has been updated (if applicable)
- [X] Files has been included where required (if applicable)
- [X] Files removed have been deleted, not just excluded from the build (if applicable)
- ~~[ ] (New product features only) Release Note added~~

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
