### PR TITLE
DOC-1532: Fixed markdown -> asciidoc conversion issue initial config docs

### DIFF
--- a/modules/ROOT/pages/editor-important-options.adoc
+++ b/modules/ROOT/pages/editor-important-options.adoc
@@ -1,7 +1,6 @@
 = Key editor options for adding TinyMCE to an application
 
 :title_nav: Integration options
-
 :description: Key editor options for integrating TinyMCE to an application
 :keywords:
 
@@ -55,5 +54,7 @@ include::partial$configuration/referrer_policy.adoc[leveloffset=+1]
 
 include::partial$configuration/suffix.adoc[leveloffset=+1]
 
-\{% comment %} Not documented, but probably belongs in a new section here somewhere.
-include::partial$configuration/iframe_attrs.adoc[] \{% endcomment %}
+////
+Not documented, but probably belongs in a new section here somewhere.
+include::partial$configuration/iframe_attrs.adoc[]
+////

--- a/modules/ROOT/pages/editor-save-and-submit.adoc
+++ b/modules/ROOT/pages/editor-save-and-submit.adoc
@@ -1,7 +1,6 @@
 = Editor save and submit options
 
 :title_nav: Save and submit
-
 :description: Editor options related to saving or submitting editor content
 :keywords:
 
@@ -20,8 +19,8 @@ include::partial$configuration/submit_patch.adoc[]
 
 == Adding save functionality to the editor
 
-{productname} can be configured to allow users to save the editor content. For information on configuring the user saving, see: link:save.html[The Save plugin].
+{productname} can be configured to allow users to save the editor content. For information on configuring the user saving, see: xref:save.adoc[The Save plugin].
 
 == Autosaving the editor content
 
-{productname} can be configured to automatically save the editor content. For information on configuring the automatic saving, see: link:autosave.html[The Autosave plugin].
+{productname} can be configured to automatically save the editor content. For information on configuring the automatic saving, see: xref:autosave.adoc[The Autosave plugin].

--- a/modules/ROOT/pages/editor-size-options.adoc
+++ b/modules/ROOT/pages/editor-size-options.adoc
@@ -1,7 +1,6 @@
 = Editor size and resize options
 
 :title_nav: Size
-
 :description: Options for setting the size of the editor and controling editor resizing
 :keywords:
 
@@ -25,4 +24,4 @@ include::partial$configuration/max_width.adoc[leveloffset=+1]
 
 == Auto-resizing the editor
 
-{productname} can be configured to automatically resize based on the editor content. For information on configuring the automatic resizing, see: link:autoresize.html[The Autoresize plugin].
+{productname} can be configured to automatically resize based on the editor content. For information on configuring the automatic resizing, see: xref:autoresize.adoc[The Autoresize plugin].

--- a/modules/ROOT/partials/configuration/auto_focus.adoc
+++ b/modules/ROOT/partials/configuration/auto_focus.adoc
@@ -1,3 +1,4 @@
+[[auto_focus]]
 == `+auto_focus+`
 
 Automatically set the focus to an editor instance. The value of this option should be an editor instance `+id+`. The editor instance id is the id for the original `+textarea+` or `+div+` element that got replaced.

--- a/modules/ROOT/partials/configuration/base_url.adoc
+++ b/modules/ROOT/partials/configuration/base_url.adoc
@@ -1,3 +1,4 @@
+[[base_url]]
 == `+base_url+`
 
 This option lets you specify the base URL for {productname}. This is useful if you want to load {productname} from one location and things like the theme and plugins from another.
@@ -8,7 +9,7 @@ Type : `+String+`
 
 === Example: Using `+base_url+`
 
-[source,js]
+[source,js,subs="attributes+"]
 ----
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML

--- a/modules/ROOT/partials/configuration/cache_suffix.adoc
+++ b/modules/ROOT/partials/configuration/cache_suffix.adoc
@@ -1,6 +1,7 @@
+[[cache_suffix]]
 == `+cache_suffix+`
 
