### PR TITLE
DOC-1532: Fixed markdown -> asciidoc conversion issues for bundling

### DIFF
--- a/modules/ROOT/pages/browserify_cjs_download.adoc
+++ b/modules/ROOT/pages/browserify_cjs_download.adoc
@@ -1,16 +1,13 @@
 = Bundling a .zip version of TinyMCE with CommonJS and Browserify
 
 :title_nav: CommonJS and a .zip archive
-
 :description_short: Bundling a .zip archive version of TinyMCE in a project using CommonJS and Browserify
 :description: Bundling a .zip archive version of TinyMCE in a project using CommonJS and Browserify
 :keywords: browserify commonjs cjs zip modules tinymce
-
-:installtype: a `+.zip+`
-
-:bundler: https
-://browserify.org/[Browserify]
+:installtype: pass:n[a `+.zip+`]
+:bundler: https://browserify.org/[Browserify]
 :syntax: http://www.commonjs.org/specs/modules/1.0/[CommonJS syntax]
+
 include::partial$module-loading/bundling-procedure-intro.adoc[]
 
 == Requirements
@@ -24,7 +21,6 @@ This guide requires the following:
 
 :is_zip_install: true
 
-
 include::partial$install/download-tinymce.adoc[]
 include::partial$module-loading/browserify-dev-dependencies.adoc[]
 
@@ -32,7 +28,6 @@ include::partial$module-loading/bundling-browserify-cjs-zip_editor.adoc[]
 
 include::partial$module-loading/bundling-browserify-cjs-main.adoc[]
 
-[arabic]
 . Run Browserify to test the bundle, such as:
 +
 [source,sh]
@@ -42,8 +37,6 @@ browserify -t brfs -g browserify-css src/main.js -o dist/main.bundle.js
 +
 If Browserify runs successfully, check that the editor loads in the application. If Browserify fails, review any errors and review the configuration changes in this procedure; you may need to adjust for conflicts or other issues when bundling {productname} into an existing project.
 
-:is_zip_install: nil
-
-
+:!is_zip_install:
 
 include::partial$module-loading/bundling-next-steps.adoc[]

--- a/modules/ROOT/pages/browserify_cjs_npm.adoc
+++ b/modules/ROOT/pages/browserify_cjs_npm.adoc
@@ -1,16 +1,13 @@
 = Bundling an npm version of TinyMCE with CommonJS and Browserify
 
 :title_nav: CommonJS and npm
-
 :description_short: Bundling an npm version of TinyMCE in a project using CommonJS and Browserify
 :description: Bundling an npm version of TinyMCE in a project using CommonJS and Browserify
 :keywords: browserify commonjs cjs npm modules tinymce
-
 :installtype: an npm
-
-:bundler: https
-://browserify.org/[Browserify]
+:bundler: https://browserify.org/[Browserify]
 :syntax: http://www.commonjs.org/specs/modules/1.0/[CommonJS syntax]
+
 include::partial$module-loading/bundling-procedure-intro.adoc[]
 
 == Requirements
@@ -25,15 +22,12 @@ This guide requires the following:
 
 :is_zip_install: false
 
-
-
 include::partial$module-loading/browserify-dev-dependencies.adoc[]
 
 include::partial$module-loading/bundling-browserify-cjs-npm_editor.adoc[]
 
 include::partial$module-loading/bundling-browserify-cjs-main.adoc[]
 
-[arabic]
 . Run Browserify to test the bundle, such as:
 +
 [source,sh]
@@ -43,8 +37,6 @@ browserify -t brfs -g browserify-css src/main.js -o dist/main.bundle.js
 +
 If Browserify runs successfully, check that the editor loads in the application. If Browserify fails, review any errors and review the configuration changes in this procedure; you may need to adjust for conflicts or other issues when bundling {productname} into an existing project.
 
-:is_zip_install: nil
-
-
+:!is_zip_install:
 
 include::partial$module-loading/bundling-next-steps.adoc[]

--- a/modules/ROOT/pages/bundling-content-css.adoc
+++ b/modules/ROOT/pages/bundling-content-css.adoc
@@ -1,12 +1,12 @@
 = Bundling TinyMCE content CSS using module loading
 
 :title_nav: Content CSS
-
 :description_short: Information on bundling the editor content CSS
 :description: Information on bundling the editor content CSS using module loading
+
 :editorcomponent: content CSS
 include::partial$module-loading/bundling-ref-example.adoc[]
-:editorcomponent: nil
+:!editorcomponent:
 
 The following table shows examples of the syntax used to bundle the following content CSS file:
 
@@ -50,8 +50,6 @@ a|
 var contentCSS = require('../tinymce/skins/content/example/content.css');
 ----
 |===
-____
-*Important*: The handling of content CSS files (such as `+content.css+` or `+content.min.css+`) varies between bundling tools. View the relevant guide for the required syntax at link:usage-with-module-loaders.html[Bundling {productname} with a module loader].
-____
+IMPORTANT: The handling of content CSS files (such as `+content.css+` or `+content.min.css+`) varies between bundling tools. View the relevant guide for the required syntax at link:usage-with-module-loaders.html[Bundling {productname} with a module loader].
 
 include::partial$module-loading/bundling-content-css-files.adoc[]

--- a/modules/ROOT/pages/bundling-icons.adoc
+++ b/modules/ROOT/pages/bundling-icons.adoc
@@ -1,15 +1,12 @@
 = Bundling TinyMCE icon packs using module loading
 
 :title_nav: Icons
-
 :description_short: Information on bundling icon packs
 :description: Information on bundling TinyMCE icon packs using module loading
 
 :editorcomponent: icon pack
-
-
 include::partial$module-loading/bundling-ref-example.adoc[]
-:editorcomponent: nil
+:!editorcomponent:
 
 The following table shows examples of the syntax used to bundle the following icon pack:
 

--- a/modules/ROOT/pages/bundling-localization.adoc
+++ b/modules/ROOT/pages/bundling-localization.adoc
@@ -1,30 +1,27 @@
 = Bundling the User Interface localizations for TinyMCE
 
 :title_nav: UI localizations
-
 :description_short: Information on bundling User Interface localizations
 :description: Information on bundling User Interface localizations
 
 == Overview
 
-* <<usingcommunitylocalizations, Using community localizations>>
-* <<usingpremiumself-hostedlocalizations, Using premium self-hosted localizations>>
+* xref:usingcommunitylocalizations[Using community localizations]
+* xref:usingpremiumself-hostedlocalizations[Using premium self-hosted localizations]
 
+[[usingcommunitylocalizations]]
 == Using community localizations
 
 :forModuleLoaders: true
-
-
-include::partial$misc/using-community-lang-packs.adoc[]
+include::partial$misc/using-community-lang-packs.adoc[leveloffset=+1]
 :forModuleLoaders: false
 
+[[usingpremiumself-hostedlocalizations]]
 == Using premium self-hosted localizations
 
 :editorcomponent: localization
-
-
-include::partial$module-loading/bundling-ref-example.adoc[]
-:editorcomponent: nil
+include::partial$module-loading/bundling-ref-example.adoc[leveloffset=+1]
+:!editorcomponent:
 
 The following table shows examples of the syntax used to bundle the following example localization file:
 
@@ -68,7 +65,5 @@ require('../tinymce/langs/sv_SE.js');
 |===
 
 :forModuleLoaders: true
-
-
-include::partial$misc/ui-languages.adoc[]
+include::partial$misc/ui-languages.adoc[leveloffset=+1]
 :forModuleLoaders: false

--- a/modules/ROOT/pages/bundling-plugins.adoc
+++ b/modules/ROOT/pages/bundling-plugins.adoc
@@ -1,12 +1,12 @@
 = Bundling TinyMCE plugins using module loading
 
 :title_nav: Plugins
-
 :description_short: Information on bundling plugins
 :description: Information on bundling TinyMCE plugins using module loading
+
 :editorcomponent: plugin
 include::partial$module-loading/bundling-ref-example.adoc[]
-:editorcomponent: nil
+:!editorcomponent:
 
 The following table shows examples of the syntax used to bundle the following plugin.
 
@@ -58,8 +58,6 @@ require('../tinymce/plugins/example/plugin.js');
 ----
 |===
 
-____
-*Important*: The handling of content CSS files (such as `+content.css+` or `+content.min.css+`) varies between bundling tools. View the relevant guide for the required syntax at link:usage-with-module-loaders.html[Bundling {productname} with a module loader].
-____
+IMPORTANT: The handling of content CSS files (such as `+content.css+` or `+content.min.css+`) varies between bundling tools. View the relevant guide for the required syntax at link:usage-with-module-loaders.html[Bundling {productname} with a module loader].
 
 include::partial$module-loading/bundling-plugin-files.adoc[]

