### PR TITLE
DOC-849: Add documentation about Jakarta servlet updates

### DIFF
--- a/enterprise/server/index.md
+++ b/enterprise/server/index.md
@@ -43,6 +43,8 @@ Deploy all the WAR files that came packaged with the {{site.productname}} Enterp
 
 The easiest way to deploy these files is to copy them into the *webapps* directory of your Tomcat/Jetty installation and then restart the application server.
 
+> **Note:** Tomcat 10 will require the applications to be placed in *webapps-javaee*. Once placed there they will be converted by Tomcat to the Jakarta servlet framework. [Tomcat 10 Migration guide](https://tomcat.apache.org/migration-10.html#Specification_APIs)
+
 More information can be found in the documentation of your chosen application server:
 
 - [Deploying applications with Tomcat 9.0](https://tomcat.apache.org/tomcat-9.0-doc/deployer-howto.html)

--- a/enterprise/server/index.md
+++ b/enterprise/server/index.md
@@ -43,7 +43,7 @@ Deploy all the WAR files that came packaged with the {{site.productname}} Enterp
 
 The easiest way to deploy these files is to copy them into the *webapps* directory of your Tomcat/Jetty installation and then restart the application server.
 
-> **Note:** Tomcat 10 will require the applications to be placed in *webapps-javaee*. Once placed there they will be converted by Tomcat to the Jakarta servlet framework. [Tomcat 10 Migration guide](https://tomcat.apache.org/migration-10.html#Specification_APIs)
+> **Important:** Tomcat 10 will require the applications to be placed in the *webapps-javaee* directory. Once placed there they will be converted by Tomcat to the Jakarta servlet framework. [Tomcat 10 Migration guide](https://tomcat.apache.org/migration-10.html#Specification_APIs)
 
 More information can be found in the documentation of your chosen application server:
 

--- a/enterprise/system-requirements.md
+++ b/enterprise/system-requirements.md
@@ -35,7 +35,7 @@ JDK 8
     - 8.0.42+
     - 7.0.76+
 
-> **Note:** Tomcat 10 will require WAR files to be places in *webapp-javaee* rather than *webapps* due to the change to Jakarta servlets. Jetty 11 is not currently supported due to this change.
+> **Important:** Tomcat 10 will require WAR files to be placed in the *webapp-javaee* directory rather than the *webapps* directory due to the change to Jakarta servlets. Jetty 11 is not currently supported due to this change.
 
 ### Operating Systems
 

--- a/enterprise/system-requirements.md
+++ b/enterprise/system-requirements.md
@@ -24,13 +24,18 @@ JDK 8
 
 ### Java (J2EE) Application Servers
 
-* Eclipse Jetty 9.4 or later
+* Eclipse Jetty:
+    - 10
+    - 9.4+
 * WebSphere Application Server (WAS) 8 or later
 * Apache Tomcat:
-    - 9 or later
+    - 10 (See note below)
+    - 9+
     - 8.5.12+
     - 8.0.42+
     - 7.0.76+
+
+> **Note:** Tomcat 10 will require WAR files to be places in *webapp-javaee* rather than *webapps* due to the change to Jakarta servlets. Jetty 11 is not currently supported due to this change.
 
 ### Operating Systems
 

--- a/enterprise/system-requirements.md
+++ b/enterprise/system-requirements.md
@@ -25,7 +25,6 @@ JDK 8
 ### Java (J2EE) Application Servers
 
 * Eclipse Jetty:
-    - 10
     - 9.4+
 * WebSphere Application Server (WAS) 8 or later
 * Apache Tomcat:


### PR DESCRIPTION
Document changes to Tomcat and Jetty regarding the move from javax to jakarta
for servlets.

Related Ticket: DOC-849

Description of Changes:
* Update supported version of tomcat and jetty
* Added notes detailing how to use our applications with Tomcat 10

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
