### PR TITLE
DOC-1499: Added documentation for the new image proxy service url options

### DIFF
--- a/modules/ROOT/pages/editimage.adoc
+++ b/modules/ROOT/pages/editimage.adoc
@@ -6,14 +6,17 @@
 :pluginname: Edit Image
 :plugincode: editimage
 :altplugincode: nil
+:pluginminimumplan: tierone
 
-Edit Image (`+editimage+`) plugin adds a contextual editing toolbar to the images in the editor. If toolbar is not appearing on image click, it might be that you need to enable `+editimage_cors_hosts+` or `+editimage_proxy+` (see below).
+Edit Image (`+editimage+`) plugin adds a contextual editing toolbar to the images in the editor. If toolbar is not appearing on image click, it might be that you need to enable `+editimage_cors_hosts+` or `+editimage_proxy_service_url+` (see below).
 
 == Interactive example
 
 liveDemo::edit-image[ ]
 
 include::partial$misc/admon_svg_not_supported.adoc[]
+
+include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Cloud Installation
 
@@ -34,8 +37,8 @@ tinymce.init({
 
 To enable the {productname} Edit Image plugin:
 
-. Add 'image' to the 'toolbar' list and 'image editimage' to the 'plugins' list
-. Enable `+editimage_cors_hosts+` and `+editimage_proxy+` options as needed
+. Add `image` to the `toolbar` list and `image editimage` to the `plugins` list.
+. Enable xref:editimage_cors_hosts[`+editimage_cors_hosts+`] and xref:editimage_proxy_service_url[`+editimage_proxy_service_url+`] options as required.
 
 === Basic self-hosted setup
 
@@ -46,25 +49,27 @@ tinymce.init({
   toolbar: 'image',
   plugins: 'image editimage',
   editimage_cors_hosts: ['mydomain.com', 'otherdomain.com'],
-  editimage_proxy: 'proxy.php'
+  editimage_proxy_service_url: 'http://mydomain.com/imageproxy'
 });
 ----
 
 == Options
 
-include::partial$configuration/image_cors_hosts.adoc[]
+include::partial$configuration/image_cors_hosts.adoc[leveloffset=+1]
 
-include::partial$configuration/editimage_credentials_hosts.adoc[]
+include::partial$configuration/editimage_credentials_hosts.adoc[leveloffset=+1]
 
-include::partial$configuration/editimage_fetch_image.adoc[]
+include::partial$configuration/editimage_fetch_image.adoc[leveloffset=+1]
 
-include::partial$configuration/image_proxy.adoc[]
+include::partial$configuration/image_proxy.adoc[leveloffset=+1]
 
-include::partial$configuration/editimage_toolbar.adoc[]
+include::partial$configuration/image_proxy_service_url.adoc[leveloffset=+1]
 
-include::partial$configuration/editimage_upload_timeout.adoc[]
+include::partial$configuration/editimage_toolbar.adoc[leveloffset=+1]
 
-include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
+include::partial$configuration/editimage_upload_timeout.adoc[leveloffset=+1]
+
+include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[leveloffset=+1]
 
 == Commands
 

--- a/modules/ROOT/pages/editor-and-features.adoc
+++ b/modules/ROOT/pages/editor-and-features.adoc
@@ -60,7 +60,7 @@ NOTE: `+spellchecker_rpc_url+` is *not* required when enabling this plugin via l
 
 * xref:editimage.adoc[Edit Image (with configured image proxy)]
 +
-NOTE: Configuration of the `+editimage_cors_hosts+` and `+editimage_proxy+` properties occurs automatically.
+NOTE: Configuration of the `+editimage_cors_hosts+` and `+editimage_proxy_service_url+` options occurs automatically.
 
 * xref:moxiemanager.adoc[Moxie Manager]
 * xref:a11ychecker.adoc[Accessibility Checker]
@@ -126,7 +126,7 @@ NOTE: `+spellchecker_rpc_url+` is *not* required when enabling this plugin via l
 
 * xref:editimage.adoc[Edit Image (with configured image proxy)]
 +
-NOTE: Configuration of the `+editimage_cors_hosts+` and `+editimage_proxy+` properties occurs automatically.
+NOTE: Configuration of the `+editimage_cors_hosts+` and `+editimage_proxy_service_url+` options occurs automatically.
 
 * xref:moxiemanager.adoc[Moxie Manager]
 * xref:a11ychecker.adoc[Accessibility Checker]

--- a/modules/ROOT/pages/export.adoc
+++ b/modules/ROOT/pages/export.adoc
@@ -23,11 +23,29 @@ liveDemo::export[ ]
 
 include::partial$misc/purchase-premium-plugins.adoc[]
 
-== Basic setup
+== Cloud Installation
 
-To add the {pluginname} plugin to the editor, add `{plugincode}` to the `+plugins+` option in the editor configuration.
+The {pluginname} plugin is provided with all subscriptions to xref:editor-and-features.adoc[{cloudname}], including an automatically configured image proxy. To add the {pluginname} plugin to the editor, add `{plugincode}` to the `+plugins+` option in the editor configuration.
 
-For example:
+=== Basic setup using Tiny Cloud
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  plugins: 'export',
+  toolbar: 'export'
+});
+----
+
+== Self-hosted Installation
+
+To add the {pluginname} plugin to the editor:
+
+. Add `{plugincode}` to the `+plugins+` option in the editor configuration.
+. Enable the xref:export_image_proxy[`+export_image_proxy+`] or xref:export_image_proxy_service_url[`+export_image_proxy_service_url+`] options as required.
+
+=== Basic self-hosted setup
 
 [source,js]
 ----