--- a/modules/ROOT/pages/bundling-skins.adoc
+++ b/modules/ROOT/pages/bundling-skins.adoc
@@ -1,12 +1,12 @@
 = Bundling TinyMCE skins using module loading
 
 :title_nav: Skins
-
 :description_short: Information on bundling TinyMCE skins
 :description: Information on bundling TinyMCE skins using module loading
+
 :editorcomponent: skin
 include::partial$module-loading/bundling-ref-example.adoc[]
-:editorcomponent: nil
+:!editorcomponent:
 
 The following table shows examples of the syntax used to bundle the following skin:
 
@@ -32,11 +32,9 @@ Optional files for the example skin:
 
 Example syntax for including the example icon pack in a bundle:
 
-____
-*Important*: The handling of content CSS files (such as `+content.css+` or `+content.min.css+`) varies between bundling tools. View the relevant guide for the required syntax at link:usage-with-module-loaders.html[Bundling {productname} with a module loader].
-____
+IMPORTANT: The handling of content CSS files (such as `+content.css+` or `+content.min.css+`) varies between bundling tools. View the relevant guide for the required syntax at link:usage-with-module-loaders.html[Bundling {productname} with a module loader].
 
-\{% comment %}
+////
 
 [source,js]
 ----
@@ -70,6 +68,6 @@ require('../tinymce/skins/ui/example/skin.css');
 var contentUiInlineCss = require('../tinymce/skins/ui/example/content.inline.css');
 ----
 
-\{% endcomment %}
+////
 
 include::partial$module-loading/bundling-skin-files.adoc[]

--- a/modules/ROOT/pages/bundling-themes.adoc
+++ b/modules/ROOT/pages/bundling-themes.adoc
@@ -1,12 +1,12 @@
 = Bundling TinyMCE themes using module loading
 
 :title_nav: Themes
-
 :description_short: Information on bundling themes
 :description: Information on bundling TinyMCE themes using module loading
+
 :editorcomponent: theme
 include::partial$module-loading/bundling-ref-example.adoc[]
-:editorcomponent: nil
+:!editorcomponent:
 
 The following table shows examples of the syntax used to bundle the silver theme:
 

--- a/modules/ROOT/pages/introduction_to_bundling_tinymce.adoc
+++ b/modules/ROOT/pages/introduction_to_bundling_tinymce.adoc
@@ -28,9 +28,9 @@ The following guides and reference pages assist with bundling {productname} usin
 
 == Reference
 
-* link:plugins.html[Plugins]
-* link:content-css.html[Content CSS]
-* link:skins.html[Skins]
-* link:icons.html[Icons]
-* link:localization.html[UI localizations]
-* link:themes.html[Themes]
+* link:bundling-plugins.html[Plugins]
+* link:bundling-content-css.html[Content CSS]
+* link:bundling-skins.html[Skins]
+* link:bundling-icons.html[Icons]
+* link:bundling-localization.html[UI localizations]
+* link:bundling-themes.html[Themes]

--- a/modules/ROOT/pages/rollup_es6_download.adoc
+++ b/modules/ROOT/pages/rollup_es6_download.adoc
@@ -1,16 +1,13 @@
 = Bundling a .zip version of TinyMCE with ES6 and Rollup.js
 
 :title_nav: ES6 and a .zip archive
-
 :description_short: Bundling a .zip archive version of TinyMCE in a project using ES6 and Rollup.js
 :description: Bundling a .zip archive version of TinyMCE in a project using ES6 and Rollup.js
 :keywords: rollupjs es6 es2015 zip modules tinymce
-
-:installtype: a `+.zip+`
-
-:bundler: https
-://www.rollupjs.org/[Rollup.js]
+:installtype: pass:n[a `+.zip+`]
+:bundler: https://www.rollupjs.org/[Rollup.js]
 :syntax: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules[ES6+ syntax]
+
 include::partial$module-loading/bundling-procedure-intro.adoc[]
 
 == Requirements
@@ -24,7 +21,6 @@ This guide requires the following:
 
 :is_zip_install: true
 
-
 include::partial$install/download-tinymce.adoc[]
 
 include::partial$module-loading/webpack-dev-dependencies.adoc[]
@@ -35,7 +31,6 @@ include::partial$module-loading/bundling-rollup-es6-zip_rollup.config.adoc[]
 
 include::partial$module-loading/bundling-rollup-es6-index.adoc[]
 
-[arabic]
 . Run Rollup.js to test the bundle, such as:
 +
 [source,sh]
@@ -45,8 +40,6 @@ rollup --config
 +
 If Rollup.js runs successfully, check that the editor loads in the application. If Rollup.js fails, review any errors and review the configuration changes in this procedure; you may need to adjust for conflicts or other issues when bundling {productname} into an existing project.
 
-:is_zip_install: nil
-
-
+:!is_zip_install:
 
 include::partial$module-loading/bundling-next-steps.adoc[]

--- a/modules/ROOT/pages/rollup_es6_npm.adoc
+++ b/modules/ROOT/pages/rollup_es6_npm.adoc
@@ -1,16 +1,13 @@
 = Bundling an npm version of TinyMCE with ES6 and Rollup.js
 
 :title_nav: ES6 and npm
-
 :description_short: Bundling an npm version of TinyMCE in a project using ES6 and Rollup.js
 :description: Bundling an npm version of TinyMCE in a project using ES6 and Rollup.js
 :keywords: rollupjs es6 es2015 npm modules tinymce
-
 :installtype: an npm
-
-:bundler: https
-://www.rollupjs.org/[Rollup.js]
+:bundler: https://www.rollupjs.org/[Rollup.js]
 :syntax: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules[ES6+ syntax]
+
 include::partial$module-loading/bundling-procedure-intro.adoc[]
 
 == Requirements
@@ -25,7 +22,6 @@ This guide requires the following:
 
 :is_zip_install: false
 
-
 include::partial$module-loading/rollupjs-dev-dependencies.adoc[]
 
 include::partial$module-loading/bundling-rollup-es6-npm_editor.adoc[]
@@ -34,7 +30,6 @@ include::partial$module-loading/bundling-rollup-es6-npm_rollup.config.adoc[]
 
 include::partial$module-loading/bundling-rollup-es6-index.adoc[]
 
-[arabic]
 . Run Rollup.js to test the bundle, such as:
 +
 [source,sh]
@@ -44,8 +39,6 @@ rollup --config
 +
 If Rollup.js runs successfully, check that the editor loads in the application. If Rollup.js fails, review any errors and review the configuration changes in this procedure; you may need to adjust for conflicts or other issues when bundling {productname} into an existing project.
 
-:is_zip_install: nil
-
-
+:!is_zip_install:
 
 include::partial$module-loading/bundling-next-steps.adoc[]

--- a/modules/ROOT/pages/webpack_cjs_download.adoc
+++ b/modules/ROOT/pages/webpack_cjs_download.adoc
@@ -1,16 +1,13 @@
 = Bundling a .zip version of TinyMCE with CommonJS and Webpack
 
 :title_nav: CommonJS and a .zip archive
-
 :description_short: Bundling a .zip archive version of TinyMCE in a project using CommonJS and Webpack
 :description: Bundling a .zip archive version of TinyMCE in a project using CommonJS and Webpack
 :keywords: webpack commonjs cjs zip modules tinymce
-
-:installtype: a `+.zip+`
-
-:bundler: https
-://webpack.js.org/[Webpack]
+:installtype: pass:n[a `+.zip+`]
+:bundler: https://webpack.js.org/[Webpack]
 :syntax: http://www.commonjs.org/specs/modules/1.0/[CommonJS syntax]
+
 include::partial$module-loading/bundling-procedure-intro.adoc[]
 
 == Requirements
@@ -24,8 +21,6 @@ This guide requires the following:
 
 :is_zip_install: true
 
-
-
 include::partial$install/download-tinymce.adoc[]
 
 include::partial$module-loading/webpack-dev-dependencies.adoc[]
@@ -36,7 +31,6 @@ include::partial$module-loading/bundling-webpack-cjs-zip_webpack.config.adoc[]
 
 include::partial$module-loading/bundling-webpack-cjs_index.adoc[]
 
-[arabic]
 . Run Webpack to test the bundle, such as:
 +
 [source,sh]
@@ -46,8 +40,6 @@ webpack --config webpack.config.js
 +
 If Webpack runs successfully, check that the editor loads in the application. If Webpack fails, review any errors and review the configuration changes in this procedure; you may need to adjust for conflicts or other issues when bundling {productname} into an existing project.
 
-:is_zip_install: nil
-
-
+:!is_zip_install:
 
 include::partial$module-loading/bundling-next-steps.adoc[]

--- a/modules/ROOT/pages/webpack_cjs_npm.adoc
+++ b/modules/ROOT/pages/webpack_cjs_npm.adoc
@@ -1,16 +1,13 @@
 = Bundling an npm version of TinyMCE with CommonJS and Webpack
 
 :title_nav: CommonJS and npm