-This option lets you add a custom cache buster URL part at the end of each request `+{prodnamecode}+` makes to load CSS, scripts, etc. Just add the query string part you want to append to each URL request, for example "?v=4.1.6".
+This option lets you add a custom cache buster URL part at the end of each request {productname} makes to load CSS, scripts, etc. Just add the query string part you want to append to each URL request, for example "?v=4.1.6".
 
 Type : `+String+`
 

--- a/modules/ROOT/partials/configuration/content_security_policy.adoc
+++ b/modules/ROOT/partials/configuration/content_security_policy.adoc
@@ -1,3 +1,4 @@
+[[content_security_policy]]
 == `+content_security_policy+`
 
 This option allows you to set a custom content security policy for the editor's iframe contents.

--- a/modules/ROOT/partials/configuration/custom_ui_selector.adoc
+++ b/modules/ROOT/partials/configuration/custom_ui_selector.adoc
@@ -1,3 +1,4 @@
+[[custom_ui_selector]]
 == `+custom_ui_selector+`
 
 Use the *custom_ui_selector* option to specify the elements that you want {productname} to treat as a part of the editor UI. Specifying elements enables the editor not to lose the selection even if the focus is moved to the elements matching this selector. The `+editor blur+` event is not fired if the focus is moved to elements matching this selector since it's treated as part of the editor UI.

--- a/modules/ROOT/partials/configuration/external_plugins.adoc
+++ b/modules/ROOT/partials/configuration/external_plugins.adoc
@@ -1,3 +1,4 @@
+[[external_plugins]]
 == `+external_plugins+`
 
 This option allows you to specify a URL based location of plugins outside of the normal {productname} plugins directory.

--- a/modules/ROOT/partials/configuration/height.adoc
+++ b/modules/ROOT/partials/configuration/height.adoc
@@ -1,10 +1,9 @@
+[[height]]
 == `+height+`
 
 `+height+` sets the height of the entire editor, including the menu bar, toolbars, and status bar.
 
-____
-*Note*: If a number is provided, {productname} sets the height in pixels. If a string is provided, {productname} assumes the value is valid CSS and sets the editor's height as the string value. This allows for alternate units such as `+%+`, `+em+`, and `+vh+`.
-____
+NOTE: If a number is provided, {productname} sets the height in pixels. If a string is provided, {productname} assumes the value is valid CSS and sets the editor's height as the string value. This allows for alternate units such as `+%+`, `+em+`, and `+vh+`.
 
 Type : `+Number+` or `+String+`
 

--- a/modules/ROOT/partials/configuration/hidden_input.adoc
+++ b/modules/ROOT/partials/configuration/hidden_input.adoc
@@ -1,3 +1,4 @@
+[[hidden_input]]
 == `+hidden_input+`
 
 The *hidden_input* option gives you the ability to disable the auto-generation of hidden input fields for inline editing elements. By default all inline editors have a hidden input element in which content gets saved when an `+editor.save()+` or `+tinymce.triggerSave()+` is executed.

--- a/modules/ROOT/partials/configuration/init_instance_callback.adoc
+++ b/modules/ROOT/partials/configuration/init_instance_callback.adoc
@@ -1,3 +1,4 @@
+[[init_instance_callback]]
 == `+init_instance_callback+`
 
 The *init_instance_callback* option allows you to specify a function name to be executed each time an editor instance is initialized. The format of this function is `+initInstance(editor)+` where `+editor+` is the editor instance object reference.
@@ -16,4 +17,4 @@ tinymce.init({
 });
 ----
 
-You may also want to take a look at the <<setup, setup callback option>> as it can be used to bind events before the editor instance is initialized.
+You may also want to take a look at the xref:editor-important-options.adoc#setup[setup callback option] as it can be used to bind events before the editor instance is initialized.

--- a/modules/ROOT/partials/configuration/max_height.adoc
+++ b/modules/ROOT/partials/configuration/max_height.adoc
@@ -1,6 +1,7 @@
+[[max_height]]
 == `+max_height+`
 
