### PR TITLE
DOC-877: Minor support page fixes

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -642,7 +642,6 @@
   - url: "advanced-tables"
   - url: "export"
   - url: "support"
-  - url: "get-tinymce-bugs-fixed"
   - url: "system-requirements"
     pages:
     - url: "#Supported TinyMCE versions"

--- a/_includes/misc/browser_compatibility.md
+++ b/_includes/misc/browser_compatibility.md
@@ -9,8 +9,6 @@
 
 {{site.productname}} may not function as expected on unlisted browsers. Try out the {{site.productname}} examples on {{site.url}} to determine any functional limitations of an unlisted browser.
 
-Please use the [issues tracker on GitHub](https://github.com/tinymce/tinymce/issues) to submit bugs on listed browsers only.
-
 |Browser | Windows       | Mac           | GNU/Linux     |
 |--------|:-------------:|:-------------:|:-------------:|
 |Chrome  | {{site.tick}} | {{site.tick}} | {{site.tick}} |

--- a/_includes/misc/mobile_platform_compatibility.md
+++ b/_includes/misc/mobile_platform_compatibility.md
@@ -10,5 +10,3 @@
 | Android 11    | Chrome  | Mobile phone |
 | iOS/iPadOS 13 | Safari  | iPhone/iPad  |
 | iOS/iPadOS 14 | Safari  | iPhone/iPad  |
-
-Please report platform issues and bugs in the [{{site.productname}} issue tracker](https://github.com/tinymce/tinymce/issues).

--- a/enterprise/get-tinymce-bugs-fixed.md
+++ b/enterprise/get-tinymce-bugs-fixed.md
@@ -6,10 +6,25 @@ description: TinyMCE Enterprise customers get priority fixes of bugs.
 keywords: enterprise bug bugs patch patches
 ---
 
-{{site.productname}} is an open source project that relies on the community, to report and fix bugs. You can do this through our [Github project](https://github.com/tinymce/tinymce).
+## Overview
 
-The team behind {{site.productname}} invests a lot of time in fixing community-reported bugs - particularly high priority issues. Just check out our [changelog]({{ site.baseurl }}/changelog/) and I am sure you will agree!
+Support for {{site.productname}} Enterprise, is provided online through the {{site.supportname}} site.  You can access the support site at: [{{site.supporturl}}]({{site.supporturl}}).
 
-However, we cannot fix all of the issues that are reported. With 5 million downloads a year we have to triage what impacts the most people.
+Prior to opening a support ticket, we require all users to register with a valid business email address. You can register on the support site at: [{{site.supporturl}}/registration]({{site.supporturl}}/registration). Upon registration you will receive an email requesting that you validate your registration. If you don't receive such a request within 5 minutes please check your spam folder to see if the email ended up there in error. If you never receive the validation email please contact the [{{site.companyname}} Client Services team by email](mailto:clientservices@tiny.cloud).
 
-If your company needs specific issues fixed on a timeline, we suggest you sign up for a {{site.accountpage}} to receive priority support. Again, we cannot guarantee that we can fix all bugs, but this is the way to ensure your issues are at the top of the queue.
+### Creating a support ticket
+
+Once you are registered on the site you will be able to interact with the {{site.supportname}} team using our support site.  To create a new ticket simply go to the following URL: [{{site.supporturl}}]({{site.supporturl}}).
+
+Note that {{site.supportname}} requires that you provide the following information along with your ticket:
+
+#### TinyMCE Enterprise Editor Client Issues
+
+* Operating System and Browser version
+* JavaScript Console Log
+* View source of the editor page (or some other means of obtaining the JS used to instantiate the editor)
+
+#### TinyMCE Enterprise Server Components Issues
+
+* Server type and version (eg. Jetty, Tomcat)
+* Server log - This will be available either on the system.out log for the server or in a separate file if you've configured the optional logging parameters for {{site.productname}} Enterprise on you server(s).


### PR DESCRIPTION
Related Ticket: DOC-877

Description of Changes:
* removed `get-tinymce-bugs-fixed` page from nav
* replaced content on `get-tinymce-bugs-fixed` with content from `support` page
* removed bug reporting info on premium support pages

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [ ] Product Manager has reviewed