-
 :description_short: Bundling an npm version of TinyMCE in a project using CommonJS and Webpack
 :description: Bundling an npm version of TinyMCE in a project using CommonJS and Webpack
 :keywords: webpack commonjs cjs npm modules tinymce
-
 :installtype: an npm
-
-:bundler: https
-://webpack.js.org/[Webpack]
+:bundler: https://webpack.js.org/[Webpack]
 :syntax: http://www.commonjs.org/specs/modules/1.0/[CommonJS syntax]
+
 include::partial$module-loading/bundling-procedure-intro.adoc[]
 
 == Requirements
@@ -25,8 +22,6 @@ This guide requires the following:
 
 :is_zip_install: false
 
-
-
 include::partial$module-loading/webpack-dev-dependencies.adoc[]
 
 include::partial$module-loading/bundling-webpack-cjs-npm_editor.adoc[]
@@ -35,7 +30,6 @@ include::partial$module-loading/bundling-webpack-cjs-npm_webpack.config.adoc[]
 
 include::partial$module-loading/bundling-webpack-cjs_index.adoc[]
 
-[arabic]
 . Run Webpack to test the bundle, such as:
 +
 [source,sh]
@@ -45,8 +39,6 @@ webpack --config webpack.config.js
 +
 If Webpack runs successfully, check that the editor loads in the application. If Webpack fails, review any errors and review the configuration changes in this procedure; you may need to adjust for conflicts or other issues when bundling {productname} into an existing project.
 
-:is_zip_install: nil
-
-
+:!is_zip_install:
 
 include::partial$module-loading/bundling-next-steps.adoc[]

--- a/modules/ROOT/pages/webpack_es6_download.adoc
+++ b/modules/ROOT/pages/webpack_es6_download.adoc
@@ -1,16 +1,13 @@
 = Bundling a .zip version of TinyMCE with ES6 and Webpack
 
 :title_nav: ES6 and a .zip archive
-
 :description_short: Bundling a .zip archive version of TinyMCE in a project using ES6 and Webpack
 :description: Bundling a .zip archive version of TinyMCE in a project using ES6 and Webpack
 :keywords: webpack es6 es2015 zip modules tinymce
-
 :installtype: a `+.zip+`
-
-:bundler: https
-://webpack.js.org/[Webpack]
+:bundler: https://webpack.js.org/[Webpack]
 :syntax: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules[ES6+ syntax]
+
 include::partial$module-loading/bundling-procedure-intro.adoc[]
 
 == Requirements
@@ -24,8 +21,6 @@ This guide requires the following:
 
 :is_zip_install: true
 
-
-
 include::partial$install/download-tinymce.adoc[]
 include::partial$module-loading/webpack-dev-dependencies.adoc[]
 
@@ -35,7 +30,6 @@ include::partial$module-loading/bundling-webpack-es6-zip_webpack.config.adoc[]
 
 include::partial$module-loading/bundling-webpack-es6_index.adoc[]
 
-[arabic]
 . Run Webpack to test the bundle, such as:
 +
 [source,sh]
@@ -45,8 +39,6 @@ webpack --config webpack.config.js
 +
 If Webpack runs successfully, check that the editor loads in the application. If Webpack fails, review any errors and review the configuration changes in this procedure; you may need to adjust for conflicts or other issues when bundling {productname} into an existing project.
 
-:is_zip_install: nil
-
-
+:!is_zip_install:
 
 include::partial$module-loading/bundling-next-steps.adoc[]

--- a/modules/ROOT/pages/webpack_es6_npm.adoc
+++ b/modules/ROOT/pages/webpack_es6_npm.adoc
@@ -1,16 +1,13 @@
 = Bundling an npm version of TinyMCE with ES6 and Webpack
 
 :title_nav: ES6 and npm
-
 :description_short: Bundling an npm version of TinyMCE in a project using ES6 and Webpack
 :description: Bundling an npm version of TinyMCE in a project using ES6 and Webpack
 :keywords: webpack es6 es2015 npm modules tinymce
-
 :installtype: an npm
-
-:bundler: https
-://webpack.js.org/[Webpack]
+:bundler: https://webpack.js.org/[Webpack]
 :syntax: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules[ES6+ syntax]
+
 include::partial$module-loading/bundling-procedure-intro.adoc[]
 
 == Requirements
@@ -25,7 +22,6 @@ This guide requires the following:
 
 :is_zip_install: false
 
-
 include::partial$module-loading/webpack-dev-dependencies.adoc[]
 
 include::partial$module-loading/bundling-webpack-es6-npm_editor.adoc[]
@@ -34,7 +30,6 @@ include::partial$module-loading/bundling-webpack-es6-npm_webpack.config.adoc[]
 
 include::partial$module-loading/bundling-webpack-es6_index.adoc[]
 
-[arabic]
 . Run Webpack to test the bundle, such as:
 +
 [source,sh]
@@ -44,8 +39,6 @@ webpack --config webpack.config.js
 +
 If Webpack runs successfully, check that the editor loads in the application. If Webpack fails, review any errors and review the configuration changes in this procedure; you may need to adjust for conflicts or other issues when bundling {productname} into an existing project.
 
-:is_zip_install: nil
-
-
+:!is_zip_install:
 
 include::partial$module-loading/bundling-next-steps.adoc[]

--- a/modules/ROOT/partials/install/download-tinymce.adoc
+++ b/modules/ROOT/partials/install/download-tinymce.adoc
@@ -1,4 +1,3 @@
-[arabic]
 . Download and unzip the latest version of {productname}:
 * For customers with access to premium self-hosted TinyMCE, download the `+.zip+` file from link:{download-enterprise}[Tiny Account: Downloads].
 * For all other users, download the *{productname} _Dev_* Package from link:{download-community}[TinyMCE Self-hosted releases].

--- a/modules/ROOT/partials/misc/ui-languages.adoc
+++ b/modules/ROOT/partials/misc/ui-languages.adoc
@@ -1,3 +1,86 @@
 == Supported Languages
 