-The `+max_height+` option has two kinds of behaviors depending on the state of the link:autoresize.html[`+autoresize+`] plugin:
+The `+max_height+` option has two kinds of behaviors depending on the state of the xref:autoresize.adoc[`+autoresize+`] plugin:
 
 * `+autoresize+` OFF (Default) : Without the `+autoresize+` plugin, this option allows you to set the maximum height that a user can stretch the entire {productname} interface (by grabbing the dragable area in the bottom right of the editor interface).
 * `+autoresize+` ON : With the `+autoresize+` plugin, this option sets the maximum height the editor can automatically expand to.
@@ -17,6 +18,4 @@ tinymce.init({
 });
 ----
 
-____
-*Note*: If you set the option link:editor-size-options.html#resize[`+resize+`] to `+false+` the resize handle will be disabled and a user will not be able to resize the editor (by manual dragging). Note that `+resize+` defaults to `+false+` when the `+autoresize+` plugin is enabled.
-____
+NOTE: If you set the option xref:editor-size-options.adoc#resize[`+resize+`] to `+false+` the resize handle will be disabled and a user will not be able to resize the editor (by manual dragging). Note that `+resize+` defaults to `+false+` when the `+autoresize+` plugin is enabled.

--- a/modules/ROOT/partials/configuration/max_width.adoc
+++ b/modules/ROOT/partials/configuration/max_width.adoc
@@ -1,10 +1,9 @@
+[[max_width]]
 == `+max_width+`
 
 This option allows you to set the maximum width that a user can stretch the entire {productname} interface (by grabbing the dragable area in the bottom right of the editor interface) when using the modern theme.
 
-____
-*Note*: This behavior is different than the link:autoresize.html[`+autoresize+`] plugin, which controls the resizing of the editable area only, not the entire editor.
-____
+NOTE: This behavior is different than the xref:autoresize.adoc[`+autoresize+`] plugin, which controls the resizing of the editable area only, not the entire editor.
 
 Type : `+Number+`
 
@@ -18,6 +17,4 @@ tinymce.init({
 });
 ----
 
-____
-*Note*: by default the link:editor-size-options.html#resize[`+resize+`] handle does not allow horizontal dragging and giving this key a value will not result in an observable behavior.
-____
+NOTE: by default the xref:editor-size-options.adoc#resize[`+resize+`] handle does not allow horizontal dragging and giving this key a value will not result in an observable behavior.

--- a/modules/ROOT/partials/configuration/min_height.adoc
+++ b/modules/ROOT/partials/configuration/min_height.adoc
@@ -1,6 +1,7 @@
+[[min_height]]
 == `+min_height+`
 
-The *min_height* option has two kinds of behaviors depending on the state of the link:autoresize.html[`+autoresize+`] plugin:
+The *min_height* option has two kinds of behaviors depending on the state of the xref:autoresize.adoc[`+autoresize+`] plugin:
 
 * `+autoresize+` OFF (Default) : Without the `+autoresize+` plugin, this option allows you to set the minimum height that a user can shrink the entire {productname} interface (by grabbing the dragable area in the bottom right of the editor interface).
 * `+autoresize+` ON : With the `+autoresize+` plugin, this option sets the minimum height the editor can automatically shrink to.
@@ -17,6 +18,4 @@ tinymce.init({
 });
 ----
 
-____
-*Note*: If you set the option link:editor-size-options.html#resize[`+resize+`] to `+false+` the resize handle will be disabled and a user will not be able to resize the editor (by manual dragging). Note that `+resize+` defaults to `+false+` when the `+autoresize+` plugin is enabled.
-____
+NOTE: If you set the option xref:editor-size-options.adoc#resize[`+resize+`] to `+false+` the resize handle will be disabled and a user will not be able to resize the editor (by manual dragging). Note that `+resize+` defaults to `+false+` when the `+autoresize+` plugin is enabled.

--- a/modules/ROOT/partials/configuration/min_width.adoc
+++ b/modules/ROOT/partials/configuration/min_width.adoc
@@ -1,10 +1,9 @@
+[[min_width]]
 == `+min_width+`
 
 This option allows you to set the minimum width that a user can stretch the entire {productname} interface (by grabbing the dragable area in the bottom right of the editor interface) when using the modern theme.
 
-____
-*Note*: This behavior is different from the link:autoresize.html[`+autoresize+`] plugin, which controls the resizing of the editable area only, not the entire editor.
-____
+NOTE: This behavior is different from the xref:autoresize.adoc[`+autoresize+`] plugin, which controls the resizing of the editable area only, not the entire editor.
 
 Type : `+Number+`
 
@@ -18,6 +17,4 @@ tinymce.init({
 });
 ----
 
-____
-*Note*: By default the link:editor-size-options.html#resize[`+resize+`] handle does not allow horizontal dragging and giving this key a value will not result in an observable behavior.
-____
+NOTE: By default the xref:editor-size-options.adoc#resize[`+resize+`] handle does not allow horizontal dragging and giving this key a value will not result in an observable behavior.

--- a/modules/ROOT/partials/configuration/placeholder.adoc
+++ b/modules/ROOT/partials/configuration/placeholder.adoc
@@ -1,10 +1,9 @@
+[[placeholder]]
 == `+placeholder+`
 
 This option adds placeholder content that will be shown when the editor is empty.
 
-____
-*Note:* If the editor is initialized on a `+textarea+` element, the placeholder attribute can be used instead.
-____
+NOTE: If the editor is initialized on a `+textarea+` element, the placeholder attribute can be used instead.
 
 Type : `+String+`
 

--- a/modules/ROOT/partials/configuration/plugins.adoc
+++ b/modules/ROOT/partials/configuration/plugins.adoc
@@ -1,3 +1,4 @@
+[[plugins]]
 == `+plugins+`
 
 This option allows you to specify which plugins {productname} will attempt to load when starting up. By default, {productname} will not load any plugins.
@@ -14,8 +15,6 @@ tinymce.init({
 });
 ----
 
-____
-*Note*: Each plugin entry should be separated by a blank space.
-____
+NOTE: Each plugin entry should be separated by a blank space.
 
 link:/plugins-ref/[Check this documentation page for a list of available plugins].

--- a/modules/ROOT/partials/configuration/readonly.adoc
+++ b/modules/ROOT/partials/configuration/readonly.adoc
@@ -1,6 +1,7 @@
+[[readonly]]
 == `+readonly+`
 
-Setting the `+readonly+` option to `+true+` will initialize the editor in `+"readonly"+` mode instead of editing (`+"design"+`) mode. Once initialized, the editor can be set to editing (`+"design"+`) mode using the link:tinymce.editormode.html#set[`+tinymce.editor.mode.set+` API].
+Setting the `+readonly+` option to `+true+` will initialize the editor in `+"readonly"+` mode instead of editing (`+"design"+`) mode. Once initialized, the editor can be set to editing (`+"design"+`) mode using the link:apis/tinymce.editormode.html#set[`+tinymce.editor.mode.set+` API].
 
 Type : `+Boolean+`
 

--- a/modules/ROOT/partials/configuration/referrer_policy.adoc
+++ b/modules/ROOT/partials/configuration/referrer_policy.adoc
@@ -1,3 +1,4 @@
+[[referrer_policy]]
 == `+referrer_policy+`
 
 Used for setting the level of referrer information sent when loading plugins and CSS. Referrer policies can be used to:

--- a/modules/ROOT/partials/configuration/resize.adoc
+++ b/modules/ROOT/partials/configuration/resize.adoc
@@ -1,3 +1,4 @@
+[[resize]]
 == `+resize+`
 
 This option gives you the ability to disable the resize handle or set it to resize both horizontal and vertically. The option can be true, false or the string `+'both'+`. `+False+` disables the resize, `+true+` enables vertical resizing only, `+'both'+` makes it possible to resize in both directions horizontal and vertical.

--- a/modules/ROOT/partials/configuration/selector.adoc
+++ b/modules/ROOT/partials/configuration/selector.adoc
@@ -1,3 +1,4 @@
+[[selector]]
 == `+selector+`
 
 This option allows you to specify a CSS selector for the areas that {productname} should make editable.
@@ -46,4 +47,4 @@ tinymce.init({
 });
 ----
 
-For more information on the differences between regular and inline editing modes please see this page link:/interface/editor-mode/use-tinymce-inline/[here].
+For more information on the differences between regular and inline editing modes please see this page link:use-tinymce-inline.html[here].

