### PR TITLE
WSRF-243: Use .svg header logo instead of .png

### DIFF
--- a/_includes/template/menu.html
+++ b/_includes/template/menu.html
@@ -192,12 +192,7 @@
       <div class="nav-container__homepage-link-container">
         <a data-marketing="link" type="primary" href="/docs">
           <img
-            src="{{site.baseurl}}/images/for-base/logo-spaces-docs-for-base.png"
-            srcset="
-            {{site.baseurl}}/images/for-base/logo-spaces-docs-for-base.png 1x,
-            {{site.baseurl}}/images/for-base/logo-spaces-docs-for-base@2x.png 2x,
-            {{site.baseurl}}/images/for-base/logo-spaces-docs-for-base@3x.png 3x
-            "
+            src="{{site.baseurl}}/images/for-base/logo-spaces-docs-for-base.svg"
             alt="Tiny logo"
             height="29px"
           />


### PR DESCRIPTION
Related Ticket: WSRF-243

Description of Changes:
* Using **6 KB** SVG logo instead of **76 KB** PNG to reduce download size.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
