### PR TITLE
DOC-1532: Fixed markdown -> asciidoc conversion issues (open source plugins)

### DIFF
--- a/modules/ROOT/pages/advlist.adoc
+++ b/modules/ROOT/pages/advlist.adoc
@@ -1,15 +1,12 @@
 = Advanced List plugin
 
 :title_nav: Advanced List
-
 :description: Create styled number and bulleted lists.
 :keywords: advlist advlist_bullet_styles advlist_number_styles
 
 The `+advlist+` plugin extends the core `+bullist+` and `+numlist+` toolbar controls by adding CSS `+list-style-type+` styled number formats and bullet types to the controls.
 
-____
-*Important*: The link:lists.html[Lists] (`+lists+`) plugin must be activated for the `+advlist+` plugin to work.
-____
+IMPORTANT: The link:lists.html[Lists] (`+lists+`) plugin must be activated for the `+advlist+` plugin to work.
 
 == Basic setup
 

--- a/modules/ROOT/pages/advlist.adoc
+++ b/modules/ROOT/pages/advlist.adoc
@@ -3,6 +3,8 @@
 :title_nav: Advanced List
 :description: Create styled number and bulleted lists.
 :keywords: advlist advlist_bullet_styles advlist_number_styles
+:plugincode: advlist
+:altplugincode: nil
 
 The `+advlist+` plugin extends the core `+bullist+` and `+numlist+` toolbar controls by adding CSS `+list-style-type+` styled number formats and bullet types to the controls.
 

--- a/modules/ROOT/pages/anchor.adoc
+++ b/modules/ROOT/pages/anchor.adoc
@@ -1,14 +1,11 @@
 = Anchor plugin
 
 :title_nav: Anchor
-
 :description: Insert anchors (sometimes referred to as a bookmarks).
 :controls: toolbar button, menu item
-
 :pluginname: Anchor
-
 :plugincode: anchor
-
+:altplugincode: nil
 
 This plugin adds an anchor/bookmark button to the toolbar that inserts an anchor at the editor's cursor insertion point. It also adds the menu item `+anchor+` under the `+Insert+` menu.
 

--- a/modules/ROOT/pages/autolink.adoc
+++ b/modules/ROOT/pages/autolink.adoc
@@ -3,6 +3,8 @@
 :title_nav: Autolink
 :description: Automatically create hyperlinks.
 :keywords: link url urls
+:plugincode: autolink
+:altplugincode: nil
 
 The Autolink plugin automatically creates hyperlinks when a user types a valid, complete URL. For example `+www.example.com+` is converted to `+http://www.example.com+`.
 

--- a/modules/ROOT/pages/autolink.adoc
+++ b/modules/ROOT/pages/autolink.adoc
@@ -1,7 +1,6 @@
 = Autolink plugin
 
 :title_nav: Autolink
-
 :description: Automatically create hyperlinks.
 :keywords: link url urls
 
@@ -9,9 +8,7 @@ The Autolink plugin automatically creates hyperlinks when a user types a valid, 
 
 Note that this option won't convert incomplete URLs. For example `+example.com+` would remain as unlinked text and URLs must include `+www+` to be automatically converted.
 
-____
-*Note*: Pasted URLs are automatically converted to `+a+` elements by {productname}'s core code, not by the autolink plugin. Therefore, behaviour and settings described here do not apply to pasted links.
-____
+NOTE: Pasted URLs are automatically converted to `+a+` elements by {productname}'s core code, not by the autolink plugin. Therefore, behaviour and settings described here do not apply to pasted links.
 
 == Basic setup
 

--- a/modules/ROOT/pages/autoresize.adoc
+++ b/modules/ROOT/pages/autoresize.adoc
@@ -1,12 +1,10 @@
 = Autoresize plugin
 
 :title_nav: Autoresize
-
 :description_short: :description: Automatically resize TinyMCE to fit content. :keywords: height width max_height min_height autoresize_on_init autoresize_overflow_padding autoresize_overflow_padding
-
 :pluginname: Autoresize
-
-
+:plugincode: autoresize
+:altplugincode: nil
 
 This plugin automatically resizes the editor to the content inside it. It is typically used to prevent the editor from expanding infinitely as a user types into the editable area. For example, by giving the `+max_height+` option a value the editor will stop resizing when the set value is reached.
 

--- a/modules/ROOT/pages/autosave.adoc
+++ b/modules/ROOT/pages/autosave.adoc
@@ -5,11 +5,9 @@
 :description: Automatically save content in your local browser.
 :controls: toolbar button, menu item
 :keywords: autosave_ask_before_unload autosave_interval autosave_prefix autosave_prefix autosave_restore_when_empty autosave_retention
-
 :pluginname: Autosave
-
 :plugincode: autosave
-
+:altplugincode: nil
 
 The autosave plugin gives the user a warning if they have unsaved changes in the editor and either:
 

--- a/modules/ROOT/pages/available-menu-items.adoc
+++ b/modules/ROOT/pages/available-menu-items.adoc
@@ -25,6 +25,7 @@ include::partial$menu-item-ids/core-menu-items.adoc[]
 
 :pluginname: A11yChecker
 :plugincode: a11ychecker
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: premium
@@ -38,132 +39,154 @@ include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :pluginname: Advanced Tables
 :plugincode: advtable
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Anchor
 :plugincode: anchor
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Autosave
 :plugincode: autosave
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: premium
 
 :pluginname: Case Change
 :plugincode: casechange
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Character Map
 :plugincode: charmap
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: premium
 
 :pluginname: Checklist
 :plugincode: checklist
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Code
 :plugincode: code
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Code Sample
 :plugincode: codesample
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: premium
 
 :pluginname: Comments
 :plugincode: comments
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Emoticons
 :plugincode: emoticons
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: premium
 
 :pluginname: Export
 :plugincode: export
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Full Screen
 :plugincode: fullscreen
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Help
 :plugincode: help
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Image
 :plugincode: image
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Insert Date/Time
 :plugincode: insertdatetime
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Link
 :plugincode: link
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Media
 :plugincode: media
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Nonbreaking Space
 :plugincode: nonbreaking
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Page Break
 :plugincode: pagebreak
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: premium
 
 :pluginname: Page Embed
 :plugincode: pageembed
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Paste
 :plugincode: paste
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: premium
 
 :pluginname: Permanent Pen
 :plugincode: permanentpen
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: premium
@@ -177,58 +200,68 @@ include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :pluginname: Preview
 :plugincode: preview
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Search and Replace
 :plugincode: searchreplace
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: premium
 
 :pluginname: Spell Checker Pro
 :plugincode: tinymcespellchecker
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Table
 :plugincode: table
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Template
 :plugincode: template
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: premium
 
 :pluginname: site.cloudfilemanager
 :plugincode: tinydrive
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Table of Contents
 :plugincode: toc
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Visual Blocks
 :plugincode: visualblocks
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Visual Characters
 :plugincode: visualchars
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Word Count
 :plugincode: wordcount
+:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]

--- a/modules/ROOT/pages/available-toolbar-buttons.adoc
+++ b/modules/ROOT/pages/available-toolbar-buttons.adoc
@@ -25,6 +25,7 @@ include::partial$toolbar-button-ids/core-toolbar-buttons.adoc[]
 
 :pluginname: A11yChecker
 :plugincode: a11ychecker
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
@@ -38,156 +39,182 @@ include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :pluginname: Advanced Tables
 :plugincode: advtable
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Anchor
 :plugincode: anchor
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Autosave
 :plugincode: autosave
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
 
 :pluginname: Case Change
 :plugincode: casechange
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Character Map
 :plugincode: charmap
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
 
 :pluginname: Checklist
 :plugincode: checklist
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Code
 :plugincode: code
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Code Sample
 :plugincode: codesample
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
 
 :pluginname: Comments
 :plugincode: comments
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Directionality
 :plugincode: directionality
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Emoticons
 :plugincode: emoticons
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
 
 :pluginname: Export
 :plugincode: export
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
 
 :pluginname: Format Painter
 :plugincode: formatpainter
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Full Screen
 :plugincode: fullscreen
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Help
 :plugincode: help
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Image
 :plugincode: image
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Image Tools
 :plugincode: imagetools
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Insert Date/Time
 :plugincode: insertdatetime
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Link
 :plugincode: link
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Lists
 :plugincode: lists
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Media
 :plugincode: media
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Nonbreaking Space
 :plugincode: nonbreaking
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Page Break
 :plugincode: pagebreak
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
 
 :pluginname: Page Embed
 :plugincode: pageembed
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Paste
 :plugincode: paste
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
 
 :pluginname: Permanent Pen
 :plugincode: permanentpen
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
@@ -201,70 +228,82 @@ include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :pluginname: Preview
 :plugincode: preview
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Quick Toolbars
 :plugincode: quickbars
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Save
 :plugincode: save
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Search and Replace
 :plugincode: searchreplace
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
 
 :pluginname: Spell Checker Pro
 :plugincode: tinymcespellchecker
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Table
 :plugincode: table
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Template
 :plugincode: template
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
 
 :pluginname: site.cloudfilemanager
 :plugincode: tinydrive
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Table of Contents
 :plugincode: toc
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Visual Blocks
 :plugincode: visualblocks
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Visual Characters
 :plugincode: visualchars
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 
 :pluginname: Word Count
 :plugincode: wordcount
+:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]

--- a/modules/ROOT/pages/code.adoc
+++ b/modules/ROOT/pages/code.adoc
@@ -1,15 +1,13 @@
 = Code plugin
 
 :title_nav: Code
-
 :description: Edit your content's HTML source.
 :keywords: wysiwyg source html edit
 :controls: toolbar button, menu item
-
 :pluginname: Code
-
 :plugincode: code
-
+:plugincode: code
+:altplugincode: nil
 
 This plugin adds a toolbar button that allows a user to edit the HTML code hidden by the WYSIWYG view. It also adds the menu item `+Source code+` under the `+Tools+` menu.
 

--- a/modules/ROOT/pages/codesample.adoc
+++ b/modules/ROOT/pages/codesample.adoc
@@ -1,13 +1,10 @@
 = Code Sample plugin
 
 :title_nav: Code Sample
-
 :description: Insert and embed syntax highlighted code snippets.
 :keywords: syntax highlight codesample code contenteditable codesample_languages
 :controls: toolbar button
-
 :pluginname: Code Sample
-
 :plugincode: codesample
 
 
