### PR TITLE
DOC-1587: Add beta prefix to docs title

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,5 +1,5 @@
 name: tinymce
-title: TinyMCE Documentation
+title: TinyMCE Documentation [BETA]
 version: '6'
 asciidoc:
   attributes:


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Add [Beta] to the docs title, to make it clear this is not production grade docs

![Screen Shot 2022-03-14 at 4 11 59 pm](https://user-images.githubusercontent.com/39354587/158115762-a8ff47b9-1996-4218-b76c-873ad3db5de2.png)


Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [ ] Documentation Team Lead has reviewed
- [ ] Product Manager has reviewed