@@ -35,7 +53,7 @@ tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
   plugins: 'export',
   toolbar: 'export',
-  export_image_proxy: 'proxy.php' // Required for rendering remote images
+  export_image_proxy_service_url: 'http://mydomain.com/imageproxy' // Required for rendering remote images
 });
 ----
 
@@ -56,7 +74,7 @@ This exporter has a few limitations or known issues that should be noted:
 * The text content in the PDF cannot be selected or copied.
 * A single line of content sliced horizontally and distributed across separate pages.
 * Due to browser limitations, there is a limit on the number of pages that can be rendered. The number of pages varies between browsers.
-* Remote images require an image proxy to render due to browser limitations. For information on proxying remote images, see the xref:export_image_proxy[export_image_proxy] option.
+* Remote images require an image proxy to render due to browser limitations. For information on proxying remote images, see the xref:export_image_proxy[export_image_proxy] or xref:export_image_proxy_service_url[export_image_proxy_service_url] options.
 * Right-to-left languages that use cursive scripts (such as Arabic) may not render correctly due to an issue with how the image of the HTML content is rendered.
 * The xref:checklist.adoc[Checklist plugin] icons will not render for Internet Explorer 11 users due to browser limitations.
 
@@ -81,6 +99,8 @@ include::partial$configuration/image_cors_hosts.adoc[leveloffset=+1]
 include::partial$configuration/export_ignore_elements.adoc[leveloffset=+1]
 
 include::partial$configuration/image_proxy.adoc[leveloffset=+1]
+
+include::partial$configuration/image_proxy_service_url.adoc[leveloffset=+1]
 
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 

--- a/modules/ROOT/pages/features-only.adoc
+++ b/modules/ROOT/pages/features-only.adoc
@@ -34,7 +34,7 @@ NOTE: `+spellchecker_rpc_url+` is *not* required when enabling this plugin via l
 
 * xref:editimage.adoc[Edit Image (with configured image proxy)]
 +
-NOTE: Configuration of the `+editimage_cors_hosts+` and `+editimage_proxy+` properties occurs automatically.
+NOTE: Configuration of the `+editimage_cors_hosts+` and `+editimage_proxy_service_url+` options occurs automatically.
 
 * xref:moxiemanager.adoc[Moxie Manager]
 * xref:a11ychecker.adoc[Accessibility Checker]

--- a/modules/ROOT/pages/introduction-to-premium-selfhosted-services.adoc
+++ b/modules/ROOT/pages/introduction-to-premium-selfhosted-services.adoc
@@ -221,7 +221,7 @@ After you've completed the steps on this page to xref:deploy-server-side-compone
 Now that the server-side components deployed and running, you'll need to tell your {productname} instances where to find them:
 
 * Set the {productname} `+spellchecker_rpc_url+` configuration property to the URL of the deployed server-side spelling component.
-* Set the {productname} `+editimage_proxy+` configuration property to the URL of the deployed server-side image proxy component.
+* Set the {productname} `+editimage_proxy_service_url+` and `+export_image_proxy_service_url+` configuration properties to the URL of the deployed server-side image proxy component.
 * Set the {productname} `+mediaembed_service_url+` and `+linkchecker_service_url+` configuration properties to the URL of the deployed server-side linkchecker and media embed component.
 
 This example assume your Java application server is running on port 80 (http) on `+yourserver.example.com+` and that all the server-side components are deployed to the same Java application server. Replace `+yourserver.example.com+` with the actual domain name or IP address of your server.
@@ -235,7 +235,8 @@ tinymce.init({
   toolbar: 'image',
   plugins: 'tinymcespellchecker image editimage media mediaembed',
   spellchecker_rpc_url: 'http://yourserver.example.com/ephox-spelling/',
-  editimage_proxy: 'http://yourserver.example.com/ephox-image-proxy/1/image',
+  editimage_proxy_service_url: 'http://yourserver.example.com/ephox-image-proxy/',
+  export_image_proxy_service_url: 'http://yourserver.example.com/ephox-image-proxy/',
   mediaembed_service_url: 'http://yourserver.example.com/ephox-hyperlinking/',
   linkchecker_service_url: 'http://yourserver.example.com/ephox-hyperlinking/'
 });

--- a/modules/ROOT/pages/tableofcontents.adoc
+++ b/modules/ROOT/pages/tableofcontents.adoc
@@ -7,8 +7,11 @@
 :pluginname: Table of Contents
 :plugincode: tableofcontents
 :altplugincode: nil
+:pluginminimumplan: tierone
 
 The `+tableofcontents+` plugin will generate basic _Table of Contents_ and insert it into the editor at the current cursor position. Items for the table will be taken from the headers found in the content.
