### PR TITLE
Fix language pack links and swapped lang pack sections

### DIFF
--- a/_includes/configuration/language.md
+++ b/_includes/configuration/language.md
@@ -9,8 +9,8 @@ Before changing the language option, ensure that the language pack is available 
 
 For information on:
 
-- Using the premium language packs, see: [Using the premium language packs](#usingthecommunitylanguagepacks).
-- Using the community language packs, see: [Using the community language packs](#usingthepremiumlanguagepacks).
+- Using the premium language packs, see: [Using the premium language packs](#usingthepremiumlanguagepacks).
+- Using the community language packs, see: [Using the community language packs](#usingthecommunitylanguagepacks).
 
 **Option:** `language`
 
@@ -29,10 +29,10 @@ tinymce.init({
 });
 ```
 
-{% include misc/using-community-lang-packs.md %}
-
 ### Using the premium language packs
 
 The following professionally localized language packs are provided to paid {{site.cloudname}} and premium self-hosted deployments. To use these language packs, set the `language` option to the corresponding language code. No additional configuration is required.
 
 {% include misc/ui-languages.md %}
+
+{% include misc/using-community-lang-packs.md %}


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* The URLs for : Using the premium language packs and : Using the community language packs got switched
* Changed the order of subsections

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
