### PR TITLE
Fixed 2 broken nav links due to headings being renamed

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -541,7 +541,7 @@
     - url: "#How to create custom autocompleters"
     - url: "#Configuration options"
     - url: "#API"
-    - url: "#Example"
+    - url: "#Interactive example"
   - url: "contextform"
     pages:
     - url: "#Registering a context form"
@@ -589,7 +589,7 @@
     - url: "#URL dialog configuration"
     - url: "#URL dialog instance API"
     - url: "#URL dialog messaging"
-    - url: "#Example"
+    - url: "#Interactive example"
   - url: "toolbarbuttons"
   - url: "typesoftoolbarbuttons"
     pages:


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* I noticed the autocompleter example nav link was broken due to a rename that happened ~9months ago. This fixes the 2 cases I found that were incorrect.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
