### PR TITLE
DOC-864: Clarify that the new table color map options do not apply to the table dialog

### DIFF
--- a/_includes/configuration/table_background_color_map.md
+++ b/_includes/configuration/table_background_color_map.md
@@ -2,7 +2,7 @@
 
 {{site.requires_5_9v}}
 
-This option is used to specify the default values for the table cell background color picker `tablecellbackgroundcolor`. If no values are defined, the toolbar button and menu item will use the values or default values of the [`color_map` option]({{site.baseurl}}/configure/content-appearance/#color_map). This option accepts Hex, RGB and HSL color values.
+This option is used to specify the default values for the table cell background color picker, which can be opened with the `tablecellbackgroundcolor` toolbar button or menu item. If no values are defined, the toolbar button and menu item will use the values or default values of the [`color_map` option]({{site.baseurl}}/configure/content-appearance/#color_map). This option does not modify the background color picker in the table dialog. This option accepts Hex, RGB and HSL color values.
 
 The [custom color picker]({{site.baseurl}}/configure/content-appearance/#custom_colors) is not available for the `tablecellbackgroundcolor` toolbar button or menu item.
 

--- a/_includes/configuration/table_background_color_map.md
+++ b/_includes/configuration/table_background_color_map.md
@@ -2,7 +2,7 @@
 
 {{site.requires_5_9v}}
 
-This option is used to specify the default values for the table cell background color picker, which can be opened with the `tablecellbackgroundcolor` toolbar button or menu item. If no values are defined, the toolbar button and menu item will use the values or default values of the [`color_map` option]({{site.baseurl}}/configure/content-appearance/#color_map). This option does not modify the background color picker in the table dialog. This option accepts Hex, RGB and HSL color values.
+This option is used to specify the default values for the table cell background color picker, which can be opened with the `tablecellbackgroundcolor` toolbar button or menu item. If no values are defined, the toolbar button and menu item will use the values or default values of the [`color_map` option]({{site.baseurl}}/configure/content-appearance/#color_map). This option does not currently modify the background color picker in the table dialogs. This option accepts Hex, RGB and HSL color values.
 
 The [custom color picker]({{site.baseurl}}/configure/content-appearance/#custom_colors) is not available for the `tablecellbackgroundcolor` toolbar button or menu item.
 

--- a/_includes/configuration/table_background_color_map.md
+++ b/_includes/configuration/table_background_color_map.md
@@ -2,7 +2,7 @@
 
 {{site.requires_5_9v}}
 
-This option is used to specify the default values for the table cell background color picker, which can be opened with the `tablecellbackgroundcolor` toolbar button or menu item. If no values are defined, the toolbar button and menu item will use the values or default values of the [`color_map` option]({{site.baseurl}}/configure/content-appearance/#color_map). This option does not currently modify the background color picker in the table dialogs. This option accepts Hex, RGB and HSL color values.
+This option is used to specify the default values for the table cell background color picker, which can be opened with the `tablecellbackgroundcolor` toolbar button or menu item. If no values are defined, the toolbar button and menu item will use the values or default values of the [`color_map` option]({{site.baseurl}}/configure/content-appearance/#color_map). This option does not modify the background color picker in the table dialogs. This option accepts Hex, RGB and HSL color values.
 
 The [custom color picker]({{site.baseurl}}/configure/content-appearance/#custom_colors) is not available for the `tablecellbackgroundcolor` toolbar button or menu item.
 

--- a/_includes/configuration/table_border_color_map.md
+++ b/_includes/configuration/table_border_color_map.md
@@ -2,7 +2,7 @@
 
 {{site.requires_5_9v}}
 
-This option is used to specify the default values for the table cell border color picker, which can be opened with the `tablecellbordercolor` toolbar button or menu item. If no values are defined, the toolbar button and menu item will use the values or default values of the [`color_map` option]({{site.baseurl}}/configure/content-appearance/#color_map). This option does not modify the border color picker in the table dialog. This option accepts Hex, RGB and HSL color values.
+This option is used to specify the default values for the table cell border color picker, which can be opened with the `tablecellbordercolor` toolbar button or menu item. If no values are defined, the toolbar button and menu item will use the values or default values of the [`color_map` option]({{site.baseurl}}/configure/content-appearance/#color_map). This option does not currently modify the border color picker in the table dialogs. This option accepts Hex, RGB and HSL color values.
 
 The [custom color picker]({{site.baseurl}}/configure/content-appearance/#custom_colors) is not available for the `tablecellbordercolor` toolbar button or menu item.
 

--- a/_includes/configuration/table_border_color_map.md
+++ b/_includes/configuration/table_border_color_map.md
@@ -2,7 +2,7 @@
 
 {{site.requires_5_9v}}
 
-This option is used to specify the default values for the table cell border color picker, which can be opened with the `tablecellbordercolor` toolbar button or menu item. If no values are defined, the toolbar button and menu item will use the values or default values of the [`color_map` option]({{site.baseurl}}/configure/content-appearance/#color_map). This option does not currently modify the border color picker in the table dialogs. This option accepts Hex, RGB and HSL color values.
+This option is used to specify the default values for the table cell border color picker, which can be opened with the `tablecellbordercolor` toolbar button or menu item. If no values are defined, the toolbar button and menu item will use the values or default values of the [`color_map` option]({{site.baseurl}}/configure/content-appearance/#color_map). This option does not modify the border color picker in the table dialogs. This option accepts Hex, RGB and HSL color values.
 
 The [custom color picker]({{site.baseurl}}/configure/content-appearance/#custom_colors) is not available for the `tablecellbordercolor` toolbar button or menu item.
 

--- a/_includes/configuration/table_border_color_map.md
+++ b/_includes/configuration/table_border_color_map.md
@@ -2,7 +2,7 @@
 
 {{site.requires_5_9v}}
 
-This option enables you to specify the default values for the table cell border color picker, which can be opened with the `tablecellbordercolor` toolbar button or menu item. If no values are defined, uses the values of the [`color_map` option]({{site.baseurl}}/configure/content-appearance/#color_map). This option accepts Hex, RGB and HSL color values.
+This option is used to specify the default values for the table cell border color picker, which can be opened with the `tablecellbordercolor` toolbar button or menu item. If no values are defined, the toolbar button and menu item will use the values or default values of the [`color_map` option]({{site.baseurl}}/configure/content-appearance/#color_map). This option does not modify the border color picker in the table dialog. This option accepts Hex, RGB and HSL color values.
 
 The [custom color picker]({{site.baseurl}}/configure/content-appearance/#custom_colors) is not available for the `tablecellbordercolor` toolbar button or menu item.
 

--- a/release-notes/release-notes59.md
+++ b/release-notes/release-notes59.md
@@ -98,13 +98,13 @@ For information on these menu items, see: [Available menu items]({{site.baseurl}
 {{site.productname}} 5.9 adds new options for the Table plugin to improve the user experience when working with tables. These new options are optional, and allows further customization of user experience.
 
 `table_background_color_map`
-: Allows setting a specific set of background colors to be used by the `tablecellbackgroundcolor` toolbar button and menu item, overriding the defaults and the colors provided by the [`color_map` option]({{site.baseurl}}/configure/content-appearance/#color_map). For information on this option, see: [Table options - table_background_color_map]({{site.baseurl}}/plugins/opensource/table/#table_background_color_map)
+: Allows setting a specific set of background colors to be used by the `tablecellbackgroundcolor` toolbar button and menu item, overriding the defaults and the colors provided by the [`color_map` option]({{site.baseurl}}/configure/content-appearance/#color_map). For information on this option, see: [Table options - table_background_color_map]({{site.baseurl}}/plugins/opensource/table/#table_background_color_map).
 
 `table_border_color_map`
-: Allows setting a specific set of border colors to be used by the `tablecellbordercolor` toolbar button and menu item, overriding the defaults and the colors provided by the [`color_map` option]({{site.baseurl}}/configure/content-appearance/#color_map). For information on this option, see: [Table options - table_border_color_map]({{site.baseurl}}/plugins/opensource/table/#table_border_color_map)
+: Allows setting a specific set of border colors to be used by the `tablecellbordercolor` toolbar button and menu item, overriding the defaults and the colors provided by the [`color_map` option]({{site.baseurl}}/configure/content-appearance/#color_map). For information on this option, see: [Table options - table_border_color_map]({{site.baseurl}}/plugins/opensource/table/#table_border_color_map).
 
 `table_border_widths`
-: Allows setting a specific set of widths to be used by the `tablecellborderwidth` toolbar button and menu item. For information on this option, see: [Table options - table_border_widths]({{site.baseurl}}/plugins/opensource/table/#table_border_widths)
+: Allows setting a specific set of widths to be used by the `tablecellborderwidth` toolbar button and menu item. For information on this option, see: [Table options - table_border_widths]({{site.baseurl}}/plugins/opensource/table/#table_border_widths).
 
 `table_border_styles`
 : Allows setting a specific set of HTML border styles to be used by the `tablecellborderstyle` toolbar button and menu item. For information on this option, see: [Table options - table_border_styles]({{site.baseurl}}/plugins/opensource/table/#table_border_styles).


### PR DESCRIPTION
Related Ticket: DOC-864

Description of Changes:
* Clarify that the new table color map options do not apply to the table dialog
* Fix some missing full stops

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] ~`_data/nav.yml` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
