### PR TITLE
DOC-987/DOC-1530/DOC-1543: Document format, command, schema changes

### DIFF
--- a/modules/ROOT/live-demos/format-custom/index.js
+++ b/modules/ROOT/live-demos/format-custom/index.js
@@ -3,17 +3,17 @@ tinymce.init({
   height: 500,
   plugins: 'table wordcount',
   content_style: '.left { text-align: left; } ' +
-    'img.left { float: left; } ' +
-    'table.left { float: left; } ' +
+    'img.left, audio.left, video.left { float: left; } ' +
+    'table.left { margin-left: 0px; margin-right: auto; } ' +
     '.right { text-align: right; } ' +
-    'img.right { float: right; } ' +
-    'table.right { float: right; } ' +
+    'img.right, audio.right, video.right { float: right; } ' +
+    'table.right { margin-left: auto; margin-right: 0px; } ' +
     '.center { text-align: center; } ' +
-    'img.center { display: block; margin: 0 auto; } ' +
-    'table.center { display: block; margin: 0 auto; } ' +
+    'img.center, audio.center, video.center { display: block; margin: 0 auto; } ' +
+    'table.center { margin: 0 auto; } ' +
     '.full { text-align: justify; } ' +
-    'img.full { display: block; margin: 0 auto; } ' +
-    'table.full { display: block; margin: 0 auto; } ' +
+    'img.full, audio.full, video.full { display: block; margin: 0 auto; } ' +
+    'table.full { margin: 0 auto; } ' +
     '.bold { font-weight: bold; } ' +
     '.italic { font-style: italic; } ' +
     '.underline { text-decoration: underline; } ' +

--- a/modules/ROOT/live-demos/valid-elements/index.js
+++ b/modules/ROOT/live-demos/valid-elements/index.js
@@ -2,7 +2,7 @@ tinymce.init({
   selector: 'textarea#valid-elements',
   plugins: 'code',
   height: 500,
-  extended_valid_elements: 'img[class=myclass|!src|border:0|alt|title|width|height|style]',
+  extended_valid_elements: 'img[class=myclass|!src|border~0|alt|title|width|height|style]',
   invalid_elements: 'strong,b,em,i',
   content_style: 'body { font-family:Helvetica,Arial,sans-serif; font-size:16px }'
 });

--- a/modules/ROOT/pages/editor-command-identifiers.adoc
+++ b/modules/ROOT/pages/editor-command-identifiers.adoc
@@ -470,17 +470,18 @@ For example:
 
 [source,js]
 ----
-tinymce.execCommand('mceAddEditor', false, '<editor_id>');
+tinymce.execCommand('mceAddEditor', false, { id: '<editor_id>', options: {} });
 tinymce.execCommand('mceRemoveEditor', false, '<editor_id>');
-tinymce.execCommand('mceToggleEditor', false, '<editor_id>');
+tinymce.execCommand('mceToggleEditor', false, { id: '<editor_id>' });
+tinymce.execCommand('mceToggleEditor', false, { index: '<editor_index>' });
 ----
 
 [cols="1,3",options="header"]
 |===
 |Command |Description
-|mceAddEditor |Converts the specified HTML or DOM element into an editor instance with the specified ID.
+|mceAddEditor |Converts an HTML or DOM element with the specified ID into an editor instance that uses the specified editor configuration options. For information on configuring the editor, see: xref:basic-setup.adoc[Basic Setup].
 |mceRemoveEditor |Removes an editor instance with the specified ID.
-|mceToggleEditor |Runs mceAddEditor if an editor is not detected for the specified ID, otherwise it runs either xref:apis/tinymce.editor.adoc#hide[hide] if the editor is visible or xref:apis/tinymce.editor.adoc#show[show] if it is not visible.
+|mceToggleEditor |Runs `mceAddEditor` if an editor is not detected for the specified ID, otherwise it runs either xref:apis/tinymce.editor.adoc#hide[hide] if the editor is visible or xref:apis/tinymce.editor.adoc#show[show] if it is not visible.
 |===
 
 [[querycommandstates]]

--- a/modules/ROOT/partials/configuration/extended_valid_elements.adoc
+++ b/modules/ROOT/partials/configuration/extended_valid_elements.adoc
@@ -7,7 +7,7 @@ When adding a new attribute by specifying an existing element rule (e.g. `+img+`
 
 The below example replaces the current `+img+` rule (including the global element rules).
 
-Type: `+String+`
+Type : `+String+`
 
 === Example: Using `+extended_valid_elements+`
 

--- a/modules/ROOT/partials/configuration/extended_valid_elements.adoc
+++ b/modules/ROOT/partials/configuration/extended_valid_elements.adoc
@@ -7,7 +7,7 @@ When adding a new attribute by specifying an existing element rule (e.g. `+img+`
 
 The below example replaces the current `+img+` rule (including the global element rules).
 
-Type : `+String+`
+Type: `+String+`
 
 === Example: Using `+extended_valid_elements+`
 
@@ -28,7 +28,7 @@ WARNING: Allowing script elements (`+<script>+`) in {productname} exposes users 
 To allow script elements in the editor, include the following in the {productname} configuration:
 
 ....
-extended_valid_elements : 'script[src|async|defer|type|charset]'
+extended_valid_elements: 'script[src|async|defer|type|charset]'
 ....
 
 === Interactive example

--- a/modules/ROOT/partials/configuration/valid_elements.adoc
+++ b/modules/ROOT/partials/configuration/valid_elements.adoc
@@ -20,7 +20,7 @@ If you just want to add or change some behavior for a few items, use the xref:co
 |] |Ends an attribute list for an element definition.
 |! |Makes attributes required. If none of the required attributes are set, the element will be removed. For example, `+'!href'+`.
 |= |Makes the attribute default to the specified value. For example, `+'target=_blank'+`
-|: |Forces the attribute to the specified value. For example, `+'border:0'+`
+|~ |Forces the attribute to the specified value. For example, `+'border~0'+`
 |< |Verifies the value of an attribute (only the listed values are allowed). For example, `+'target<_blank?_self'+`
 |? |Separates attribute verification values. See above.
 |+ |Makes the element open if no child nodes exists. For example, `+'+a'+`.
@@ -36,12 +36,12 @@ Wildcards such as `+*+`,`+++`,`+?+` may be used in element or attribute name mat
 [cols="1,5",options="header"]
 |===
 |Name |Summary
-|`+{$uid}+` |Results in a unique ID. For example, `+'p[id:{$uid}]'+`.
+|`+{$uid}+` |Results in a unique ID. For example, `+'p[id~{$uid}]'+`.
 |===
 
 Use `+*[*]+` to include all elements and all attributes. This can be very useful when used with the xref:content-filtering.adoc#invalid_elements[invalid_elements] option.
 
-Type : `+String+`
+Type: `+String+`
 
 === Example: Using `+valid_elements+`
 
@@ -49,7 +49,7 @@ Type : `+String+`
 ----
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  valid_elements : 'a[href|target=_blank],strong/b,div[align],br'
+  valid_elements: 'a[href|target=_blank],strong/b,div[align],br'
 });
 ----
 

--- a/modules/ROOT/partials/configuration/valid_elements.adoc
+++ b/modules/ROOT/partials/configuration/valid_elements.adoc
@@ -41,7 +41,7 @@ Wildcards such as `+*+`,`+++`,`+?+` may be used in element or attribute name mat
 
 Use `+*[*]+` to include all elements and all attributes. This can be very useful when used with the xref:content-filtering.adoc#invalid_elements[invalid_elements] option.
 
-Type: `+String+`
+Type : `+String+`
 
 === Example: Using `+valid_elements+`
 


### PR DESCRIPTION
Related Ticket: DOC-987, DOC-1530, DOC-1543

Description of Changes:
* DOC-987: Document alignleft and alignright format change for tables
* DOC-1530: Document mceAddEditor and mceToggleEditor command value change
* DOC-1543: Update valid_elements documentation to replace : with ~

Pre-checks:
- [X] Branch prefixed with `feature/` or `hotfix/`
- [X] `_data/nav.yml` has been updated (if applicable)
- [X] Files has been included where required (if applicable)
- [X] Files removed have been deleted, not just excluded from the build (if applicable)
- [X] ~~(New product features only) Release Note added~~

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