-\{% if forModuleLoaders == true %} | Language | Code | Filename | |---------------------------|:-----:|:------------------:| | Arabic | ar | `+./langs/ar.js+` | | Basque | eu | `+./langs/eu.js+` | | Bulgarian (Bulgaria) | bg_BG | `+./langs/bg_BG.js+` | | Catalan | ca | `+./langs/ca.js+` | | Chinese (China) | zh_CN | `+./langs/zh_CN.js+` | | Chinese (Taiwan) | zh_TW | `+./langs/zh_TW.js+` | | Croatian | hr | `+./langs/hr.js+` | | Czech | cs | `+./langs/cs.js+` | | Danish | da | `+./langs/da.js+` | | Dutch | nl | `+./langs/nl.js+` | | Finnish | fi | `+./langs/fi.js+` | | French (France) | fr_FR | `+./langs/fr_FR.js+` | | German | de | `+./langs/de.js+` | | Greek | el | `+./langs/el.js+` | | Hebrew (Israel) | he_IL | `+./langs/he_IL.js+` | | Hungarian (Hungary) | hu_HU | `+./langs/hu_HU.js+` | | Indonesian | id | `+./langs/id.js+` | | Italian | it | `+./langs/it.js+` | | Japanese | ja | `+./langs/ja.js+` | | Kazakh | kk | `+./langs/kk.js+` | | Korean (Korea) | ko_KR | `+./langs/ko_KR.js+` | | Norwegian Bokmål (Norway) | nb_NO | `+./langs/nb_NO.js+` | | Persian | fa | `+./langs/fa.js+` | | Polish | pl | `+./langs/pl.js+` | | Portuguese (Brazil) | pt_BR | `+./langs/pt_BR.js+` | | Portuguese (Portugal) | pt_PT | `+./langs/pt_PT.js+` | | Romanian | ro | `+./langs/ro.js+` | | Russian | ru | `+./langs/ru.js+` | | Slovak | sk | `+./langs/sk.js+` | | Slovenian (Slovenia) | sl_SI | `+./langs/sl_SI.js+` | | Spanish | es | `+./langs/es.js+` | | Swedish (Sweden) | sv_SE | `+./langs/sv_SE.js+` | | Thai (Thailand) | th_TH | `+./langs/th_TH.js+` | | Turkish | tr | `+./langs/tr.js+` | | Ukrainian | uk | `+./langs/uk.js+` | \{% else %} | Language | Code | |---------------------------|:-----:| | Arabic | ar | | Basque | eu | | Bulgarian (Bulgaria) | bg_BG | | Catalan | ca | | Chinese (China) | zh_CN | | Chinese (Taiwan) | zh_TW | | Croatian | hr | | Czech | cs | | Danish | da | | Dutch | nl | | Finnish | fi | | French (France) | fr_FR | | German | de | | Greek | el | | Hebrew (Israel) | he_IL | | Hungarian (Hungary) | hu_HU | | Indonesian | id | | Italian | it | | Japanese | ja | | Kazakh | kk | | Korean (Korea) | ko_KR | | Norwegian Bokmål (Norway) | nb_NO | | Persian | fa | | Polish | pl | | Portuguese (Brazil) | pt_BR | | Portuguese (Portugal) | pt_PT | | Romanian | ro | | Russian | ru | | Slovak | sk | | Slovenian (Slovenia) | sl_SI | | Spanish | es | | Swedish (Sweden) | sv_SE | | Thai (Thailand) | th_TH | | Turkish | tr | | Ukrainian | uk | \{% endif %}
+ifeval::[{forModuleLoaders} == true]
+[cols="<2,^1,^2"]
+|===
+| Language | Code | Filename
+
+| Arabic | ar | `+./langs/ar.js+`
+| Basque | eu | `+./langs/eu.js+`
+| Bulgarian (Bulgaria) | bg_BG | `+./langs/bg_BG.js+`
+| Catalan | ca | `+./langs/ca.js+`
+| Chinese (China) | zh_CN | `+./langs/zh_CN.js+`
+| Chinese (Taiwan) | zh_TW | `+./langs/zh_TW.js+`
+| Croatian | hr | `+./langs/hr.js+`
+| Czech | cs | `+./langs/cs.js+`
+| Danish | da | `+./langs/da.js+`
+| Dutch | nl | `+./langs/nl.js+`
+| Finnish | fi | `+./langs/fi.js+`
+| French (France) | fr_FR | `+./langs/fr_FR.js+`
+| German | de | `+./langs/de.js+`
+| Greek | el | `+./langs/el.js+`
+| Hebrew (Israel) | he_IL | `+./langs/he_IL.js+`
+| Hungarian (Hungary) | hu_HU | `+./langs/hu_HU.js+`
+| Indonesian | id | `+./langs/id.js+`
+| Italian | it | `+./langs/it.js+`
+| Japanese | ja | `+./langs/ja.js+`
+| Kazakh | kk | `+./langs/kk.js+`
+| Korean (Korea) | ko_KR | `+./langs/ko_KR.js+`
+| Norwegian Bokmål (Norway) | nb_NO | `+./langs/nb_NO.js+`
+| Persian | fa | `+./langs/fa.js+`
+| Polish | pl | `+./langs/pl.js+`
+| Portuguese (Brazil) | pt_BR | `+./langs/pt_BR.js+`
+| Portuguese (Portugal) | pt_PT | `+./langs/pt_PT.js+`
+| Romanian | ro | `+./langs/ro.js+`
+| Russian | ru | `+./langs/ru.js+`
+| Slovak | sk | `+./langs/sk.js+`
+| Slovenian (Slovenia) | sl_SI | `+./langs/sl_SI.js+`
+| Spanish | es | `+./langs/es.js+`
+| Swedish (Sweden) | sv_SE | `+./langs/sv_SE.js+`
+| Thai (Thailand) | th_TH | `+./langs/th_TH.js+`
+| Turkish | tr | `+./langs/tr.js+`
+| Ukrainian | uk | `+./langs/uk.js+`
+|===
+endif::[]
+ifeval::[{forModuleLoaders} != true]
+[cols="<2,^1"]
+|===
+| Language | Code
+
+| Arabic | ar
+| Basque | eu
+| Bulgarian (Bulgaria) | bg_BG
+| Catalan | ca
+| Chinese (China) | zh_CN
+| Chinese (Taiwan) | zh_TW
+| Croatian | hr
+| Czech | cs
+| Danish | da
+| Dutch | nl
+| Finnish | fi
+| French (France) | fr_FR
+| German | de
+| Greek | el
+| Hebrew (Israel) | he_IL
+| Hungarian (Hungary) | hu_HU
+| Indonesian | id
+| Italian | it
+| Japanese | ja
+| Kazakh | kk
+| Korean (Korea) | ko_KR
+| Norwegian Bokmål (Norway) | nb_NO
+| Persian | fa
+| Polish | pl
+| Portuguese (Brazil) | pt_BR
+| Portuguese (Portugal) | pt_PT
+| Romanian | ro
+| Russian | ru
+| Slovak | sk
+| Slovenian (Slovenia) | sl_SI
+| Spanish | es
+| Swedish (Sweden) | sv_SE
+| Thai (Thailand) | th_TH
+| Turkish | tr
+| Ukrainian | uk
+|===
+endif::[]

--- a/modules/ROOT/partials/misc/using-community-lang-packs.adoc
+++ b/modules/ROOT/partials/misc/using-community-lang-packs.adoc
@@ -1,26 +1,21 @@
 == Using the community language packs
 
-\{% if forModuleLoaders == false %}
-
-____
-*Note*: {companyname} recommends using the `+language_url+` for the community language packs, to avoid copying the language pack into the `+tinymce/langs+` folder every time you upgrade {productname}.
-\{% endif %}
-____
+ifeval::[{forModuleLoaders} == false]
+NOTE: {companyname} recommends using the `+language_url+` for the community language packs, to avoid copying the language pack into the `+tinymce/langs+` folder every time you upgrade {productname}.
+endif::[]
 
 To use change the user interface language using a community language pack:
 
-[arabic]
-. Download the language pack from link:{gettiny}/language-packages/[the {site. companyname} Community Language Packages download page].
-\{% if forModuleLoaders == true %}
+. Download the language pack from link:{gettiny}/language-packages/[the {companyname} Community Language Packages download page].
+ifeval::[{forModuleLoaders} == true]
 . Unzip and import/require the language file.
-\{% else %}
+endif::[]
+ifeval::[{forModuleLoaders} == false]
 . Unpack the language file into the `+tinymce/langs+` folder.
-\{% endif %}
+endif::[]
 . Set the link:ui-localization.html#language[`+language+`] option in your {productname} configuration to the language code, matching the filename on the language pack. For example: If the language pack has the filename `+sv_SE.js+`, then set `+language: 'sv_SE',+`
 . Confirm that the language has been set successfully by loading {productname}.
 
-____
-*Note*: The language code set in the {productname} configuration must match the filename of the language file. If the language file is not found, {productname} will not load.
-____
+NOTE: The language code set in the {productname} configuration must match the filename of the language file. If the language file is not found, {productname} will not load.
 
 If a language you need is not available, you may wish to translate it yourself. To contribute to translating {productname}, go to our https://www.transifex.com/projects/p/tinymce/[Transifex translation] page and sign up, then request to join a team or create a new team if your language are not listed.

--- a/modules/ROOT/partials/module-loading/admon-bundling-plugin-langs.adoc
+++ b/modules/ROOT/partials/module-loading/admon-bundling-plugin-langs.adoc
@@ -1,3 +1,1 @@
-____
-*Note*: The plugin language files (such as `+./plugins/plugin/langs/sv_SE.js+`) are required where the editor user interface is localized using the link:ui-localization.html#language[`+language+` option].
-____
+NOTE: The plugin language files (such as `+./plugins/plugin/langs/sv_SE.js+`) are required where the editor user interface is localized using the link:ui-localization.html#language[`+language+` option].

--- a/modules/ROOT/partials/module-loading/browserify-dev-dependencies.adoc
+++ b/modules/ROOT/partials/module-loading/browserify-dev-dependencies.adoc
@@ -1,6 +1,4 @@
-\{% if is_zip_install == true %}
-
-[arabic]
+ifeval::[{is_zip_install} == true]
 . Add the following development dependencies to the project.
 * https://www.npmjs.com/package/promise-polyfill[`+promise-polyfill+`]
 * https://www.npmjs.com/package/browserify[`+browserify+`]
@@ -18,9 +16,8 @@ npm install --save-dev \
   brfs
 ----
 
-\{% else %}
-
-[arabic]
+endif::[]
+ifeval::[{is_zip_install} != true]
 . Add `+tinymce+` and the following development dependencies to the project.
 * https://www.npmjs.com/package/promise-polyfill[`+promise-polyfill+`]
 * https://www.npmjs.com/package/browserify[`+browserify+`]
@@ -39,4 +36,4 @@ npm install --save-dev \
   brfs
 ----
 
-\{% endif %}
+endif::[]

--- a/modules/ROOT/partials/module-loading/bundling-browserify-cjs-main.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-browserify-cjs-main.adoc
@@ -1,4 +1,3 @@
-[arabic]
 . Add the {productname} assets and configuration into the project and provide a target element to initialize the editor.
 +
 Example `+src/main.js+`

--- a/modules/ROOT/partials/module-loading/bundling-browserify-cjs-npm_editor.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-browserify-cjs-npm_editor.adoc
@@ -1,4 +1,3 @@
-[arabic]
 . Create a new source file for importing the required components from {productname} and configuring the editor.
 +
 include::partial$module-loading/bundling-required-components.adoc[]

--- a/modules/ROOT/partials/module-loading/bundling-browserify-cjs-zip_editor.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-browserify-cjs-zip_editor.adoc
@@ -1,4 +1,3 @@
-[arabic]
 . Create a new source file for importing the required components from {productname} and configuring the editor.
 +
 include::partial$module-loading/bundling-required-components.adoc[]

--- a/modules/ROOT/partials/module-loading/bundling-content-css-files.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-content-css-files.adoc
@@ -1,18 +1,22 @@
 == Community
 
-Default : ``` ./skins/content/default/content.css
-
+Default::
 ....
-Dark
-: ```
+./skins/content/default/content.css
+....
+
+Dark::
+....
 ./skins/content/dark/content.css
 ....
 
-Document : ``` ./skins/content/document/content.css
-
+Document::
 ....
-Writer
-: ```
+./skins/content/document/content.css
+....
+
+Writer::
+....
 ./skins/content/writer/content.css
 ....
 
@@ -20,18 +24,22 @@ Writer
 
 For information on premium content CSS, see: link:premium-skins-and-icons.html[{prem_skins_icons}].
 
-Fabric : ``` ./skins/content/fabric/content.css
-
+Fabric::
 ....
-Fluent
-: ```
+./skins/content/fabric/content.css
+....
+
+Fluent::
+....
 ./skins/content/fluent/content.css
 ....
 
-Material (Classic) : ``` ./skins/content/material-classic/content.css
-
+Material (Classic)::
 ....
-Material (Outline)
-: ```
+./skins/content/material-classic/content.css
+....
+
+Material (Outline)::
+....
 ./skins/content/material-outline/content.css
 ....

--- a/modules/ROOT/partials/module-loading/bundling-icon-files.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-icon-files.adoc
@@ -1,29 +1,35 @@
 == Community
 
-Default icons : ``` ./icons/default/icons.js
-
+Default icons::
 ....
-## Premium
+./icons/default/icons.js
+....
+
+== Premium
 
 For information on premium icon packs, see: link:/interface/editor-appearance/premium-skins-and-icons/[{prem_skins_icons}].
 
-Bootstrap icons
-: ```
+Bootstrap icons::
+....
 ./icons/bootstrap/icons.js
 ....
 
-Jam icons : ``` ./icons/jam/icons.js
-
+Jam icons::
 ....
-Material icons
-: ```
+./icons/jam/icons.js
+....
+
+Material icons::
+....
 ./icons/material/icons.js
 ....
 
-Small icons : ``` ./icons/small/icons.js
-
+Small icons::
 ....
-Thin icons
-: ```
+./icons/small/icons.js
+....
+
+Thin icons::
+....
 ./icons/thin/icons.js
 ....

--- a/modules/ROOT/partials/module-loading/bundling-next-steps.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-next-steps.adoc
@@ -5,7 +5,7 @@ For information on:
 * Adding {productname} plugins to the bundle, see: link:plugins.html[Bundling {productname} plugins using module loading].
 * Using editor content CSS provided by {companyname}, including premium CSS included with the {prem_skins_icons}, see: link:content-css.html[Bundling {productname} content CSS using module loading].
 * Creating custom editor content CSS, see: link:add-css-options.html#content_css[Content appearance options - `+content_css+`].
-* Using {productname} skins provided by {companyname}, including premium skins included with the {prem_skins_icons}, see: link:skins.html[Bundling {productname} skins using module loading].
+* Using {productname} skins provided by {companyname}, including premium skins included with the {prem_skins_icons}, see: link:bundling-skins.html[Bundling {productname} skins using module loading].
 * Creating a custom skin for {productname}, see: link:creating-a-skin.html[Create a skin for {productname}].
 * Using icon packs provided by {companyname}, including premium icons packs included with the {prem_skins_icons}, see: link:icons.html[Bundling {productname} icon packs using module loading].
 * Creating a custom icon pack for {productname}, see: link:creating-an-icon-pack.html[Create an icon pack for {productname}].

--- a/modules/ROOT/partials/module-loading/bundling-plugin-files.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-plugin-files.adoc
@@ -2,259 +2,309 @@
 
 include::partial$module-loading/bundling-plugins-that-cant-bundle.adoc[]
 
-* <<premiumplugins, Premium plugins>>
-** <<accessibilitycheckera11ychecker, Accessibility Checker (a11ychecker)>>
-** <<advancedcodeadvcode, Advanced Code (advcode)>>
-** <<advancedtablesadvtable, Advanced Tables (advtable)>>
-** <<casechangecasechange, Case Change (casechange)>>
-** <<checklistchecklist, Checklist (checklist)>>
-** <<commentstinycomments, Comments (tinycomments)>>
-** <<enhancedmediaembedmediaembed, Enhanced Media Embed (mediaembed)>>
-** <<exportexport, Export (export)>>
-** <<formatpainterformatpainter, Format Painter (formatpainter)>>
-** <<linkcheckerlinkchecker, Link Checker (linkchecker)>>
-** <<mentionsmentions, Mentions (mentions)>>
-** <<pageembedpageembed, Page Embed (pageembed)>>
-** <<permanentpenpermanentpen, Permanent Pen (permanentpen)>>
-** <<powerpastepowerpaste, PowerPaste (powerpaste)>>
-** <<spellcheckerprotinymcespellchecker, Spell Checker Pro (tinymcespellchecker)>>
-* <<communityplugins, Community plugins>>
-** <<advancedlistadvlist, Advanced List (advlist)>>
-** <<anchoranchor, Anchor (anchor)>>
-** <<autolinkautolink, Autolink (autolink)>>
-** <<autoresizeautoresize, Autoresize (autoresize)>>
-** <<autosaveautosave, Autosave (autosave)>>
-** <<charactermapcharmap, Character Map (charmap)>>
-** <<codecode, Code (code)>>
-** <<codesamplecodesample, Code Sample (codesample)>>
-** <<directionalitydirectionality, Directionality (directionality)>>
-** <<emoticonsemoticons, Emoticons (emoticons)>>
-** <<fullscreenfullscreen, Full Screen (fullscreen)>>
-** <<helphelp, Help (help)>>
-** <<imageimage, Image (image)>>
-** <<imagetoolsimagetools, Image Tools (imagetools)>>
-** <<importcssimportcss, Import CSS (importcss)>>
-** <<insertdatetimeinsertdatetime, Insert Date/Time (insertdatetime)>>
-** <<linklink, Link (link)>>
-** <<listslists, Lists (lists)>>
-** <<mediamedia, Media (media)>>
-** <<nonbreakingspacenonbreaking, Nonbreaking Space (nonbreaking)>>
-** <<pagebreakpagebreak, Page Break (pagebreak)>>
-** <<pastepaste, Paste (paste)>>
-** <<previewpreview, Preview (preview)>>
-** <<quicktoolbarquickbars, Quick Toolbar (quickbars)>>
-** <<savesave, Save (save)>>
-** <<searchandreplacesearchreplace, Search and Replace (searchreplace)>>
-** <<tabletable, Table (table)>>
-** <<templatetemplate, Template (template)>>
-** <<textpatterntextpattern, Text Pattern (textpattern)>>
-** <<tableofcontentstoc, Table of Contents (toc)>>
-** <<visualblockvisualblocks, Visual Block (visualblocks)>>
-** <<visualcharactersvisualchars, Visual Characters (visualchars)>>
-** <<wordcountwordcount, Word Count (wordcount)>>
+* xref:premiumplugins[Premium plugins]
+** xref:accessibilitycheckera11ychecker[Accessibility Checker (a11ychecker)]
+** xref:advancedcodeadvcode[Advanced Code (advcode)]
+** xref:advancedtablesadvtable[Advanced Tables (advtable)]
+** xref:casechangecasechange[Case Change (casechange)]
+** xref:checklistchecklist[Checklist (checklist)]
+** xref:commentstinycomments[Comments (tinycomments)]
+** xref:enhancedmediaembedmediaembed[Enhanced Media Embed (mediaembed)]
+** xref:exportexport[Export (export)]
+** xref:formatpainterformatpainter[Format Painter (formatpainter)]
+** xref:linkcheckerlinkchecker[Link Checker (linkchecker)]
+** xref:mentionsmentions[Mentions (mentions)]
+** xref:pageembedpageembed[Page Embed (pageembed)]
+** xref:permanentpenpermanentpen[Permanent Pen (permanentpen)]
+** xref:powerpastepowerpaste[PowerPaste (powerpaste)]
+** xref:spellcheckerprotinymcespellchecker[Spell Checker Pro (tinymcespellchecker)]
+* xref:communityplugins[Community plugins]
+** xref:advancedlistadvlist[Advanced List (advlist)]
+** xref:anchoranchor[Anchor (anchor)]
+** xref:autolinkautolink[Autolink (autolink)]
+** xref:autoresizeautoresize[Autoresize (autoresize)]
+** xref:autosaveautosave[Autosave (autosave)]
+** xref:charactermapcharmap[Character Map (charmap)]
+** xref:codecode[Code (code)]
+** xref:codesamplecodesample[Code Sample (codesample)]
+** xref:directionalitydirectionality[Directionality (directionality)]
+** xref:emoticonsemoticons[Emoticons (emoticons)]
+** xref:fullscreenfullscreen[Full Screen (fullscreen)]
+** xref:helphelp[Help (help)]
+** xref:imageimage[Image (image)]
+** xref:imagetoolsimagetools[Image Tools (imagetools)]
+** xref:importcssimportcss[Import CSS (importcss)]
+** xref:insertdatetimeinsertdatetime[Insert Date/Time (insertdatetime)]
+** xref:linklink[Link (link)]
+** xref:listslists[Lists (lists)]
+** xref:mediamedia[Media (media)]
+** xref:nonbreakingspacenonbreaking[Nonbreaking Space (nonbreaking)]
+** xref:pagebreakpagebreak[Page Break (pagebreak)]
+** xref:pastepaste[Paste (paste)]
+** xref:previewpreview[Preview (preview)]
+** xref:quicktoolbarquickbars[Quick Toolbar (quickbars)]
+** xref:savesave[Save (save)]
+** xref:searchandreplacesearchreplace[Search and Replace (searchreplace)]
+** xref:tabletable[Table (table)]
+** xref:templatetemplate[Template (template)]
+** xref:textpatterntextpattern[Text Pattern (textpattern)]
+** xref:tableofcontentstoc[Table of Contents (toc)]
+** xref:visualblockvisualblocks[Visual Block (visualblocks)]
+** xref:visualcharactersvisualchars[Visual Characters (visualchars)]
+** xref:wordcountwordcount[Word Count (wordcount)]
 
+[[premiumplugins]]
 == Premium plugins
 
+[[accessibilitycheckera11ychecker]]
 === Accessibility Checker (`+a11ychecker+`)
 
 include::partial$module-loading/admon-bundling-plugin-langs.adoc[]
 
 include::partial$plugin_files/plugin-file-list-a11ychecker.adoc[]
 
+[[advancedcodeadvcode]]
 === Advanced Code (`+advcode+`)
 
 include::partial$plugin_files/plugin-file-list-advcode.adoc[]
 
+[[advancedtablesadvtable]]
 === Advanced Tables (`+advtable+`)
 
 include::partial$plugin_files/plugin-file-list-advtable.adoc[]
 
+[[casechangecasechange]]
 === Case Change (`+casechange+`)
 
 include::partial$plugin_files/plugin-file-list-casechange.adoc[]
 
+[[checklistchecklist]]
 === Checklist (`+checklist+`)
 
 include::partial$plugin_files/plugin-file-list-checklist.adoc[]
 
+[[commentstinycomments]]
 === Comments (`+tinycomments+`)
 
 include::partial$module-loading/admon-bundling-plugin-langs.adoc[]
 
 include::partial$plugin_files/plugin-file-list-tinycomments.adoc[]
 
+[[enhancedmediaembedmediaembed]]
 === Enhanced Media Embed (`+mediaembed+`)
 
 include::partial$plugin_files/plugin-file-list-mediaembed.adoc[]
 
+[[exportexport]]
 === Export (`+export+`)
 
 include::partial$module-loading/admon-bundling-plugin-langs.adoc[]
 
 include::partial$plugin_files/plugin-file-list-export.adoc[]
 
+[[formatpainterformatpainter]]
 === Format Painter (`+formatpainter+`)
 
 include::partial$plugin_files/plugin-file-list-formatpainter.adoc[]
 
+[[linkcheckerlinkchecker]]
 === Link Checker (`+linkchecker+`)
 
 include::partial$plugin_files/plugin-file-list-linkchecker.adoc[]
 
+[[mentionsmentions]]
 === Mentions (`+mentions+`)
 
 include::partial$plugin_files/plugin-file-list-mentions.adoc[]
 
+[[pageembedpageembed]]
 === Page Embed (`+pageembed+`)
 
 include::partial$plugin_files/plugin-file-list-pageembed.adoc[]
 
+[[permanentpenpermanentpen]]
 === Permanent Pen (`+permanentpen+`)
 
 include::partial$plugin_files/plugin-file-list-permanentpen.adoc[]
 
+[[powerpastepowerpaste]]
 === PowerPaste (`+powerpaste+`)
 
 include::partial$module-loading/admon-bundling-plugin-langs.adoc[]
 
 include::partial$plugin_files/plugin-file-list-powerpaste.adoc[]
 
+[[spellcheckerprotinymcespellchecker]]
 === Spell Checker Pro (`+tinymcespellchecker+`)
 
 include::partial$module-loading/admon-bundling-plugin-langs.adoc[]
 
 include::partial$plugin_files/plugin-file-list-tinymcespellchecker.adoc[]
 
+[[communityplugins]]
 == Community plugins
 
+[[advancedlistadvlist]]
 === Advanced List (`+advlist+`)
 
 include::partial$plugin_files/plugin-file-list-advlist.adoc[]
 
+[[anchoranchor]]
 === Anchor (`+anchor+`)
 
 include::partial$plugin_files/plugin-file-list-anchor.adoc[]
 
+[[autolinkautolink]]
 === Autolink (`+autolink+`)
 
 include::partial$plugin_files/plugin-file-list-autolink.adoc[]
 
+[[autoresizeautoresize]]
 === Autoresize (`+autoresize+`)
 
 include::partial$plugin_files/plugin-file-list-autoresize.adoc[]
 
+[[autosaveautosave]]
 === Autosave (`+autosave+`)
 
 include::partial$plugin_files/plugin-file-list-autosave.adoc[]
 
+[[charactermapcharmap]]
 === Character Map (`+charmap+`)
 
 include::partial$plugin_files/plugin-file-list-charmap.adoc[]
 
+[[codecode]]
 === Code (`+code+`)
 
 include::partial$plugin_files/plugin-file-list-code.adoc[]
 
+[[codesamplecodesample]]
 === Code Sample (`+codesample+`)
 
 include::partial$plugin_files/plugin-file-list-codesample.adoc[]
 
+[[directionalitydirectionality]]
 === Directionality (`+directionality+`)
 
 include::partial$plugin_files/plugin-file-list-directionality.adoc[]
 
+[[emoticonsemoticons]]
 === Emoticons (`+emoticons+`)
 
 include::partial$plugin_files/plugin-file-list-emoticons.adoc[]
 
+[[fullscreenfullscreen]]
 === Full Screen (`+fullscreen+`)
 
 include::partial$plugin_files/plugin-file-list-fullscreen.adoc[]
 
+[[helphelp]]
 === Help (`+help+`)
 
 include::partial$plugin_files/plugin-file-list-help.adoc[]
 
+[[imageimage]]
 === Image (`+image+`)
 
 include::partial$plugin_files/plugin-file-list-image.adoc[]
 
+[[imagetoolsimagetools]]
 === Image Tools (`+imagetools+`)
 
 include::partial$plugin_files/plugin-file-list-imagetools.adoc[]
 
+[[importcssimportcss]]
 === Import CSS (`+importcss+`)
 
 include::partial$plugin_files/plugin-file-list-importcss.adoc[]
 
+[[insertdatetimeinsertdatetime]]
 === Insert Date/Time (`+insertdatetime+`)
 
 include::partial$plugin_files/plugin-file-list-insertdatetime.adoc[]
 
+[[linklink]]
 === Link (`+link+`)
 
 include::partial$plugin_files/plugin-file-list-link.adoc[]
 
+[[listslists]]
 === Lists (`+lists+`)
 
 include::partial$plugin_files/plugin-file-list-lists.adoc[]
 
+[[mediamedia]]
 === Media (`+media+`)
 
 include::partial$plugin_files/plugin-file-list-media.adoc[]
 
+[[nonbreakingspacenonbreaking]]
 === Nonbreaking Space (`+nonbreaking+`)
 
 include::partial$plugin_files/plugin-file-list-nonbreaking.adoc[]
 
+[[pagebreakpagebreak]]
 === Page Break (`+pagebreak+`)
 
 include::partial$plugin_files/plugin-file-list-pagebreak.adoc[]
 
+[[pastepaste]]
 === Paste (`+paste+`)
 
 include::partial$plugin_files/plugin-file-list-paste.adoc[]
 
+[[previewpreview]]
 === Preview (`+preview+`)
 
 include::partial$plugin_files/plugin-file-list-preview.adoc[]
 
+[[quicktoolbarquickbars]]
 === Quick Toolbar (`+quickbars+`)
 
 include::partial$plugin_files/plugin-file-list-quickbars.adoc[]
 
+[[savesave]]
 === Save (`+save+`)
 
 include::partial$plugin_files/plugin-file-list-save.adoc[]
 
+[[searchandreplacesearchreplace]]
 === Search and Replace (`+searchreplace+`)
 
 include::partial$plugin_files/plugin-file-list-searchreplace.adoc[]
 
