### PR TITLE
Fix minor inaccuracies in RTC snapshot handling

### DIFF
--- a/_includes/configuration/rtc_snapshot.md
+++ b/_includes/configuration/rtc_snapshot.md
@@ -4,7 +4,7 @@ Real-time collaboration integrations regularly store the content, eliminating th
 
 For any given document ID, the server guarantees the version number will only increase. It can be safely used for conflict resolution. For each document ID and version combination, the snapshot content is guaranteed to be identical.
 
-The snapshot callback will be executed shortly after edits are made with access to the serialized editor content. The content is retrieved through a `getContent` function to reduce CPU load if the callback decides to not use the editor content.
+The snapshot callback will be executed in response to local changes, with access to the serialized editor content. The content is retrieved through a `getContent` function to reduce CPU load if the callback decides to not use the editor content.
 
 {% if plugincode != "rtc" %}
 Required plugin

--- a/_includes/configuration/rtc_snapshot.md
+++ b/_includes/configuration/rtc_snapshot.md
@@ -1,10 +1,10 @@
 ### `rtc_snapshot`
 
-Real-time collaboration integrations regularly store the content, eliminating the need for a save button. The {{site.productname}} RTC plugin provides a version number to assist with storing the regular content snapshots. These snapshots are not stored on the RTC server and must be handled by the integrator.
+Real-time collaboration integrations regularly store the content, eliminating the need for a save button. The {{site.productname}} RTC plugin provides a version number to assist with storing the HTML content snapshots. These snapshots are not stored on the RTC server and must be handled by the integrator.
 
 For any given document ID, the server guarantees the version number will only increase. It can be safely used for conflict resolution. For each document ID and version combination, the snapshot content is guaranteed to be identical.
 
-The snapshot callback will be executed at regular intervals with access to the serialized editor content. The content is retrieved through a `getContent` function to reduce CPU load if the callback decides to not use the editor content.
+The snapshot callback will be executed shortly after edits are made with access to the serialized editor content. The content is retrieved through a `getContent` function to reduce CPU load if the callback decides to not use the editor content.
 
 {% if plugincode != "rtc" %}
 Required plugin


### PR DESCRIPTION
The snapshot callback is not executed at regular intervals, but instead after edits are made to the document.

Snapshots are also stored on the server, but only as a editor checkpoint so operations do not need to be replayed from the beginning of the document editing session. By replacing "regular" with "HTML", the statement is more correct. There may be some HTML snapshots currently being sent to the server, but as legacy behaviour that is likely to be removed. (In all cases, these snapshots are encrypted before being sent to the server, and not readable without the client.)

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
