### PR TITLE
Clarified that `forced_root_block: false` isn't supported for RTC in the deprecations page

### DIFF
--- a/release-notes/6.0-upcoming-changes.md
+++ b/release-notes/6.0-upcoming-changes.md
@@ -56,7 +56,7 @@ toolbar_mode
 : The [`toolbar_mode`]({{site.baseurl}}/configure/editor-appearance/#toolbar_mode) option no-longer accepts the `false` value in {{site.productname}} 6.0, which was retained for backwards compatibility with the `toolbar_drawer` option. Use `'wrap'` instead to keep the same functionality as `false`.
 
 forced_root_block
-: The [`forced_root_block`]({{site.baseurl}}/configure/content-filtering/#forced_root_block) option no-longer accepts the `false` value or an empty string value in {{site.productname}} 6.0. Setting `forced_root_block` to `false` blocks most editor functionality from working and caused non-semantic HTML to be generated.
+: The [`forced_root_block`]({{site.baseurl}}/configure/content-filtering/#forced_root_block) option no-longer accepts the `false` value or an empty string value in {{site.productname}} 6.0. Setting `forced_root_block` to `false` is not compatible with Real-Time Collaboration, blocks various editor functionality from working and caused non-semantic HTML to be generated.
 
 The following options have been deprecated in {{site.productname}} 5.10 or earlier and will be removed in {{site.productname}} 6.0.
 


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* This clarifies `forced_root_block: false` also doesn't/won't work for RTC and also changes the language a little, as it wasn't most but certain parts that wouldn't work.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] ~(New product features only) Release Note added~

Review:
- [ ] Documentation Team Lead has reviewed
- [ ] Product Manager has reviewed
