### PR TITLE
DOC-829: Move sticky toolbar offset to enhancements section

### DIFF
--- a/release-notes/release-notes59.md
+++ b/release-notes/release-notes59.md
@@ -28,12 +28,6 @@ keywords: releasenotes bugfixes
 
 The following new features were added for the {{site.productname}} 5.9 release.
 
-### New `toolbar_sticky_offset` option for customizing sticky toolbars
-
-The new `toolbar_sticky_offset` option allows the main toolbar to "dock" at a specified offset from the top or bottom of the view, depending on the toolbar location (set using the [`toolbar_location` option]({{site.baseurl}}/configure/editor-appearance/#toolbar_location)).
-
-For information on the `toolbar_sticky_offset` option, see: [User interface options - toolbar_sticky_offset]({{site.baseurl}}/configure/editor-appearance/#toolbar_sticky_offset).
-
 ### New `language` toolbar button and menu item in core
 
 {{site.productname}} 5.9 now supports multilingual content, using the `lang` attribute. There is a new `language` toolbar button, and a new `language` menu item, both configured using the `content_langs` option. There is also a new `Lang` editor command for changing the language of the selection.
@@ -130,6 +124,12 @@ For information on the Table plugin, see: [Table plugin]({{site.baseurl}}/plugin
 ## Enhancements
 
 The following enhancements were made for the {{site.productname}} 5.9 release.
+
+### New `toolbar_sticky_offset` option for customizing sticky toolbars
+
+The new `toolbar_sticky_offset` option allows the main toolbar to "dock" at a specified offset from the top or bottom of the view, depending on the toolbar location (set using the [`toolbar_location` option]({{site.baseurl}}/configure/editor-appearance/#toolbar_location)).
+
+For information on the `toolbar_sticky_offset` option, see: [User interface options - toolbar_sticky_offset]({{site.baseurl}}/configure/editor-appearance/#toolbar_sticky_offset).
 
 ### Enhancement name
 


### PR DESCRIPTION
Related Ticket: DOC-829

Description of Changes:
* As was discussed yesterday, this should be an improvement not a new feature, so I've moved the release note to the appropriate section.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
