### PR TITLE
DOC-988: Fixed broken code samples, due to incorrectly embedding the COPY CODE button

### DIFF
--- a/advanced/usage-with-module-loaders/reference/content-css.md
+++ b/advanced/usage-with-module-loaders/reference/content-css.md
@@ -31,14 +31,14 @@ Example syntax for including the example content CSS in a bundle:
 <td>npm</td>
 <td>
 <div class="language-js highlighter-rouge"><div class="highlight"><pre class="prettyprint prettyprinted" style=""><code><span class="k"><span class="kwd">import</span></span><span class="pln"> </span><span class="nx"><span class="pln">contentCSS</span></span><span class="pln"> </span><span class="k"><span class="kwd">from</span></span><span class="pln"> </span><span class="s1"><span class="str">'tinymce/skins/content/example/content.css'</span></span><span class="p"><span class="pun">;</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 <tr>
 <td><code>.zip</code>&nbsp;</td>
 <td>
 <div class="language-js highlighter-rouge"><div class="highlight"><pre class="prettyprint prettyprinted" style=""><code><span class="k"><span class="kwd">import</span></span><span class="pln"> </span><span class="nx"><span class="pln">contentCSS</span></span><span class="pln"> </span><span class="k"><span class="kwd">from</span></span><span class="pln"> </span><span class="s1"><span class="str">'../tinymce/skins/content/example/content.css'</span></span><span class="p"><span class="pun">;</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 <tr>
@@ -46,14 +46,14 @@ Example syntax for including the example content CSS in a bundle:
 <td>npm</td>
 <td>
 <div class="language-js highlighter-rouge"><div class="highlight"><pre class="prettyprint prettyprinted" style=""><code><span class="kd"><span class="kwd">var</span></span><span class="pln"> </span><span class="nx"><span class="pln">contentCSS</span></span><span class="pln"> </span><span class="o"><span class="pun">=</span></span><span class="pln"> </span><span class="nx"><span class="kwd">require</span></span><span class="p"><span class="pun">(</span></span><span class="s1"><span class="str">'tinymce/skins/content/example/content.css'</span></span><span class="p"><span class="pun">);</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 <tr>
 <td><code>.zip</code>&nbsp;</td>
 <td>
 <div class="language-js highlighter-rouge"><div class="highlight"><pre class="prettyprint prettyprinted" style=""><code><span class="kd"><span class="kwd">var</span></span><span class="pln"> </span><span class="nx"><span class="pln">contentCSS</span></span><span class="pln"> </span><span class="o"><span class="pun">=</span></span><span class="pln"> </span><span class="nx"><span class="kwd">require</span></span><span class="p"><span class="pun">(</span></span><span class="s1"><span class="str">'../tinymce/skins/content/example/content.css'</span></span><span class="p"><span class="pun">);</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 </tbody>

--- a/advanced/usage-with-module-loaders/reference/icons.md
+++ b/advanced/usage-with-module-loaders/reference/icons.md
@@ -32,14 +32,14 @@ Example syntax for including the example icon pack in a bundle:
 <td>npm</td>
 <td>
 <div class="language-js highlighter-rouge"><div class="highlight"><pre class="prettyprint prettyprinted" style=""><code><span class="k"><span class="kwd">import</span></span><span class="pln"> </span><span class="s1"><span class="str">'tinymce/icons/example'</span></span><span class="p"><span class="pun">;</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 <tr>
 <td><code>.zip</code>&nbsp;</td>
 <td>
 <div class="language-js highlighter-rouge"><div class="highlight"><pre class="prettyprint prettyprinted" style=""><code><span class="k"><span class="kwd">import</span></span><span class="pln"> </span><span class="s1"><span class="str">'../tinymce/icons/example/icons'</span></span><span class="p"><span class="pun">;</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 <tr>
