### PR TITLE
DOC-811: Added PowerPaste release notes and documented gdocs support

### DIFF
--- a/_includes/misc/support-powerpaste.md
+++ b/_includes/misc/support-powerpaste.md
@@ -1,13 +1,13 @@
-## PowerPaste support (Word Copy and Paste)
+## PowerPaste support (Copy and Paste)
 
-{{site.companynameformal}} tests and supports using the PowerPaste plugin for copying content from versions of Microsoft Word and Microsoft Excel:
+{{site.companynameformal}} tests and supports using the PowerPaste plugin for copying content from Google Docs and versions of Microsoft Word and Microsoft Excel:
 
 * Covered by Microsoft Mainstream Support based on the [Microsoft Fixed Lifecycle Policy](https://support.microsoft.com/en-us/help/14085/fixed-lifecycle-policy).
 * Provided by Microsoft Office 365.
 
 ### PowerPaste Feature and Browser Support
 
-PowerPaste (Word copy and paste) is supported on all the browsers supported by {{site.productname}} Enterprise. There is some variances of functionality for different browsers.
+PowerPaste (Copy and Paste) is supported on all the browsers supported by {{site.productname}} Enterprise. There is some variances of functionality for different browsers.
 
 |                       | HTML Cleaning | Improved HTML Cleaning | Image Import  |
 |-----------------------| :-----------: | :--------------------: | :-----------: |
@@ -15,7 +15,7 @@ PowerPaste (Word copy and paste) is supported on all the browsers supported by {
 | Microsoft Edge Latest | {{site.tick}} | {{site.tick}}          | {{site.tick}} |
 | Chrome Latest         | {{site.tick}} | {{site.tick}}          | {{site.tick}} |
 | Firefox Latest        | {{site.tick}} | {{site.tick}}          | {{site.tick}} |
-| Safari Latest         | {{site.tick}} | {{site.tick}}          | {{site.cross}}|
+| Safari Latest         | {{site.tick}} | {{site.tick}}          | {{site.tick}} |
 
 #### HTML Cleaning
 
@@ -23,8 +23,8 @@ On all browsers, PowerPaste provides basic HTML cleaning. For browsers where HTM
 
 #### Improved HTML Cleaning
 
-On browsers that support HTML5 APIs, PowerPaste is able to use improved HTML cleaning techniques.  Improved HTML cleaning uses the HTML5 clipboard APIs to access the clipboard directly. The original document structure and formatting (when importing formatting) is more likely to be preserved. Where available this approach gives the highest fidelity copy and paste from Microsoft Word to HTML.
+On browsers that support HTML5 APIs, PowerPaste is able to use improved HTML cleaning techniques.  Improved HTML cleaning uses the HTML5 clipboard APIs to access the clipboard directly. The original document structure and formatting (when importing formatting) is more likely to be preserved. Where available this approach gives the highest fidelity copy and paste from supported applications to HTML.
 
 #### Image Import
 
-On browsers that support HTML5, PowerPaste is able to import images embedded in the content (e.g. from Microsoft Word) into the editor.  These images can then be uploaded via a HTTP post as required.
+On browsers that support HTML5, PowerPaste is able to import images embedded in the content (e.g. from Microsoft Word) into the editor. These images can then be uploaded via a HTTP post as required.

--- a/_includes/misc/support-powerpaste.md
+++ b/_includes/misc/support-powerpaste.md
@@ -1,9 +1,25 @@
 ## PowerPaste support (Copy and Paste)
 
-{{site.companynameformal}} tests and supports using the PowerPaste plugin for copying content from Google Docs and versions of Microsoft Word and Microsoft Excel:
+This section details supported use of the {{site.companyname}} PowerPaste plugin.
+
+### Pasting from Microsoft Word
+
+{{site.companynameformal}} tests and supports using the PowerPaste plugin for copying content from versions of Microsoft Word and Microsoft Excel:
 
 * Covered by Microsoft Mainstream Support based on the [Microsoft Fixed Lifecycle Policy](https://support.microsoft.com/en-us/help/14085/fixed-lifecycle-policy).
 * Provided by Microsoft Office 365.
+
+### Pasting from Google Docs
+
+{{site.companynameformal}} tests and supports using the PowerPaste plugin for copying content from [Google Docs](https://www.google.com/docs/about/) for:
+
+* Copying content from the latest version of Google Docs.
+* Pasting into any supported version of {{site.productname}} using PowerPaste 5.5.0 or later.
+
+The following may work, but is _not officially supported_:
+
+* Pasting Google Docs content into {{site.productname}} on Microsoft Internet Explorer 11.
+* Copying content from other Google suite applications such as Google Sheets into {{site.productname}}.
 
 ### PowerPaste Feature and Browser Support
 

--- a/_includes/misc/support-powerpaste.md
+++ b/_includes/misc/support-powerpaste.md
@@ -23,7 +23,7 @@ On all browsers, PowerPaste provides basic HTML cleaning. For browsers where HTM
 
 #### Improved HTML Cleaning
 
-On browsers that support HTML5 APIs, PowerPaste is able to use improved HTML cleaning techniques.  Improved HTML cleaning uses the HTML5 clipboard APIs to access the clipboard directly. The original document structure and formatting (when importing formatting) is more likely to be preserved. Where available this approach gives the highest fidelity copy and paste from supported applications to HTML.
+On browsers that support HTML5 APIs, PowerPaste is able to use improved HTML cleaning techniques. Improved HTML cleaning uses the HTML5 clipboard APIs to access the clipboard directly. The original document structure and formatting (when importing formatting) is more likely to be preserved. Where available this approach gives the highest fidelity copy and paste from supported applications to HTML.
 
 #### Image Import
 

--- a/_includes/misc/support-powerpaste.md
+++ b/_includes/misc/support-powerpaste.md
@@ -7,7 +7,7 @@
 
 ### PowerPaste Feature and Browser Support
 
-PowerPaste (Copy and Paste) is supported on all the browsers supported by {{site.productname}} Enterprise. There is some variances of functionality for different browsers.
+PowerPaste (Copy and Paste) is supported on all the browsers supported by {{site.productname}} Enterprise. There are some variances of functionality for different browsers.
 
 |                       | HTML Cleaning | Improved HTML Cleaning | Image Import  |
 |-----------------------| :-----------: | :--------------------: | :-----------: |

--- a/plugins/premium/powerpaste.md
+++ b/plugins/premium/powerpaste.md
@@ -125,7 +125,7 @@ The supported values are:
 
 ### powerpaste_html_import
 
-This option controls how content pasted from sources other than Microsoft Word and Google Docs is filtered. Note that this includes content copied from {{site.productname}} itself.
+This option controls how content pasted from sources other than Microsoft Word and Google Docs are filtered. Note that this includes content copied from {{site.productname}} itself.
 
 **Type:** `String`
 

--- a/plugins/premium/powerpaste.md
+++ b/plugins/premium/powerpaste.md
@@ -121,11 +121,11 @@ The supported values are:
 
 * `clean` - Preserve the structure of the content such as headings, tables and lists but remove inline styles and classes. This results in simple content that uses the site's CSS stylesheet while retaining the semantic structure from the original document.
 * `merge` - Preserve the inline formatting and structure of the original document. Invalid and proprietary styles, tags and attributes are still removed ensuring that the HTML is valid while more closely matching the original document formatting.
-* `prompt` - Prompt the user to choose between the clean and merge options after attempting to paste Microsoft Word content.
+* `prompt` - Prompt the user to choose between the clean and merge options after attempting to paste Google Docs content.
 
 ### powerpaste_html_import
 
-This option controls how content pasted from sources other than Microsoft Word is filtered. Note that this includes content copied from {{site.productname}} itself.
+This option controls how content pasted from sources other than Microsoft Word and Google Docs is filtered. Note that this includes content copied from {{site.productname}} itself.
 
 **Type:** `String`
 

--- a/plugins/premium/powerpaste.md
+++ b/plugins/premium/powerpaste.md
@@ -93,7 +93,9 @@ tinymce.init({
 
 ### powerpaste_word_import
 
-This setting controls how content pasted from Microsoft Word is filtered.
+This option controls how content pasted from Microsoft Word is filtered.
+
+**Type:** `String`
 
 **Default value:** `prompt`
 
@@ -105,16 +107,34 @@ The supported values are:
 
 > **Note:** When using the Windows operating system, copying and pasting content from Microsoft Word 2013 (or later) in "Protected View" will result in plain, unformatted text. This is due to how Protected View interacts with the clipboard.
 
+### powerpaste_googledocs_import
+
+{{site.requires_5_8v}}
+
+This option controls how content pasted from Google Docs is filtered.
+
+**Type:** `String`
+
+**Default value:** `prompt`
+
+The supported values are:
+
+* `clean` - Preserve the structure of the content such as headings, tables and lists but remove inline styles and classes. This results in simple content that uses the site's CSS stylesheet while retaining the semantic structure from the original document.
+* `merge` - Preserve the inline formatting and structure of the original document. Invalid and proprietary styles, tags and attributes are still removed ensuring that the HTML is valid while more closely matching the original document formatting.
+* `prompt` - Prompt the user to choose between the clean and merge options after attempting to paste Microsoft Word content.
+
 ### powerpaste_html_import
 
-This setting controls how content pasted from sources other than Microsoft Word is filtered. Note that this includes content copied from {{site.productname}} itself.
+This option controls how content pasted from sources other than Microsoft Word is filtered. Note that this includes content copied from {{site.productname}} itself.
+
+**Type:** `String`
 
 **Default value:** `clean`
 
 The supported values are:
 
 * `clean` - Preserve the structure of the content such as headings, tables, and lists but remove inline styles and classes. This results in simple content that uses the site's CSS stylesheet while retaining the semantic structure from the original document.
-* `merge` Preserve the inline formatting and structure of the original document. Invalid and proprietary styles, tags and attributes are still removed ensuring that the HTML is valid while more closely matching the original document formatting.
+* `merge` - Preserve the inline formatting and structure of the original document. Invalid and proprietary styles, tags and attributes are still removed ensuring that the HTML is valid while more closely matching the original document formatting.
 * `prompt` - Prompt the user to choose between the clean and merge options after attempting to paste HTML content.
 
 ### powerpaste_allow_local_images
@@ -123,7 +143,7 @@ When set to `true`, Base64 encoded images using a data URI in the copied content
 
 **Default value:** `true`
 
-**Possible values:**  `true`, `false`
+**Possible values:** `true`, `false`
 
 > **Note:** If you configure ***PowerPaste*** to allow local images, you can have {{site.productname}} automatically upload Base64 encoded images for conversion back to a standard image as described on the [image upload documentation]({{ site.baseurl }}/advanced/handle-async-image-uploads/).
 

--- a/release-notes/release-notes58.md
+++ b/release-notes/release-notes58.md
@@ -122,7 +122,10 @@ This release adds support for copying and pasting content from Google Docs, maki
 - Fixed an issue where it was possible for the width to be stripped from a table when pasted.
 - Fixed merge and clean dialog button text incorrectly using title-style capitalization.
 
-For information on the PowerPaste plugin, see: [PowerPaste plugin]({{site.baseurl}}/plugins/premium/powerpaste/).
+For information on:
+
+- The PowerPaste plugin, see: [PowerPaste plugin]({{site.baseurl}}/plugins/premium/powerpaste/).
+- PowerPaste support and compatibility, including Google Docs support, see: [Supported Premium Versions and Platforms - PowerPaste support]({{site.baseurl}}/enterprise/system-requirements/#powerpastesupportcopyandpaste).
 
 ### Spell Checker Pro 2.3.1
 

--- a/release-notes/release-notes58.md
+++ b/release-notes/release-notes58.md
@@ -105,7 +105,7 @@ For information on the Export plugin, see: [Export plugin]({{site.baseurl}}/plug
 
 The {{site.productname}} 5.8 release includes an accompanying release of the **PowerPaste** premium plugin.
 
-This release adds support for copying and pasting content from Google Docs, making it possible to copy and retain styles from Google Docs content. By default, a dialog will now appear asking users if the content should be cleaned or merged when pasting Google Docs content.
+This release adds support for copying and pasting content from Google Docs, making it possible to copy content and retain styles from Google Docs. By default, a dialog will appear asking users if the content should be cleaned or merged when pasting Google Docs content.
 
 **PowerPaste** 5.5.0 provides the following new features:
 

--- a/release-notes/release-notes58.md
+++ b/release-notes/release-notes58.md
@@ -109,7 +109,7 @@ This release adds support for copying and pasting content from Google Docs, maki
 
 **PowerPaste** 5.5.0 provides the following new features:
 
-- Added Google Docs paste support which can be controlled using the new [`powerpaste_googledocs_import`]({{site.baseurl}}/plugins/premium/powerpaste/#powerpaste_googledocs_import) option.
+- Added Google Docs paste support which can be controlled using the new [`powerpaste_googledocs_import` option]({{site.baseurl}}/plugins/premium/powerpaste/#powerpaste_googledocs_import).
 
 **PowerPaste** 5.5.0 provides the following improvements:
 

--- a/release-notes/release-notes58.md
+++ b/release-notes/release-notes58.md
@@ -101,6 +101,29 @@ The {{site.productname}} 5.8 release includes an accompanying release of the **E
 
 For information on the Export plugin, see: [Export plugin]({{site.baseurl}}/plugins/premium/export/).
 
+### PowerPaste 5.5.0
+
+The {{site.productname}} 5.8 release includes an accompanying release of the **PowerPaste** premium plugin.
+
+This release adds support for copying and pasting content from Google Docs, making it possible to copy and retain styles from Google Docs content. By default, a dialog will now appear asking users if the content should be cleaned or merged when pasting Google Docs content.
+
+**PowerPaste** 5.5.0 provides the following new features:
+
+- Added Google Docs paste support which can be controlled using the new [`powerpaste_googledocs_import`]({{site.baseurl}}/plugins/premium/powerpaste/#powerpaste_googledocs_import) option.
+
+**PowerPaste** 5.5.0 provides the following improvements:
+
+- The editor will now show a "loading" screen while paste events are processed.
+
+**PowerPaste** 5.5.0 provides the following bug fixes:
+
+- Fixed an issue where automatic linking didn't work with URLs containing commas in the path.
+- Fixed an issue where tables or images sometimes had negative left margins after being pasted.
+- Fixed an issue where it was possible for the width to be stripped from a table when pasted.
+- Fixed merge and clean dialog button text incorrectly using title-style capitalization.
+
+For information on the PowerPaste plugin, see: [PowerPaste plugin]({{site.baseurl}}/plugins/premium/powerpaste/).
+
 ### Spell Checker Pro 2.3.1
 
 The {{site.productname}} 5.8 release includes an accompanying release of the **Spell Checker Pro** premium plugin.


### PR DESCRIPTION
Related Ticket: DOC-811

Description of Changes:
* Added new `powerpaste_googledocs_import` setting details
* Added PowerPaste 5.5.0 release notes
* Fixed some incorrect `setting` references (should be `option` in the docs)

**Note:** Known issues will be done in a separate PR.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