@@ -26,9 +23,7 @@ tinymce.init({
 
 By default, `+codesample+` uses `+http://prismjs.com/+` to embed the code samples within the editor and works out of the box. That is, when a user copies valid code syntax into the editable area the code will be automatically formatted according to Prism default CSS rules.
 
-____
-*Note*: Prism.js and prism.css need to be added to a page for syntax highlighting to work. See the instructions below to learn how to do this.
-____
+NOTE: Prism.js and prism.css need to be added to a page for syntax highlighting to work. See the instructions below to learn how to do this.
 
 [[using-prismjs-on-your-web-page]]
 == Using Prism.js on your web page

--- a/modules/ROOT/pages/codesample.adoc
+++ b/modules/ROOT/pages/codesample.adoc
@@ -6,6 +6,7 @@
 :controls: toolbar button
 :pluginname: Code Sample
 :plugincode: codesample
+:altplugincode: nil
 
 
 The Code Sample plugin (`+codesample+`) lets a user insert and embed syntax color highlighted code snippets into the editable area. It also adds a button to the toolbar which on click will open a dialog box to accept raw code input.

--- a/modules/ROOT/pages/emoticons.adoc
+++ b/modules/ROOT/pages/emoticons.adoc
@@ -1,23 +1,17 @@
 = Emoticons plugin
 
 :title_nav: Emoticons
-
 :description: Bring a smiley to your content.
 :keywords: smiley happy smiling emoji
 :controls: toolbar button
-
 :pluginname: Emoticons
-
 :plugincode: emoticons
-
 
 This plugin adds a dialog to the editor lets users insert emoji into {productname}'s editable area. The dialog can be invoked via a toolbar button - `+emoticons+` - or a dedicated menu item added as `+Insert > Emoticons+`.
 
 The emoticons plugin provides an autocompleter for adding emoji without using the toolbar button or menu item. Adding a colon `+:+`, followed by at least two characters will open the emoticon picker showing matching emoji.
 
-____
-*Note*: The emoticons plugin does not automatically convert text emoticons into graphical emoji.
-____
+NOTE: The emoticons plugin does not automatically convert text emoticons into graphical emoji.
 
 == Basic setup
 
@@ -74,4 +68,4 @@ include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 The {pluginname} plugin provides the following {productname} command.
 
-include::partial$commands/{plugincode}-cmds.adoc[]
+include::partial$commands/emoticons-cmds.adoc[]

--- a/modules/ROOT/pages/emoticons.adoc
+++ b/modules/ROOT/pages/emoticons.adoc
@@ -6,6 +6,7 @@
 :controls: toolbar button
 :pluginname: Emoticons
 :plugincode: emoticons
+:altplugincode: nil
 
 This plugin adds a dialog to the editor lets users insert emoji into {productname}'s editable area. The dialog can be invoked via a toolbar button - `+emoticons+` - or a dedicated menu item added as `+Insert > Emoticons+`.
 

--- a/modules/ROOT/pages/fullscreen.adoc
+++ b/modules/ROOT/pages/fullscreen.adoc
@@ -5,11 +5,9 @@
 :description: Zoom TinyMCE up to the whole screen.
 :keywords: fullscreen view
 :controls: toolbar button, menu item
-
 :pluginname: Full Screen
-
 :plugincode: fullscreen
-
+:altplugincode: nil
 
 This plugin adds full screen editing capabilities to {productname}. When the toolbar button is pressed the editable area will fill the browser's viewport. The plugin adds a toolbar button and a menu item `+Fullscreen+` under the `+View+` menu.
 

--- a/modules/ROOT/pages/help.adoc
+++ b/modules/ROOT/pages/help.adoc
@@ -1,15 +1,12 @@
 = Help plugin
 
 :title_nav: Help
-
 :description: Shows the help dialog.
 :keywords: help
 :controls: toolbar button, menu item
-
 :pluginname: Help
-
 :plugincode: help
-
+:altplugincode: nil
 
 The help plugin adds a button and/or menu item that opens a dialog showing two tabs:
 

--- a/modules/ROOT/pages/help.adoc
+++ b/modules/ROOT/pages/help.adoc
@@ -32,6 +32,7 @@ tinymce.init({
 
 include::partial$configuration/help_tabs.adoc[]
 
+[[tabapi]]
 == API
 
 [cols=",,",options="header",]

--- a/modules/ROOT/pages/image.adoc
+++ b/modules/ROOT/pages/image.adoc
@@ -1,14 +1,10 @@
 = Image plugin
 
 :title_nav: Image
-
 :description: Insert an image into TinyMCE.
 :keywords: photo insert edit style format image_caption image_list image_advtab image_title image_class_list image_prepend_url image_description image_dimensions image_title image_prepend_url
-
 :pluginname: Image
-
 :plugincode: image
-
 
 This plugin enables the user to insert an image into {productname}'s editable area. The plugin also adds a toolbar button and an `+Insert/edit image+` menu item under the `+Insert+` menu.
 
@@ -28,9 +24,7 @@ tinymce.init({
 });
 ----
 
-____
-*Note*: This is not drag-drop functionality and the user is required to enter the path to the image. Optionally the user can also enter the image description, dimensions, and whether image proportions should be constrained (selected via a checkbox). Some of these settings can be preset using the plugin's configuration options.
-____
+NOTE: This is not drag-drop functionality and the user is required to enter the path to the image. Optionally the user can also enter the image description, dimensions, and whether image proportions should be constrained (selected via a checkbox). Some of these settings can be preset using the plugin's configuration options.
 
 include::partial$misc/admon_svg_not_supported.adoc[]
 
@@ -41,8 +35,6 @@ These configuration options affect the execution of the `+image+` plugin. Many o
 If you wish to align the image, you can also use the text align buttons while images are selected.
 
 :includedSection: imagePlugin
-
-
 include::partial$configuration/a11y_advanced_options.adoc[leveloffset=+1]
 :includedSection: false
 include::partial$configuration/file_picker_callback.adoc[leveloffset=+1]

--- a/modules/ROOT/pages/image.adoc
+++ b/modules/ROOT/pages/image.adoc
@@ -5,6 +5,7 @@
 :keywords: photo insert edit style format image_caption image_list image_advtab image_title image_class_list image_prepend_url image_description image_dimensions image_title image_prepend_url
 :pluginname: Image
 :plugincode: image
+:altplugincode: nil
 
 This plugin enables the user to insert an image into {productname}'s editable area. The plugin also adds a toolbar button and an `+Insert/edit image+` menu item under the `+Insert+` menu.
 

--- a/modules/ROOT/pages/imagetools.adoc
+++ b/modules/ROOT/pages/imagetools.adoc
@@ -5,6 +5,7 @@
 :keywords: imagetools rotate rotateleft rotateright flip flipv fliph editimage imageoptions
 :pluginname: Image Tools
 :plugincode: imagetools
+:altplugincode: nil
 
 include::partial$DEPRECATED/imagetools.adoc[]
 

--- a/modules/ROOT/pages/imagetools.adoc
+++ b/modules/ROOT/pages/imagetools.adoc
@@ -1,14 +1,10 @@
 = Image Tools plugin
 
 :title_nav: Image Tools
-
 :description: Image editing features for TinyMCE.
 :keywords: imagetools rotate rotateleft rotateright flip flipv fliph editimage imageoptions
-
 :pluginname: Image Tools
-
 :plugincode: imagetools
-
 
 include::partial$DEPRECATED/imagetools.adoc[]
 
@@ -39,7 +35,6 @@ tinymce.init({
 
 To enable the {productname} Image Tools plugin:
 
-[arabic]
 . Add 'image' to the 'toolbar' list and 'image imagetools' to the 'plugins' list
 . Enable `+imagetools_cors_hosts+` and `+imagetools_proxy+` options as needed
 

--- a/modules/ROOT/pages/importcss.adoc
+++ b/modules/ROOT/pages/importcss.adoc
@@ -1,9 +1,10 @@
 = Import CSS plugin
 
 :title_nav: Import CSS
-
 :description: Automatically populate CSS class names into the Format dropdown.
 :keywords: importcss content_css importcss_append importcss_file_filter importcss_selector_filter importcss_groups importcss_merge_classes importcss_selector_converter importcss_exclusive
+:plugincode: importcss
+:altplugincode: nil
 
 The `+importcss+` plugin adds the ability to automatically import CSS classes from the CSS file specified in the link:add-css-options.html#content_css[`+content_css+`] configuration setting.
 

--- a/modules/ROOT/pages/insertdatetime.adoc
+++ b/modules/ROOT/pages/insertdatetime.adoc
@@ -5,11 +5,9 @@
 :description: Insert the current date and/or time into TinyMCE.
 :keywords: insertdatetime insertdatetime_dateformat insertdatetime_formats insertdatetime_timeformat insertdatetime_element dateformats
 :controls: toolbar button, menu item
-
 :pluginname: Insert Date/Time
-
 :plugincode: insertdatetime
-
+:altplugincode: nil
 
 The `+insertdatetime+` plugin provides a toolbar control and menu item `+Insert date/time+` (under the `+Insert+` menu) that lets a user easily insert the current date and/or time into the editable area at the cursor insertion point.
 

--- a/modules/ROOT/pages/link.adoc
+++ b/modules/ROOT/pages/link.adoc
@@ -1,14 +1,12 @@
 = Link plugin
 
 :title_nav: Link
-
 :description: Add hyperlinks to content.
 :keywords: url urls insert edit link_default_target link_assume_external_targets link_class_list link_list link_target_list link_rel_list link_title
 :controls: toolbar button, menu item
-
 :pluginname: Link
-
 :plugincode: link
+:altplugincode: nil
 
 
 The *link* plugin allows a user to link external resources such as website URLs, to selected text in their document.

--- a/modules/ROOT/pages/link.adoc
+++ b/modules/ROOT/pages/link.adoc
@@ -13,7 +13,7 @@ The *link* plugin allows a user to link external resources such as website URLs,
 
 It adds two toolbar buttons called `+link+` and `+unlink+` and three menu items called `+link+`, `+unlink+` and `+openlink+`. The toolbar button and menu item called `+link+` are included in {productname}'s default configuration. The `+link+` menu item can be found in the `+Insert+` menu.
 
-The *link* plugin also includes a context menu and context toolbar. The context toolbar can be configured using the <<link_context_toolbar, `+link_context_toolbar+`>> and <<link_quicklink, `+link_quicklink+`>> options documented below.
+The *link* plugin also includes a context menu and context toolbar. The context toolbar can be configured using the xref:link_context_toolbar[+link_context_toolbar+`] and xref:link_quicklink[`+link_quicklink+`] options documented below.
 
 == Basic setup
 

--- a/modules/ROOT/pages/lists.adoc
+++ b/modules/ROOT/pages/lists.adoc
@@ -1,13 +1,11 @@
 = Lists plugin
 
 :title_nav: Lists
-
 :description: Normalizes list behavior between browsers.
 :keywords: list lists browser normalize
-
 :pluginname: Lists
-
 :plugincode: lists
+:altplugincode: nil
 
 
 The `+lists+` plugin allows you to add numbered and bulleted lists to {productname}. To enable advanced lists (e.g. alpha numbered lists, square bullets) you should also enable the link:advlist.html[Advanced List] (`+advlist+`) plugin.

--- a/modules/ROOT/pages/media.adoc
+++ b/modules/ROOT/pages/media.adoc
@@ -1,14 +1,12 @@
 = Media plugin
 
 :title_nav: Media
-
 :description: Add HTML5 video and audio elements.
 :keywords: video youtube vimeo mp3 mp4 mov movie clip film media_live_embeds audio_template_callback media_alt_source media_poster media_dimensions media_filter_html media_scripts video_template_callback
 :controls: toolbar button, menu item
-
 :pluginname: Media
-
 :plugincode: media
+:altplugincode: nil
 
 
 The `+media+` plugin adds the ability for users to be able to add HTML5 video and audio elements to the editable area. It also adds the item `+Insert/edit video+` under the `+Insert+` menu as well as a toolbar button.

--- a/modules/ROOT/pages/nonbreaking.adoc
+++ b/modules/ROOT/pages/nonbreaking.adoc
@@ -5,11 +5,9 @@
 :description: Insert a nonbreaking space.
 :keywords: nonbreaking nonbreaking_force_tab insert
 :controls: toolbar button, menu item
-
 :pluginname: Nonbreaking Space
-
 :plugincode: nonbreaking
-
+:altplugincode: nil
 
 This plugin adds a button for inserting nonbreaking space entities `+&nbsp;+` at the current caret location (cursor insert point). It also adds a menu item `+Nonbreaking space+` under the `+Insert+` menu dropdown and a toolbar button.
 

--- a/modules/ROOT/pages/pagebreak.adoc
+++ b/modules/ROOT/pages/pagebreak.adoc
@@ -1,15 +1,12 @@
 = Page Break plugin
 
 :title_nav: Page Break
-
 :description: Add a page break.
 :keywords: pagebreak insert pagebreak_separator pagebreak_split_block
 :controls: toolbar button, menu item
-
 :pluginname: Page Break
-
 :plugincode: pagebreak
-
+:altplugincode: nil
 
 This plugin adds page break support and enables a user to insert page breaks in the editable area. This is useful where a CMS uses a special separator to break content into pages.
 

--- a/modules/ROOT/pages/paste.adoc
+++ b/modules/ROOT/pages/paste.adoc
@@ -1,15 +1,11 @@
 = Paste plugin
 
 :title_nav: Paste
-
 :description: Standard version of features for copying-and-pasting content from Microsoft Word.
 :keywords: microsoft word excel cut copy paste_data_images paste_as_text paste_enable_default_filters paste_filter_drop paste_preprocess paste_postprocess paste_word_valid_elements paste_webkit_styles paste_retain_style_properties paste_merge_formats paste_convert_word_fake_lists paste_remove_styles_if_webkit
 :controls: toolbar button, menu item
-
 :pluginname: Paste
-
 :plugincode: paste
-
 
 ____
 Looking for more advanced Microsoft Word importing and pasting? Try the link:powerpaste.html[PowerPaste] plugin.
@@ -19,9 +15,7 @@ This plugin will filter/cleanup content pasted from Microsoft Word. The power of
 
 The plugin also adds a menu item `+Paste as text+` under the `+Edit+` menu dropdown and a toolbar button.
 
-____
-*Note:* The toolbar button won't work in browsers that don't support direct access to the clipboard. In such cases the user will be presented with a modal/dialog box advising them of this along with a reminder of standard keyboard shortcuts.
-____
+NOTE: The toolbar button won't work in browsers that don't support direct access to the clipboard. In such cases the user will be presented with a modal/dialog box advising them of this along with a reminder of standard keyboard shortcuts.
 
 == Basic setup
 

--- a/modules/ROOT/pages/paste.adoc
+++ b/modules/ROOT/pages/paste.adoc
@@ -6,6 +6,7 @@
 :controls: toolbar button, menu item
 :pluginname: Paste
 :plugincode: paste
+:altplugincode: nil
 
 ____
 Looking for more advanced Microsoft Word importing and pasting? Try the link:powerpaste.html[PowerPaste] plugin.

--- a/modules/ROOT/pages/preview.adoc
+++ b/modules/ROOT/pages/preview.adoc
@@ -1,15 +1,12 @@
 = Preview plugin
 
 :title_nav: Preview
-
 :description: Shows a popup of the current content in read-only format.
 :keywords: view preview
 :controls: toolbar button, menu item
-
 :pluginname: Preview
-
 :plugincode: preview
-
+:altplugincode: nil
 
 This plugin adds a preview button to the toolbar. Pressing the button opens a dialog box showing the current content in a preview mode. It also adds a menu item `+Preview+` under the `+File+` and `+View+` menu dropdowns.
 

--- a/modules/ROOT/pages/quickbars.adoc
+++ b/modules/ROOT/pages/quickbars.adoc
@@ -1,14 +1,10 @@
 = Quick Toolbars plugin
 
 :title_nav: Quick Toolbars
-
 :description: User interface controls to create content faster.
 :keywords: plugin inlite quickbar
-
 :pluginname: Quick Toolbars
-
 :plugincode: quickbars
-
 
 The Quick Toolbar plugin adds three context toolbars:
 
@@ -102,9 +98,7 @@ tinymce.init({
 
 The Quick Image (`+quickimage+`) toolbar button allows users to quickly insert images from their computer into the editor. It is included in the Quick Insert context toolbar by default and can be used in other toolbars.
 
-____
-*Note*: To enable automatic upload of images on insertion, link:/how-to-guides/image-handling-guide/upload-images/[image upload] must be configured.
-____
+NOTE: To enable automatic upload of images on insertion, link:/how-to-guides/image-handling-guide/upload-images/[image upload] must be configured.
 
 ==== Example: Using quickimage in the editor toolbar
 

--- a/modules/ROOT/pages/quickbars.adoc
+++ b/modules/ROOT/pages/quickbars.adoc
@@ -5,6 +5,7 @@
 :keywords: plugin inlite quickbar
 :pluginname: Quick Toolbars
 :plugincode: quickbars
+:altplugincode: nil
 
 The Quick Toolbar plugin adds three context toolbars:
 

--- a/modules/ROOT/pages/save.adoc
+++ b/modules/ROOT/pages/save.adoc
@@ -5,11 +5,9 @@
 :description: Adds a save button to the TinyMCE toolbar.
 :keywords: submit save_enablewhendirty save_oncancelcallback save_onsavecallback
 :controls: toolbar button
-
 :pluginname: Save
-
 :plugincode: save
-
+:altplugincode: nil
 
 This plugin adds a save button to the {productname} toolbar, which will submit the form that the editor is within.
 

--- a/modules/ROOT/pages/searchreplace.adoc
+++ b/modules/ROOT/pages/searchreplace.adoc
@@ -1,15 +1,12 @@
 = Search and Replace plugin
 
 :title_nav: Search and Replace
-
 :description: Find and replace content in TinyMCE.
 :keywords: searchreplace edit
 :controls: toolbar button, menu item
-
 :pluginname: Search and Replace
-
 :plugincode: searchreplace
-
+:altplugincode: nil
 
 This plugin adds search/replace dialogs to {productname}. It also adds a toolbar button and the menu item `+Find and replace+` under the `+Edit+` menu dropdown.
 

--- a/modules/ROOT/pages/table.adoc
+++ b/modules/ROOT/pages/table.adoc
@@ -1,15 +1,11 @@
 = Table plugin
 
 :title_nav: Table
-
 :description: Table editing features.
 :keywords: row cell column table_appearance_options table_clone_elements table_grid table_tab_navigation table_default_attributes table_default_styles table_class_list table_cell_class_list table_row_class_list table_advtab table_cell_advtab table_row_advtab
 :controls: toolbar button, menu item
-
 :pluginname: Table
-
 :plugincode: table
-
 
 The `+table+` plugin adds table management functionality to {productname}. It also adds a new menubar item `+Table+` with various options in its dropdown including `+Insert table+` and options to modify cells, rows and columns, and a toolbar button with the same functionality.
 
@@ -117,9 +113,7 @@ tinymce.init({
 });
 ----
 
-____
-*Note*: The advanced tabs of the table, row, and cell properties dialogs use the `+colorpicker+` to allow for border and background colors to be applied. See docs to use and configure a custom link:user-formatting-options.html#textcoloroptions[colorpicker].
-____
+NOTE: The advanced tabs of the table, row, and cell properties dialogs use the `+colorpicker+` to allow for border and background colors to be applied. See docs to use and configure a custom link:user-formatting-options.html#textcoloroptions[colorpicker].
 
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 

--- a/modules/ROOT/pages/table.adoc
+++ b/modules/ROOT/pages/table.adoc
@@ -6,6 +6,7 @@
 :controls: toolbar button, menu item
 :pluginname: Table
 :plugincode: table
+:altplugincode: nil
 
 The `+table+` plugin adds table management functionality to {productname}. It also adds a new menubar item `+Table+` with various options in its dropdown including `+Insert table+` and options to modify cells, rows and columns, and a toolbar button with the same functionality.
 

--- a/modules/ROOT/pages/template.adoc
+++ b/modules/ROOT/pages/template.adoc
@@ -1,15 +1,11 @@
 = Template plugin
 
 :title_nav: Template
-
 :description: Custom templates for your content.
 :keywords: insert template_cdate_classes template_cdate_format template_mdate_classes template_mdate_format template_replace_values template_selected_content_classes template_preview_replace_values
 :controls: toolbar button, menu item
-
 :pluginname: Template
-
 :plugincode: template
-
 
 The `+template+` plugin adds support for custom templates. It also adds a menu item `+Insert template+` under the `+Insert+` menu and a toolbar button.
 

--- a/modules/ROOT/pages/template.adoc
+++ b/modules/ROOT/pages/template.adoc
@@ -6,6 +6,7 @@
 :controls: toolbar button, menu item
 :pluginname: Template
 :plugincode: template
+:altplugincode: nil
 
 The `+template+` plugin adds support for custom templates. It also adds a menu item `+Insert template+` under the `+Insert+` menu and a toolbar button.
 

--- a/modules/ROOT/pages/textpattern.adoc
+++ b/modules/ROOT/pages/textpattern.adoc
@@ -3,6 +3,8 @@
 :title_nav: Text Pattern
 :description: Matches special patterns in the text and applies formats or executed commands on these patterns.
 :keywords: textpattern textpattern_patterns format cmd
+:plugincode: textpattern
+:altplugincode: nil
 
 The Text Pattern plugin matches special patterns in the text and applies formats, replaces text, or executes commands on these patterns.
 

--- a/modules/ROOT/pages/textpattern.adoc
+++ b/modules/ROOT/pages/textpattern.adoc
@@ -1,7 +1,6 @@
 = Text Pattern plugin
 
 :title_nav: Text Pattern
-
 :description: Matches special patterns in the text and applies formats or executed commands on these patterns.
 :keywords: textpattern textpattern_patterns format cmd
 

--- a/modules/ROOT/pages/toc.adoc
+++ b/modules/ROOT/pages/toc.adoc
@@ -6,6 +6,7 @@
 :controls: toolbar button, menu item
 :pluginname: Table of Contents
 :plugincode: toc
+:altplugincode: nil
 
 include::partial$DEPRECATED/toc.adoc[]
 

--- a/modules/ROOT/pages/toc.adoc
+++ b/modules/ROOT/pages/toc.adoc
@@ -1,15 +1,11 @@
 = Table of Contents plugin
 
 :title_nav: Table of Contents
-
 :description: Insert a simple Table of Contents into TinyMCE editor
 :keywords: toc toc_depth toc_class toc_header
 :controls: toolbar button, menu item
-
 :pluginname: Table of Contents
-
 :plugincode: toc
-
 
 include::partial$DEPRECATED/toc.adoc[]
 

--- a/modules/ROOT/pages/visualblocks.adoc
+++ b/modules/ROOT/pages/visualblocks.adoc
@@ -6,7 +6,7 @@
 :controls: toolbar button, menu item
 :pluginname: Visual Blocks
 :plugincode: visualblocks
-
+:altplugincode: nil
 
 This plugin allows a user to see block level elements in the editable area. It is similar to WYSIWYG hidden character functionality, but at block level. It also adds a toolbar button and a menu item `+Show blocks+` under the `+View+` menu dropdown.
 

--- a/modules/ROOT/pages/visualblocks.adoc
+++ b/modules/ROOT/pages/visualblocks.adoc
@@ -1,13 +1,10 @@
 = Visual Blocks plugin
 
 :title_nav: Visual Blocks
-
 :description: Allows a user to see block level elements such as paragraphs.
 :keywords: visualblocks wysiwyg hidden view visualblocks_default_state
 :controls: toolbar button, menu item
-
 :pluginname: Visual Blocks
-
 :plugincode: visualblocks
 
 

--- a/modules/ROOT/pages/visualchars.adoc
+++ b/modules/ROOT/pages/visualchars.adoc
@@ -1,15 +1,11 @@
 = Visual Characters plugin
 
 :title_nav: Visual Characters
-
 :description: See invisible characters like non-breaking spaces.
 :keywords: visualchars
 :controls: toolbar button, menu item
-
 :pluginname: Visual Characters
-
 :plugincode: visualchars
-
 
 This plugin adds the ability to see invisible characters like `+&nbsp;+` displayed in the editable area. It also adds a toolbar control and a menu item `+Show invisible characters+` under the `+View+` menu.
 

--- a/modules/ROOT/pages/visualchars.adoc
+++ b/modules/ROOT/pages/visualchars.adoc
@@ -6,6 +6,7 @@
 :controls: toolbar button, menu item
 :pluginname: Visual Characters
 :plugincode: visualchars
+:altplugincode: nil
 
 This plugin adds the ability to see invisible characters like `+&nbsp;+` displayed in the editable area. It also adds a toolbar control and a menu item `+Show invisible characters+` under the `+View+` menu.
 

--- a/modules/ROOT/pages/wordcount.adoc
+++ b/modules/ROOT/pages/wordcount.adoc
@@ -1,14 +1,10 @@
 = Word Count plugin
 
 :title_nav: Word Count
-
 :description: Show a word count in the TinyMCE status bar.
 :keywords: wordcount
-
 :pluginname: Word Count
-
 :plugincode: wordcount
-
 
 The Word Count plugin adds the functionality for counting words to the {productname} editor by placing a counter on the right edge of the status bar. Clicking *Word Count* in the status bar switches between counting words and characters. A dialog box with both word and character counts can be opened using the menu item situated in the *Tools* drop-down, or the toolbar button.
 
@@ -31,7 +27,7 @@ include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 The {pluginname} plugin provides the following {productname} command.
 
-include::partial$commands/{plugincode}-cmds.adoc[]
+include::partial$commands/wordcount-cmds.adoc[]
 
 == API
 

--- a/modules/ROOT/pages/wordcount.adoc
+++ b/modules/ROOT/pages/wordcount.adoc
@@ -5,6 +5,7 @@
 :keywords: wordcount
 :pluginname: Word Count
 :plugincode: wordcount
+:altplugincode: nil
 
 The Word Count plugin adds the functionality for counting words to the {productname} editor by placing a counter on the right edge of the status bar. Clicking *Word Count* in the status bar switches between counting words and characters. A dialog box with both word and character counts can be opened using the menu item situated in the *Tools* drop-down, or the toolbar button.
 

--- a/modules/ROOT/partials/DEPRECATED/generic-5_10.adoc
+++ b/modules/ROOT/partials/DEPRECATED/generic-5_10.adoc
@@ -1,3 +1,1 @@
-____
-*Important:* This option has been deprecated in {productname} 5.10 and will be removed in {productname} 6.0.
-____
+IMPORTANT: This option has been deprecated in {productname} 5.10 and will be removed in {productname} 6.0.

--- a/modules/ROOT/partials/DEPRECATED/imagetools.adoc
+++ b/modules/ROOT/partials/DEPRECATED/imagetools.adoc
@@ -1,3 +1,1 @@
-____
-*Important*: {productname} {productminorversion} will include the final release of the Image Tools plugin (`+imagetools+`) as an open source plugin. The Image Tools plugin will be removed from the open source bundle and be available as a premium plugin for {productname} 6.0.
-____
+IMPORTANT: {productname} {productminorversion} will include the final release of the Image Tools plugin (`+imagetools+`) as an open source plugin. The Image Tools plugin will be removed from the open source bundle and be available as a premium plugin for {productname} 6.0.

--- a/modules/ROOT/partials/DEPRECATED/toc.adoc
+++ b/modules/ROOT/partials/DEPRECATED/toc.adoc
@@ -1,3 +1,1 @@
-____
-*Important*: {productname} {productminorversion} will include the final release of the Table of Contents plugin (`+toc+`) as an open source plugin. The Table of Contents plugin will be removed from the open source bundle and be available as a premium plugin for {productname} 6.0.
-____
+IMPORTANT: {productname} {productminorversion} will include the final release of the Table of Contents plugin (`+toc+`) as an open source plugin. The Table of Contents plugin will be removed from the open source bundle and be available as a premium plugin for {productname} 6.0.

--- a/modules/ROOT/partials/commands/table-cmds.adoc
+++ b/modules/ROOT/partials/commands/table-cmds.adoc
@@ -1,6 +1,4 @@
-____
-*Note*: Table row and table column cut, copy, and paste commands work with {productname}'s internal table clipboard, not the user's system clipboard.
-____
+NOTE: Table row and table column cut, copy, and paste commands work with {productname}'s internal table clipboard, not the user's system clipboard.
 
 [cols=",",options="header",]
 |===

--- a/modules/ROOT/partials/configuration/a11y_advanced_options.adoc
+++ b/modules/ROOT/partials/configuration/a11y_advanced_options.adoc
@@ -44,8 +44,7 @@ tinymce.init({
 ----
 
 endif::[]
-// TODO: This isn't work for some reason
-ifeval::[{includedSection} == false]
+ifndef::includedSection[]
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/a11y_advanced_options.adoc
+++ b/modules/ROOT/partials/configuration/a11y_advanced_options.adoc
@@ -10,9 +10,7 @@ Setting `+a11y_advanced_options+` to `+true+`:
 * Adds the *Image is decorative* option to the _Insert/Edit Image_ dialog, allowing users to specify that an image is decorative and does not require alternative text for accessibility purposes.
 * Adds the *Image is decorative* option to the _Accessibility Checker error_ dialog for images without alternative text or the `+role="presentation"+` attribute.
 
-____
-*Important*: When `+a11y_advanced_options+` is set to `+true+`, link:a11ychecker.html#a11ychecker_allow_decorative_images[`+a11ychecker_allow_decorative_images+`] will default to `+true+`.
-____
+IMPORTANT: When `+a11y_advanced_options+` is set to `+true+`, link:a11ychecker.html#a11ychecker_allow_decorative_images[`+a11ychecker_allow_decorative_images+`] will default to `+true+`.
 
 Type : `+Boolean+`
 
@@ -22,7 +20,7 @@ Possible Values : `+true+`, `+false+`
 
 === Example: Using `+a11y_advanced_options+`
 
-\{% if includedSection == 'imagePlugin' %}
+ifeval::["{includedSection}" == "imagePlugin"]
 
 [source,js]
 ----
@@ -33,7 +31,8 @@ tinymce.init({
 });
 ----
 
-\{% elsif includedSection == 'a11yPlugin' %}
+endif::[]
+ifeval::["{includedSection}" == "a11yPlugin"]
 
 [source,js]
 ----
@@ -44,7 +43,9 @@ tinymce.init({
 });
 ----
 
-\{% else %}
+endif::[]
+// TODO: This isn't work for some reason
+ifeval::[{includedSection} == false]
 
 [source,js]
 ----
@@ -55,4 +56,4 @@ tinymce.init({
 });
 ----
 
-\{% endif %}
+endif::[]

--- a/modules/ROOT/partials/configuration/advlist_bullet_styles.adoc
+++ b/modules/ROOT/partials/configuration/advlist_bullet_styles.adoc
@@ -2,11 +2,11 @@
 
 This option allows you to include specific unordered list item markers in the default `+bullist+` toolbar control.
 
-Type : `+String+`
+Type: `+String+`
 
-Default Value : `+'default,circle,disc,square'+`
+Default Value: `+'default,circle,disc,square'+`
 
-Possible Values : * `+default+`: your browser's default style
+Possible Values: * `+default+`: your browser's default style
 
 * `+circle+`: a hollow circle
 * `+disc+`: a filled circle

--- a/modules/ROOT/partials/configuration/advlist_number_styles.adoc
+++ b/modules/ROOT/partials/configuration/advlist_number_styles.adoc
@@ -2,11 +2,11 @@
 
 This option allows you to include specific ordered list item markers in the default `+numlist+` toolbar control.
 
-Type : `+String+`
+Type: `+String+`
 
-Default Value : `+'default,lower-alpha,lower-greek,lower-roman,upper-alpha,upper-roman'+`
+Default Value: `+'default,lower-alpha,lower-greek,lower-roman,upper-alpha,upper-roman'+`
 
-Possible Values : * `+default+`: your browser's default style
+Possible Values: * `+default+`: your browser's default style
 
 * `+lower-alpha+`: lowercase ASCII letters, e.g. a, b, c, ... z
 * `+lower-greek+`: lowercase classical Greek (alpha, beta, gamma), e.g. α, β, γ ...

--- a/modules/ROOT/partials/configuration/anchor_bottom.adoc
+++ b/modules/ROOT/partials/configuration/anchor_bottom.adoc
@@ -2,7 +2,7 @@
 
 Lets you specify a custom name for the bottom anchor in the url type ahead drop down. To disable the bottom anchor from the drop down set it `+false+`.
 
-Type : `+String+`
+Type: `+String+`
 
 Default : `+'#bottom+`'
 

--- a/modules/ROOT/partials/configuration/anchor_top.adoc
+++ b/modules/ROOT/partials/configuration/anchor_top.adoc
@@ -2,7 +2,7 @@
 
 Lets you specify a custom name for the top anchor in the url type ahead drop down. To disable the to anchor from the drop down set it `+false+`.
 
-Type : `+String+`
+Type: `+String+`
 
 Default : `+'#top'+`
 

--- a/modules/ROOT/partials/configuration/autoresize_bottom_margin.adoc
+++ b/modules/ROOT/partials/configuration/autoresize_bottom_margin.adoc
@@ -2,7 +2,7 @@
 
 This option allows you to specify the size of the `+padding+` at the bottom of the editor's `+body+` set on initialization.
 
-Type : `+Number+`
+Type: `+Number+`
 
 === Example: Using `+autoresize_bottom_margin+`
 

--- a/modules/ROOT/partials/configuration/autoresize_on_init.adoc
+++ b/modules/ROOT/partials/configuration/autoresize_on_init.adoc
@@ -4,11 +4,11 @@ include::partial$DEPRECATED/generic-5_10.adoc[]
 
 This option allows you to set whether the editor will attempt to resize itself upon initialization. By default this option is set to `+true+`.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: `+autoresize_on_init+`
 

--- a/modules/ROOT/partials/configuration/autoresize_overflow_padding.adoc
+++ b/modules/ROOT/partials/configuration/autoresize_overflow_padding.adoc
@@ -2,7 +2,7 @@
 
 This option allows you to specify the size of the `+padding+` at the sides of the editor's `+body+` set on initialization.
 
-Type : `+Number+`
+Type: `+Number+`
 
 === Example: `+autoresize_overflow_padding+`
 

--- a/modules/ROOT/partials/configuration/autosave_ask_before_unload.adoc
+++ b/modules/ROOT/partials/configuration/autosave_ask_before_unload.adoc
@@ -2,11 +2,11 @@
 
 This option allows you to set whether the editor should prompt the user to advise them that they have unsaved changes when attempting to close the current window. By default this option is enabled and an example of disabling this setting is included below.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+autosave_ask_before_unload+`
 

--- a/modules/ROOT/partials/configuration/autosave_interval.adoc
+++ b/modules/ROOT/partials/configuration/autosave_interval.adoc
@@ -2,9 +2,9 @@
 
 This option enables you to specify the time the editor should wait between taking snapshots of the current content and saving them to local storage. The syntax is to append the letter `+s+` to the end of a number value. For example, "30s" for 30 seconds.
 
-Type : `+String+`
+Type: `+String+`
 
-Default Value : `+'30s'+`
+Default Value: `+'30s'+`
 
 === Example: Using `+autosave_interval+`
 

--- a/modules/ROOT/partials/configuration/autosave_prefix.adoc
+++ b/modules/ROOT/partials/configuration/autosave_prefix.adoc
@@ -2,9 +2,9 @@
 
 This option allows you to set the prefix that is used for local storage keys.
 
-Type : `+String+`
+Type: `+String+`
 
-Default Value : `+'tinymce-autosave-{path}{query}-{id}-'+`
+Default Value: `+'tinymce-autosave-{path}{query}-{id}-'+`
 
 === Example: Using `+autosave_prefix+`
 

--- a/modules/ROOT/partials/configuration/autosave_restore_when_empty.adoc
+++ b/modules/ROOT/partials/configuration/autosave_restore_when_empty.adoc
@@ -2,11 +2,11 @@
 
 This option enables you to specify if {productname} should automatically restore the content stored in local storage when the editor is empty on initialization. This can be useful for users who don't know that they can restore lost work if the browser crashed by selecting `+Restore last draft+` from the `+File+` menu.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+false+`
+Default Value: `+false+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+autosave_restore_when_empty+`
 

--- a/modules/ROOT/partials/configuration/autosave_retention.adoc
+++ b/modules/ROOT/partials/configuration/autosave_retention.adoc
@@ -2,9 +2,9 @@
 
 This option lets you to specify the duration editor content should remain in local storage. Content older than the set time will be ignored. The syntax is to append the letter `+m+` to the end of a number value. For example, "20m" for 20 minutes.
 
-Type : `+String+`
+Type: `+String+`
 
-Default Value : `+'20m'+`
+Default Value: `+'20m'+`
 
 === Example: Using `+autosave_retention+`
 

--- a/modules/ROOT/partials/configuration/charmap.adoc
+++ b/modules/ROOT/partials/configuration/charmap.adoc
@@ -2,7 +2,7 @@
 
 With this option it is possible to fully override the default character map. This can be an array or a function that returns an array in the above mentioned format.
 
-Type : `+Array+`, `+Function+`
+Type: `+Array+`, `+Function+`
 
 === Example: Using `+charmap+`
 

--- a/modules/ROOT/partials/configuration/charmap.adoc
+++ b/modules/ROOT/partials/configuration/charmap.adoc
@@ -1,5 +1,8 @@
 == `+charmap+`
 
+:plugincode: charmap
+:altplugincode: nil
+
 With this option it is possible to fully override the default character map. This can be an array or a function that returns an array in the above mentioned format.
 
 Type: `+Array+`, `+Function+`

--- a/modules/ROOT/partials/configuration/charmap_append.adoc
+++ b/modules/ROOT/partials/configuration/charmap_append.adoc
@@ -2,7 +2,7 @@
 
 This option provides a way to append some additional characters to the default character map. This can be array or a function that returns an array in the above mentioned format.
 
-Type : `+Array+`, `+Function+`
+Type: `+Array+`, `+Function+`
 
 === Example: Using `+charmap_append+`
 

--- a/modules/ROOT/partials/configuration/codesample_global_prismjs.adoc
+++ b/modules/ROOT/partials/configuration/codesample_global_prismjs.adoc
@@ -10,7 +10,7 @@ When using this option, ensure that Prism.js and any language add-ons are loaded
 <script src="tinymce.js"></script>
 ----
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
 Default value : `+false+`
 

--- a/modules/ROOT/partials/configuration/directionality.adoc
+++ b/modules/ROOT/partials/configuration/directionality.adoc
@@ -1,5 +1,8 @@
 == `+directionality+`
 
+:plugincode: directionality
+:altplugincode: nil
+
 This option allows you to set the base direction of directionally neutral text (i.e., text that doesn't have inherent directionality as defined in Unicode) within the editor. This is similar to the use of the `+'dir'+` attribute when using content editable elements by themselves.
 
 Type: `+String+`

--- a/modules/ROOT/partials/configuration/directionality.adoc
+++ b/modules/ROOT/partials/configuration/directionality.adoc
@@ -2,11 +2,11 @@
 
 This option allows you to set the base direction of directionally neutral text (i.e., text that doesn't have inherent directionality as defined in Unicode) within the editor. This is similar to the use of the `+'dir'+` attribute when using content editable elements by themselves.
 
-Type : `+String+`
+Type: `+String+`
 
-Default Value : `+'ltr'+`
+Default Value: `+'ltr'+`
 
-Possible Values : `+'ltr'+`, `+'rtl'+`
+Possible Values: `+'ltr'+`, `+'rtl'+`
 
 === Example: Using `+directionality+`
 

--- a/modules/ROOT/partials/configuration/emoticons_append.adoc
+++ b/modules/ROOT/partials/configuration/emoticons_append.adoc
@@ -2,7 +2,7 @@
 
 This option provides a way to append some additional emoji to the default emoji database. This should be an object in the above mentioned format.
 
-Type : `+Object+`
+Type: `+Object+`
 
 === Example: Using `+emoticons_append+`
 

--- a/modules/ROOT/partials/configuration/emoticons_database.adoc
+++ b/modules/ROOT/partials/configuration/emoticons_database.adoc
@@ -5,13 +5,13 @@ This option provides the ability to specify which built-in emoji database to use
 * `+emojis+` - This database uses Unicode characters to represent emoji in the editor content.
 * `+emojiimages+` - This database uses images provided by the Twitter Emoji (twemoji) project to represent emoji in the editor content.
 
-:feature: `+emojiimages+` database
+:feature: emojiimages database
 
 :third_party_product: Twitter Emoji (twemoji) graphics
 :license_agreement_name: CC-BY 4.0
 include::partial$misc/under-license.adoc[]
 
-Type : `+String+`
+Type: `+String+`
 
 Default : `+'emojis'+`
 

--- a/modules/ROOT/partials/configuration/emoticons_database_url.adoc
+++ b/modules/ROOT/partials/configuration/emoticons_database_url.adoc
@@ -2,7 +2,7 @@
 
 This option provides the default location to load the emoji database from. The database should be an external JavaScript file, that registers a `+tinymce.plugins.emoticons+` resource.
 
-Type : `+String+`
+Type: `+String+`
 
 Default : `+'${pluginUrl}/js/emojis.js'+`
 

--- a/modules/ROOT/partials/configuration/emoticons_images_url.adoc
+++ b/modules/ROOT/partials/configuration/emoticons_images_url.adoc
@@ -4,7 +4,7 @@ This option sets the base URL for the images used to represent emojis when using
 
 By default, this option loads the required image _assets_ from the Twemoji CDN. To use self-hosted emoji images, download the image _assets_ from the https://github.com/twitter/twemoji/#download[Twitter Emoji (twemoji) GitHub repository].
 
-Type : `+String+`
+Type: `+String+`
 
 Default : `+'https://twemoji.maxcdn.com/v/13.0.1/72x72/'+`
 

--- a/modules/ROOT/partials/configuration/file_picker_callback.adoc
+++ b/modules/ROOT/partials/configuration/file_picker_callback.adoc
@@ -1,6 +1,6 @@
 == `+file_picker_callback+`
 
-This hook can be used to add custom file picker to those dialogs that have it. Once you define `+file_picker_callback+`, small browse button will appear along the fields of supported file types (see <<file_picker_types, file_picker_types>>). When user clicks the button, {productname} will automatically call the callback with three arguments:
+This hook can be used to add custom file picker to those dialogs that have it. Once you define `+file_picker_callback+`, small browse button will appear along the fields of supported file types (see xref:file_picker_types[file_picker_types]). When user clicks the button, {productname} will automatically call the callback with three arguments:
 
 * *callback* - _a callback to call, once you have hold of the file; it expects new value for the field as the first argument and optionally meta information for other fields in the dialog as the second one_
 * *value* - _current value of the affected field_
@@ -10,7 +10,7 @@ It should be noted, that we only provide a hook. It is up to you to implement sp
 
 Type : `+JavaScript Function+`
 
-NOTE: The following example demonstrates how you can use `+file_picker_callback+` API, but doesn't pick any real files. Check the <<interactiveexample, Interactive example>> for a more functional example.
+NOTE: The following example demonstrates how you can use `+file_picker_callback+` API, but doesn't pick any real files. Check the xref:interactiveexample[Interactive example] for a more functional example.
 
 === Example: Using `+file_picker_callback+`
 
@@ -37,6 +37,7 @@ tinymce.init({
 });
 ----
 
+[[interactiveexample]]
 === Interactive example
 
 liveDemo::file-picker[ ]

--- a/modules/ROOT/partials/configuration/file_picker_callback.adoc
+++ b/modules/ROOT/partials/configuration/file_picker_callback.adoc
@@ -10,9 +10,7 @@ It should be noted, that we only provide a hook. It is up to you to implement sp
 
 Type : `+JavaScript Function+`
 
-____
-*Note*: The following example demonstrates how you can use `+file_picker_callback+` API, but doesn't pick any real files. Check the <<interactiveexample, Interactive example>> for a more functional example.
-____
+NOTE: The following example demonstrates how you can use `+file_picker_callback+` API, but doesn't pick any real files. Check the <<interactiveexample, Interactive example>> for a more functional example.
 
 === Example: Using `+file_picker_callback+`
 

--- a/modules/ROOT/partials/configuration/file_picker_types.adoc
+++ b/modules/ROOT/partials/configuration/file_picker_types.adoc
@@ -1,3 +1,4 @@
+[[file_picker_types]]
 == `+file_picker_types+`
 
 This option enables you to specify what types of file pickers you need by a space or comma separated list of type names. There are currently three valid types: `+file+`, `+image+` and `+media+`.

--- a/modules/ROOT/partials/configuration/fullscreen_native.adoc
+++ b/modules/ROOT/partials/configuration/fullscreen_native.adoc
@@ -1,17 +1,14 @@
 == `+fullscreen_native+`
 
-\{% if pluginname != "fullscreen" %}
-
-____
-*Note*: The `+fullscreen_native+` option requires the Fullscreen plugin.
-\{% endif %}
-____
+ifeval::["{plugincode}" != "fullscreen"]
+NOTE: The `+fullscreen_native+` option requires the Fullscreen plugin.
+endif::[]
 
 The `+fullscreen_native+` option allows the editor to use the browser full screen mode, rather than only filling the https://developer.mozilla.org/en-US/docs/Web/CSS/Viewport_concepts#What_is_a_viewport[browser window] when full screen mode is enabled. This functionality is the same as full screen mode for online videos.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+false+`
+Default Value: `+false+`
 
 Possible values : `+true+`, `+false+`
 

--- a/modules/ROOT/partials/configuration/help_tabs.adoc
+++ b/modules/ROOT/partials/configuration/help_tabs.adoc
@@ -1,6 +1,6 @@
 == `+help_tabs+`
 
-This option allows you to specify which tabs the Help dialog should show, and in what order. The default {productname} tabs are called `+shortcuts+`, `+keyboardnav+`, `+plugins+` and `+versions+`. These tabs can be overwritten by providing a new link:dialog-components.html#tabpanel[tab panel] specification with the same `+name+`, and new tabs can be added by registering a tab panel with a new `+name+`. New tabs can be registered in the `+help_tabs+` configuration or at initialization or runtime using the <<api, `+addTab+` API method>>.
+This option allows you to specify which tabs the Help dialog should show, and in what order. The default {productname} tabs are called `+shortcuts+`, `+keyboardnav+`, `+plugins+` and `+versions+`. These tabs can be overwritten by providing a new link:dialog-components.html#tabpanel[tab panel] specification with the same `+name+`, and new tabs can be added by registering a tab panel with a new `+name+`. New tabs can be registered in the `+help_tabs+` configuration or at initialization or runtime using the xref:tabapi[`+addTab+` API method].
 
 If `+help_tabs+` is configured, only tabs named in `+help_tabs+` will be displayed. Any tabs defined using `+addTab+` that are not named in `+help_tabs+` will be ignored.
 

--- a/modules/ROOT/partials/configuration/help_tabs.adoc
+++ b/modules/ROOT/partials/configuration/help_tabs.adoc
@@ -6,9 +6,9 @@ If `+help_tabs+` is configured, only tabs named in `+help_tabs+` will be display
 
 If `+help_tabs+` is not configured, any tabs defined using `+addTab+` will be displayed after the default tabs.
 
-Type : `+Array+`
+Type: `+Array+`
 
-Default Value : `+['shortcuts', 'keyboardnav', 'plugins', 'versions']+`
+Default Value: `+['shortcuts', 'keyboardnav', 'plugins', 'versions']+`
 
 === Example: Using `+help_tabs+`
 

--- a/modules/ROOT/partials/configuration/image_advtab.adoc
+++ b/modules/ROOT/partials/configuration/image_advtab.adoc
@@ -2,11 +2,11 @@
 
 This option adds an "Advanced" tab to the image dialog allowing you to add custom styles, spacing and borders to images.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+false+`
+Default Value: `+false+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+image_advtab+`
 

--- a/modules/ROOT/partials/configuration/image_caption.adoc
+++ b/modules/ROOT/partials/configuration/image_caption.adoc
@@ -2,11 +2,11 @@
 
 This option lets users enable captions for images. When this option is enabled the image dialog will have an extra checkbox called "Caption". When a user checks the checkbox the image will get wrapped in an HTML5 `+figure+` element with a `+figcaption+` inside it. The user will then be able to type caption content inside the editor.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+false+`
+Default Value: `+false+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+image_caption+`
 

--- a/modules/ROOT/partials/configuration/image_class_list.adoc
+++ b/modules/ROOT/partials/configuration/image_class_list.adoc
@@ -2,7 +2,7 @@
 
 This option lets you specify a predefined list of classes to add to an image. It takes the form of an array with items to set classes on links.
 
-Type : `+String+`
+Type: `+String+`
 
 === Example: Using `+image_class_list+`
 

--- a/modules/ROOT/partials/configuration/image_cors_hosts.adoc
+++ b/modules/ROOT/partials/configuration/image_cors_hosts.adoc
@@ -1,28 +1,21 @@
-\{% if plugincode == "export" %}
-
+ifeval::["{plugincode}" == "export"]
 == `+export_cors_hosts+`
-
-\{% else %}
-
+endif::[]
+ifeval::["{plugincode}" != "export"]
 == `+imagetools_cors_hosts+`
-
-\{% endif %}
+endif::[]
 
 The {pluginname} plugin cannot work with images from another domains due to security measures imposed by browsers on so called cross-origin HTTP requests. To overcome these constraints, Cross-Origin Resource Sharing (CORS) must be explicitly enabled on the specified domain(s) (for more information check https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS[HTTP access control]).
 
 An array of supported domains for the images (with CORS enabled on them) can be supplied to {productname} via the `+{plugincode}_cors_hosts+` option.
 
-____
-*Note*: Each string in the array _must_ be in the format of `+mydomain.com+`. Do not include protocols (`+http://, https://+`) or any trailing slashes in your domains.
-____
+NOTE: Each string in the array _must_ be in the format of `+mydomain.com+`. Do not include protocols (`+http://, https://+`) or any trailing slashes in your domains.
 
-____
-*Note*: `+{plugincode}_cors_hosts+` is *not* required when enabling this plugin via link:/how-to-guides/cloud-deployment-guide/editor-and-features/[{cloudname}].
-____
+NOTE: `+{plugincode}_cors_hosts+` is *not* required when enabling this plugin via link:/how-to-guides/cloud-deployment-guide/editor-and-features/[{cloudname}].
 
-Type : `+String[]+`
+Type: `+String[]+`
 
-Default Value : `+[]+`
+Default Value: `+[]+`
 
 === Example: `+{plugincode}_cors_hosts+`
 

--- a/modules/ROOT/partials/configuration/image_description.adoc
+++ b/modules/ROOT/partials/configuration/image_description.adoc
@@ -2,11 +2,11 @@
 
 This options allows you disable the image description input field in the image dialog.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+image_description+`
 

--- a/modules/ROOT/partials/configuration/image_dimensions.adoc
+++ b/modules/ROOT/partials/configuration/image_dimensions.adoc
@@ -2,11 +2,11 @@
 
 This options allows you disable the image dimensions input field in the image dialog.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+image_dimensions+`
 

--- a/modules/ROOT/partials/configuration/image_file_types.adoc
+++ b/modules/ROOT/partials/configuration/image_file_types.adoc
@@ -1,6 +1,6 @@
 == `+image_file_types+`
 
-This option configures which image file formats will be recognized and placed in an `+img+` element by the <<smart_paste, `+smart_paste+`>> functionality when content is pasted into the editor.
+This option configures which image file formats will be recognized and placed in an `+img+` element by the xref:smart_paste[`+smart_paste+`] functionality when content is pasted into the editor.
 
 Type: `+String+`
 

--- a/modules/ROOT/partials/configuration/image_file_types.adoc
+++ b/modules/ROOT/partials/configuration/image_file_types.adoc
@@ -2,11 +2,11 @@
 
 This option configures which image file formats will be recognized and placed in an `+img+` element by the <<smart_paste, `+smart_paste+`>> functionality when content is pasted into the editor.
 
-Type : `+String+`
+Type: `+String+`
 
-Default Value : `+'jpeg,jpg,jpe,jfi,jfif,png,gif,bmp,webp'+`
+Default Value: `+'jpeg,jpg,jpe,jfi,jfif,png,gif,bmp,webp'+`
 
-Possible Values : A list of valid web image file extensions. For a list of possible values see: https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types[MDN Web Docs - Image file type and format guide].
+Possible Values: A list of valid web image file extensions. For a list of possible values see: https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types[MDN Web Docs - Image file type and format guide].
 
 === Example: Using `+image_file_types+`
 

--- a/modules/ROOT/partials/configuration/image_list.adoc
+++ b/modules/ROOT/partials/configuration/image_list.adoc
@@ -2,7 +2,7 @@
 
 This option lets you specify a predefined list of sources for images. `+image_list+` takes the form of an array containing items to add to a list with a corresponding image. Each item has a `+title+` and a `+value+`.
 
-Type : `+String+`
+Type: `+String+`
 
 === Example: Using `+image_list+`
 

--- a/modules/ROOT/partials/configuration/image_prepend_url.adoc
+++ b/modules/ROOT/partials/configuration/image_prepend_url.adoc
@@ -2,7 +2,7 @@
 
 This option allows you to specify a URL prefix that will be applied to images when appropriate.
 
-Type : `+String+`
+Type: `+String+`
 
 === Example: Using `+image_prepend_url+`
 

--- a/modules/ROOT/partials/configuration/image_proxy.adoc
+++ b/modules/ROOT/partials/configuration/image_proxy.adoc
@@ -1,24 +1,21 @@
-\{% if plugincode == "export" %}
+ifeval::["{plugincode}" == "export"]
 :proxy_setting_name: export_image_proxy
 
 == `+export_image_proxy+`
-
-\{% else %}
+endif::[]
+ifeval::["{plugincode}" != "export"]
 :proxy_setting_name: imagetools_proxy
 
 == `+imagetools_proxy+`
-
-\{% endif %}
+endif::[]
 
 This option can be used as a way of getting images across domains using a local server-side proxy. A proxy is basically a script, that will retrieve a remote image and pipe it back to {productname}, as if it was a local image. An example of such a proxy (written in PHP) can be found below.
 
 link:{pricingpage}/[Paid TinyMCE subscriptions] also includes a proxy service written in Java. Check the link:premium-server-side-guide.html[Install Server-side Components] guide for details.
 
-____
-*Note*: `+{proxy_setting_name}+` is *not* required when enabling this plugin via link:/how-to-guides/cloud-deployment-guide/editor-and-features/[{cloudname}].
-____
+NOTE: `+{proxy_setting_name}+` is *not* required when enabling this plugin via link:/how-to-guides/cloud-deployment-guide/editor-and-features/[{cloudname}].
 
-Type : `+String+`
+Type: `+String+`
 
 === Example: Using `+{proxy_setting_name}+`
 

--- a/modules/ROOT/partials/configuration/image_title.adoc
+++ b/modules/ROOT/partials/configuration/image_title.adoc
@@ -2,11 +2,11 @@
 
 This options allows you enable the image title input field in the image dialog.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+false+`
+Default Value: `+false+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+image_title+`
 

--- a/modules/ROOT/partials/configuration/image_toolbar.adoc
+++ b/modules/ROOT/partials/configuration/image_toolbar.adoc
@@ -4,7 +4,7 @@ The *quickbars_image_toolbar* option configures the Quick Image toolbar provided
 
 To disable the Quick Image toolbar, set `+quickbars_image_toolbar+` to `+false+`.
 
-Type : `+String+` or `+false+`
+Type: `+String+` or `+false+`
 
 Defaults : `+'alignleft aligncenter alignright'+`
 

--- a/modules/ROOT/partials/configuration/image_uploadtab.adoc
+++ b/modules/ROOT/partials/configuration/image_uploadtab.adoc
@@ -2,11 +2,11 @@
 
 This option adds an "Upload" tab to the image dialog allowing you to upload local images, when the link:file-image-upload.html#images_upload_url[`+images_upload_url+`] is also configured.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+image_uploadtab+`
 

--- a/modules/ROOT/partials/configuration/images_dataimg_filter.adoc
+++ b/modules/ROOT/partials/configuration/images_dataimg_filter.adoc
@@ -1,12 +1,10 @@
 == `+images_dataimg_filter+`
 
-____
-*Important*: This option was deprecated with the release of {productname} 5.3. `+images_dataimg_filter+` will be removed in {productname} 6.0.
-____
+IMPORTANT: This option was deprecated with the release of {productname} 5.3. `+images_dataimg_filter+` will be removed in {productname} 6.0.
 
 The *images_dataimg_filter* option is used to filter `+<img>+` elements before they are passed to link:file-image-upload.html#images_upload_handler[`+image_upload_handler+`] or link:file-image-upload.html#images_upload_url[`+images_upload_url+`]. If the callback function provided returns `+false+` for an image, the image will not be uploaded.
 
-Type : `+JavaScript Function+`
+Type: `+JavaScript Function+`
 
 === Example: Using `+images_dataimg_filter+`
 
@@ -21,6 +19,4 @@ tinymce.init({
 });
 ----
 
-____
-*Note*: The `+images_dataimg_filter+` option can also be used to specify a filter predicate function for disabling the logic that converts base64 images into blobs while within the editor. {companyname} discourages using `+images_dataimg_filter+` for this purpose.
-____
+NOTE: The `+images_dataimg_filter+` option can also be used to specify a filter predicate function for disabling the logic that converts base64 images into blobs while within the editor. {companyname} discourages using `+images_dataimg_filter+` for this purpose.

--- a/modules/ROOT/partials/configuration/images_file_types.adoc
+++ b/modules/ROOT/partials/configuration/images_file_types.adoc
@@ -5,11 +5,11 @@ This option configures which image file formats are accepted by the editor. Chan
 * Which image file formats are allowed to be uploaded in the link:image.html[Image] dialog.
 * Which image file formats are recognized and placed in an `+img+` element by the link:paste.html[Paste] and link:powerpaste.html[PowerPaste] `+smart_paste+` functionality.
 
-Type : `+String+`
+Type: `+String+`
 
-Default Value : `+'jpeg,jpg,jpe,jfi,jif,jfif,png,gif,bmp,webp'+`
+Default Value: `+'jpeg,jpg,jpe,jfi,jif,jfif,png,gif,bmp,webp'+`
 
-Possible Values : A list of valid web image file extensions. For a list of possible values see: https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types[MDN Web Docs - Image file type and format guide].
+Possible Values: A list of valid web image file extensions. For a list of possible values see: https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types[MDN Web Docs - Image file type and format guide].
 
 === Example: Using `+images_file_types+`
 

--- a/modules/ROOT/partials/configuration/images_reuse_filename.adoc
+++ b/modules/ROOT/partials/configuration/images_reuse_filename.adoc
@@ -4,11 +4,11 @@ By default {productname} will generate unique filename for each uploaded file (f
 
 Setting `+images_reuse_filename+` to _true_ tells {productname} to use the actual filename of the image, instead of generating a new one each time. Take into account that `+src+` attribute of the corresponding `+<img>+` tag gets replaced with whatever filename you send back from the server (see <<images_upload_url, images_upload_url>>). It can be the same filename or something else, but the next time that filename is used for the upload.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+false+`
+Default Value: `+false+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+images_reuse_filename+`
 

--- a/modules/ROOT/partials/configuration/images_reuse_filename.adoc
+++ b/modules/ROOT/partials/configuration/images_reuse_filename.adoc
@@ -2,7 +2,7 @@
 
 By default {productname} will generate unique filename for each uploaded file (for details refer to link:upload-images.html#imageuploaderrequirements[Upload Images]). Sometimes this might have undesirable side-effects. For example, ,when `+automatic_uploads+` is enabled, every manipulation on the image done with link:imagetools.html[Image Tools] plugin, results in file upload and each time under a different filename, despite the fact that the image stays the same.
 
-Setting `+images_reuse_filename+` to _true_ tells {productname} to use the actual filename of the image, instead of generating a new one each time. Take into account that `+src+` attribute of the corresponding `+<img>+` tag gets replaced with whatever filename you send back from the server (see <<images_upload_url, images_upload_url>>). It can be the same filename or something else, but the next time that filename is used for the upload.
+Setting `+images_reuse_filename+` to _true_ tells {productname} to use the actual filename of the image, instead of generating a new one each time. Take into account that `+src+` attribute of the corresponding `+<img>+` tag gets replaced with whatever filename you send back from the server (see xref:images_upload_url[images_upload_url]). It can be the same filename or something else, but the next time that filename is used for the upload.
 
 Type: `+Boolean+`
 

--- a/modules/ROOT/partials/configuration/images_upload_base_path.adoc
+++ b/modules/ROOT/partials/configuration/images_upload_base_path.adoc
@@ -1,6 +1,6 @@
 == `+images_upload_base_path+`
 
-This option lets you specify a `+basepath+` to prepend to URLs returned from the configured <<images_upload_url, `+images_upload_url+`>> page.
+This option lets you specify a `+basepath+` to prepend to URLs returned from the configured xref:images_upload_url[`+images_upload_url+`] page.
 
 Type: `+String+`
 

--- a/modules/ROOT/partials/configuration/images_upload_base_path.adoc
+++ b/modules/ROOT/partials/configuration/images_upload_base_path.adoc
@@ -2,7 +2,7 @@
 
 This option lets you specify a `+basepath+` to prepend to URLs returned from the configured <<images_upload_url, `+images_upload_url+`>> page.
 
-Type : `+String+`
+Type: `+String+`
 
 === Example: Using `+images_upload_base_path+`
 

--- a/modules/ROOT/partials/configuration/images_upload_credentials.adoc
+++ b/modules/ROOT/partials/configuration/images_upload_credentials.adoc
@@ -1,6 +1,6 @@
 == `+images_upload_credentials+`
 
-The *images_upload_credentials* option specifies whether calls to the configured <<images_upload_url, `+images_upload_url+`>> should pass along credentials (such as cookies, authorization headers, or TLS client certificates) for cross-domain uploads. When set to `+true+`, credentials will be sent to the upload handler, similar to the https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials[`+withCredentials+` property of `+XMLHttpRequest+`s].
+The *images_upload_credentials* option specifies whether calls to the configured xref:images_upload_url[`+images_upload_url+`] should pass along credentials (such as cookies, authorization headers, or TLS client certificates) for cross-domain uploads. When set to `+true+`, credentials will be sent to the upload handler, similar to the https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials[`+withCredentials+` property of `+XMLHttpRequest+`s].
 
 Type: `+Boolean+`
 

--- a/modules/ROOT/partials/configuration/images_upload_credentials.adoc
+++ b/modules/ROOT/partials/configuration/images_upload_credentials.adoc
@@ -2,11 +2,11 @@
 
 The *images_upload_credentials* option specifies whether calls to the configured <<images_upload_url, `+images_upload_url+`>> should pass along credentials (such as cookies, authorization headers, or TLS client certificates) for cross-domain uploads. When set to `+true+`, credentials will be sent to the upload handler, similar to the https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials[`+withCredentials+` property of `+XMLHttpRequest+`s].
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+false+`
+Default Value: `+false+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+images_upload_credentials+`
 

--- a/modules/ROOT/partials/configuration/images_upload_handler.adoc
+++ b/modules/ROOT/partials/configuration/images_upload_handler.adoc
@@ -12,11 +12,9 @@ The upload handler function takes four arguments:
 
 When this option is not set, {productname} utilizes an `+XMLHttpRequest+` to upload images one at a time to the server and calls the success callback with the location of the remote image.
 
-____
-*Note*: To replace the `+<img>+` tag's `+src+` attribute with the remote location, please use the success callback defined in the `+images_upload_handler+` function with the returned JSON object's location property.
-____
+NOTE: To replace the `+<img>+` tag's `+src+` attribute with the remote location, please use the success callback defined in the `+images_upload_handler+` function with the returned JSON object's location property.
 
-Type : `+JavaScript Function+`
+Type: `+JavaScript Function+`
 
 === Example: Using `+images_upload_handler+`
 

--- a/modules/ROOT/partials/configuration/images_upload_url.adoc
+++ b/modules/ROOT/partials/configuration/images_upload_url.adoc
@@ -1,3 +1,4 @@
+[[images_upload_url]]
 == `+images_upload_url+`
 
 This option lets you specify a URL for the server-side upload handler. Upload will get triggered whenever you call `+editor.uploadImages()+` or - automatically, if `+automatic_uploads+` option is enabled. Upload handler should return a new location for the uploaded file in the following format:

--- a/modules/ROOT/partials/configuration/images_upload_url.adoc
+++ b/modules/ROOT/partials/configuration/images_upload_url.adoc
@@ -9,7 +9,7 @@ This option lets you specify a URL for the server-side upload handler. Upload wi
 
 Be sure to checkout a demo implementation of the server-side upload handler link:/how-to-guides/image-handling-guide/php-upload-handler/[here] (written in PHP).
 
-Type : `+String+`
+Type: `+String+`
 
 === Example: Using `+images_upload_url+`
 

--- a/modules/ROOT/partials/configuration/imagetools_credentials_hosts.adoc
+++ b/modules/ROOT/partials/configuration/imagetools_credentials_hosts.adoc
@@ -2,7 +2,7 @@
 
 This option can be used together with the `+imagetools_cors_hosts+` option to allow credentials to be sent to the CORS host. This is not enabled by default since the server needs to have proper CORS headers to support this.
 
-Type : `+String[]+`
+Type: `+String[]+`
 
 === Example: Using `+imagetools_credentials_hosts+`
 

--- a/modules/ROOT/partials/configuration/imagetools_fetch_image.adoc
+++ b/modules/ROOT/partials/configuration/imagetools_fetch_image.adoc
@@ -2,7 +2,7 @@
 
 This option can be used to define a custom fetch function, which provides another way to access images in complex situations. The function will be passed the HTML element of the image to be fetched and should return a `+Promise+` containing a `+Blob+` representation of the image.
 
-Type : `+Function+`
+Type: `+Function+`
 
 === Example: Using `+imagetools_fetch_image+`
 

--- a/modules/ROOT/partials/configuration/imagetools_toolbar.adoc
+++ b/modules/ROOT/partials/configuration/imagetools_toolbar.adoc
@@ -2,7 +2,7 @@
 
 The exact selection of buttons that will appear on the contextual toolbar can be controlled via `+imagetools_toolbar+` option.
 
-Possible Values : * `+rotateleft+`
+Possible Values: * `+rotateleft+`
 
 * `+rotateright+`
 * `+flipv+`
@@ -10,9 +10,9 @@ Possible Values : * `+rotateleft+`
 * `+editimage+`
 * `+imageoptions+`
 
-Type : `+String+`
+Type: `+String+`
 
-Default Value : `+'rotateleft rotateright | flipv fliph | editimage imageoptions'+`
+Default Value: `+'rotateleft rotateright | flipv fliph | editimage imageoptions'+`
 
 === Example: Using `+imagetools_toolbar+`
 

--- a/modules/ROOT/partials/configuration/importcss_append.adoc
+++ b/modules/ROOT/partials/configuration/importcss_append.adoc
@@ -2,9 +2,9 @@
 
 If set to `+true+` this option will append the imported styles to the end of the `+Format+` menu and will replace the default formats.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+false+`
+Default Value: `+false+`
 
 === Example: Using `+importcss_append+`
 

--- a/modules/ROOT/partials/configuration/importcss_exclusive.adoc
+++ b/modules/ROOT/partials/configuration/importcss_exclusive.adoc
@@ -2,9 +2,9 @@
 
 If set to `+false+` then selectors will not be globally exclusive meaning they can exist in two separate groups. This can be useful for scenarios where you want to have a ".class" imported as a paragraph selector and as a span format selector.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
 === Example: Using `+importcss_exclusive+`
 

--- a/modules/ROOT/partials/configuration/importcss_file_filter.adoc
+++ b/modules/ROOT/partials/configuration/importcss_file_filter.adoc
@@ -2,7 +2,7 @@
 
 This option enables you to add the CSS files that should be used for populating the styles drop down. This will go through any `+@import+` rules and only target the specified file. This option can be either a `+string+`, `+regexp+` or a `+function+`. This also allows you to import styles form existing files on the currently editable page in inline mode.
 
-Type : `+String+`
+Type: `+String+`
 
 === Example: Using `+importcss_file_filter+`
 

--- a/modules/ROOT/partials/configuration/importcss_merge_classes.adoc
+++ b/modules/ROOT/partials/configuration/importcss_merge_classes.adoc
@@ -2,7 +2,7 @@
 
 This option is used in cases where the class attribute should be replaced or merged. For example, if you have multiple classes you can apply all of them to the same element. If this option is set to `+false+` it will always replace the contents of the class attribute.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
 === Example: Using `+importcss_merge_classes+`
 

--- a/modules/ROOT/partials/configuration/importcss_selector_converter.adoc
+++ b/modules/ROOT/partials/configuration/importcss_selector_converter.adoc
@@ -2,7 +2,7 @@
 
 This option allows you to override the default selector to format converter function. This allows you to parse the CSS selectors manually and produce format objects out of them. If the converter returns a `+false+` value the selector is ignored from import.
 
-Type : `+String+`
+Type: `+String+`
 
 === Example: Using `+importcss_selector_converter+`
 

--- a/modules/ROOT/partials/configuration/importcss_selector_filter.adoc
+++ b/modules/ROOT/partials/configuration/importcss_selector_filter.adoc
@@ -2,7 +2,7 @@
 
 This option enables you to only import classes from selectors matching the filter. The filter can be a `+string+`, `+regexp+` or a `+function+`. See the examples below.
 
-Type : `+String+`
+Type: `+String+`
 
 === Example using a string filter with `+importcss_selector_filter+`
 

--- a/modules/ROOT/partials/configuration/insertdatetime_element.adoc
+++ b/modules/ROOT/partials/configuration/insertdatetime_element.adoc
@@ -2,9 +2,9 @@
 
 When this option is enabled HTML5 time elements gets generated when you insert dates/times.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+insertdatetime_element+`
 

--- a/modules/ROOT/partials/configuration/link_assume_external_targets.adoc
+++ b/modules/ROOT/partials/configuration/link_assume_external_targets.adoc
@@ -7,9 +7,9 @@ Set whether {productname} should prepend a `+http://+` prefix if the supplied UR
 * `+'http'+`: URLs are assumed to be external. URLs without a protocol prefix are prepended a `+http://+` prefix.
 * `+'https'+`: URLs are assumed to be external. URLs without a protocol prefix are prepended a `+https://+` prefix.
 
-Default Value : `+false+`
+Default Value: `+false+`
 
-Possible Values : `+true+`, `+false+`, `+'http'+`, `+'https'+`
+Possible Values: `+true+`, `+false+`, `+'http'+`, `+'https'+`
 
 === Example: Using `+link_assume_external_targets+`
 

--- a/modules/ROOT/partials/configuration/link_context_toolbar.adoc
+++ b/modules/ROOT/partials/configuration/link_context_toolbar.adoc
@@ -1,3 +1,4 @@
+[[link_context_toolbar]]
 == `+link_context_toolbar+`
 
 By default it is not possible to open links directly from the editor. Setting `+link_context_toolbar+` to `+true+` will enable a context toolbar that will appear when the user's cursor is within a link. This context toolbar contains fields to modify, remove and open the selected link. External links will be opened in a separate tab, while relative links scroll to a target within the editor (if the target is found).

--- a/modules/ROOT/partials/configuration/link_context_toolbar.adoc
+++ b/modules/ROOT/partials/configuration/link_context_toolbar.adoc
@@ -2,15 +2,13 @@
 
 By default it is not possible to open links directly from the editor. Setting `+link_context_toolbar+` to `+true+` will enable a context toolbar that will appear when the user's cursor is within a link. This context toolbar contains fields to modify, remove and open the selected link. External links will be opened in a separate tab, while relative links scroll to a target within the editor (if the target is found).
 
-____
-*Note*: This context toolbar is the same as the context toolbar mentioned in the link:link.html#link_quicklink[Link plugin - `+link_quicklink+`] documentation.
-____
+NOTE: This context toolbar is the same as the context toolbar mentioned in the link:link.html#link_quicklink[Link plugin - `+link_quicklink+`] documentation.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+false+`
+Default Value: `+false+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+link_context_toolbar+`
 

--- a/modules/ROOT/partials/configuration/link_default_protocol.adoc
+++ b/modules/ROOT/partials/configuration/link_default_protocol.adoc
@@ -2,13 +2,11 @@
 
 This option allows you to set a default protocol for links when inserting/editing a link via the link dialog. The protocol will apply to any links where the protocol has not been specified and the prefix prompt has been accepted.
 
-____
-*Note*: This option also applies to the link:autolink.html[autolink] plugin.
-____
+NOTE: This option also applies to the link:autolink.html[autolink] plugin.
 
-Type : `+String+`
+Type: `+String+`
 
-Default Value : `+'http'+`
+Default Value: `+'http'+`
 
 === Example: Using `+link_default_protocol+`
 

--- a/modules/ROOT/partials/configuration/link_default_target.adoc
+++ b/modules/ROOT/partials/configuration/link_default_target.adoc
@@ -1,3 +1,4 @@
+[[link_default_target]]
 == `+link_default_target+`
 
 This option allows you to set a default `+target+` value for links when inserting/editing a link via the link dialog. If the value of `+link_default_target+` matches a value specified by the link:link.html#link_target_list[`+link_target_list+`] option, that item will be set as the default item for the targets dropdown in the link dialog.

--- a/modules/ROOT/partials/configuration/link_default_target.adoc
+++ b/modules/ROOT/partials/configuration/link_default_target.adoc
@@ -2,11 +2,9 @@
 
 This option allows you to set a default `+target+` value for links when inserting/editing a link via the link dialog. If the value of `+link_default_target+` matches a value specified by the link:link.html#link_target_list[`+link_target_list+`] option, that item will be set as the default item for the targets dropdown in the link dialog.
 
-____
-*Note*: This option also applies to the link:autolink.html[autolink] plugin.
-____
+NOTE: This option also applies to the link:autolink.html[autolink] plugin.
 
-Type : `+String+`
+Type: `+String+`
 
 === Example: Using `+link_default_target+`
 

--- a/modules/ROOT/partials/configuration/link_list.adoc
+++ b/modules/ROOT/partials/configuration/link_list.adoc
@@ -4,7 +4,7 @@ This option lets you specify a predefined list of links for the link dialog. The
 
 There are multiple ways to specify how to get the data for the link list, but all methods rely on the returned data containing an array of link items. A link item is an object with a `+title+` and a `+value+`. For example: `+{title: 'My page 1', value: 'https://www.tiny.cloud'}+`.
 
-Type : `+String+` or `+Array+` or `+Function+`
+Type: `+String+` or `+Array+` or `+Function+`
 
 === Example of an array of link items
 

--- a/modules/ROOT/partials/configuration/link_quicklink.adoc
+++ b/modules/ROOT/partials/configuration/link_quicklink.adoc
@@ -2,15 +2,13 @@
 
 This option changes the behaviour of the `+CTRL + K+` shortcut. By default, pressing `+CTRL + K+` will open the link dialog. If `+link_quicklink+` is set to `+true+`, pressing `+CTRL + K+` will instead open the link context toolbar. If the cursor is within an existing link, this context toolbar will contain fields for modifying, removing and opening the selected link. If not, the context toolbar allows for the quick insertion of a link.
 
-____
-*Note*: This context toolbar is the same as the context toolbar mentioned in the <<link_context_toolbar, `+link_context_toolbar+`>> documentation above.
-____
+NOTE: This context toolbar is the same as the context toolbar mentioned in the <<link_context_toolbar, `+link_context_toolbar+`>> documentation above.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+false+`
+Default Value: `+false+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+link_quicklink+`
 

--- a/modules/ROOT/partials/configuration/link_quicklink.adoc
+++ b/modules/ROOT/partials/configuration/link_quicklink.adoc
@@ -1,8 +1,9 @@
+[[link_quicklink]]
 == `+link_quicklink+`
 
 This option changes the behaviour of the `+CTRL + K+` shortcut. By default, pressing `+CTRL + K+` will open the link dialog. If `+link_quicklink+` is set to `+true+`, pressing `+CTRL + K+` will instead open the link context toolbar. If the cursor is within an existing link, this context toolbar will contain fields for modifying, removing and opening the selected link. If not, the context toolbar allows for the quick insertion of a link.
 
-NOTE: This context toolbar is the same as the context toolbar mentioned in the <<link_context_toolbar, `+link_context_toolbar+`>> documentation above.
+NOTE: This context toolbar is the same as the context toolbar mentioned in the xref:link_context_toolbar[`+link_context_toolbar+`] documentation above.
 
 Type: `+Boolean+`
 

--- a/modules/ROOT/partials/configuration/link_target_list.adoc
+++ b/modules/ROOT/partials/configuration/link_target_list.adoc
@@ -2,7 +2,7 @@
 
 The `+link_target_list+` option lets you specify a list of named targets for the `+link+` dialog. These targets will appear in a dropdown menu in the link dialog. Each target must be defined as an object with a `+title+` and a `+value+`. For example: `+{title: 'Same page', value: '_self'}+`. When the dialog is submitted, the `+value+` of the selected target item will be set as the link's `+target+` attribute.
 
-If <<link_default_target, `+link_default_target+`>> is also configured and its value matches a value specified by `+link_target_list+`, that item will be set as the default item for the targets dropdown in the link dialog.
+If xref:link_default_target[`+link_default_target+`] is also configured and its value matches a value specified by `+link_target_list+`, that item will be set as the default item for the targets dropdown in the link dialog.
 
 Default Value :
 [source,js]

--- a/modules/ROOT/partials/configuration/link_target_list.adoc
+++ b/modules/ROOT/partials/configuration/link_target_list.adoc
@@ -4,12 +4,19 @@ The `+link_target_list+` option lets you specify a list of named targets for the
 
 If <<link_default_target, `+link_default_target+`>> is also configured and its value matches a value specified by `+link_target_list+`, that item will be set as the default item for the targets dropdown in the link dialog.
 
-Default Value : ```js [ \{ text: 'Current window', value: '' }, \{ text: 'New window', value: '_blank' } ]
+Default Value :
+[source,js]
+----
+[
+  { text: 'Current window', value: '' },
+  { text: 'New window', value: '_blank' }
+]
+----
 
-....
-#### Example: Adding a `_parent` target to the dropdown list
+=== Example: Adding a `_parent` target to the dropdown list
 
-```js
+[source,js]
+----
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
   plugins: 'link',
@@ -22,7 +29,7 @@ tinymce.init({
     {title: 'Parent frame', value: '_parent'}
   ]
 });
-....
+----
 
 To disable the option dialog, set `+link_target_list+` to `+false+`.
 

--- a/modules/ROOT/partials/configuration/link_title.adoc
+++ b/modules/ROOT/partials/configuration/link_title.adoc
@@ -2,11 +2,11 @@
 
 This options allows you disable the link `+title+` input field in the `+link+` dialog.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+link_title+`
 

--- a/modules/ROOT/partials/configuration/linkchecker_preprocess.adoc
+++ b/modules/ROOT/partials/configuration/linkchecker_preprocess.adoc
@@ -2,7 +2,7 @@
 
 The `+linkchecker_preprocess+` function is used for adjusting links before performing a link check.
 
-Type : `+Function+`
+Type: `+Function+`
 
 === Example: Using `+linkchecker_preprocess+`
 

--- a/modules/ROOT/partials/configuration/linkchecker_service_url.adoc
+++ b/modules/ROOT/partials/configuration/linkchecker_service_url.adoc
@@ -2,7 +2,7 @@
 
 A URL of the server-side link validation service. This is required option, without it plugin will fail to operate and will throw a corresponding warning on the screen.
 
-Type : `+String+`
+Type: `+String+`
 
 === Example: Using `+linkchecker_service_url+`
 

--- a/modules/ROOT/partials/configuration/max_height.adoc
+++ b/modules/ROOT/partials/configuration/max_height.adoc
@@ -17,6 +17,4 @@ tinymce.init({
 });
 ----
 
-____
-*Note*: If you set the option link:editor-size-options.html#resize[`+resize+`] to `+false+` the resize handle will be disabled and a user will not be able to resize the editor (by manual dragging). Note that `+resize+` defaults to `+false+` when the `+autoresize+` plugin is enabled.
-____
+NOTE: If you set the option link:editor-size-options.html#resize[`+resize+`] to `+false+` the resize handle will be disabled and a user will not be able to resize the editor (by manual dragging). Note that `+resize+` defaults to `+false+` when the `+autoresize+` plugin is enabled.

--- a/modules/ROOT/partials/configuration/media_alt_source.adoc
+++ b/modules/ROOT/partials/configuration/media_alt_source.adoc
@@ -2,11 +2,11 @@
 
 This options allows you disable the `+Alternative source+` input field in the media dialog.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+media_alt_source+`
 

--- a/modules/ROOT/partials/configuration/media_dimensions.adoc
+++ b/modules/ROOT/partials/configuration/media_dimensions.adoc
@@ -2,11 +2,11 @@
 
 This options allows you disable the `+Dimensions+` input fields in the media dialog.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+media_dimensions+`
 

--- a/modules/ROOT/partials/configuration/media_filter_html.adoc
+++ b/modules/ROOT/partials/configuration/media_filter_html.adoc
@@ -2,11 +2,11 @@
 
 This option allows you disable the XSS sanitation filter for video/object elements. Scripts, conditional comments, etc, can't be used within these elements by default for security reasons. If you want to include that and have server side sanitizers or if you trust your users, then you can disable this feature.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+media_filter_html+`
 

--- a/modules/ROOT/partials/configuration/media_live_embeds.adoc
+++ b/modules/ROOT/partials/configuration/media_live_embeds.adoc
@@ -4,11 +4,11 @@ When you enable this option users will see a live preview of embedded video cont
 
 This option is enabled by default and accepts URLs input into the source field or embed field in the dialog box by the user.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+media_live_embeds+`
 

--- a/modules/ROOT/partials/configuration/media_poster.adoc
+++ b/modules/ROOT/partials/configuration/media_poster.adoc
@@ -2,11 +2,11 @@
 
 To remove the `+Poster+` input field in the media dialog, set this option to `+false+`.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+media_poster+`
 

--- a/modules/ROOT/partials/configuration/media_scripts.adoc
+++ b/modules/ROOT/partials/configuration/media_scripts.adoc
@@ -4,7 +4,7 @@ include::partial$DEPRECATED/generic-5_10.adoc[]
 
 This option allows you to embed videos using script elements.
 
-Type : `+Array+`
+Type: `+Array+`
 
 === Example: Using `+media_scripts+`
 

--- a/modules/ROOT/partials/configuration/media_url_resolver.adoc
+++ b/modules/ROOT/partials/configuration/media_url_resolver.adoc
@@ -8,7 +8,7 @@ If you in your handler would like fall back to the default media embed logic you
 
 If something goes wrong in your function and you want to show an error to the user you can do so by calling the `+reject+` callback with an object where the message you want to show the user is set under the `+msg+` property, like this: `+reject({msg: 'YOUR_ERROR_MESSAGE'})+`. The message entered will be shown in an error notification to the user.
 
-Type : `+Function+`
+Type: `+Function+`
 
 === Example: Using `+media_url_resolver+`
 

--- a/modules/ROOT/partials/configuration/mediaembed_inline_styles.adoc
+++ b/modules/ROOT/partials/configuration/mediaembed_inline_styles.adoc
@@ -2,4 +2,4 @@
 
 This option will inline all styles, instead of using CSS classes, when rendering the embedded snippet. This is useful when the additional CSS classes can't be added to your site. Defaults to `+false+`.
 
-Type : `+Boolean+`
+Type: `+Boolean+`

--- a/modules/ROOT/partials/configuration/mediaembed_max_width.adoc
+++ b/modules/ROOT/partials/configuration/mediaembed_max_width.adoc
@@ -2,4 +2,4 @@
 
 This option specifies a maximum width in pixels of the embedded content. Defaults to `+650+`.
 
-Type : `+Number+`
+Type: `+Number+`

--- a/modules/ROOT/partials/configuration/mediaembed_service_url.adoc
+++ b/modules/ROOT/partials/configuration/mediaembed_service_url.adoc
@@ -2,4 +2,4 @@
 
 This option specifies the URL to the service that will handle your requests and return the embeddable snippets used by the *Media Embed* plugin. Please follow these link:premium-server-side-guide.html[instructions] to configure the *WAR* file that you will get as a part of your link:{pricingpage}/[{enterpriseversion} subscription]. This option is not required for link:editor-and-features.html[{cloudname}].
 
-Type : `+String+`
+Type: `+String+`

--- a/modules/ROOT/partials/configuration/min_height.adoc
+++ b/modules/ROOT/partials/configuration/min_height.adoc
@@ -17,6 +17,4 @@ tinymce.init({
 });
 ----
 
-____
-*Note*: If you set the option link:editor-size-options.html#resize[`+resize+`] to `+false+` the resize handle will be disabled and a user will not be able to resize the editor (by manual dragging). Note that `+resize+` defaults to `+false+` when the `+autoresize+` plugin is enabled.
-____
+NOTE: If you set the option link:editor-size-options.html#resize[`+resize+`] to `+false+` the resize handle will be disabled and a user will not be able to resize the editor (by manual dragging). Note that `+resize+` defaults to `+false+` when the `+autoresize+` plugin is enabled.

--- a/modules/ROOT/partials/configuration/nonbreaking_force_tab.adoc
+++ b/modules/ROOT/partials/configuration/nonbreaking_force_tab.adoc
@@ -6,15 +6,13 @@ It's important to note that this does not change the behavior of the menu and to
 
 However, the `+true+` condition does capture the tab key and contain it within the editable area, whereas when set to its default state of `+false+` a tab keypress will move the cursor to the next editable area (e.g. a browser url bar or form field on the current page).
 
-____
-*Note*: Review <<usagewithtableorlistsplugin, Usage with `+table+` or `+lists+` plugin>> before using this setting.
-____
+NOTE: Review <<usagewithtableorlistsplugin, Usage with `+table+` or `+lists+` plugin>> before using this setting.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+false+`
+Default Value: `+false+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+nonbreaking_force_tab+`
 

--- a/modules/ROOT/partials/configuration/nonbreaking_force_tab.adoc
+++ b/modules/ROOT/partials/configuration/nonbreaking_force_tab.adoc
@@ -6,7 +6,7 @@ It's important to note that this does not change the behavior of the menu and to
 
 However, the `+true+` condition does capture the tab key and contain it within the editable area, whereas when set to its default state of `+false+` a tab keypress will move the cursor to the next editable area (e.g. a browser url bar or form field on the current page).
 
-NOTE: Review <<usagewithtableorlistsplugin, Usage with `+table+` or `+lists+` plugin>> before using this setting.
+NOTE: Review xref:usagewithtableorlistsplugin[Usage with `+table+` or `+lists+` plugin] before using this setting.
 
 Type: `+Boolean+`
 
@@ -27,6 +27,7 @@ tinymce.init({
 });
 ----
 
+[[usagewithtableorlistsplugin]]
 === Usage with `+table+` or `+lists+` plugin
 
 The `+nonbreaking_force_tab+` setting can break the following functionality:

--- a/modules/ROOT/partials/configuration/nonbreaking_wrap.adoc
+++ b/modules/ROOT/partials/configuration/nonbreaking_wrap.adoc
@@ -2,11 +2,11 @@
 
 This option allows you to force {productname} to wrap non-breaking space characters inserted by the plugin in a `+<span class="mce-nbsp-wrap"></span>+` element. This will prevent the non-breaking space being replaced by the editor or browser when typing additional spaces.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+nonbreaking_wrap+`
 

--- a/modules/ROOT/partials/configuration/noneditable_class.adoc
+++ b/modules/ROOT/partials/configuration/noneditable_class.adoc
@@ -1,3 +1,4 @@
+[[noneditable_class]]
 == `+noneditable_class+`
 
 This option allows you to specify the class name that {productname} will use to determine which areas of content are non-editable. This would be the same as `+contenteditable=false+`.

--- a/modules/ROOT/partials/configuration/noneditable_regexp.adoc
+++ b/modules/ROOT/partials/configuration/noneditable_regexp.adoc
@@ -2,9 +2,7 @@
 
 This option is used to specify a regular expression or array of regular expressions that {productname} will use to determine which areas of content are non-editable. The regular expressions needs to be global so that all instances within the document are matched. The text content of the matches will be wrapped in spans, hiding the structure and styling while editing.
 
-____
-*Note*: If elements are matched by the regular expression, the elements will be replaced with spans. Use <<noneditable_class, `+noneditable_class+`>> for elements.
-____
+NOTE: If elements are matched by the regular expression, the elements will be replaced with spans. Use <<noneditable_class, `+noneditable_class+`>> for elements.
 
 Type : `+String+`
 

--- a/modules/ROOT/partials/configuration/noneditable_regexp.adoc
+++ b/modules/ROOT/partials/configuration/noneditable_regexp.adoc
@@ -2,7 +2,7 @@
 
 This option is used to specify a regular expression or array of regular expressions that {productname} will use to determine which areas of content are non-editable. The regular expressions needs to be global so that all instances within the document are matched. The text content of the matches will be wrapped in spans, hiding the structure and styling while editing.
 
-NOTE: If elements are matched by the regular expression, the elements will be replaced with spans. Use <<noneditable_class, `+noneditable_class+`>> for elements.
+NOTE: If elements are matched by the regular expression, the elements will be replaced with spans. Use xref:noneditable_class[`+noneditable_class+`] for elements.
 
 Type : `+String+`
 

--- a/modules/ROOT/partials/configuration/pagebreak_separator.adoc
+++ b/modules/ROOT/partials/configuration/pagebreak_separator.adoc
@@ -1,8 +1,8 @@
 == `+pagebreak_separator+`
 
-Type : `+String+`
+Type: `+String+`
 
-Default Value : `+'<!-- pagebreak -->'+`
+Default Value: `+'<!-- pagebreak -->'+`
 
 === Example: Using `+pagebreak_separator+`
 

--- a/modules/ROOT/partials/configuration/pagebreak_split_block.adoc
+++ b/modules/ROOT/partials/configuration/pagebreak_split_block.adoc
@@ -2,11 +2,11 @@
 
 When enabled this option makes it easier to split block elements with a page break.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+false+`
+Default Value: `+false+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+pagebreak_split_block+`
 

--- a/modules/ROOT/partials/configuration/paste_as_text.adoc
+++ b/modules/ROOT/partials/configuration/paste_as_text.adoc
@@ -2,11 +2,11 @@
 
 This option enables you to set the default state of the `+Paste as text+` menu item, which is added by the `+{plugincode}+` plugin under the `+Edit+` menu dropdown. It's disabled by default.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+false+`
+Default Value: `+false+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+paste_as_text+`
 

--- a/modules/ROOT/partials/configuration/paste_block_drop.adoc
+++ b/modules/ROOT/partials/configuration/paste_block_drop.adoc
@@ -1,9 +1,9 @@
-ifeval::["{plugincode}" == "paste"]
+ifeval::["{pluginname}" == "Paste"]
 :plugin: paste
 
 == paste_block_drop
 endif::[]
-ifeval::["{plugincode}" != "paste"]
+ifeval::["{pluginname}" != "Paste"]
 :plugin: powerpaste
 
 == powerpaste_block_drop
@@ -15,11 +15,11 @@ Default value : `+false+`
 
 Possible values : `+true+`, `+false+`
 
-ifeval::["{plugincode}" == "paste"]
+ifeval::["{pluginname}" == "Paste"]
 
 === Example: Using `+paste_block_drop+`
 endif::[]
-ifeval::["{plugincode}" != "paste"]
+ifeval::["{pluginname}" != "Paste"]
 
 === Example: Using `+powerpaste_block_drop+`
 endif::[]

--- a/modules/ROOT/partials/configuration/paste_block_drop.adoc
+++ b/modules/ROOT/partials/configuration/paste_block_drop.adoc
@@ -1,14 +1,13 @@
-\{% if page.title == "Paste plugin" %}
+ifeval::["{plugincode}" == "paste"]
 :plugin: paste
 
 == paste_block_drop
-
-\{% else %}
+endif::[]
+ifeval::["{plugincode}" != "paste"]
 :plugin: powerpaste
 
 == powerpaste_block_drop
-
-\{% endif %}
+endif::[]
 
 Due to browser limitations, it is not possible to filter content that is dragged and dropped into the editor. When `+{plugin}_block_drop+` is set to true the plugin will disable drag and dropping content into the editor. This prevents the unfiltered content from being introduced. Copy and paste is still enabled.
 
@@ -16,21 +15,20 @@ Default value : `+false+`
 
 Possible values : `+true+`, `+false+`
 
-\{% if page.title == "Paste plugin" %}
+ifeval::["{plugincode}" == "paste"]
 
 === Example: Using `+paste_block_drop+`
-
-\{% else %}
+endif::[]
+ifeval::["{plugincode}" != "paste"]
 
 === Example: Using `+powerpaste_block_drop+`
-
-\{% endif %}
+endif::[]
 
 [source,js,subs="attributes+"]
 ----
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  plugins: '{plugin}',
-  {plugin}_block_drop: false
+  plugins: '{plugincode}',
+  {plugincode}_block_drop: false
 });
 ----

--- a/modules/ROOT/partials/configuration/paste_convert_word_fake_lists.adoc
+++ b/modules/ROOT/partials/configuration/paste_convert_word_fake_lists.adoc
@@ -4,11 +4,11 @@ include::partial$DEPRECATED/generic-5_10.adoc[]
 
 This option lets you disable the logic that converts list like paragraph structures into real semantic HTML lists.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+paste_convert_word_fake_lists+`
 

--- a/modules/ROOT/partials/configuration/paste_data_images.adoc
+++ b/modules/ROOT/partials/configuration/paste_data_images.adoc
@@ -6,11 +6,11 @@ Setting `+paste_data_images+` to `+"true"+` will allow the pasted images, while 
 
 For example, Firefox enables you to paste images directly into any `+contentEditable+` field. This is normally not something people want, so this option is `+"false"+` by default. For example, a 600kb embedded image would block page loads and prevents it from being cached on multiple pages.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+false+`
+Default Value: `+false+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+paste_data_images+`
 

--- a/modules/ROOT/partials/configuration/paste_enable_default_filters.adoc
+++ b/modules/ROOT/partials/configuration/paste_enable_default_filters.adoc
@@ -2,11 +2,11 @@
 
 This option allows you to disable {productname}'s default paste filters when set to false.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+paste_enable_default_filters+`
 

--- a/modules/ROOT/partials/configuration/paste_filter_drop.adoc
+++ b/modules/ROOT/partials/configuration/paste_filter_drop.adoc
@@ -2,11 +2,11 @@
 
 This option allows developers to disable the default drop filters when set to `+false+`.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+paste_filter_drop+`
 

--- a/modules/ROOT/partials/configuration/paste_merge_formats.adoc
+++ b/modules/ROOT/partials/configuration/paste_merge_formats.adoc
@@ -1,18 +1,19 @@
-\{% if page.title == "Paste plugin" %}
+ifeval::["{page.title}" == "Paste plugin"]
 :plugin: paste :pluginname: Paste
-\{% else %}
+endif::[]
+ifeval::["{page.title}" != "Paste plugin"]
 :plugin: powerpaste :pluginname: PowerPaste
-\{% endif %}
+endif::[]
 
 == `+paste_merge_formats+`
 
 This option enables the merge format feature of the {pluginname} plugin. This merges identical text format elements to reduce the number of HTML elements produced. For example: `+<b>abc <b>bold</b> 123</b>+` becomes `+<b>abc bold 123</b>+` since the inner format is redundant. This option is enabled by default but can be disabled if retaining nested or identical format elements is important.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+paste_merge_formats+`
 

--- a/modules/ROOT/partials/configuration/paste_merge_formats.adoc
+++ b/modules/ROOT/partials/configuration/paste_merge_formats.adoc
@@ -1,8 +1,10 @@
-ifeval::["{page.title}" == "Paste plugin"]
-:plugin: paste :pluginname: Paste
+ifeval::["{pluginname}" == "Paste"]
+:plugin: paste
+:pluginname: Paste
 endif::[]
-ifeval::["{page.title}" != "Paste plugin"]
-:plugin: powerpaste :pluginname: PowerPaste
+ifeval::["{pluginname}" != "Paste"]
+:plugin: powerpaste
+:pluginname: PowerPaste
 endif::[]
 
 == `+paste_merge_formats+`

--- a/modules/ROOT/partials/configuration/paste_postprocess.adoc
+++ b/modules/ROOT/partials/configuration/paste_postprocess.adoc
@@ -1,4 +1,4 @@
-ifeval::["{page.title}" == "Paste plugin"]
+ifeval::["{pluginname}" == "Paste"]
 
 == `+paste_postprocess+`
 
@@ -23,7 +23,7 @@ tinymce.init({
 ----
 
 endif::[]
-ifeval::["{page.title}" != "Paste plugin"]
+ifeval::["{pluginname}" != "Paste"]
 
 == `+paste_postprocess+`
 

--- a/modules/ROOT/partials/configuration/paste_postprocess.adoc
+++ b/modules/ROOT/partials/configuration/paste_postprocess.adoc
@@ -1,10 +1,10 @@
-\{% if page.title == "Paste plugin" %}
+ifeval::["{page.title}" == "Paste plugin"]
 
 == `+paste_postprocess+`
 
 This option enables you to modify the pasted content before it gets inserted into the editor but after it's been parsed into a DOM structure.
 
-Type : `+Function+`
+Type: `+Function+`
 
 === Example: Using `+paste_postprocess+`
 
@@ -22,7 +22,8 @@ tinymce.init({
 });
 ----
 
-\{% else %}
+endif::[]
+ifeval::["{page.title}" != "Paste plugin"]
 
 == `+paste_postprocess+`
 
@@ -33,9 +34,7 @@ This option allows you to run custom filtering on the pasted content after it is
 * `+mode+` - A string indicating whether PowerPaste is in `+clean+`, `+merge+`, or `+auto+` mode.
 * `+source+` - A string indicating which kind of filtering PowerPaste will run based on the source of the content. This will return `+html+`, `+msoffice+`, `+googledocs+`, `+image+`, `+imagedrop+`, `+plaintext+`, `+text+`, or `+invalid+`.
 
-____
-*Note*: The mode 'auto' is used when the content source does not have formatting to "clean" or "merge". For example, when pasting an image with no text or markup content.
-____
+NOTE: The mode 'auto' is used when the content source does not have formatting to "clean" or "merge". For example, when pasting an image with no text or markup content.
 
 Example {productname} configuration:
 
@@ -54,4 +53,4 @@ tinymce.init({
 });
 ----
 
-\{% endif %}
+endif::[]

--- a/modules/ROOT/partials/configuration/paste_preprocess.adoc
+++ b/modules/ROOT/partials/configuration/paste_preprocess.adoc
@@ -1,10 +1,10 @@
-\{% if page.title == "Paste plugin" %}
+ifeval::["{plugincode}" == "paste"]
 
 == `+paste_preprocess+`
 
 This option enables you to modify the pasted content before it gets inserted into the editor.
 
-Type : `+Function+`
+Type: `+Function+`
 
 === Example: Using `+paste_preprocess+`
 
@@ -22,7 +22,8 @@ tinymce.init({
 });
 ----
 
-\{% else %}
+endif::[]
+ifeval::["{plugincode}" != "paste"]
 
 == `+paste_preprocess+`
 
@@ -33,9 +34,7 @@ This option allows you to run custom filtering on the content from the clipboard
 * `+mode+` - A string indicating whether PowerPaste is in `+clean+`, `+merge+`, or `+auto+` mode.
 * `+source+` - A string indicating which kind of filtering PowerPaste will run based on the source of the content. This will return `+html+`, `+msoffice+`, `+googledocs+`, `+image+`, `+imagedrop+`, `+plaintext+`, `+text+`, or `+invalid+`.
 
-____
-*Note*: The mode 'auto' is used when the content source does not have formatting to "clean" or "merge". For example, when pasting an image with no text or markup content.
-____
+NOTE: The mode 'auto' is used when the content source does not have formatting to "clean" or "merge". For example, when pasting an image with no text or markup content.
 
 Example {productname} configuration:
 
@@ -60,4 +59,4 @@ tinymce.init({
 });
 ----
 
-\{% endif %}
+endif::[]

--- a/modules/ROOT/partials/configuration/paste_preprocess.adoc
+++ b/modules/ROOT/partials/configuration/paste_preprocess.adoc
@@ -1,4 +1,4 @@
-ifeval::["{plugincode}" == "paste"]
+ifeval::["{pluginname}" == "Paste"]
 
 == `+paste_preprocess+`
 
@@ -23,7 +23,7 @@ tinymce.init({
 ----
 
 endif::[]
-ifeval::["{plugincode}" != "paste"]
+ifeval::["{pluginname}" != "Paste"]
 
 == `+paste_preprocess+`
 

--- a/modules/ROOT/partials/configuration/paste_remove_styles_if_webkit.adoc
+++ b/modules/ROOT/partials/configuration/paste_remove_styles_if_webkit.adoc
@@ -2,11 +2,11 @@
 
 This option allows you to disable {productname}'s default paste filters for webkit styles.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+paste_remove_styles_if_webkit+`
 

--- a/modules/ROOT/partials/configuration/paste_retain_style_properties.adoc
+++ b/modules/ROOT/partials/configuration/paste_retain_style_properties.adoc
@@ -4,7 +4,7 @@ include::partial$DEPRECATED/generic-5_10.adoc[]
 
 This option allows you to specify which styles you want to retain when pasting contents from MS Word and similar Office suite products. This option can be set to a space-separated list of CSS style names, or `+"all"+` if you want all styles to be retained.
 
-Type : `+String+`
+Type: `+String+`
 
 === Example: Using `+paste_retain_style_properties+`
 

--- a/modules/ROOT/partials/configuration/paste_tab_spaces.adoc
+++ b/modules/ROOT/partials/configuration/paste_tab_spaces.adoc
@@ -1,16 +1,17 @@
-\{% if page.title == "Paste plugin" %}
+ifeval::["{page.title}" == "Paste plugin"]
 :plugin: paste :pluginname: Paste
-\{% else %}
+endif::[]
+ifeval::["{page.title}" != "Paste plugin"]
 :plugin: powerpaste :pluginname: PowerPaste
-\{% endif %}
+endif::[]
 
 == `+paste_tab_spaces+`
 
 This option controls how many spaces are used to represent a tab character in HTML when pasting plain text content. By default, the {pluginname} plugin will convert each tab character into 4 sequential space characters.
 
-Type : `+Number+`
+Type: `+Number+`
 
-Default Value : `+4+`
+Default Value: `+4+`
 
 === Example: Using `+paste_tab_spaces+`
 

--- a/modules/ROOT/partials/configuration/paste_webkit_styles.adoc
+++ b/modules/ROOT/partials/configuration/paste_webkit_styles.adoc
@@ -2,7 +2,7 @@
 
 This option allows you to specify styles you want to keep when pasting in WebKit. WebKit has a bug where it will take all the computed CSS properties for an element and add them to spans within the editor. Since most users don't want random spans added all over their document, we need to manually clean that up until the bug is fixed. This option defaults to `+"none"+` but can be set to `+"all"+` or a specific list of styles to retain.
 
-Type : `+String+`
+Type: `+String+`
 
 === Example: Using `+paste_webkit_styles+`
 

--- a/modules/ROOT/partials/configuration/paste_word_valid_elements.adoc
+++ b/modules/ROOT/partials/configuration/paste_word_valid_elements.adoc
@@ -4,11 +4,9 @@ include::partial$DEPRECATED/generic-5_10.adoc[]
 
 This option enables you to configure the `+valid_elements+` specific to MS Office. Word produces a lot of junk HTML, so when users paste things from Word we do extra restrictive filtering on it to remove as much of this as possible. This option enables you to specify which elements and attributes you want to include when Word contents are intercepted.
 
-____
-*Note:* To access this feature, you need to set the value of link:paste.html#paste_enable_default_filters[paste_enable_default_filters] to `+"false"+` in your configuration.
-____
+NOTE: To access this feature, you need to set the value of link:paste.html#paste_enable_default_filters[paste_enable_default_filters] to `+"false"+` in your configuration.
 
-Type : `+String+`
+Type: `+String+`
 
 === Example: Using `+paste_word_valid_elements+`
 

--- a/modules/ROOT/partials/configuration/preview_styles.adoc
+++ b/modules/ROOT/partials/configuration/preview_styles.adoc
@@ -4,11 +4,11 @@ This option lets you configure the preview of styles in format/style listboxes. 
 
 If unset the editor will preview the styles listed in the default value listed below.
 
-Type : `+Boolean+` or `+String+`
+Type: `+Boolean+` or `+String+`
 
-Default Value : `+'font-family font-size font-weight font-style text-decoration text-transform color background-color border border-radius outline text-shadow'+`
+Default Value: `+'font-family font-size font-weight font-style text-decoration text-transform color background-color border border-radius outline text-shadow'+`
 
-Possible Values : `+String+`, `+false+`
+Possible Values: `+String+`, `+false+`
 
 === Example: Using `+preview_styles+`
 

--- a/modules/ROOT/partials/configuration/ref_time_date_formats.adoc
+++ b/modules/ROOT/partials/configuration/ref_time_date_formats.adoc
@@ -1,3 +1,4 @@
+[[referencedatetimeformats]]
 == Reference Date/Time formats
 
 [cols=",",options="header",]

--- a/modules/ROOT/partials/configuration/save_enablewhendirty.adoc
+++ b/modules/ROOT/partials/configuration/save_enablewhendirty.adoc
@@ -2,7 +2,7 @@
 
 This option allows you to disable the save button until modifications have been made to the content of the editor. This option is enabled by default.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
 === Example: Using `+save_enablewhendirty+`
 

--- a/modules/ROOT/partials/configuration/save_oncancelcallback.adoc
+++ b/modules/ROOT/partials/configuration/save_oncancelcallback.adoc
@@ -2,7 +2,7 @@
 
 This option allows you to specify the function that will be executed when the cancel button/command is invoked.
 
-Type : `+String+`
+Type: `+String+`
 
 === Example: Using `+save_oncancelcallback+`
 

--- a/modules/ROOT/partials/configuration/save_onsavecallback.adoc
+++ b/modules/ROOT/partials/configuration/save_onsavecallback.adoc
@@ -2,7 +2,7 @@
 
 This option allows you to specify the function that will be executed when the save button/command is invoked.
 
-Type : `+String+`
+Type: `+String+`
 
 === Example: Using `+save_onsavecallback+`
 

--- a/modules/ROOT/partials/configuration/smart_paste.adoc
+++ b/modules/ROOT/partials/configuration/smart_paste.adoc
@@ -1,3 +1,4 @@
+[[smart_paste]]
 == `+smart_paste+`
 
 The `+smart_paste+` function will:

--- a/modules/ROOT/partials/configuration/table_advtab.adoc
+++ b/modules/ROOT/partials/configuration/table_advtab.adoc
@@ -2,11 +2,11 @@
 
 This option makes it possible to disable the advanced tab in the table dialog box. The advanced tab allows a user to input `+style+`, `+border color+` and `+background color+` values.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+table_advtab+`
 

--- a/modules/ROOT/partials/configuration/table_appearance_options.adoc
+++ b/modules/ROOT/partials/configuration/table_appearance_options.adoc
@@ -2,11 +2,11 @@
 
 This option allows you to disable some of the options available to a user when inserting or editing a table. When set to `+false+` the following fields will not appear: Cell spacing, Cell padding, Border and Caption.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+table_appearance_options+`
 

--- a/modules/ROOT/partials/configuration/table_background_color_map.adoc
+++ b/modules/ROOT/partials/configuration/table_background_color_map.adoc
@@ -4,9 +4,9 @@ This option is used to specify the default values for the table cell background 
 
 The link:user-formatting-options.html#custom_colors[custom color picker] is not available for the `+tablecellbackgroundcolor+` toolbar button or menu item.
 
-Type : `+Array+`
+Type: `+Array+`
 
-Default Value : See link:user-formatting-options.html#color_map[`+color_map+` option]
+Default Value: See link:user-formatting-options.html#color_map[`+color_map+` option]
 
 === Example: Using `+table_background_color_map+`
 

--- a/modules/ROOT/partials/configuration/table_border_color_map.adoc
+++ b/modules/ROOT/partials/configuration/table_border_color_map.adoc
@@ -4,9 +4,9 @@ This option is used to specify the default values for the table cell border colo
 
 The link:user-formatting-options.html#custom_colors[custom color picker] is not available for the `+tablecellbordercolor+` toolbar button or menu item.
 
-Type : `+Array+`
+Type: `+Array+`
 
-Default Value : See link:user-formatting-options.html#color_map[`+color_map+` option]
+Default Value: See link:user-formatting-options.html#color_map[`+color_map+` option]
 
 === Example: Using `+table_border_color_map+`
 

--- a/modules/ROOT/partials/configuration/table_border_styles.adoc
+++ b/modules/ROOT/partials/configuration/table_border_styles.adoc
@@ -2,14 +2,29 @@
 
 This option is used to specify a list of pre-defined cell border widths for quick access on the `+tablecellborderstyle+` toolbar button or menu item, in addition to the dialog options. This option accepts any valid https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#values[CSS border style].
 
-Type : `+Array+`
+Type: `+Array+`
 
-Default Value : ``` [ \{title: 'Solid', value: 'solid'}, \{title: 'Dotted', value: 'dotted'}, \{title: 'Dashed', value: 'dashed'}, \{title: 'Double', value: 'double'}, \{title: 'Groove', value: 'groove'}, \{title: 'Ridge', value: 'ridge'}, \{title: 'Inset', value: 'inset'}, \{title: 'Outset', value: 'outset'}, \{title: 'None', value: 'none'}, \{title: 'Hidden', value: 'hidden'} ]
+Default Value:
+[source,js,subs="attributes+"]
+----
+[
+  {title: 'Solid', value: 'solid'},
+  {title: 'Dotted', value: 'dotted'},
+  {title: 'Dashed', value: 'dashed'},
+  {title: 'Double', value: 'double'},
+  {title: 'Groove', value: 'groove'},
+  {title: 'Ridge', value: 'ridge'},
+  {title: 'Inset', value: 'inset'},
+  {title: 'Outset', value: 'outset'},
+  {title: 'None', value: 'none'},
+  {title: 'Hidden', value: 'hidden'}
+]
+----
 
-....
-#### Example: Using `table_border_styles`
+=== Example: Using `table_border_styles`
 
-```js
+[source,js,subs="attributes+"]
+----
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
   plugins: 'table',
@@ -21,4 +36,4 @@ tinymce.init({
     {title: 'Dashed', value: 'dashed'}
   ]
 });
-....
+----

--- a/modules/ROOT/partials/configuration/table_border_widths.adoc
+++ b/modules/ROOT/partials/configuration/table_border_widths.adoc
@@ -2,14 +2,24 @@
 
 This option is used to specify a list of pre-defined cell border widths for quick access on the `+tablecellborderwidth+` toolbar button or menu item. This option accepts any valid https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Values_and_Units#numeric_data_types[CSS numeric value].
 
-Type : `+Array+`
+Type: `+Array+`
 
-Default Value : ``` [ \{title: '1px', value: '1px'}, \{title: '2px', value: '2px'}, \{title: '3px', value: '3px'}, \{title: '4px', value: '4px'}, \{title: '5px', value: '5px'} ]
+Default Value:
+[source,js,subs="attributes+"]
+----
+[
+  {title: '1px', value: '1px'},
+  {title: '2px', value: '2px'},
+  {title: '3px', value: '3px'},
+  {title: '4px', value: '4px'},
+  {title: '5px', value: '5px'}
+]
+----
 
-....
-#### Example: Using `table_border_widths`
+=== Example: Using `table_border_widths`
 
-```js
+[source,js,subs="attributes+"]
+----
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
   plugins: 'table',
@@ -21,4 +31,4 @@ tinymce.init({
     {title: 'large', value: '5px'},
   ]
 });
-....
+----

--- a/modules/ROOT/partials/configuration/table_cell_advtab.adoc
+++ b/modules/ROOT/partials/configuration/table_cell_advtab.adoc
@@ -2,11 +2,11 @@
 
 This option makes it possible to disable the advanced tab in the table cell dialog box. The advanced tab allows a user to input `+style+`, `+border color+` and `+background color+` values.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+table_cell_advtab+`
 

--- a/modules/ROOT/partials/configuration/table_cell_class_list.adoc
+++ b/modules/ROOT/partials/configuration/table_cell_class_list.adoc
@@ -2,7 +2,7 @@
 
 This option enables you to specify a list of classes to present in the table cell options dialog box. This is useful if you want users to assign predefined classes to table cells.
 
-Type : `+Array+`
+Type: `+Array+`
 
 === Example: Using `+table_cell_class_list+`
 

--- a/modules/ROOT/partials/configuration/table_class_list.adoc
+++ b/modules/ROOT/partials/configuration/table_class_list.adoc
@@ -2,7 +2,7 @@
 
 This option enables you to specify a list of classes to present in the table options dialog box. This is useful if you want users to assign predefined classes to table elements.
 
-Type : `+Array+`
+Type: `+Array+`
 
 === Example: Using `+table_class_list+`
 

--- a/modules/ROOT/partials/configuration/table_clone_elements.adoc
+++ b/modules/ROOT/partials/configuration/table_clone_elements.adoc
@@ -2,7 +2,7 @@
 
 This option enables you to specify which elements should be cloned as empty children when inserting rows/columns to a table. By default it will clone these '`+strong+` `+em+` `+b+` `+i+` `+span+` `+font+` `+h1+` `+h2+` `+h3+` `+h4+` `+h5+` `+h6+` `+p+` `+div+`' into new cells.
 
-Type : `+String+`
+Type: `+String+`
 
 === Example: Using `+table_clone_elements+`
 

--- a/modules/ROOT/partials/configuration/table_column_resizing.adoc
+++ b/modules/ROOT/partials/configuration/table_column_resizing.adoc
@@ -1,11 +1,9 @@
 == `+table_column_resizing+`
 
-\{% if page.dir != "/plugins/opensource/table/" %}
+ifeval::["{pluginname}" != "Table"]
 
-____
-*Note*: The `+table_column_resizing+` option requires the `+table+` plugin.
-\{% endif %}
-____
+NOTE: The `+table_column_resizing+` option requires the `+table+` plugin.
+endif::[]
 
 The `+table_column_resizing+` option sets whether a table or other columns are resized when a user resizes, inserts, or deletes a table column.
 
@@ -14,9 +12,9 @@ There are two settings:
 * `+preservetable+`: The table width is maintained when manipulating table columns by changing the size of nearby columns.
 * `+resizetable+`: The table width is changed when manipulating table columns and the size of other columns is maintained.
 
-Type : `+String+`
+Type: `+String+`
 
-Default Value : `+'preservetable'+`
+Default Value: `+'preservetable'+`
 
 Possible values : `+'preservetable'+`, `+'resizetable'+`
 

--- a/modules/ROOT/partials/configuration/table_default_attributes.adoc
+++ b/modules/ROOT/partials/configuration/table_default_attributes.adoc
@@ -2,9 +2,9 @@
 
 This option enables you to specify default attributes for inserted tables.
 
-Type : `+Object+`
+Type: `+Object+`
 
-Default Value : `+{ border: '1' }+`
+Default Value: `+{ border: '1' }+`
 
 === Example: Using `+table_default_attributes+`
 

--- a/modules/ROOT/partials/configuration/table_default_styles.adoc
+++ b/modules/ROOT/partials/configuration/table_default_styles.adoc
@@ -2,9 +2,9 @@
 
 This option enables you to specify the default styles for inserted tables.
 
-Type : `+Object+`
+Type: `+Object+`
 
-Default Value : `+{ 'border-collapse': 'collapse', 'width': '100%' }+`
+Default Value: `+{ 'border-collapse': 'collapse', 'width': '100%' }+`
 
 === Example: Using `+table_default_styles+`
 

--- a/modules/ROOT/partials/configuration/table_grid.adoc
+++ b/modules/ROOT/partials/configuration/table_grid.adoc
@@ -4,15 +4,13 @@ This option allows you to disable the grid-like table picker in the Table menu. 
 
 However, if `+table_grid+` is set to `+false+` the table picker will be replaced by a menu item that opens a dialog that users can use to insert a table. This dialog allows users to set various parameters such as the number of columns and rows, width, height, cell spacing and padding, border width, alignment, and whether to display a caption. There are also advanced style options available if `+table_advtab+` is set to `+true+`.
 
-____
-*Note*: To configure the Table menu to include both the table picker and the table dialog menu items, set `+table_grid+` to `+true+` and configure link:menus-configuration-options.html#menu[`+menu+`] to include both the `+inserttable+` and `+inserttabledialog+` menu items.
-____
+NOTE: To configure the Table menu to include both the table picker and the table dialog menu items, set `+table_grid+` to `+true+` and configure link:menus-configuration-options.html#menu[`+menu+`] to include both the `+inserttable+` and `+inserttabledialog+` menu items.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 include::partial$misc/admon_different_default_for_mobile.adoc[]
 

--- a/modules/ROOT/partials/configuration/table_header_type.adoc
+++ b/modules/ROOT/partials/configuration/table_header_type.adoc
@@ -67,11 +67,11 @@ For example:
 ----
 * `+auto+` - Finds the first existing header row in the table and uses the same structure. If no other table header row exists, the `+section+` header type will be applied.
 
-Type : `+String+`
+Type: `+String+`
 
-Default Value : `+'section'+`
+Default Value: `+'section'+`
 
-Possible Values : `+'section+`', `+'cells'+`, `+'sectionCells'+`, `+'auto'+`
+Possible Values: `+'section+`', `+'cells'+`, `+'sectionCells'+`, `+'auto'+`
 
 === Example: Using `+table_header_type+`
 

--- a/modules/ROOT/partials/configuration/table_resize_bars.adoc
+++ b/modules/ROOT/partials/configuration/table_resize_bars.adoc
@@ -2,11 +2,11 @@
 
 This option makes it possible to disable the ability to resize table columns and rows by dragging the border between two columns or rows.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+table_resize_bars+`
 

--- a/modules/ROOT/partials/configuration/table_responsive_width.adoc
+++ b/modules/ROOT/partials/configuration/table_responsive_width.adoc
@@ -1,6 +1,6 @@
 == `+table_responsive_width+`
 
-NOTE: This option was deprecated with the release of {productname} 5.4. This option has been replaced by <<table_sizing_mode, `+table_sizing_mode+`>>. This option will be removed in {productname} 6.0.
+NOTE: This option was deprecated with the release of {productname} 5.4. This option has been replaced by xref:table_sizing_mode[`+table_sizing_mode+`]. This option will be removed in {productname} 6.0.
 
 This option enables you to force pixels or percentage sizes for tables. Setting this to true will force resizing by percentages and setting this to false will force pixel resizing. The default is to automatically detect what the table size is and just use that unit for resizing.
 

--- a/modules/ROOT/partials/configuration/table_responsive_width.adoc
+++ b/modules/ROOT/partials/configuration/table_responsive_width.adoc
@@ -1,12 +1,10 @@
 == `+table_responsive_width+`
 
-____
-*Note*: This option was deprecated with the release of {productname} 5.4. This option has been replaced by <<table_sizing_mode, `+table_sizing_mode+`>>. This option will be removed in {productname} 6.0.
-____
+NOTE: This option was deprecated with the release of {productname} 5.4. This option has been replaced by <<table_sizing_mode, `+table_sizing_mode+`>>. This option will be removed in {productname} 6.0.
 
 This option enables you to force pixels or percentage sizes for tables. Setting this to true will force resizing by percentages and setting this to false will force pixel resizing. The default is to automatically detect what the table size is and just use that unit for resizing.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
 === Example: Using `+table_responsive_width+`
 

--- a/modules/ROOT/partials/configuration/table_row_advtab.adoc
+++ b/modules/ROOT/partials/configuration/table_row_advtab.adoc
@@ -2,11 +2,11 @@
 
 This option makes it possible to disable the advanced tab in the table row dialog box. The advanced tab allows a user to input `+style+`, `+border color+` and `+background color+` values.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+table_row_advtab+`
 

--- a/modules/ROOT/partials/configuration/table_row_class_list.adoc
+++ b/modules/ROOT/partials/configuration/table_row_class_list.adoc
@@ -2,7 +2,7 @@
 
 This option enables you to specify a list of classes to present in the table row options dialog. This is useful if you want users to assign predefined classes to table rows.
 
-Type : `+Array+`
+Type: `+Array+`
 
 === Example: Using `+table_row_class_list+`
 

--- a/modules/ROOT/partials/configuration/table_sizing_mode.adoc
+++ b/modules/ROOT/partials/configuration/table_sizing_mode.adoc
@@ -9,11 +9,11 @@ This option accepts the following values:
 * `+responsive+` - Use no specified widths. *Note*: If a `+responsive+` table is resized, it will be converted to a `+relative+` table (a table cannot be resized without widths).
 * `+auto+` - Detects the table sizing based on the width style or attribute and attempts to keep the current sizing mode.
 
-Type : `+String+`
+Type: `+String+`
 
-Default Value : `+'auto'+`
+Default Value: `+'auto'+`
 
-Possible Values : `+'fixed'+`, `+'relative'+`, `+'responsive'+`, `+'auto'+`
+Possible Values: `+'fixed'+`, `+'relative'+`, `+'responsive'+`, `+'auto'+`
 
 === Example: Using `+table_sizing_mode+`
 

--- a/modules/ROOT/partials/configuration/table_sizing_mode.adoc
+++ b/modules/ROOT/partials/configuration/table_sizing_mode.adoc
@@ -1,3 +1,4 @@
+[[table_sizing_mode]]
 == `+table_sizing_mode+`
 
 The `+table_sizing_mode+` option enforces the table sizing method used for new and modified tables (including resizing operations on tables). This option only impacts the _width_ of tables and cells and does not apply to the _height_ of tables and cells.

--- a/modules/ROOT/partials/configuration/table_style_by_css.adoc
+++ b/modules/ROOT/partials/configuration/table_style_by_css.adoc
@@ -2,11 +2,11 @@
 
 This option enables you to force the Table Properties dialog to use HTML5/CSS3 standards for setting cell spacing and cellpadding. By default, these are added as attributes to the table element. By setting this to true, cell spacing is applied to the table element as a `+border-spacing+` style and cell padding is applied to all `+td+` elements as a `+padding+` style.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+false+`
+Default Value: `+false+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+table_style_by_css+`
 

--- a/modules/ROOT/partials/configuration/table_tab_navigation.adoc
+++ b/modules/ROOT/partials/configuration/table_tab_navigation.adoc
@@ -2,11 +2,11 @@
 
 This option enables you to disable the default tab between table cells feature. By default, when a user presses tab the cursor will move between cells within the table. By setting the `+table_tab_navigation+` value to `+false+` the cursor will tab between browser elements (such as the URL bar or form fields, etc).
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+true+`
+Default Value: `+true+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+table_tab_navigation+`
 

--- a/modules/ROOT/partials/configuration/table_toolbar.adoc
+++ b/modules/ROOT/partials/configuration/table_toolbar.adoc
@@ -4,11 +4,11 @@ This option allows you to specify the toolbar buttons shown on the contextual to
 
 To disable the table toolbar, set the value to an empty string.
 
-Type : `+String+`
+Type: `+String+`
 
-Default Value : `+'tableprops tabledelete | tableinsertrowbefore tableinsertrowafter tabledeleterow | tableinsertcolbefore tableinsertcolafter tabledeletecol'+`
+Default Value: `+'tableprops tabledelete | tableinsertrowbefore tableinsertrowafter tabledeleterow | tableinsertcolbefore tableinsertcolafter tabledeletecol'+`
 
-Possible Values : Any toolbar button. For a list of predefined toolbar buttons, see: link:available-toolbar-buttons.html[Toolbar Buttons Available for {productname}].
+Possible Values: Any toolbar button. For a list of predefined toolbar buttons, see: link:available-toolbar-buttons.html[Toolbar Buttons Available for {productname}].
 
 === Example: Default table_toolbar configuration
 

--- a/modules/ROOT/partials/configuration/table_use_colgroups.adoc
+++ b/modules/ROOT/partials/configuration/table_use_colgroups.adoc
@@ -4,11 +4,11 @@ This option adds `+colgroup+` and `+col+` elements to new tables for specifying 
 
 {productname} only supports the `+width+` attribute on `+col+` elements. Other attributes are not supported, such as the `+span+` attribute.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+false+`
+Default Value: `+false+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Enabling `+colgroup+` support using `+table_use_colgroups+`
 

--- a/modules/ROOT/partials/configuration/template_cdate_classes.adoc
+++ b/modules/ROOT/partials/configuration/template_cdate_classes.adoc
@@ -4,9 +4,9 @@ When HTML elements in a template are assigned this class, the content of the ele
 
 A creation date is one that is set if no previous date existed within the element. Once set, the original date is stored inside the element in an HTML comment and is designed not to change even with a template change.
 
-Type : `+String+`
+Type: `+String+`
 
-Default Value : `+'cdate'+`
+Default Value: `+'cdate'+`
 
 === Example: Using `+template_cdate_classes+`
 

--- a/modules/ROOT/partials/configuration/template_cdate_format.adoc
+++ b/modules/ROOT/partials/configuration/template_cdate_format.adoc
@@ -29,4 +29,4 @@ If the creation date is set as 9:00AM on January 15th 2000, then inserting this 
 <p class="cdate">01/15/2000 : 09:00</p>
 ----
 
-For a list of available date and time formats, see: <<referencedatetimeformats, Reference Date/Time formats>>.
+For a list of available date and time formats, see: xref:referencedatetimeformats[Reference Date/Time formats].

--- a/modules/ROOT/partials/configuration/template_cdate_format.adoc
+++ b/modules/ROOT/partials/configuration/template_cdate_format.adoc
@@ -2,7 +2,7 @@
 
 This option allows you to provide a date format that all 'creation' date templates will use.
 
-Type : `+String+`
+Type: `+String+`
 
 Default : `+'%Y-%m-%d'+`
 

--- a/modules/ROOT/partials/configuration/template_mdate_classes.adoc
+++ b/modules/ROOT/partials/configuration/template_mdate_classes.adoc
@@ -4,9 +4,9 @@ When HTML elements in a template are assigned this class, the content of the ele
 
 A modified date is one that is updated with each edit.
 
-Type : `+String+`
+Type: `+String+`
 
-Default Value : `+'mdate'+`
+Default Value: `+'mdate'+`
 
 === Example: Using `+template_mdate_classes+`
 

--- a/modules/ROOT/partials/configuration/template_mdate_format.adoc
+++ b/modules/ROOT/partials/configuration/template_mdate_format.adoc
@@ -2,7 +2,7 @@
 
 This option allows you to provide {productname} with a date/time format that all 'modified' date templates will use.
 
-Type : `+String+`
+Type: `+String+`
 
 Default : `+'%Y-%m-%d'+`
 

--- a/modules/ROOT/partials/configuration/template_mdate_format.adoc
+++ b/modules/ROOT/partials/configuration/template_mdate_format.adoc
@@ -29,4 +29,4 @@ If the date modified is set as 9:00AM on January 15th 2000, then inserting this 
 <p class="mdate">01/15/2000 : 09:00</p>
 ----
 
-For a list of available date and time formats, see: <<referencedatetimeformats, Reference Date/Time formats>>.
+For a list of available date and time formats, see: xref:referencedatetimeformats[Reference Date/Time formats].

--- a/modules/ROOT/partials/configuration/template_preview_replace_values.adoc
+++ b/modules/ROOT/partials/configuration/template_preview_replace_values.adoc
@@ -2,7 +2,7 @@
 
 This is an object containing items that will be replaced with their respective string values in the template preview shown in the template dialog; *but will not be replaced when a template is inserted into the editor content*.
 
-Type : `+Object+`
+Type: `+Object+`
 
 === Example: Using `+template_preview_replace_values+`
 

--- a/modules/ROOT/partials/configuration/template_replace_values.adoc
+++ b/modules/ROOT/partials/configuration/template_replace_values.adoc
@@ -2,7 +2,7 @@
 
 This is an object containing items that will be replaced with their respective string values when a template is inserted into the editor content.
 
-Type : `+Object+`
+Type: `+Object+`
 
 === Example: Using `+template_replace_values+`
 

--- a/modules/ROOT/partials/configuration/template_selected_content_classes.adoc
+++ b/modules/ROOT/partials/configuration/template_selected_content_classes.adoc
@@ -2,9 +2,9 @@
 
 When HTML elements in a template are assigned this class, the content of the element will be replaced with selected content from the editor. This option accepts a list of classes (separated by spaces).
 
-Type : `+String+`
+Type: `+String+`
 
-Default Value : `+'selcontent'+`
+Default Value: `+'selcontent'+`
 
 === Example: Using `+template_selected_content_classes+`
 

--- a/modules/ROOT/partials/configuration/textpattern_patterns.adoc
+++ b/modules/ROOT/partials/configuration/textpattern_patterns.adoc
@@ -4,12 +4,13 @@ This option allows configuring the text patterns that get matched by the `+textp
 
 There are three types of patterns: `+inline+`, `+block+`, and `+replacement+` patterns. Inline patterns have a `+start+` and an `+end+` text pattern whereas the block and replacement patterns only have a `+start+`. A user can specify the formats to be applied to the selection, commands to be executed, or text to be replaced.
 
-____
-*Important*: Any formats or commands used by `+textpatterns+` need to be registered with the editor when it is initialized. This may include enabling relevant plugins, such as the `+lists+` plugin. For information on:
+[IMPORTANT]
+====
+Any formats or commands used by `+textpatterns+` need to be registered with the editor when it is initialized. This may include enabling relevant plugins, such as the `+lists+` plugin. For information on:
 
 * Registering formats for {productname}, see: link:content-formatting.html#formats[Content formatting options - `+formats+`].
 * Registering commands for {productname}, see: link:tinymce.editorcommands.html[{productname} APIs - EditorCommands].
-____
+====
 
 === The default patterns for the `+textpattern+` plugin
 
@@ -41,9 +42,7 @@ Inline patterns must have the following:
 
 This allows for patterns to be used to either apply a format or execute a command, optionally with the given value.
 
-____
-*Note*: Inline patterns are executed on either pressing the *spacebar* or the *Enter* key.
-____
+NOTE: Inline patterns are executed on either pressing the *spacebar* or the *Enter* key.
 
 ==== Example: Using `+textpattern+` inline patterns
 
@@ -77,9 +76,7 @@ Block patterns must have the following:
 
 The block patterns do not have an `+end+` property. This allows for patterns to be used to either apply a block format or execute a command, optionally, with the given value.
 
-____
-*Note*: Block patterns are only executed on *Enter*, *not* on pressing the *spacebar*.
-____
+NOTE: Block patterns are only executed on *Enter*, *not* on pressing the *spacebar*.
 
 ==== Example: Using `+textpattern+` block patterns
 
@@ -122,9 +119,7 @@ Replacement patterns must have the following:
 
 Whether a replacement pattern inserts a block or inline element depends on what the `+replacement+` string is.
 
-____
-*Note*: Replacement patterns are executed on either pressing the *spacebar* or the *Enter* key.
-____
+NOTE: Replacement patterns are executed on either pressing the *spacebar* or the *Enter* key.
 
 ==== Example: Using `+textpattern+` replacement patterns
 

--- a/modules/ROOT/partials/configuration/toc_class.adoc
+++ b/modules/ROOT/partials/configuration/toc_class.adoc
@@ -2,9 +2,9 @@
 
 With `+toc_class+` you can change the class name that gets assigned to the wrapper `+div+`. Please note that you will have to alter link:/how-to-guides/learn-the-basics/editor-content-css/[Boilerplate Content CSS] accordingly.
 
-Type : `+String+`
+Type: `+String+`
 
-Default Value : `+'mce-toc'+`
+Default Value: `+'mce-toc'+`
 
 === Example: Using `+toc_class+`
 

--- a/modules/ROOT/partials/configuration/toc_depth.adoc
+++ b/modules/ROOT/partials/configuration/toc_depth.adoc
@@ -2,9 +2,9 @@
 
 By default headers in the content will be inspected only three levels deep, so - `+H1+` through `+H3+`. But it is possible to change this behavior by setting `+toc_depth+` to any number in 1-9 range, therefore matching all the headers beginning with `+H1+` and all the way down to `+H9+`.
 
-Type : `+Number+`
+Type: `+Number+`
 
-Default Value : `+3+`
+Default Value: `+3+`
 
 === Example: Using `+toc_depth+`
 

--- a/modules/ROOT/partials/configuration/toc_header.adoc
+++ b/modules/ROOT/partials/configuration/toc_header.adoc
@@ -2,9 +2,9 @@
 
 Table of contents has a header and by default it will be marked up with `+H2+` tag. With the `+toc_header+` option you can change it to some other tag.
 
-Type : `+String+`
+Type: `+String+`
 
-Default Value : `+'h2'+`
+Default Value: `+'h2'+`
 
 === Example: Using `+toc_header+`
 

--- a/modules/ROOT/partials/configuration/visualblocks_default_state.adoc
+++ b/modules/ROOT/partials/configuration/visualblocks_default_state.adoc
@@ -2,11 +2,11 @@
 
 This option enables you to specify the default state of the Visual Blocks plugin.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+false+`
+Default Value: `+false+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+visualblocks_default_state+`
 

--- a/modules/ROOT/partials/configuration/visualchars_default_state.adoc
+++ b/modules/ROOT/partials/configuration/visualchars_default_state.adoc
@@ -2,11 +2,11 @@
 
 This option enables specifying the default state of the Visual Characters plugin.
 
-Type : `+Boolean+`
+Type: `+Boolean+`
 
-Default Value : `+false+`
+Default Value: `+false+`
 
-Possible Values : `+true+`, `+false+`
+Possible Values: `+true+`, `+false+`
 
 === Example: Using `+visualchars_default_state+`
 

--- a/modules/ROOT/partials/css-codeblock/image-plugin-css.adoc
+++ b/modules/ROOT/partials/css-codeblock/image-plugin-css.adoc
@@ -1,9 +1,9 @@
-figure.image \{ display: inline-block; border: 1px solid gray; margin: 0 2px 0 1px; background: #f5f2f0; }
+figure.image { display: inline-block; border: 1px solid gray; margin: 0 2px 0 1px; background: #f5f2f0; }
 
-figure.align-left \{ float: left; }
+figure.align-left { float: left; }
 
-figure.align-right \{ float: right; }
+figure.align-right { float: right; }
 
-figure.image img \{ margin: 8px 8px 0 8px; }
+figure.image img { margin: 8px 8px 0 8px; }
 
-figure.image figcaption \{ margin: 6px 8px 6px 8px; text-align: center; }
+figure.image figcaption { margin: 6px 8px 6px 8px; text-align: center; }

--- a/modules/ROOT/partials/css-codeblock/toc-plugin-css.adoc
+++ b/modules/ROOT/partials/css-codeblock/toc-plugin-css.adoc
@@ -1,5 +1,6 @@
-/* Basic styles for Table of Contents plugin (toc) */ .mce-toc \{ border: 1px solid gray; }
+/* Basic styles for Table of Contents plugin (toc) */
+.mce-toc { border: 1px solid gray; }
 
-.mce-toc h2 \{ margin: 4px; }
+.mce-toc h2 { margin: 4px; }
 
-.mce-toc li \{ list-style-type: none; }
+.mce-toc li { list-style-type: none; }

--- a/modules/ROOT/partials/misc/admon_different_default_for_mobile.adoc
+++ b/modules/ROOT/partials/misc/admon_different_default_for_mobile.adoc
@@ -1,3 +1,1 @@
-____
-*Note*: The default option for this setting is different for mobile devices. For information on the default mobile setting, see: link:tinymce-for-mobile.html#mobiledefaultsforselectedsettings[{productname} Mobile - Configuration settings with mobile defaults].
-____
+NOTE: The default option for this setting is different for mobile devices. For information on the default mobile setting, see: link:tinymce-for-mobile.html#mobiledefaultsforselectedsettings[{productname} Mobile - Configuration settings with mobile defaults].

--- a/modules/ROOT/partials/misc/admon_svg_not_supported.adoc
+++ b/modules/ROOT/partials/misc/admon_svg_not_supported.adoc
@@ -1,3 +1,1 @@
-____
-*Note*: SVGs (Scalable Vector Graphics) are not supported in {productname} to protect our users and their end-users. SVGs can be used to perform both client-side and server-side attacks.
-____
+NOTE: SVGs (Scalable Vector Graphics) are not supported in {productname} to protect our users and their end-users. SVGs can be used to perform both client-side and server-side attacks.

--- a/modules/ROOT/partials/misc/plugin-menu-item-id-boilerplate.adoc
+++ b/modules/ROOT/partials/misc/plugin-menu-item-id-boilerplate.adoc
@@ -1,28 +1,28 @@
-ifeval::["{page.name}" == "available-menu-items.adoc"]
+ifeval::["{docname}" == "available-menu-items"]
 
 == {pluginname} plugin
 
 The {pluginname} plugin provides the following menu items:
 
-ifeval::[altplugincode != nil]
+ifeval::["{altplugincode}" != "nil"]
 include::partial$menu-item-ids/{altplugincode}-menu-items.adoc[]
 endif::[]
-ifeval::[altplugincode == nil]
+ifeval::["{altplugincode}" == "nil"]
 include::partial$menu-item-ids/{plugincode}-menu-items.adoc[]
 endif::[]
 
 For information on the {pluginname} plugin, see: link:{plugincode}.html[Plugins - The {pluginname} plugin]
 
 endif::[]
-ifeval::["{page.name}" != "available-menu-items.adoc"]
+ifeval::["{docname}" != "available-menu-items"]
 == Menu items
 
 The {pluginname} plugin provides the following menu items:
 
-ifeval::[altplugincode != nil]
+ifeval::["{altplugincode}" != "nil"]
 include::partial$menu-item-ids/{altplugincode}-menu-items.adoc[]
 endif::[]
-ifeval::[altplugincode == nil]
+ifeval::["{altplugincode}" == "nil"]
 include::partial$menu-item-ids/{plugincode}-menu-items.adoc[]
 endif::[]
 

--- a/modules/ROOT/partials/misc/plugin-menu-item-id-boilerplate.adoc
+++ b/modules/ROOT/partials/misc/plugin-menu-item-id-boilerplate.adoc
@@ -1,26 +1,32 @@
-\{% if page.name == "available-menu-items.md" %}
+ifeval::["{page.name}" == "available-menu-items.adoc"]
 
 == {pluginname} plugin
 
 The {pluginname} plugin provides the following menu items:
 
-\{% if altplugincode %}
-include::partial$menu-item-ids/{altplugincode}-menu-items.adoc[] \{% else %}
-include::partial$menu-item-ids/{plugincode}-menu-items.adoc[] \{% endif %}
+ifeval::[altplugincode != nil]
+include::partial$menu-item-ids/{altplugincode}-menu-items.adoc[]
+endif::[]
+ifeval::[altplugincode == nil]
+include::partial$menu-item-ids/{plugincode}-menu-items.adoc[]
+endif::[]
 
 For information on the {pluginname} plugin, see: link:{plugincode}.html[Plugins - The {pluginname} plugin]
 
-\{% else %}
-
+endif::[]
+ifeval::["{page.name}" != "available-menu-items.adoc"]
 == Menu items
 
 The {pluginname} plugin provides the following menu items:
 
-\{% if altplugincode %}
-include::partial$menu-item-ids/{altplugincode}-menu-items.adoc[] \{% else %}
-include::partial$menu-item-ids/{plugincode}-menu-items.adoc[] \{% endif %}
+ifeval::[altplugincode != nil]
+include::partial$menu-item-ids/{altplugincode}-menu-items.adoc[]
+endif::[]
+ifeval::[altplugincode == nil]
+include::partial$menu-item-ids/{plugincode}-menu-items.adoc[]
+endif::[]
 
 include::partial$misc/menu-item-settings.adoc[]
 
-\{% endif %}
+endif::[]
 :altplugincode: nil

--- a/modules/ROOT/partials/misc/plugin-menu-item-id-boilerplate.adoc
+++ b/modules/ROOT/partials/misc/plugin-menu-item-id-boilerplate.adoc
@@ -29,4 +29,3 @@ endif::[]
 include::partial$misc/menu-item-settings.adoc[]
 
 endif::[]
-:altplugincode: nil

--- a/modules/ROOT/partials/misc/plugin-toolbar-button-id-boilerplate.adoc
+++ b/modules/ROOT/partials/misc/plugin-toolbar-button-id-boilerplate.adoc
@@ -1,26 +1,32 @@
-\{% if page.name == "available-toolbar-buttons.md" %}
+ifeval::["{page.name}" == "available-toolbar-buttons.adoc"]
 
 == {pluginname} plugin
 
 The {pluginname} plugin provides the following toolbar buttons:
 
-\{% if altplugincode %}
-include::partial$toolbar-button-ids/{altplugincode}-toolbar-buttons.adoc[] \{% else %}
-include::partial$toolbar-button-ids/{plugincode}-toolbar-buttons.adoc[] \{% endif %}
+ifeval::[altplugincode != nil]
+include::partial$toolbar-button-ids/{altplugincode}-toolbar-buttons.adoc[]
+endif::[]
+ifeval::[altplugincode == nil]
+include::partial$toolbar-button-ids/{plugincode}-toolbar-buttons.adoc[]
+endif::[]
 
 For information on the {pluginname} plugin, see: link:{plugincode}.html[Plugins - The {pluginname} plugin]
 
-\{% else %}
-
+endif::[]
+ifeval::["{page.name}" != "available-toolbar-buttons.adoc"]
 == Toolbar buttons
 
 The {pluginname} plugin provides the following toolbar buttons:
 
-\{% if altplugincode %}
-include::partial$toolbar-button-ids/{altplugincode}-toolbar-buttons.adoc[] \{% else %}
-include::partial$toolbar-button-ids/{plugincode}-toolbar-buttons.adoc[] \{% endif %}
+ifeval::[altplugincode != nil]
+include::partial$toolbar-button-ids/{altplugincode}-toolbar-buttons.adoc[]
+endif::[]
+ifeval::[altplugincode == nil]
+include::partial$toolbar-button-ids/{plugincode}-toolbar-buttons.adoc[]
+endif::[]
 
 include::partial$misc/toolbar-button-settings.adoc[]
 
-\{% endif %}
+endif::[]
 :altplugincode: nil

--- a/modules/ROOT/partials/misc/plugin-toolbar-button-id-boilerplate.adoc
+++ b/modules/ROOT/partials/misc/plugin-toolbar-button-id-boilerplate.adoc
@@ -1,28 +1,28 @@
-ifeval::["{page.name}" == "available-toolbar-buttons.adoc"]
+ifeval::["{docname}" == "available-toolbar-buttons"]
 
 == {pluginname} plugin
 
 The {pluginname} plugin provides the following toolbar buttons:
 
-ifeval::[altplugincode != nil]
+ifeval::["{altplugincode}" != "nil"]
 include::partial$toolbar-button-ids/{altplugincode}-toolbar-buttons.adoc[]
 endif::[]
-ifeval::[altplugincode == nil]
+ifeval::["{altplugincode}" == "nil"]
 include::partial$toolbar-button-ids/{plugincode}-toolbar-buttons.adoc[]
 endif::[]
 
 For information on the {pluginname} plugin, see: link:{plugincode}.html[Plugins - The {pluginname} plugin]
 
 endif::[]
-ifeval::["{page.name}" != "available-toolbar-buttons.adoc"]
+ifeval::["{docname}" != "available-toolbar-buttons"]
 == Toolbar buttons
 
 The {pluginname} plugin provides the following toolbar buttons:
 
-ifeval::[altplugincode != nil]
+ifeval::["{altplugincode}" != "nil"]
 include::partial$toolbar-button-ids/{altplugincode}-toolbar-buttons.adoc[]
 endif::[]
-ifeval::[altplugincode == nil]
+ifeval::["{altplugincode}" == "nil"]
 include::partial$toolbar-button-ids/{plugincode}-toolbar-buttons.adoc[]
 endif::[]
 

--- a/modules/ROOT/partials/misc/plugin-toolbar-button-id-boilerplate.adoc
+++ b/modules/ROOT/partials/misc/plugin-toolbar-button-id-boilerplate.adoc
@@ -29,4 +29,3 @@ endif::[]
 include::partial$misc/toolbar-button-settings.adoc[]
 
 endif::[]
-:altplugincode: nil

--- a/modules/ROOT/partials/misc/under-license.adoc
+++ b/modules/ROOT/partials/misc/under-license.adoc
@@ -1,3 +1,1 @@
-____
-*Important*: The {feature} provided by {companynameformal} uses {third_party_product} under the {license_agreement_name} license agreement.
-____
+IMPORTANT: The {feature} provided by {companynameformal} uses {third_party_product} under the {license_agreement_name} license agreement.


### PR DESCRIPTION
Related Ticket: DOC-1532

Description of Changes:
* Replace all liquid logic with asciidoc ifeval, etc... logic instead
* Fixed other conversion issues caused by the liquid syntax that prevented it being converted automatically
* Fixed conversion issues with admonitions (these were converted to blockquotes since markdown doesn't have this concept)
* Fixed xref conversion issues (basically replace the legacy <<id, title>> format with xref:id[title])

Pre-checks:
- [X] Branch prefixed with `feature/` or `hotfix/`
- [X] `_data/nav.yml` has been updated (if applicable)
- [X] Files has been included where required (if applicable)
- [X] Files removed have been deleted, not just excluded from the build (if applicable)
- [X] ~~(New product features only) Release Note added~~

Review:
- [ ] Documentation Team Lead has reviewed
- [ ] Product Manager has reviewed
