### PR TITLE
DOC-799: Updated export plugin details for 1.0.0 release

### DIFF
--- a/_includes/misc/beta-note.md
+++ b/_includes/misc/beta-note.md
@@ -1,1 +1,1 @@
-> **Important**: {{beta_feature}} is currently in {{pre-release_type}}. To learn about our pre-release commitment, please read our [software licence agreement](https://about.tiny.cloud/legal/tiny-self-hosted-software-license-agreement-oem-saas/).
+> **Important**: {{beta_feature}} is currently in {{pre-release_type}}. To learn about our pre-release commitment, please read our [software license agreement](https://about.tiny.cloud/legal/tiny-self-hosted-software-license-agreement-oem-saas/).

--- a/_includes/misc/plugin_support_table.md
+++ b/_includes/misc/plugin_support_table.md
@@ -2,21 +2,22 @@
 
 The following table lists the premium plugins supported by {{site.companynameformal}} and indicates the supported version of {{site.productname}} required for the plugin.
 
-| Plugin                                                            | TinyMCE 4     | TinyMCE 5     |
-| ----------------------------------------------------------------- | :-----------: | :-----------: |
-| [Accessibility Checker]({{site.baseurl}}/plugins/premium/a11ychecker)     | {{site.tick}} | {{site.tick}} |
-| [Advanced Code Editor]({{site.baseurl}}/plugins/premium/advcode)          | {{site.tick}} | {{site.tick}} |
-| [Advanced Tables]({{site.baseurl}}/plugins/premium/advtable)| {{site.cross}} | Version **5.1.2** and higher |
-| [Case Change]({{site.baseurl}}/plugins/premium/casechange)                | {{site.cross}}| {{site.tick}} |
-| [Checklist]({{site.baseurl}}/plugins/premium/checklist)                   | {{site.cross}}| {{site.tick}} |
-| [Comments]({{site.baseurl}}/plugins/premium/comments)                     | {{site.tick}} | {{site.tick}} |
-| [Enhanced Media Embed]({{site.baseurl}}/plugins/premium/mediaembed)       | {{site.tick}} | {{site.tick}} |
-| [Format Painter]({{site.baseurl}}/plugins/premium/formatpainter)          | {{site.tick}} | {{site.tick}} |
-| [Link Checker]({{site.baseurl}}/plugins/premium/linkchecker)              | {{site.tick}} | {{site.tick}} |
-| [AtMentions]({{site.baseurl}}/plugins/premium/mentions)                     | {{site.tick}} | {{site.tick}} |
-| [MoxieManager]({{site.baseurl}}/plugins/premium/moxiemanager)             | {{site.tick}} | {{site.tick}} |
-| [Page Embed]({{site.baseurl}}/plugins/premium/pageembed)                  | {{site.cross}}| {{site.tick}} |
-| [Permanent Pen]({{site.baseurl}}/plugins/premium/permanentpen)            | {{site.cross}}| {{site.tick}} |
-| [PowerPaste]({{site.baseurl}}/plugins/premium/powerpaste)                 | {{site.tick}} | {{site.tick}} |
-| [Spell Checker Pro]({{site.baseurl}}/plugins/premium/tinymcespellchecker) | {{site.tick}} | {{site.tick}} |
+| Plugin                                                                     | TinyMCE 4     | TinyMCE 5     |
+| -------------------------------------------------------------------------- | :-----------: | :-----------: |
+| [Accessibility Checker]({{site.baseurl}}/plugins/premium/a11ychecker/)     | {{site.tick}} | {{site.tick}} |
+| [Advanced Code Editor]({{site.baseurl}}/plugins/premium/advcode/)          | {{site.tick}} | {{site.tick}} |
+| [Advanced Tables]({{site.baseurl}}/plugins/premium/advtable/)              | {{site.cross}} | Version **5.1.2** and higher |
+| [Case Change]({{site.baseurl}}/plugins/premium/casechange/)                | {{site.cross}}| {{site.tick}} |
+| [Checklist]({{site.baseurl}}/plugins/premium/checklist/)                   | {{site.cross}}| {{site.tick}} |
+| [Comments]({{site.baseurl}}/plugins/premium/comments/)                     | {{site.tick}} | {{site.tick}} |
+| [Enhanced Media Embed]({{site.baseurl}}/plugins/premium/mediaembed/)       | {{site.tick}} | {{site.tick}} |
+| [Export]({{site.baseurl}}/plugins/premium/export/)                         | {{site.cross}} | Version **5.5.0** and higher |
+| [Format Painter]({{site.baseurl}}/plugins/premium/formatpainter/)          | {{site.tick}} | {{site.tick}} |
+| [Link Checker]({{site.baseurl}}/plugins/premium/linkchecker/)              | {{site.tick}} | {{site.tick}} |
+| [AtMentions]({{site.baseurl}}/plugins/premium/mentions/)                   | {{site.tick}} | {{site.tick}} |
+| [MoxieManager]({{site.baseurl}}/plugins/premium/moxiemanager/)             | {{site.tick}} | {{site.tick}} |
+| [Page Embed]({{site.baseurl}}/plugins/premium/pageembed/)                  | {{site.cross}}| {{site.tick}} |
+| [Permanent Pen]({{site.baseurl}}/plugins/premium/permanentpen/)            | {{site.cross}}| {{site.tick}} |
+| [PowerPaste]({{site.baseurl}}/plugins/premium/powerpaste/)                 | {{site.tick}} | {{site.tick}} |
+| [Spell Checker Pro]({{site.baseurl}}/plugins/premium/tinymcespellchecker/) | {{site.tick}} | {{site.tick}} |
 | [{{site.prem_skins_icons}}]({{site.baseurl}}/enterprise/premium-skins-and-icon-packs/)|{{site.cross}}|{{site.tick}}|

--- a/_includes/plugin-apis/export-apis.md
+++ b/_includes/plugin-apis/export-apis.md
@@ -1,7 +1,7 @@
 | Name | Arguments | Description |
 |------| ------| ----------- |
-| convert | format: string, settings: object | Converts the editor content using the specified exporter format and returns a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that once resolved will contain the exported content. |
-| download | format: string, settings: object | Converts the editor content using the specified exporter format and downloads the converted content. |
+| convert | format: string, settings: Object | Converts the editor content using the specified exporter format and returns a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that once resolved will contain the exported content. |
+| download | format: string, settings: Object | Converts the editor content using the specified exporter format and downloads the converted content. |
 
 > **Note:** There are no settings available when using the 'clientpdf' format.
 

--- a/enterprise/export.md
+++ b/enterprise/export.md
@@ -6,10 +6,6 @@ description: Export content from TinyMCE, into varying formats.
 keywords: export pdf premium
 ---
 
-{% assign beta_feature = "The Export plugin" %}
-{% assign pre-release_type = "Open Beta" %}
-{% include misc/beta-note.md %}
-
 {{site.requires_5_5v}}
 
 The Export plugin provides the ability to export content from the editor to a user's local machine as a PDF.

--- a/plugins/premium/export.md
+++ b/plugins/premium/export.md
@@ -9,10 +9,6 @@ keywords: plugin export pdf
 {% assign pluginname = "Export" %}
 {% assign plugincode = "export" %}
 
-{% assign beta_feature = "The Export plugin" %}
-{% assign pre-release_type = "Open Beta" %}
-{% include misc/beta-note.md %}
-
 {{site.requires_5_5v}}<br/>
 {{site.premiumplugin}}
 
@@ -63,7 +59,6 @@ This exporter has a few limitations or known issues that should be noted:
 
 The following plugins are not supported:
 
-- [Anchor]({{site.baseurl}}/plugins/opensource/anchor/)
 - [BBCode]({{site.baseurl}}/plugins/opensource/bbcode/)
 - [Comments]({{site.baseurl}}/plugins/premium/comments/)
 - [Enhanced Media Embed]({{site.baseurl}}/plugins/premium/mediaembed/)

--- a/release-notes/release-notes58.md
+++ b/release-notes/release-notes58.md
@@ -81,6 +81,19 @@ This release adds new resolve conversation functionality, making it is possible 
 - Added a new `tinycomments_resolve` option for adding and configuring resolve conversation functionality for Comments in callback mode. For details, see: [Configuring comments callbacks - `tinycomments_resolve`]({{site.baseurl}}/advanced/configuring-comments-callbacks/#tinycomments_resolve).
 - Added a new `tinycomments_can_resolve` option for adding and configuring resolve conversation functionality for Comments in embedded mode. For details, see: [Comments plugin - `tinycomments_can_resolve`]({{site.baseurl}}/plugins/premium/comments/#tinycomments_can_resolve).
 
+### Export 1.0.0
+
+The {{site.productname}} 5.8 release includes an accompanying release of the **Export** premium plugin.
+
+**Export** 1.0.0 provides the following improvements:
+
+- Improved error handling when a PDF conversion failure occurs due to browser limitations.
+- Changed how image proxy errors are handled to gracefully fail and render a transparent image when an image proxy error occurs.
+
+**Export** 1.0.0 provides the following bug fixes:
+
+- Fixed an issue where internal document links did not navigate within the client-side PDF exporter output.
+
 ### Tiny Drive 1.4.0
 
 The {{site.productname}} 5.8 release includes an accompanying release of **Tiny Drive**.


### PR DESCRIPTION
Related Ticket: DOC-799

Description of Changes:
* Adds a release note entry for Export 1.0.0
* Updates the export plugin page to include changes made for Export 1.0.0
* Adds the export plugin to the supported plugins page (and fixes some minor formatting issues)

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] ~`_data/nav.yml` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