@@ -47,14 +47,14 @@ Example syntax for including the example icon pack in a bundle:
 <td>npm</td>
 <td>
 <div class="language-js highlighter-rouge"><div class="highlight"><pre class="prettyprint prettyprinted" style=""><code><span class="nx"><span class="kwd">require</span></span><span class="p"><span class="pun">(</span></span><span class="s1"><span class="str">'tinymce/icons/example'</span></span><span class="p"><span class="pun">);</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 <tr>
 <td><code>.zip</code>&nbsp;</td>
 <td>
 <div class="language-js highlighter-rouge"><div class="highlight"><pre class="prettyprint prettyprinted" style=""><code><span class="nx"><span class="kwd">require</span></span><span class="p"><span class="pun">(</span></span><span class="s1"><span class="str">'../tinymce/icons/example/icons.js'</span></span><span class="p"><span class="pun">);</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 </tbody>

--- a/advanced/usage-with-module-loaders/reference/localization.md
+++ b/advanced/usage-with-module-loaders/reference/localization.md
@@ -43,14 +43,14 @@ The following table shows examples of the syntax used to bundle the following ex
 <td>npm</td>
 <td>
 <div class="language-js highlighter-rouge"><div class="highlight"><pre class="prettyprint prettyprinted" style=""><code><span class="k"><span class="kwd">import</span></span><span class="pln"> </span><span class="s1"><span class="str">'tinymce/langs/sv_SE'</span></span><span class="p"><span class="pun">;</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 <tr>
 <td><code>.zip</code>&nbsp;</td>
 <td>
 <div class="language-js highlighter-rouge"><div class="highlight"><pre class="prettyprint prettyprinted" style=""><code><span class="k"><span class="kwd">import</span></span><span class="pln"> </span><span class="s1"><span class="str">'../tinymce/langs/sv_SE'</span></span><span class="p"><span class="pun">;</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 <tr>
@@ -58,14 +58,14 @@ The following table shows examples of the syntax used to bundle the following ex
 <td>npm</td>
 <td>
 <div class="language-js highlighter-rouge"><div class="highlight"><pre class="prettyprint prettyprinted" style=""><code><span class="nx"><span class="kwd">require</span></span><span class="p"><span class="pun">(</span></span><span class="s1"><span class="str">'tinymce/langs/sv_SE'</span></span><span class="p"><span class="pun">);</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 <tr>
 <td><code>.zip</code>&nbsp;</td>
 <td>
 <div class="language-js highlighter-rouge"><div class="highlight"><pre class="prettyprint prettyprinted" style=""><code><span class="nx"><span class="kwd">require</span></span><span class="p"><span class="pun">(</span></span><span class="s1"><span class="str">'../tinymce/langs/sv_SE.js'</span></span><span class="p"><span class="pun">);</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 </tbody>

--- a/advanced/usage-with-module-loaders/reference/plugins.md
+++ b/advanced/usage-with-module-loaders/reference/plugins.md
@@ -35,7 +35,7 @@ Example syntax for including the example "plugin" in a bundle:
 <td>
 <div class="language-js highlighter-rouge"><div class="highlight"><pre class="prettyprint prettyprinted" style=""><code><span class="k"><span class="kwd">import</span></span><span class="pln"> </span><span class="nx"><span class="pln">pluginCss</span></span><span class="pln"> </span><span class="k"><span class="kwd">from</span></span><span class="pln"> </span><span class="s1"><span class="str">'tinymce/plugins/example/content.css'</span></span><span class="p"><span class="pun">;</span></span><span class="pln">
 </span><span class="k"><span class="kwd">import</span></span><span class="pln"> </span><span class="s1"><span class="str">'tinymce/plugins/example'</span></span><span class="p"><span class="pun">;</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 <tr>
@@ -43,7 +43,7 @@ Example syntax for including the example "plugin" in a bundle:
 <td>
 <div class="language-js highlighter-rouge"><div class="highlight"><pre class="prettyprint prettyprinted" style=""><code><span class="k"><span class="kwd">import</span></span><span class="pln"> </span><span class="nx"><span class="pln">pluginCss</span></span><span class="pln"> </span><span class="k"><span class="kwd">from</span></span><span class="pln"> </span><span class="s1"><span class="str">'../tinymce/plugins/example/content.css'</span></span><span class="p"><span class="pun">;</span></span><span class="pln">
 </span><span class="k"><span class="kwd">import</span></span><span class="pln"> </span><span class="s1"><span class="str">'../tinymce/plugins/example/plugin'</span></span><span class="p"><span class="pun">;</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 <tr>
