### PR TITLE
DOC-817: Added Spell Checker Pro release notes

### DIFF
--- a/release-notes/release-notes58.md
+++ b/release-notes/release-notes58.md
@@ -83,6 +83,18 @@ The {{site.productname}} 5.8 release includes an accompanying release of the **E
 
 - Fixed an issue where internal document links did not navigate within the client-side PDF exporter output.
 
+For information on the Export plugin, see: [Export plugin]({{site.baseurl}}/plugins/premium/export/).
+
+### Spell Checker Pro 2.3.1
+
+The {{site.productname}} 5.8 release includes an accompanying release of the **Spell Checker Pro** premium plugin.
+
+**Spell Checker Pro** 2.3.1 provides the following bug fixes:
+
+- Fixed as-you-type spellchecking not running when editor content is changed programmatically.
+
+For information on the Spell Checker Pro plugin, see: [Spell Checker Pro plugin]({{site.baseurl}}/plugins/premium/tinymcespellchecker/).
+
 ### Tiny Drive 1.4.0
 
 The {{site.productname}} 5.8 release includes an accompanying release of **Tiny Drive**.


### PR DESCRIPTION
Related Ticket: DOC-816

Description of Changes:
* Add release notes for spellchecker 2.3.1.
* Fixed missing "see more" link in export release notes

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] ~`_data/nav.yml` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
