### PR TITLE
WSRF-244: Docs performance tweaks

### DIFF
--- a/_includes/template/head.html
+++ b/_includes/template/head.html
@@ -12,10 +12,8 @@
 
     <title>{{ page.meta_title | or:page.title }} | Docs | TinyMCE</title>
 
-    <link href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" rel="stylesheet"/>
+    <link href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" rel="stylesheet" media="print" onload="this.media='all'; this.onload=null;"/>
     <link href="{{ site.shared_baseurl }}{{ site.baseurl }}/css/common.min.css" rel="stylesheet">
-    <link href="{{ site.shared_baseurl }}{{ site.baseurl }}/css/docs.min.css" rel="stylesheet">
-    <link href="//fast.fonts.net/cssapi/5d4ae438-4aca-4c75-8249-d9486d12b12e.css" rel="stylesheet">
 
     {% include_remote {{ site.origin }}/_docs/head.html css="head > *" %}
 


### PR DESCRIPTION
Related Ticket: WSRF-244

Description of Changes:
* Removed Avenir font load from fonts.net in favor of locally hosted files
* Defer the loading of the third-party `docsearch.min.css`
* Remove the link to the `docs.min.css` since it’s contents are now inlined in the `_docs/head.html` partial

Pre-checks:
- [X] Branch prefixed with `feature/` or `hotfix/`
- [n/a] `_data/nav.yml` has been updated (if applicable)
- [n/a] Files has been included where required (if applicable)
- [n/a] Files removed have been deleted, not just excluded from the build (if applicable)
- [n/a] (New product features only) Release Note added
- [x] Updates to the `_docs/head.html` have been deployed (on Staging)

Review:
- [x] Documentation Team Lead has reviewed
- [N/A] Product Manager has reviewed