+[[tabletable]]
 === Table (`+table+`)
 
 include::partial$plugin_files/plugin-file-list-table.adoc[]
 
+[[templatetemplate]]
 === Template (`+template+`)
 
 include::partial$plugin_files/plugin-file-list-template.adoc[]
 
+[[textpatterntextpattern]]
 === Text Pattern (`+textpattern+`)
 
 include::partial$plugin_files/plugin-file-list-textpattern.adoc[]
 
+[[tableofcontentstoc]]
 === Table of Contents (`+toc+`)
 
 include::partial$plugin_files/plugin-file-list-toc.adoc[]
 
+[[visualblockvisualblocks]]
 === Visual Block (`+visualblocks+`)
 
 include::partial$plugin_files/plugin-file-list-visualblocks.adoc[]
 
+[[visualcharactersvisualchars]]
 === Visual Characters (`+visualchars+`)
 
 include::partial$plugin_files/plugin-file-list-visualchars.adoc[]
 
+[[wordcountwordcount]]
 === Word Count (`+wordcount+`)
 
 include::partial$plugin_files/plugin-file-list-wordcount.adoc[]

--- a/modules/ROOT/partials/module-loading/bundling-plugins-that-cant-bundle.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-plugins-that-cant-bundle.adoc
@@ -1,5 +1,6 @@
-____
-*Important*: The following premium plugins *can not* be bundled at this time:
+[IMPORTANT]
+--
+The following premium plugins *can not* be bundled at this time:
 
 * Accessibility Checker (`+a11ychecker+`)
 * Advanced Code (`+advcode+`)
@@ -8,4 +9,4 @@ ____
 * Link Checker (`+linkchecker+`)
 * Mentions (`+mentions+`)
 * Page Embed (`+pageembed+`)
-____
+--

--- a/modules/ROOT/partials/module-loading/bundling-ref-example.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-ref-example.adoc
@@ -1,6 +1,6 @@
-\{% if editorcomponent.size < 1 %}
+ifndef::editorcomponent[]
 :editorcomponent: component
-\{% endif %}
+endif::[]
 
 == Overview
 

--- a/modules/ROOT/partials/module-loading/bundling-required-components.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-required-components.adoc
@@ -1,6 +1,6 @@
+--
 The following components are required to bundle {productname}:
 
-....
 - The `tinymce` global
 - The `silver` theme
 - The `default` icon pack. It is required, but the default icons can be overridden using a custom or premium icon pack.
@@ -11,4 +11,4 @@ The following components are likely required:
 - _Content CSS_ for styling editor content. This can be a community, premium, or custom content CSS.
 - Any plugins to be used with the editor.
 - A custom or premium _icon pack_ to extend or override the default icons for toolbar buttons, including contextual toolbars. This can be a premium or custom icon pack.
-....
+--

--- a/modules/ROOT/partials/module-loading/bundling-rollup-es6-index.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-rollup-es6-index.adoc
@@ -1,4 +1,3 @@
-[arabic]
 . Add the {productname} assets and configuration into the project and provide a target element to initialize the editor.
 +
 Example `+src/index.js+`

--- a/modules/ROOT/partials/module-loading/bundling-rollup-es6-npm_editor.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-rollup-es6-npm_editor.adoc
@@ -1,4 +1,3 @@
-[arabic]
 . Create a new source file for importing the required components from {productname} and configuring the editor.
 +
 include::partial$module-loading/bundling-required-components.adoc[]

--- a/modules/ROOT/partials/module-loading/bundling-rollup-es6-npm_rollup.config.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-rollup-es6-npm_rollup.config.adoc
@@ -1,4 +1,3 @@
-[arabic]
 . Update the project Rollup.js configuration to load the {productname} CSS.
 +
 Example `+rollup.config.js+`

--- a/modules/ROOT/partials/module-loading/bundling-rollup-es6-zip_editor.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-rollup-es6-zip_editor.adoc
@@ -1,4 +1,3 @@
-[arabic]
 . Create a new source file for importing the required components from {productname} and configuring the editor.
 +
 include::partial$module-loading/bundling-required-components.adoc[]

--- a/modules/ROOT/partials/module-loading/bundling-rollup-es6-zip_rollup.config.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-rollup-es6-zip_rollup.config.adoc
@@ -1,4 +1,3 @@
-[arabic]
 . Update the project Rollup.js configuration to load the {productname} CSS.
 +
 Example `+rollup.config.js+`

--- a/modules/ROOT/partials/module-loading/bundling-skin-files.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-skin-files.adoc
@@ -1,10 +1,18 @@
 == Community Skins
 
-Default skin (oxide) : ``` ./skins/ui/oxide/content.css ./skins/ui/oxide/content.inline.css ./skins/ui/oxide/content.mobile.css ./skins/ui/oxide/fonts/tinymce-mobile.woff ./skins/ui/oxide/skin.css ./skins/ui/oxide/skin.mobile.css ./skins/ui/oxide/skin.shadowdom.css
-
+Default skin (oxide)::
 ....
-Dark skin (oxide-dark)
-: ```
+./skins/ui/oxide/content.css
+./skins/ui/oxide/content.inline.css
+./skins/ui/oxide/content.mobile.css
+./skins/ui/oxide/fonts/tinymce-mobile.woff
+./skins/ui/oxide/skin.css
+./skins/ui/oxide/skin.mobile.css
+./skins/ui/oxide/skin.shadowdom.css
+....
+
+Dark skin (oxide-dark)::
+....
 ./skins/ui/oxide-dark/content.css
 ./skins/ui/oxide-dark/content.inline.css
 ./skins/ui/oxide-dark/content.mobile.css
@@ -18,11 +26,18 @@ Dark skin (oxide-dark)
 
 For information on premium editor skins, see: link:premium-skins-and-icons.html[{prem_skins_icons}].
 
-Bootstrap skin : ``` ./skins/ui/bootstrap/content.css ./skins/ui/bootstrap/content.inline.css ./skins/ui/bootstrap/content.mobile.css ./skins/ui/bootstrap/skin.css ./skins/ui/bootstrap/skin.mobile.css ./skins/ui/bootstrap/skin.shadowdom.css
-
+Bootstrap skin::
 ....
-Borderless skin
-: ```
+./skins/ui/bootstrap/content.css
+./skins/ui/bootstrap/content.inline.css
+./skins/ui/bootstrap/content.mobile.css
+./skins/ui/bootstrap/skin.css
+./skins/ui/bootstrap/skin.mobile.css
+./skins/ui/bootstrap/skin.shadowdom.css
+....
+
+Borderless skin::
+....
 ./skins/ui/borderless/content.css
 ./skins/ui/borderless/content.inline.css
 ./skins/ui/borderless/content.mobile.css
@@ -31,11 +46,18 @@ Borderless skin
 ./skins/ui/borderless/skin.shadowdom.css
 ....
 
-Fabric skin : ``` ./skins/ui/fabric/content.css ./skins/ui/fabric/content.inline.css ./skins/ui/fabric/content.mobile.css ./skins/ui/fabric/skin.css ./skins/ui/fabric/skin.mobile.css ./skins/ui/fabric/skin.shadowdom.css
-
+Fabric skin::
 ....
-Fluent skin
-: ```
+./skins/ui/fabric/content.css
+./skins/ui/fabric/content.inline.css
+./skins/ui/fabric/content.mobile.css
+./skins/ui/fabric/skin.css
+./skins/ui/fabric/skin.mobile.css
+./skins/ui/fabric/skin.shadowdom.css
+....
+
+Fluent skin::
+....
 ./skins/ui/fluent/content.css
 ./skins/ui/fluent/content.inline.css
 ./skins/ui/fluent/content.mobile.css
@@ -44,11 +66,18 @@ Fluent skin
 ./skins/ui/fluent/skin.shadowdom.css
 ....
 
-Jam skin : ``` ./skins/ui/jam/content.css ./skins/ui/jam/content.inline.css ./skins/ui/jam/content.mobile.css ./skins/ui/jam/skin.css ./skins/ui/jam/skin.mobile.css ./skins/ui/jam/skin.shadowdom.css
-
+Jam skin::
 ....
-Material (Classic) skin
-: ```
+./skins/ui/jam/content.css
+./skins/ui/jam/content.inline.css
+./skins/ui/jam/content.mobile.css
+./skins/ui/jam/skin.css
+./skins/ui/jam/skin.mobile.css
+./skins/ui/jam/skin.shadowdom.css
+....
+
+Material (Classic) skin::
+....
 ./skins/ui/material-classic/content.css
 ./skins/ui/material-classic/content.inline.css
 ./skins/ui/material-classic/content.mobile.css
@@ -57,11 +86,18 @@ Material (Classic) skin
 ./skins/ui/material-classic/skin.shadowdom.css
 ....
 