@@ -52,7 +52,7 @@ Example syntax for including the example "plugin" in a bundle:
 <td>
 <div class="language-js highlighter-rouge"><div class="highlight"><pre class="prettyprint prettyprinted" style=""><code><span class="kd"><span class="kwd">var</span></span><span class="pln"> </span><span class="nx"><span class="pln">pluginCss</span></span><span class="pln"> </span><span class="o"><span class="pun">=</span></span><span class="pln"> </span><span class="nx"><span class="kwd">require</span></span><span class="p"><span class="pun">(</span></span><span class="s1"><span class="str">'tinymce/plugins/example/content.css'</span></span><span class="p"><span class="pun">);</span></span><span class="pln">
 </span><span class="nx"><span class="kwd">require</span></span><span class="p"><span class="pun">(</span></span><span class="s1"><span class="str">'tinymce/plugins/example'</span></span><span class="p"><span class="pun">);</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 <tr>
@@ -60,7 +60,7 @@ Example syntax for including the example "plugin" in a bundle:
 <td>
 <div class="language-js highlighter-rouge"><div class="highlight"><pre class="prettyprint prettyprinted" style=""><code><span class="kd"><span class="kwd">var</span></span><span class="pln"> </span><span class="nx"><span class="pln">pluginCss</span></span><span class="pln"> </span><span class="o"><span class="pun">=</span></span><span class="pln"> </span><span class="nx"><span class="kwd">require</span></span><span class="p"><span class="pun">(</span></span><span class="s1"><span class="str">'../tinymce/plugins/example/content.css'</span></span><span class="p"><span class="pun">);</span></span><span class="pln">
 </span><span class="nx"><span class="kwd">require</span></span><span class="p"><span class="pun">(</span></span><span class="s1"><span class="str">'../tinymce/plugins/example/plugin.js'</span></span><span class="p"><span class="pun">);</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 </tbody>

--- a/advanced/usage-with-module-loaders/reference/skins.md
+++ b/advanced/usage-with-module-loaders/reference/skins.md
@@ -48,7 +48,7 @@ Example syntax for including the example icon pack in a bundle:
 </span><span class="k"><span class="kwd">import</span></span><span class="pln"> </span><span class="s1"><span class="str">'tinymce/skins/ui/example/skin.css'</span></span><span class="p"><span class="pun">;</span></span><span class="pln">
 </span><span class="cm"><span class="com">/* Only required for inline editors */</span></span><span class="pln">
 </span><span class="k"><span class="kwd">import</span></span><span class="pln"> </span><span class="nx"><span class="pln">contentUiInlineCss</span></span><span class="pln"> </span><span class="k"><span class="kwd">from</span></span><span class="pln"> </span><span class="s1"><span class="str">'tinymce/skins/ui/example/content.inline.css'</span></span><span class="p"><span class="pun">;</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 <tr>
@@ -58,7 +58,7 @@ Example syntax for including the example icon pack in a bundle:
 </span><span class="k"><span class="kwd">import</span></span><span class="pln"> </span><span class="s1"><span class="str">'../tinymce/skins/ui/example/skin.css'</span></span><span class="p"><span class="pun">;</span></span><span class="pln">
 </span><span class="cm"><span class="com">/* Only required for inline editors */</span></span><span class="pln">
 </span><span class="k"><span class="kwd">import</span></span><span class="pln"> </span><span class="nx"><span class="pln">contentUiInlineCss</span></span><span class="pln"> </span><span class="k"><span class="kwd">from</span></span><span class="pln"> </span><span class="s1"><span class="str">'../tinymce/skins/ui/example/content.inline.css'</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 <tr>