--- a/modules/ROOT/partials/configuration/setup.adoc
+++ b/modules/ROOT/partials/configuration/setup.adoc
@@ -1,3 +1,4 @@
+[[setup]]
 == `+setup+`
 
 This option allows you to specify a callback that will be executed before the {productname} editor instance is rendered.

--- a/modules/ROOT/partials/configuration/suffix.adoc
+++ b/modules/ROOT/partials/configuration/suffix.adoc
@@ -1,3 +1,4 @@
+[[suffix]]
 == `+suffix+`
 
 This option lets you specify the suffix of {productname}. By default this value will be set to the same as the suffix of the script holding {productname}. When loading things like the theme and plugins this suffix will be inserted into all requests. For example, loading {productname} with a `+tinymce.min.js+` file will make {productname} load `+.min+` versions of everything it lazy-loads, like `+theme.min.js+` and `+plugin.min.js+` The suffix option is useful for overriding this behaviour.

--- a/modules/ROOT/partials/configuration/taborder.adoc
+++ b/modules/ROOT/partials/configuration/taborder.adoc
@@ -1,3 +1,4 @@
+[[taborder]]
 == Tab order
 
 The tab order of the elements in a page, including {productname}, should be configured by setting the https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex[`+tabindex+` attribute] on the relevant HTML elements. The browser will then natively handle the tab order.

--- a/modules/ROOT/partials/configuration/target.adoc
+++ b/modules/ROOT/partials/configuration/target.adoc
@@ -1,10 +1,9 @@
+[[target]]
 == `+target+`
 
 Sometimes there might be already a reference to a DOM element at hand, for example when element is created dynamically. In such case initialising editor on it by link:editor-important-options.html#selector[selector] might seem irrational (since selector - _id_ or _class_ should be created first). In such cases you can supply that element directly via `+target+` option.
 
-____
-*Important:* `+selector+` option has precedence over `+target+`, so in order for `+target+` to work, do not use the `+selector+` option.
-____
+IMPORTANT: `+selector+` option has precedence over `+target+`, so in order for `+target+` to work, do not use the `+selector+` option.
 
 Type : `+Node+`
 

--- a/modules/ROOT/partials/configuration/width.adoc
+++ b/modules/ROOT/partials/configuration/width.adoc
@@ -1,10 +1,9 @@
+[[width]]
 == `+width+`
 
 Set the width of the editor.
 
-____
-*Note*: {productname} sets the width in pixels if a number is provided. However, if {productname} is provided a string it assumes the value is valid CSS and simply sets the editor's width as the string value. This allows for alternate units such as `+%+`, `+em+` and `+vh+`.
-____
+NOTE: {productname} sets the width in pixels if a number is provided. However, if {productname} is provided a string it assumes the value is valid CSS and simply sets the editor's width as the string value. This allows for alternate units such as `+%+`, `+em+` and `+vh+`.
 
 Type : `+Number+` or `+String+`
 

--- a/modules/ROOT/partials/misc/admon_different_default_for_mobile.adoc
+++ b/modules/ROOT/partials/misc/admon_different_default_for_mobile.adoc
@@ -1,3 +1,1 @@
-____
-*Note*: The default option for this setting is different for mobile devices. For information on the default mobile setting, see: link:tinymce-for-mobile.html#mobiledefaultsforselectedsettings[{productname} Mobile - Configuration settings with mobile defaults].
-____
+NOTE: The default option for this setting is different for mobile devices. For information on the default mobile setting, see: link:tinymce-for-mobile.html#mobiledefaultsforselectedsettings[{productname} Mobile - Configuration settings with mobile defaults].


### PR DESCRIPTION
Related Ticket: DOC-1532

Description of Changes:
* Replace all liquid logic with asciidoc ifeval, etc... logic instead
* Fixed conversion issues with admonitions (these were converted to blockquotes since markdown doesn't have this concept)
* Fixed xref conversion issues (basically replace the legacy `<<id, title>>` format with `xref:id[title]`)

**Note:** I'd suggest running this locally instead of trying to review the actual markup here.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [ ] Product Manager has reviewed
