### PR TITLE
TINY-7894: Fixed incorrect live demo ids which caused the editor to not hide when swapping tabs

### DIFF
--- a/_includes/live-demos/autocompleter-autocompleteitem/index.html
+++ b/_includes/live-demos/autocompleter-autocompleteitem/index.html
@@ -1,4 +1,4 @@
-<textarea id="autocompleter">
+<textarea id="autocompleter-autocompleteitem">
   <p>Type <b>:</b> below and then keep typing to reduce further matches. For example, typing <b>:amp</b> should show the ampersand item in the menu. Pressing esc should close the autocomplete menu.</p>
   <p></p>
 </textarea>

--- a/_includes/live-demos/autocompleter-autocompleteitem/index.js
+++ b/_includes/live-demos/autocompleter-autocompleteitem/index.js
@@ -9,7 +9,7 @@ var specialChars = [
   { text: 'asterisk', value: '*' }
 ];
 tinymce.init({
-  selector: 'textarea#autocompleter',
+  selector: 'textarea#autocompleter-autocompleteitem',
   height: 250,
   setup: function (editor) {
     var onAction = function (autocompleteApi, rng, value) {

--- a/_includes/live-demos/comments-callback/example.js
+++ b/_includes/live-demos/comments-callback/example.js
@@ -183,7 +183,7 @@ function tinycomments_lookup({ conversationUid }, done, fail) {
 }
 
 tinymce.init({
-  selector: 'textarea#callback-mode',
+  selector: 'textarea#comments-callback',
   height: 800,
   plugins: 'paste code tinycomments help lists',
   toolbar:

--- a/_includes/live-demos/comments-callback/index.html
+++ b/_includes/live-demos/comments-callback/index.html
@@ -1,4 +1,4 @@
-<textarea id="callback-mode">
+<textarea id="comments-callback">
     <h2>Welcome to Tiny Comments!</h2>
     <p>Please try out this demo of our Tiny Comments premium plugin.</p>
     <ol>

--- a/_includes/live-demos/comments-callback/index.js
+++ b/_includes/live-demos/comments-callback/index.js
@@ -644,7 +644,7 @@ tinymce.ScriptLoader.loadScripts(
     }
 
     tinymce.init({
-      selector: 'textarea#callback-mode',
+      selector: 'textarea#comments-callback',
       height: 800,
       plugins: 'paste code tinycomments help lists',
       toolbar:

--- a/_includes/live-demos/comments-embedded/index.html
+++ b/_includes/live-demos/comments-embedded/index.html
@@ -1,5 +1,5 @@
 <div id="tiny-ui">
-  <textarea class="editor" style="width: 100%; height: 500px;">
+  <textarea id="comments-embedded" style="width: 100%; height: 500px;">
     <h2>Welcome to Tiny Comments!</h2>
     <p>Please try out this demo of our new Tiny Comments premium plugin.</p>
     <ol>

--- a/_includes/live-demos/comments-embedded/index.js
+++ b/_includes/live-demos/comments-embedded/index.js
@@ -2,7 +2,7 @@ var currentAuthor = 'A Tiny User';
 var userAllowedToResolve = 'Admin1';
 
 tinymce.init({
-  selector: '#tiny-ui .editor',
+  selector: 'textarea#comments-embedded',
   toolbar: 'bold italic underline | addcomment showcomments',
   menubar: 'file edit view insert format tools tc',
   menu: {

--- a/_includes/live-demos/dialog-pet-machine/index.html
+++ b/_includes/live-demos/dialog-pet-machine/index.html
@@ -1,3 +1,3 @@
-<textarea class="petMachine">
+<textarea id="dialog-pet-machine">
   <p>Click on the custom {;} toolbar button</p>
 </textarea>

--- a/_includes/live-demos/dialog-pet-machine/index.js
+++ b/_includes/live-demos/dialog-pet-machine/index.js
@@ -43,7 +43,7 @@ var dialogConfig =  {
 };
 
 tinymce.init({
-  selector: 'textarea.petMachine',
+  selector: 'textarea#dialog-pet-machine',
   toolbar: 'dialog-example-btn',
   setup: function (editor) {
     editor.ui.registry.addButton('dialog-example-btn', {

--- a/_includes/live-demos/file-picker/index.html
+++ b/_includes/live-demos/file-picker/index.html
@@ -1,1 +1,1 @@
-<textarea id="editor"></textarea>
+<textarea id="file-picker"></textarea>

--- a/_includes/live-demos/file-picker/index.js
+++ b/_includes/live-demos/file-picker/index.js
@@ -1,5 +1,5 @@
 tinymce.init({
-  selector: '#editor',
+  selector: '#file-picker',
   plugins: 'image code',
   toolbar: 'undo redo | link image | code',
   /* enable title field in the Image dialog*/

--- a/_includes/live-demos/file-picker/index.js
+++ b/_includes/live-demos/file-picker/index.js
@@ -1,5 +1,5 @@
 tinymce.init({
-  selector: '#file-picker',
+  selector: 'textarea#file-picker',
   plugins: 'image code',
   toolbar: 'undo redo | link image | code',
   /* enable title field in the Image dialog*/

--- a/_includes/live-demos/format-html5/index.html
+++ b/_includes/live-demos/format-html5/index.html
@@ -1,4 +1,4 @@
-<textarea id="format-hmtl5">
+<textarea id="format-html5">
   <section>Section
     <p>Paragraph</p>
   </section>

--- a/_includes/live-demos/format-html5/index.js
+++ b/_includes/live-demos/format-html5/index.js
@@ -1,5 +1,5 @@
 tinymce.init({
-  selector: 'textarea#format-hmtl5',
+  selector: 'textarea#format-html5',
   height: 500,
   plugins: 'visualblocks',
   style_formats: [

--- a/_includes/live-demos/notifications/index.html
+++ b/_includes/live-demos/notifications/index.html
@@ -1,4 +1,4 @@
-<textarea id="notification">
+<textarea id="notifications">
   {{site.logoForDemosHTML}}
   <h2 style="text-align: center;">Welcome to the TinyMCE editor demo!</h2>
 

--- a/_includes/live-demos/notifications/index.js
+++ b/_includes/live-demos/notifications/index.js
@@ -27,7 +27,7 @@ function createErrorNotification() {
 }
 
 tinymce.init({
-  selector: 'textarea#notification',
+  selector: 'textarea#notifications',
   height: 500,
   menubar: false,
   plugins: [

--- a/_includes/live-demos/open-source-plugins/index.html
+++ b/_includes/live-demos/open-source-plugins/index.html
@@ -1,4 +1,4 @@
-<textarea id="full-featured-non-premium">
+<textarea id="open-source-plugins">
   {{site.logoForDemosHTML}}
   <h2 style="text-align: center;">Welcome to the TinyMCE Cloud demo!</h2>
   <p>Please try out the features provided in this full featured example (excluding <a href="https://www.tiny.cloud/apps/">Premium Plugins</a> ).</p>

--- a/_includes/live-demos/open-source-plugins/index.js
+++ b/_includes/live-demos/open-source-plugins/index.js
@@ -1,7 +1,7 @@
 var useDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
 
 tinymce.init({
-  selector: 'textarea#full-featured-non-premium',
+  selector: 'textarea#open-source-plugins',
   plugins: 'print preview paste importcss searchreplace autolink autosave save directionality code visualblocks visualchars fullscreen image link media template codesample table charmap hr pagebreak nonbreaking anchor toc insertdatetime advlist lists wordcount imagetools textpattern noneditable help charmap quickbars emoticons',
   imagetools_cors_hosts: ['picsum.photos'],
   menubar: 'file edit view insert format tools table help',

--- a/_includes/live-demos/redial-demo/index.html
+++ b/_includes/live-demos/redial-demo/index.html
@@ -1,3 +1,3 @@
-<textarea class="wizard">
+<textarea id="redial-demo">
   <p>Click on the custom {;} toolbar button to open a dialog that uses Redial to render a multipage form.</p>
 </textarea>

--- a/_includes/live-demos/redial-demo/index.js
+++ b/_includes/live-demos/redial-demo/index.js
@@ -90,7 +90,7 @@ var page2Config = {
 };
 
 tinymce.init({
-  selector: 'textarea.wizard',
+  selector: 'textarea#redial-demo',
   toolbar: 'wizardExample',
   height: '900px',
   setup: function (editor) {

--- a/_includes/live-demos/url-dialog/example.js
+++ b/_includes/live-demos/url-dialog/example.js
@@ -1,5 +1,5 @@
 tinymce.init({
-  selector: 'textarea.urldialog',
+  selector: 'textarea#url-dialog',
   toolbar: 'urldialog',
   height: 300,
   setup: function (editor) {

--- a/_includes/live-demos/url-dialog/index.html
+++ b/_includes/live-demos/url-dialog/index.html
@@ -1,3 +1,3 @@
-<textarea class="urldialog">
+<textarea id="url-dialog">
   <p>Click on the custom {;} toolbar button.</p>
 </textarea>

--- a/_includes/live-demos/url-dialog/index.js
+++ b/_includes/live-demos/url-dialog/index.js
@@ -1,5 +1,5 @@
 tinymce.init({
-  selector: 'textarea.urldialog',
+  selector: 'textarea#url-dialog',
   toolbar: 'urldialog',
   height: 300,
   setup: function (editor) {

--- a/ui-components/dialog.md
+++ b/ui-components/dialog.md
@@ -310,7 +310,7 @@ The following example demonstrates one way of implementing a multipage form dial
 
 To see the output of the code, click on the {{site.productname}} tab on the fiddle below.
 
-{% include live-demo.html id="redial" height="900" tab="js" %}
+{% include live-demo.html id="redial-demo" height="900" tab="js" %}
 
 The example JavaScript code contains two dialog configurations - `page1Config` and `page2Config`. The {{site.productname}} initialization code adds a button to the editor that when clicked calls `editor.windowManager.open(page1Config)` to open a dialog using the first configuration.
 


### PR DESCRIPTION
Related Ticket: TINY-7894

Description of Changes:

The live demos for the docs requires the demo name and the id used for the editor to be the same. This is a bit of a flaw and it doesn't work with demos that have multiple editors (e.g. inline, distraction free, RTC, etc...). As such we probably need to look at changing how that logic works but I want to talk to @tylerkelly13 about that first. So for now this fixes a number of issues reported as side notes in TINY-7894, which was caused by the editor not being hidden when swapping tabs.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