+
+include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Basic setup
 

--- a/modules/ROOT/partials/configuration/image_proxy.adoc
+++ b/modules/ROOT/partials/configuration/image_proxy.adoc
@@ -1,19 +1,19 @@
 ifeval::["{plugincode}" == "export"]
 :proxy_setting_name: export_image_proxy
+:proxy_service_setting_name: export_image_proxy_service_url
 [[export_image_proxy]]
 endif::[]
 ifeval::["{plugincode}" != "export"]
 :proxy_setting_name: editimage_proxy
+:proxy_service_setting_name: editimage_proxy_service_url
 [[editimage_proxy]]
 endif::[]
 
 == `{proxy_setting_name}`
 
-This option can be used as a way of getting images across domains using a local server-side proxy. A proxy is basically a script, that will retrieve a remote image and pipe it back to {productname}, as if it was a local image. An example of such a proxy (written in PHP) can be found below.
+This option can be used as a way of editing images across domains using a third-party local server-side proxy. A proxy is a script, that will retrieve a remote image and pipe it back to {productname}, as if it was an image hosted on the same domain.
 
-link:{pricingpage}/[Paid TinyMCE subscriptions] also includes a proxy service written in Java. Check the xref:introduction-to-premium-selfhosted-services.adoc[Install Server-side Components] guide for details.
-
-NOTE: `{proxy_setting_name}` is *not* required when enabling this plugin via xref:editor-and-features.adoc[{cloudname}].
+NOTE: `{proxy_setting_name}` is *not* required when enabling this plugin via xref:editor-and-features.adoc[{cloudname}]. If using the self-hosted Java proxy service provided as part of Paid {productname} subscriptions, use the xref:{plugincode}.adoc#{proxy_service_setting_name}[`{proxy_service_setting_name}`] option instead.
 
 Type: `+String+`
 
@@ -27,37 +27,4 @@ tinymce.init({
   plugins: 'image {plugincode}',
   {proxy_setting_name}: 'proxy.php'
 });
-----
-
-=== Example of a PHP script for the image proxy
-
-[source,php]
-----
-<?php
-// We recommend to extend this script with authentication logic
-// so it can be used only by an authorized user
-$validMimeTypes = array("image/gif", "image/jpeg", "image/png");
-
-if (!isset($_GET["url"]) || !trim($_GET["url"])) {
-    header("HTTP/1.0 500 Url parameter missing or empty.");
-    return;
-}
-
-$scheme = parse_url($_GET["url"], PHP_URL_SCHEME);
-if ($scheme === false || in_array($scheme, array("http", "https")) === false) {
-    header("HTTP/1.0 500 Invalid protocol.");
-    return;
-}
-
-$content = file_get_contents($_GET["url"]);
-$info = getimagesizefromstring($content);
-
-if ($info === false || in_array($info["mime"], $validMimeTypes) === false) {
-    header("HTTP/1.0 500 Url doesn't seem to be a valid image.");
-    return;
-}
-
-header('Content-Type:' . $info["mime"]);
-echo $content;
-?>
 ----

--- a/modules/ROOT/partials/configuration/image_proxy_service_url.adoc
+++ b/modules/ROOT/partials/configuration/image_proxy_service_url.adoc
@@ -1,0 +1,29 @@
+ifeval::["{plugincode}" == "export"]
+:proxy_setting_name: export_image_proxy_service_url
+:plugin_proxy_action: exported
+[[export_image_proxy_service_url]]
+endif::[]
+ifeval::["{plugincode}" != "export"]
+:proxy_setting_name: editimage_proxy_service_url
+:plugin_proxy_action: edited
+[[editimage_proxy_service_url]]
+endif::[]
+
+== `{proxy_setting_name}`
+
+This option configures the URL to the server-side proxy service which allows remote images hosted on different domains to be retrieved by the {pluginname} plugin. If a proxy is not configured, then remote images may not be able to be {plugin_proxy_action}. Check the xref:introduction-to-premium-selfhosted-services.adoc[Install Server-side Components] guide for details on configuring the self-hosted Java proxy service.
+
+NOTE: `{proxy_setting_name}` is *not* required when enabling this plugin via xref:editor-and-features.adoc[{cloudname}].
+
+Type: `+String+`
+
+=== Example: Using `{proxy_setting_name}`
+
+[source,js,subs="attributes+"]
+----
+tinymce.init({
+  selector: 'textarea',
+  plugins: 'image {plugincode}',
+  {proxy_setting_name}: 'http://mydomain.com/imageproxy'
+});
+----


### PR DESCRIPTION
Related Ticket: DOC-1499

Description of Changes:
* Adds the documentation for the new `export_image_proxy_service_url` and `editimage_proxy_service_url` options
* Updates the existing `export_image_proxy` and `editimage_proxy` options to clarify they should only be used with third-party or custom proxy options.
* Removes the old example proxy.php script, as we'd prefer customers using the image proxy service we provide.
* Fixes an issue with the editimage and tableofcontents pages missing the premium include at the top to detail how to get it.
* Fixes an issue on the editmage page where the options where using the wrong heading levels.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
