### PR TITLE
DOC-816: Added A11ychecker release notes

### DIFF
--- a/release-notes/release-notes58.md
+++ b/release-notes/release-notes58.md
@@ -59,6 +59,20 @@ The {{site.productname}} 5.8 release includes an accompanying release of the **<
 
 For information on the <<Premium Plugin Name>> plugin, see: [<<Premium Plugin Name>> plugin]({{site.baseurl}}/plugins/<<Premium Plugin Name>>/).
 
+### Accessibility Checker 2.3.2
+
+The {{site.productname}} 5.8 release includes an accompanying release of the **Accessibility Checker** premium plugin.
+
+**Accessibility Checker** 2.3.2 provides the following bug fixes:
+
+- Fixed an issue where the ordered list structure rule was not enforced when list items were separated by `br` elements.
+- Fixed an issue where adjacent links were not detected when separated by zero-width unicode characters.
+- Fixed an issue that could cause paragraphs that were used as headings to not be detected.
+- Fixed help documentation URLs pointing to old website locations.
+- Fixed dialog button text incorrectly using title-style capitalization.
+
+For information on the Accessibility Checker plugin, see: [Accessibility Checker plugin]({{site.baseurl}}/plugins/premium/a11ychecker/).
+
 ### Comments 2.4.0
 
 The {{site.productname}} 5.8 release includes an accompanying release of the **Comments** premium plugin.
@@ -69,6 +83,8 @@ This release adds new resolve conversation functionality, making it is possible 
 
 - Added a new `tinycomments_resolve` option for adding and configuring resolve conversation functionality for Comments in callback mode. For details, see: [Configuring comments callbacks - `tinycomments_resolve`]({{site.baseurl}}/advanced/configuring-comments-callbacks/#tinycomments_resolve).
 - Added a new `tinycomments_can_resolve` option for adding and configuring resolve conversation functionality for Comments in embedded mode. For details, see: [Comments plugin - `tinycomments_can_resolve`]({{site.baseurl}}/plugins/premium/comments/#tinycomments_can_resolve).
+
+For information on the Comments plugin, see: [Comments plugin]({{site.baseurl}}/plugins/premium/comments/).
 
 ### Export 1.0.0
 


### PR DESCRIPTION
Related Ticket: DOC-816

Description of Changes:
* Add release notes for a11ychecker 2.3.2.
* Fixed missing "see more" link in comments release notes

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] ~`_data/nav.yml` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
