### PR TITLE
DOC-1490: Updated doc for default settings

### DIFF
--- a/modules/ROOT/partials/configuration/a11ychecker_html_version.adoc
+++ b/modules/ROOT/partials/configuration/a11ychecker_html_version.adoc
@@ -19,6 +19,6 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'a11ychecker',
   toolbar: 'a11ycheck',
-  a11ychecker_html_version: 'html5'
+  a11ychecker_html_version: 'html4'
 });
 ----

--- a/modules/ROOT/partials/configuration/a11ychecker_html_version.adoc
+++ b/modules/ROOT/partials/configuration/a11ychecker_html_version.adoc
@@ -7,7 +7,7 @@ For example: Setting the version to HTML 4 will enable the rule "Complex tables 
 
 Type : `+String+`
 
-Default value : `+html4+`
+Default value : `+html5+`
 
 Possible Values : `+html4+`, `+html5+`
 

--- a/modules/ROOT/partials/configuration/element_format.adoc
+++ b/modules/ROOT/partials/configuration/element_format.adoc
@@ -13,9 +13,9 @@ Possible Values : `+'xhtml'+`, `+'html'+`
 
 [source,js]
 ----
-// Output elements in HTML style
+// Output elements in XHTML style
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  element_format : 'html'
+  element_format : 'xhtml'
 });
 ----

--- a/modules/ROOT/partials/configuration/element_format.adoc
+++ b/modules/ROOT/partials/configuration/element_format.adoc
@@ -1,11 +1,11 @@
 [[element_format]]
 == `+element_format+`
 
-This option controls whether elements are output in the HTML or XHTML mode. `+xhtml+` is the default state for this option. This means that for example `+<br />+` will be `+<br>+` if you set this option to `+html+`.
+This option controls whether elements are output in the HTML or XHTML mode. `+html+` is the default state for this option. This means that for example `+<br />+` will be `+<br>+` by default.
 
 Type : `+String+`
 
-Default Value : `+'xhtml'+`
+Default Value : `+'html'+`
 
 Possible Values : `+'xhtml'+`, `+'html'+`
 

--- a/modules/ROOT/partials/configuration/link_default_protocol.adoc
+++ b/modules/ROOT/partials/configuration/link_default_protocol.adoc
@@ -7,7 +7,7 @@ NOTE: This option also applies to the xref:autolink.adoc[autolink] plugin.
 
 Type: `+String+`
 
-Default Value: `+'http'+`
+Default Value: `+'https'+`
 
 === Example: Using `+link_default_protocol+`
 
@@ -18,6 +18,6 @@ tinymce.init({
   plugins: 'link',
   menubar: 'insert',
   toolbar: 'link',
-  link_default_protocol: 'https'
+  link_default_protocol: 'http'
 });
 ----

--- a/modules/ROOT/partials/configuration/table_style_by_css.adoc
+++ b/modules/ROOT/partials/configuration/table_style_by_css.adoc
@@ -1,11 +1,11 @@
 [[table_style_by_css]]
 == `+table_style_by_css+`
 
-This option enables you to force the Table Properties dialog to use HTML5/CSS3 standards for setting cell spacing and cellpadding. By default, these are added as attributes to the table element. By setting this to true, cell spacing is applied to the table element as a `+border-spacing+` style and cell padding is applied to all `+td+` elements as a `+padding+` style.
+This option enables you to force the Table Properties dialog to use HTML5/CSS3 standards for setting cell spacing and cellpadding. By default, cell spacing is applied to the table element as a `+border-spacing+` style and cell padding is applied to all `+td+` elements as a `+padding+` style. By setting this to false, these are added as attributes to the table element.
 
 Type: `+Boolean+`
 
-Default Value: `+false+`
+Default Value: `+true+`
 
 Possible Values: `+true+`, `+false+`
 

--- a/modules/ROOT/partials/configuration/table_style_by_css.adoc
+++ b/modules/ROOT/partials/configuration/table_style_by_css.adoc
@@ -1,7 +1,7 @@
 [[table_style_by_css]]
 == `+table_style_by_css+`
 
-This option enables you to force the Table Properties dialog to use HTML5/CSS3 standards for setting cell spacing and cellpadding. By default, cell spacing is applied to the table element as a `+border-spacing+` style and cell padding is applied to all `+td+` elements as a `+padding+` style. By setting this to false, these are added as attributes to the table element.
+This option enables you to force the Table Properties dialog to use HTML5/CSS3 standards for setting cell spacing and cellpadding. By default, cell spacing is applied to the table element as a `+border-spacing+` style and cell padding is applied to all `+td+` elements as a `+padding+` style. By setting this to `false`, these are added as attributes to the table element.
 
 Type: `+Boolean+`
 

--- a/modules/ROOT/partials/configuration/table_use_colgroups.adoc
+++ b/modules/ROOT/partials/configuration/table_use_colgroups.adoc
@@ -7,17 +7,17 @@ This option adds `+colgroup+` and `+col+` elements to new tables for specifying 
 
 Type: `+Boolean+`
 
-Default Value: `+false+`
+Default Value: `+true+`
 
 Possible Values: `+true+`, `+false+`
 
-=== Example: Enabling `+colgroup+` support using `+table_use_colgroups+`
+=== Example: Disable `+colgroup+` support using `+table_use_colgroups+`
 
 [source,js]
 ----
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
   plugins: 'table',
-  table_use_colgroups: true
+  table_use_colgroups: false
 });
 ----


### PR DESCRIPTION
Related Ticket:  DOC-1490

Description of Changes:
- Updated the default value of `a11ycheck_html_version`, `element_format`, `table_style_by_css`, `link_default_protocol` and `table_use_colgroups` settings. 
- Changed the wording in a few places

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] ~`_data/nav.yml` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed