### PR TITLE
TINY-7537: exp should be unix timestamp

### DIFF
--- a/rtc/jwt-authentication.md
+++ b/rtc/jwt-authentication.md
@@ -33,7 +33,7 @@ Claims are additional data that can be sent as part of the JWT payload. RTC requ
 | Data | Optional or required | Description |
 |---|:---:|---|
 | `sub` | required | The unique user ID (for example, if `sub` is the same for two clients, you should trust them as if they're the same user). |
-| `exp` | required | The timestamp when the token expires. |
+| `exp` | required | The unix timestamp when the token expires. |
 
 The `sub` field is used to identify users to avoid sending sensitive or identity information to {{site.companyname}} in plain text. By minimizing the information in JWT claims and relying on the client-side resolution of user IDs, no private data will be transmitted through the RTC server without encryption.
 


### PR DESCRIPTION
Related Ticket: TINY-7537

Description of Changes:
* require exp to be the unix timestamp

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- ~[ ] `_data/nav.yml` has been updated (if applicable)~
- ~[ ] Files has been included where required (if applicable)~
- ~[ ] Files removed have been deleted, not just excluded from the build (if applicable)~
- ~[ ] (New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
