### PR TITLE
textarea selector to div for inline examples

### DIFF
--- a/_includes/configuration/event-root.md
+++ b/_includes/configuration/event-root.md
@@ -10,7 +10,7 @@ By default all events gets bound to the editable area. But in some implementatio
 
 ```js
 tinymce.init({
-  selector: 'textarea',  // change this value according to your HTML
+  selector: 'div',  // change this value according to your HTML
   inline: true,
   event_root: '#root'
 });

--- a/_includes/configuration/fixed-toolbar-container.md
+++ b/_includes/configuration/fixed-toolbar-container.md
@@ -10,7 +10,7 @@ This example takes a CSS 3 selector named `'#mytoolbar'` and renders any inline 
 
 ```js
 tinymce.init({
-  selector: 'textarea',  // change this value according to your HTML
+  selector: 'div',  // change this value according to your HTML
   inline: true,
   fixed_toolbar_container: '#mytoolbar'
 });

--- a/_includes/configuration/hidden-input.md
+++ b/_includes/configuration/hidden-input.md
@@ -14,7 +14,7 @@ The **hidden_input** option can be disabled if you don't need these controls.
 
 ```js
 tinymce.init({
-  selector: 'textarea',  // change this value according to your HTML
+  selector: 'div',  // change this value according to your HTML
   inline: true,
   hidden_input: false
 });

--- a/_includes/configuration/toolbar-persist.md
+++ b/_includes/configuration/toolbar-persist.md
@@ -12,7 +12,7 @@ This option disables the automatic show and hide behavior of the toolbar and men
 
 ```js
 tinymce.init({
-  selector: 'textarea',  // change this value according to your HTML
+  selector: 'div',  // change this value according to your HTML
   inline: true,
   toolbar_persist: true
 });

--- a/release-notes/release-notes52.md
+++ b/release-notes/release-notes52.md
@@ -270,7 +270,7 @@ If the editor is set to `inline: true`, and `toolbar_drawer` or `toolbar_mode` i
 
 ```js
 tinymce.init({
-  selector: 'textarea',
+  selector: 'div',
   inline: true,
   toolbar_drawer: 'floating'
 });
@@ -280,7 +280,7 @@ or
 
 ```js
 tinymce.init({
-  selector: 'textarea',
+  selector: 'div',
   inline: true,
   toolbar_mode: 'floating'
 });


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* changing selector for inline examples (textarea to div) 

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