-Material (Outline) skin : ``` ./skins/ui/material-outline/content.css ./skins/ui/material-outline/content.inline.css ./skins/ui/material-outline/content.mobile.css ./skins/ui/material-outline/skin.css ./skins/ui/material-outline/skin.mobile.css ./skins/ui/material-outline/skin.shadowdom.css
-
+Material (Outline) skin::
 ....
-Naked skin
-: ```
+./skins/ui/material-outline/content.css
+./skins/ui/material-outline/content.inline.css
+./skins/ui/material-outline/content.mobile.css
+./skins/ui/material-outline/skin.css
+./skins/ui/material-outline/skin.mobile.css
+./skins/ui/material-outline/skin.shadowdom.css
+....
+
+Naked skin::
+....
 ./skins/ui/naked/content.css
 ./skins/ui/naked/content.inline.css
 ./skins/ui/naked/content.mobile.css
@@ -70,11 +106,18 @@ Naked skin
 ./skins/ui/naked/skin.shadowdom.css
 ....
 
-Outside skin : ``` ./skins/ui/outside/content.css ./skins/ui/outside/content.inline.css ./skins/ui/outside/content.mobile.css ./skins/ui/outside/skin.css ./skins/ui/outside/skin.mobile.css ./skins/ui/outside/skin.shadowdom.css
-
+Outside skin::
 ....
-Small skin
-: ```
+./skins/ui/outside/content.css
+./skins/ui/outside/content.inline.css
+./skins/ui/outside/content.mobile.css
+./skins/ui/outside/skin.css
+./skins/ui/outside/skin.mobile.css
+./skins/ui/outside/skin.shadowdom.css
+....
+
+Small skin::
+....
 ./skins/ui/small/content.css
 ./skins/ui/small/content.inline.css
 ./skins/ui/small/content.mobile.css
@@ -83,7 +126,12 @@ Small skin
 ./skins/ui/small/skin.shadowdom.css
 ....
 
-Snow skin : ``` ./skins/ui/snow/content.css ./skins/ui/snow/content.inline.css ./skins/ui/snow/content.mobile.css ./skins/ui/snow/skin.css ./skins/ui/snow/skin.mobile.css ./skins/ui/snow/skin.shadowdom.css
-
+Snow skin::
 ....
+./skins/ui/snow/content.css
+./skins/ui/snow/content.inline.css
+./skins/ui/snow/content.mobile.css
+./skins/ui/snow/skin.css
+./skins/ui/snow/skin.mobile.css
+./skins/ui/snow/skin.shadowdom.css
 ....

--- a/modules/ROOT/partials/module-loading/bundling-theme-files.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-theme-files.adoc
@@ -1,4 +1,4 @@
-Default theme (silver) : ``` ./themes/silver/theme.js
-
+Default theme (silver)::
 ....
+./themes/silver/theme.js
 ....

--- a/modules/ROOT/partials/module-loading/bundling-webpack-cjs-npm_editor.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-webpack-cjs-npm_editor.adoc
@@ -1,4 +1,3 @@
-[arabic]
 . Create a new source file for importing the required components from {productname} and configuring the editor.
 +
 include::partial$module-loading/bundling-required-components.adoc[]

--- a/modules/ROOT/partials/module-loading/bundling-webpack-cjs-npm_webpack.config.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-webpack-cjs-npm_webpack.config.adoc
@@ -1,4 +1,3 @@
-[arabic]
 . Update the project Webpack configuration to load the {productname} CSS and to optimize the {productname} assets.
 +
 Example `+webpack.config.js+`

--- a/modules/ROOT/partials/module-loading/bundling-webpack-cjs-zip_editor.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-webpack-cjs-zip_editor.adoc
@@ -1,4 +1,3 @@
-[arabic]
 . Create a new source file for importing the required components from {productname} and configuring the editor.
 +
 include::partial$module-loading/bundling-required-components.adoc[]

--- a/modules/ROOT/partials/module-loading/bundling-webpack-cjs-zip_webpack.config.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-webpack-cjs-zip_webpack.config.adoc
@@ -1,4 +1,3 @@
-[arabic]
 . Update the project Webpack configuration to load the {productname} CSS and to optimize the {productname} assets.
 +
 Example `+webpack.config.js+`

--- a/modules/ROOT/partials/module-loading/bundling-webpack-cjs_index.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-webpack-cjs_index.adoc
@@ -1,4 +1,3 @@
-[arabic]
 . Add the {productname} assets and configuration into the project and provide a target element to initialize the editor.
 +
 Example `+src/index.js+`

--- a/modules/ROOT/partials/module-loading/bundling-webpack-es6-npm_editor.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-webpack-es6-npm_editor.adoc
@@ -1,4 +1,3 @@
-[arabic]
 . Create a new source file for importing the required components from {productname} and configuring the editor.
 +
 include::partial$module-loading/bundling-required-components.adoc[]

--- a/modules/ROOT/partials/module-loading/bundling-webpack-es6-npm_webpack.config.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-webpack-es6-npm_webpack.config.adoc
@@ -1,4 +1,3 @@
-[arabic]
 . Update the project Webpack configuration to load the {productname} CSS and to optimize the {productname} assets.
 +
 Example `+webpack.config.js+`

--- a/modules/ROOT/partials/module-loading/bundling-webpack-es6-zip_editor.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-webpack-es6-zip_editor.adoc
@@ -1,4 +1,3 @@
-[arabic]
 . Create a new source file for importing the required components from {productname} and configuring the editor.
 +
 include::partial$module-loading/bundling-required-components.adoc[]

--- a/modules/ROOT/partials/module-loading/bundling-webpack-es6-zip_webpack.config.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-webpack-es6-zip_webpack.config.adoc
@@ -1,4 +1,3 @@
-[arabic]
 . Update the project Webpack configuration to load the {productname} CSS and to optimize the {productname} assets.
 +
 Example `+webpack.config.js+`

--- a/modules/ROOT/partials/module-loading/bundling-webpack-es6_index.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-webpack-es6_index.adoc
@@ -1,4 +1,3 @@
-[arabic]
 . Add the {productname} assets and configuration into the project and provide a target element to initialize the editor.
 +
 Example `+src/index.js+`

--- a/modules/ROOT/partials/module-loading/rollupjs-dev-dependencies.adoc
+++ b/modules/ROOT/partials/module-loading/rollupjs-dev-dependencies.adoc
@@ -1,6 +1,4 @@
-\{% if is_zip_install == true %}
-
-[arabic]
+ifeval::[{is_zip_install} == true]
 . Add the following development dependencies to the project.
 * https://www.npmjs.com/package/postcss[`+postcss+`]
 * https://www.npmjs.com/package/rollup[`+rollup+`]
@@ -22,9 +20,8 @@ npm install --save-dev \
   rollup-plugin-string
 ----
 
-\{% else %}
-
-[arabic]
+endif::[]
+ifeval::[{is_zip_install} != true]
 . Add `+tinymce+` and the following development dependencies to the project.
 * https://www.npmjs.com/package/postcss[`+postcss+`]
 * https://www.npmjs.com/package/rollup[`+rollup+`]
@@ -49,4 +46,4 @@ npm install --save-dev \
   rollup-plugin-string
 ----
 
-\{% endif %}
+endif::[]

--- a/modules/ROOT/partials/module-loading/webpack-dev-dependencies.adoc
+++ b/modules/ROOT/partials/module-loading/webpack-dev-dependencies.adoc
@@ -1,6 +1,4 @@
-\{% if is_zip_install == true %}
-
-[arabic]
+ifeval::[{is_zip_install} == true]
 . Add the following development dependencies to the project.
 * https://www.npmjs.com/package/webpack[`+webpack+`]
 * https://www.npmjs.com/package/webpack-cli[`+webpack-cli+`]
@@ -20,9 +18,8 @@ npm install --save-dev \
   css-loader
 ----
 
-\{% else %}
-
-[arabic]
+endif::[]
+ifeval::[{is_zip_install} != true]
 . Add `+tinymce+` and the following development dependencies to the project.
 * https://www.npmjs.com/package/webpack[`+webpack+`]
 * https://www.npmjs.com/package/webpack-cli[`+webpack-cli+`]
@@ -43,4 +40,4 @@ npm install --save-dev \
   css-loader
 ----
 
-\{% endif %}
+endif::[]


### PR DESCRIPTION
Related Ticket: DOC-1532

Description of Changes:
* Replace all liquid logic with asciidoc ifeval, etc... logic instead
* Fixed other conversion issues caused by the liquid syntax that prevented it being converted automatically
* Fixed conversion issues that caused numbering issues in lists
* Fixed conversion issues with admonitions (these were converted to blockquotes since markdown doesn't have this concept)
* Fixed xref conversion issues (basically replace the legacy `<<id, title>>` format with `xref:id[title]`)

**Note:** I'd suggest running this locally instead of trying to review the actual markup here.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