@@ -69,7 +69,7 @@ Example syntax for including the example icon pack in a bundle:
 </span><span class="nx"><span class="kwd">require</span></span><span class="p"><span class="pun">(</span></span><span class="s1"><span class="str">'tinymce/skins/ui/example/skin.css'</span></span><span class="p"><span class="pun">);</span></span><span class="pln">
 </span><span class="cm"><span class="com">/* Only required for inline editors */</span></span><span class="pln">
 </span><span class="kd"><span class="kwd">var</span></span><span class="pln"> </span><span class="nx"><span class="pln">contentUiInlineCss</span></span><span class="pln"> </span><span class="o"><span class="pun">=</span></span><span class="pln"> </span><span class="nx"><span class="kwd">require</span></span><span class="p"><span class="pun">(</span></span><span class="s1"><span class="str">'tinymce/skins/ui/example/content.inline.css'</span></span><span class="p"><span class="pun">);</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 <tr>
@@ -79,7 +79,7 @@ Example syntax for including the example icon pack in a bundle:
 </span><span class="nx"><span class="kwd">require</span></span><span class="p"><span class="pun">(</span></span><span class="s1"><span class="str">'../tinymce/skins/ui/example/skin.css'</span></span><span class="p"><span class="pun">);</span></span><span class="pln">
 </span><span class="cm"><span class="com">/* Only required for inline editors */</span></span><span class="pln">
 </span><span class="kd"><span class="kwd">var</span></span><span class="pln"> </span><span class="nx"><span class="pln">contentUiInlineCss</span></span><span class="pln"> </span><span class="o"><span class="pun">=</span></span><span class="pln"> </span><span class="nx"><span class="kwd">require</span></span><span class="p"><span class="pun">(</span></span><span class="s1"><span class="str">'../tinymce/skins/ui/example/content.inline.css'</span></span><span class="p"><span class="pun">);</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 </tbody>

--- a/advanced/usage-with-module-loaders/reference/themes.md
+++ b/advanced/usage-with-module-loaders/reference/themes.md
@@ -32,14 +32,14 @@ Example syntax for including the silver theme in a bundle:
 <td>npm</td>
 <td>
 <div class="language-js highlighter-rouge"><div class="highlight"><pre class="prettyprint prettyprinted" style=""><code><span class="k"><span class="kwd">import</span></span><span class="pln"> </span><span class="s1"><span class="str">'tinymce/themes/silver'</span></span><span class="p"><span class="pun">;</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 <tr>
 <td><code>.zip</code>&nbsp;</td>
 <td>
 <div class="language-js highlighter-rouge"><div class="highlight"><pre class="prettyprint prettyprinted" style=""><code><span class="k"><span class="kwd">import</span></span><span class="pln"> </span><span class="s1"><span class="str">'../tinymce/themes/silver/theme'</span></span><span class="p"><span class="pun">;</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 <tr>
@@ -47,14 +47,14 @@ Example syntax for including the silver theme in a bundle:
 <td>npm</td>
 <td>
 <div class="language-js highlighter-rouge"><div class="highlight"><pre class="prettyprint prettyprinted" style=""><code><span class="nx"><span class="kwd">require</span></span><span class="p"><span class="pun">(</span></span><span class="s1"><span class="str">'tinymce/themes/silver'</span></span><span class="p"><span class="pun">);</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 <tr>
 <td><code>.zip</code>&nbsp;</td>
 <td>
 <div class="language-js highlighter-rouge"><div class="highlight"><pre class="prettyprint prettyprinted" style=""><code><span class="nx"><span class="kwd">require</span></span><span class="p"><span class="pun">(</span></span><span class="s1"><span class="str">'../tinymce/themes/silver/theme.js'</span></span><span class="p"><span class="pun">);</span></span>
-</code><button class="copy-to-clipboard-button">COPY CODE</button></pre></div></div>
+</code></pre></div></div>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
Related Ticket: DOC-988

Description of Changes:

The `COPY CODE` button is added via JS, so it was ending up in the DOM twice due to it being embedded in these code examples. This in turn lead to the button only ever placing the button text onto the clipboard instead of the code example. As such, this just removes all the buttons that were incorrectly embedded into the output.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
