### PR TITLE
DOC-1577: Fixed code samples/snippets in the UI components section

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -6,8 +6,8 @@ asciidoc:
     companyurl: https://www.tiny.cloud
     cdnurl: https://cdn.tiny.cloud/1/no-api-key/tinymce/6/tinymce.min.js
     tdcdnurl: https://cdn.tiny.cloud/1/_your_api_key_/tinydrive/6-stable/tinydrive.min.js
-    tinymce_live_demo_url: https://cdn.tiny.cloud/1/qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc/tinymce/5-stable/tinymce.min.js
-    tinydrive_live_demo_url: https://cdn.tiny.cloud/1/qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc/tinydrive/5-stable/tinydrive.min.js
+    tinymce_live_demo_url: https://cdn.tiny.cloud/1/qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc/tinymce/6-testing/tinymce.min.js
+    tinydrive_live_demo_url: https://cdn.tiny.cloud/1/qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc/tinydrive/6-testing/tinydrive.min.js
     webcomponent_url: https://cdn.jsdelivr.net/npm/@tinymce/tinymce-webcomponent@1/dist/tinymce-webcomponent.min.js
     default_meta_keywords: tinymce, documentation, docs, plugins, customizable skins, configuration, examples, html, php, java, javascript, image editor, inline editor, distraction-free editor, classic editor, wysiwyg
     # product variables

--- a/modules/ROOT/attachments/url-dialog-demo/external-page.html
+++ b/modules/ROOT/attachments/url-dialog-demo/external-page.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>External Page Demo</title>
+
+  <style>
+    body {
+      background-color: #1976D2;
+      color: #ffffff;
+      font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+    }
+
+    h1 {
+      text-align: center;
+    }
+
+    .footer {
+
+    }
+  </style>
+</head>
+<body>
+<h1>Example External Page</h1>
+<p>This is a demo page that is loaded via an external URL. This page doesn't do anything fancy, but it's meant to show that an external page can be loaded to show or create very complex applications that can then be run inside a TinyMCE dialog.</p>
+<div class="footer"><button id="close">Close</button></div>
+<script>
+  const closeButton = document.getElementById('close');
+  closeButton.addEventListener('click', () => {
+    window.parent.postMessage({ mceAction: 'close' });
+  });
+</script>
+</body>
+</html>

--- a/modules/ROOT/examples/live-demos/annotations/index.js
+++ b/modules/ROOT/examples/live-demos/annotations/index.js
@@ -1,43 +1,39 @@
-var settings = {
+tinymce.init({
   selector: 'textarea#annotations',
-  toolbar: ['annotate-alpha'],
+  toolbar: [ 'annotate-alpha' ],
   menubar: false,
   height: '750px',
-  content_style: '.mce-annotation { background-color: darkgreen; color: white; } ' + 'body { font-family:Helvetica,Arial,sans-serif; font-size:16px }',
-
-  setup: function (editor) {
+  content_style: '.mce-annotation { background-color: darkgreen; color: white; } ' +
+    'body { font-family:Helvetica,Arial,sans-serif; font-size:16px }',
+  setup: (editor) => {
     editor.ui.registry.addButton('annotate-alpha', {
       text: 'Annotate',
-      onAction: function() {
-        var comment = prompt('Comment with?');
+      onAction: () => {
+        const comment = prompt('Comment with?');
         editor.annotator.annotate('alpha', {
           uid: 'custom-generated-id',
           comment: comment
         });
         editor.focus();
       },
-      onSetup: function (btnApi) {
-        editor.annotator.annotationChanged('alpha', function (state, name, obj) {
+      onSetup: (btnApi) => {
+        editor.annotator.annotationChanged('alpha', (state, name, obj) => {
           console.log('Current selection has an annotation: ', state);
-          btnApi.setDisabled(state);
+          btnApi.setEnabled(!state);
         });
       }
     });
 
-    editor.on('init', function () {
+    editor.on('init', () => {
       editor.annotator.register('alpha', {
         persistent: true,
-        decorate: function (uid, data) {
-          return {
-            attributes: {
-              'data-mce-comment': data.comment ? data.comment : '',
-              'data-mce-author': data.author ? data.author : 'anonymous'
-            }
-          };
-        }
+        decorate: (uid, data) => ({
+          attributes: {
+            'data-mce-comment': data.comment ? data.comment : '',
+            'data-mce-author': data.author ? data.author : 'anonymous'
+          }
+        })
       });
     });
   }
-};
-
-tinymce.init(settings);
+});

--- a/modules/ROOT/examples/live-demos/autocompleter-autocompleteitem/index.js
+++ b/modules/ROOT/examples/live-demos/autocompleter-autocompleteitem/index.js
@@ -1,4 +1,4 @@
-var specialChars = [
+const specialChars = [
   { text: 'exclamation mark', value: '!' },
   { text: 'at', value: '@' },
   { text: 'hash', value: '#' },
@@ -11,17 +11,15 @@ var specialChars = [
 tinymce.init({
   selector: 'textarea#autocompleter-autocompleteitem',
   height: 250,
-  setup: function (editor) {
-    var onAction = function (autocompleteApi, rng, value) {
+  setup: (editor) => {
+    const onAction = (autocompleteApi, rng, value) => {
       editor.selection.setRng(rng);
       editor.insertContent(value);
       autocompleteApi.hide();
     };
 
-    var getMatchedChars = function (pattern) {
-      return specialChars.filter(function (char) {
-        return char.text.indexOf(pattern) !== -1;
-      });
+    const getMatchedChars = (pattern) => {
+      return specialChars.filter((char) => char.text.indexOf(pattern) !== -1);
     };
 
     /* An autocompleter that allows you to insert special characters */
@@ -30,16 +28,14 @@ tinymce.init({
       minChars: 1,
       columns: 'auto',
       onAction: onAction,
-      fetch: function (pattern) {
-        return new tinymce.util.Promise(function (resolve) {
-          var results = getMatchedChars(pattern).map(function (char) {
-            return {
-              type: 'autocompleteitem',
-              value: char.value,
-              text: char.text,
-              icon: char.value
-            }
-          });
+      fetch: (pattern) => {
+        return new Promise((resolve) => {
+          const results = getMatchedChars(pattern).map((char) => ({
+            type: 'autocompleteitem',
+            value: char.value,
+            text: char.text,
+            icon: char.value
+          }));
           resolve(results);
         });
       }

--- a/modules/ROOT/examples/live-demos/autocompleter-cardmenuitem/index.js
+++ b/modules/ROOT/examples/live-demos/autocompleter-cardmenuitem/index.js
@@ -1,4 +1,4 @@
-var specialChars = [
+const specialChars = [
   { text: 'exclamation mark', value: '!' },
   { text: 'at', value: '@' },
   { text: 'hash', value: '#' },
@@ -11,17 +11,15 @@ var specialChars = [
 tinymce.init({
   selector: 'textarea#autocompleter-cardmenuitem',
   height: 250,
-  setup: function (editor) {
-    var onAction = function (autocompleteApi, rng, value) {
+  setup: (editor) => {
+    const onAction = (autocompleteApi, rng, value) => {
       editor.selection.setRng(rng);
       editor.insertContent(value);
       autocompleteApi.hide();
     };
 
-    var getMatchedChars = function (pattern) {
-      return specialChars.filter(function (char) {
-        return char.text.indexOf(pattern) !== -1;
-      });
+    const getMatchedChars = (pattern) => {
+      return specialChars.filter(char => char.text.indexOf(pattern) !== -1);
     };
 
     /**
@@ -34,32 +32,30 @@ tinymce.init({
       columns: 1,
       highlightOn: ['char_name'],
       onAction: onAction,
-      fetch: function (pattern) {
-        return new tinymce.util.Promise(function (resolve) {
-          var results = getMatchedChars(pattern).map(function (char) {
-            return {
-              type: 'cardmenuitem',
-              value: char.value,
-              label: char.text,
-              items: [
-                {
-                  type: 'cardcontainer',
-                  direction: 'vertical',
-                  items: [
-                    {
-                      type: 'cardtext',
-                      text: char.text,
-                      name: 'char_name'
-                    },
-                    {
-                      type: 'cardtext',
-                      text: char.value
-                    }
-                  ]
-                }
-              ]
-            }
-          });
+      fetch: (pattern) => {
+        return new Promise((resolve) => {
+          const results = getMatchedChars(pattern).map(char => ({
+            type: 'cardmenuitem',
+            value: char.value,
+            label: char.text,
+            items: [
+              {
+                type: 'cardcontainer',
+                direction: 'vertical',
+                items: [
+                  {
+                    type: 'cardtext',
+                    text: char.text,
+                    name: 'char_name'
+                  },
+                  {
+                    type: 'cardtext',
+                    text: char.value
+                  }
+                ]
+              }
+            ]
+          }));
           resolve(results);
         });
       }

--- a/modules/ROOT/examples/live-demos/context-form/index.js
+++ b/modules/ROOT/examples/live-demos/context-form/index.js
@@ -1,13 +1,13 @@
 tinymce.init({
   selector: 'textarea#context-form',
   height: 300,
-  setup: function (editor) {
-    var isAnchorElement = function (node) {
+  setup: (editor) => {
+    const isAnchorElement = (node) => {
       return node.nodeName.toLowerCase() === 'a' && node.href;
-    };
+    }
 
-    var getAnchorElement = function () {
-      var node = editor.selection.getNode();
+    const getAnchorElement = () => {
+      const node = editor.selection.getNode();
       return isAnchorElement(node) ? node : null;
     };
 
@@ -18,8 +18,8 @@ tinymce.init({
       },
       label: 'Link',
       predicate: isAnchorElement,
-      initValue: function () {
-        var elm = getAnchorElement();
+      initValue: () => {
+        const elm = getAnchorElement();
         return !!elm ? elm.href : '';
       },
       commands: [
@@ -28,18 +28,16 @@ tinymce.init({
           icon: 'link',
           tooltip: 'Link',
           primary: true,
-          onSetup: function (buttonApi) {
+          onSetup: (buttonApi) => {
             buttonApi.setActive(!!getAnchorElement());
-            var nodeChangeHandler = function () {
+            const nodeChangeHandler = () => {
               buttonApi.setActive(!editor.readonly && !!getAnchorElement());
             };
             editor.on('nodechange', nodeChangeHandler);
-            return function () {
-              editor.off('nodechange', nodeChangeHandler);
-            }
+            return () => editor.off('nodechange', nodeChangeHandler)
           },
-          onAction: function (formApi) {
-            var value = formApi.getValue();
+          onAction: (formApi) => {
+            const value = formApi.getValue();
             console.log('Save link clicked with value: ' + value);
             formApi.hide();
           }
@@ -49,7 +47,7 @@ tinymce.init({
           icon: 'unlink',
           tooltip: 'Remove link',
           active: false,
-          onAction: function (formApi) {
+          onAction: (formApi) => {
             console.log('Remove link clicked');
             formApi.hide();
           }

--- a/modules/ROOT/examples/live-demos/context-menu/index.js
+++ b/modules/ROOT/examples/live-demos/context-menu/index.js
@@ -1,9 +1,7 @@
 tinymce.init({
   selector: 'textarea#context-menu',
   height: 500,
-  plugins: [
-    'link image table lists'
-  ],
+  plugins: 'link image table lists',
   contextmenu: 'link image table lists',
   content_style: 'body { font-family:Helvetica,Arial,sans-serif; font-size:16px }'
 });

--- a/modules/ROOT/examples/live-demos/context-toolbar/index.js
+++ b/modules/ROOT/examples/live-demos/context-toolbar/index.js
@@ -1,20 +1,16 @@
 tinymce.init({
   selector: 'textarea#context-toolbar',
   height: 350,
-  setup: function (editor) {
+  setup: (editor) => {
     editor.ui.registry.addContextToolbar('imagealignment', {
-      predicate: function (node) {
-        return node.nodeName.toLowerCase() === 'img'
-      },
+      predicate: (node) => node.nodeName.toLowerCase() === 'img',
       items: 'alignleft aligncenter alignright',
       position: 'node',
       scope: 'node'
     });
 
     editor.ui.registry.addContextToolbar('textselection', {
-      predicate: function (node) {
-        return !editor.selection.isCollapsed();
-      },
+      predicate: (node) => !editor.selection.isCollapsed(),
       items: 'bold italic | blockquote',
       position: 'selection',
       scope: 'node'

--- a/modules/ROOT/examples/live-demos/contextmenu-section/index.js
+++ b/modules/ROOT/examples/live-demos/contextmenu-section/index.js
@@ -1,17 +1,15 @@
-tinymce.PluginManager.add('my-example-plugin', function (editor) {
+tinymce.PluginManager.add('my-example-plugin', (editor) => {
   editor.ui.registry.addMenuItem('image', {
     icon: 'image',
     text: 'Image',
-    onAction: function () {
+    onAction: () => {
       console.log('context menu clicked');
       alert('context menu clicked');
     }
   });
 
   editor.ui.registry.addContextMenu('image', {
-    update: function (element) {
-      return !element.src ? '' : 'image';
-    }
+    update: (element) => !element.src ? '' : 'image'
   });
 });
 

--- a/modules/ROOT/examples/live-demos/custom-menu-item/index.js
+++ b/modules/ROOT/examples/live-demos/custom-menu-item/index.js
@@ -6,40 +6,34 @@ tinymce.init({
   menu: {
     custom: { title: 'Custom menu', items: 'basicitem nesteditem toggleitem' }
   },
-  setup: function (editor) {
-    var toggleState = false;
+  setup: (editor) => {
+    let toggleState = false;
 
     editor.ui.registry.addMenuItem('basicitem', {
       text: 'My basic menu item',
-      onAction: function () {
-        editor.insertContent('<p>Here\'s some content inserted from a basic menu!</p>');
-      }
+      onAction: () => editor.insertContent(`<p>Here's some content inserted from a basic menu!</p>`)
     });
 
     editor.ui.registry.addNestedMenuItem('nesteditem', {
       text: 'My nested menu item',
-      getSubmenuItems: function () {
-        return [
-          {
-            type: 'menuitem',
-            text: 'My submenu item',
-            onAction: function () {
-              editor.insertContent('<p>Here\'s some content inserted from a submenu item!</p>');
-            }
-          }
-        ];
-      }
+      getSubmenuItems: () => [
+        {
+          type: 'menuitem',
+          text: 'My submenu item',
+          onAction: () => editor.insertContent(`<p>Here's some content inserted from a submenu item!</p>`)
+        }
+      ]
     });
 
     editor.ui.registry.addToggleMenuItem('toggleitem', {
       text: 'My toggle menu item',
-      onAction: function () {
+      onAction: () => {
         toggleState = !toggleState;
-        editor.insertContent('<p class="toggle-item">Here\'s some content inserted from a toggle menu!</p>');
+        editor.insertContent(`<p class="toggle-item">Here's some content inserted from a toggle menu!</p>`);
       },
-      onSetup: function (api) {
+      onSetup: (api) => {
         api.setActive(toggleState);
-        return function () {};
+        return () => {};
       }
     });
   },

--- a/modules/ROOT/examples/live-demos/custom-plugin/index.js
+++ b/modules/ROOT/examples/live-demos/custom-plugin/index.js
@@ -3,43 +3,41 @@
   instance for display purposes only. Tiny recommends not maintaining the plugin
   with the TinyMCE instance and using the `external_plugins` option.
 */
-tinymce.PluginManager.add('example', function(editor, url) {
-  var openDialog = function () {
-    return editor.windowManager.open({
-      title: 'Example plugin',
-      body: {
-        type: 'panel',
-        items: [
-          {
-            type: 'input',
-            name: 'title',
-            label: 'Title'
-          }
-        ]
-      },
-      buttons: [
+tinymce.PluginManager.add('example', (editor, url) => {
+  const openDialog = () => editor.windowManager.open({
+    title: 'Example plugin',
+    body: {
+      type: 'panel',
+      items: [
         {
-          type: 'cancel',
-          text: 'Close'
-        },
-        {
-          type: 'submit',
-          text: 'Save',
-          primary: true
+          type: 'input',
+          name: 'title',
+          label: 'Title'
         }
-      ],
-      onSubmit: function (api) {
-        var data = api.getData();
-        /* Insert content when the window form is submitted */
-        editor.insertContent('Title: ' + data.title);
-        api.close();
+      ]
+    },
+    buttons: [
+      {
+        type: 'cancel',
+        text: 'Close'
+      },
+      {
+        type: 'submit',
+        text: 'Save',
+        primary: true
       }
-    });
-  };
+    ],
+    onSubmit: (api) => {
+      const data = api.getData();
+      /* Insert content when the window form is submitted */
+      editor.insertContent('Title: ' + data.title);
+      api.close();
+    }
+  });
   /* Add a button that opens a window */
   editor.ui.registry.addButton('example', {
     text: 'My button',
-    onAction: function () {
+    onAction: () => {
       /* Open window */
       openDialog();
     }
@@ -47,19 +45,17 @@ tinymce.PluginManager.add('example', function(editor, url) {
   /* Adds a menu item, which can then be included in any menu via the menu/menubar configuration */
   editor.ui.registry.addMenuItem('example', {
     text: 'Example plugin',
-    onAction: function() {
+    onAction: () => {
       /* Open window */
       openDialog();
     }
   });
   /* Return the metadata for the help plugin */
   return {
-    getMetadata: function () {
-      return  {
-        name: 'Example plugin',
-        url: 'http://exampleplugindocsurl.com'
-      };
-    }
+    getMetadata: () => ({
+      name: 'Example plugin',
+      url: 'http://exampleplugindocsurl.com'
+    })
   };
 });
 

--- a/modules/ROOT/examples/live-demos/custom-shortcut-2/index.js
+++ b/modules/ROOT/examples/live-demos/custom-shortcut-2/index.js
@@ -3,26 +3,24 @@ tinymce.init({
   height: 300,
   plugins: 'autolink lists link',
   toolbar: 'undo redo | bold italic link bullist | insertUsername',
-  setup: function (editor) {
-    var insertUsername = function () {
+  setup: (editor) => {
+    const insertUsername = () => {
       editor.insertContent(`@username`);
     };
 
-    editor.addShortcut('meta+alt+U', 'Insert username', function () {
+    editor.addShortcut('meta+alt+U', 'Insert username', () => {
       insertUsername();
     });
 
     editor.ui.registry.addMenuButton('insertUsername', {
       icon: 'plus',
-      fetch: function (callback) {
-        var items = [
+      fetch: (callback) => {
+        const items = [
           {
             type: 'menuitem',
             text: 'Insert username',
             shortcut: 'meta+alt+U',
-            onAction: function () {
-              insertUsername();
-            }
+            onAction: () => insertUsername()
           }
         ];
         callback(items);

--- a/modules/ROOT/examples/live-demos/custom-shortcut/index.js
+++ b/modules/ROOT/examples/live-demos/custom-shortcut/index.js
@@ -1,9 +1,8 @@
 tinymce.init({
   selector: 'textarea#custom-shortcut',
   height: 300,
-  setup: function (editor) {
-    editor.addShortcut(
-      'meta+alt+y', 'Add yellow highlight to selected text.', function () {
+  setup: (editor) => {
+    editor.addShortcut('meta+alt+y', 'Add yellow highlight to selected text.', () => {
       editor.execCommand('hilitecolor', false , '#FFFF00');
     });
   },

--- a/modules/ROOT/examples/live-demos/custom-toolbar-button/index.js
+++ b/modules/ROOT/examples/live-demos/custom-toolbar-button/index.js
@@ -1,36 +1,28 @@
 tinymce.init({
   selector: 'textarea#custom-toolbar-button',
   toolbar: 'customInsertButton customDateButton',
-  setup: function (editor) {
+  setup: (editor) => {
 
     editor.ui.registry.addButton('customInsertButton', {
       text: 'My Button',
-      onAction: function (_) {
-        editor.insertContent('&nbsp;<strong>It\'s my button!</strong>&nbsp;');
-      }
+      onAction: (_) => editor.insertContent(`&nbsp;<strong>It's my button!</strong>&nbsp;`)
     });
 
-    var toTimeHtml = function (date) {
-      return '<time datetime="' + date.toString() + '">' + date.toDateString() + '</time>';
-    };
+    const toTimeHtml = (date) => `<time datetime="${date.toString()}">${date.toDateString()}</time>`;
 
     editor.ui.registry.addButton('customDateButton', {
       icon: 'insert-time',
       tooltip: 'Insert Current Date',
       disabled: true,
-      onAction: function (_) {
-        editor.insertContent(toTimeHtml(new Date()));
-      },
-      onSetup: function (buttonApi) {
-        var editorEventCallback = function (eventApi) {
-          buttonApi.setDisabled(eventApi.element.nodeName.toLowerCase() === 'time');
+      onAction: (_) => editor.insertContent(toTimeHtml(new Date())),
+      onSetup: (buttonApi) => {
+        const editorEventCallback = (eventApi) => {
+          buttonApi.setEnabled(eventApi.element.nodeName.toLowerCase() !== 'time');
         };
         editor.on('NodeChange', editorEventCallback);
 
         /* onSetup should always return the unbind handlers */
-        return function (buttonApi) {
-          editor.off('NodeChange', editorEventCallback);
-        };
+        return () => editor.off('NodeChange', editorEventCallback);
       }
     });
   },

--- a/modules/ROOT/examples/live-demos/custom-toolbar-group-button/index.js
+++ b/modules/ROOT/examples/live-demos/custom-toolbar-group-button/index.js
@@ -3,8 +3,7 @@ tinymce.init({
   height: 500,
   toolbar_mode: 'floating',
   toolbar: 'alignment',
-
-  setup: function (editor) {
+  setup: (editor) => {
 
     /* example, adding a group toolbar button */
     editor.ui.registry.addGroupToolbarButton('alignment', {

--- a/modules/ROOT/examples/live-demos/custom-toolbar-menu-button/index.js
+++ b/modules/ROOT/examples/live-demos/custom-toolbar-menu-button/index.js
@@ -3,58 +3,50 @@ tinymce.init({
   height: 500,
   toolbar: 'mybutton',
 
-  setup: function (editor) {
+  setup: (editor) => {
     /* Menu items are recreated when the menu is closed and opened, so we need
        a variable to store the toggle menu item state. */
-    var toggleState = false;
+    let toggleState = false;
 
     /* example, adding a toolbar menu button */
     editor.ui.registry.addMenuButton('mybutton', {
       text: 'My button',
-      fetch: function (callback) {
-        var items = [
+      fetch: (callback) => {
+        const items = [
           {
             type: 'menuitem',
             text: 'Menu item 1',
-            onAction: function () {
-              editor.insertContent('&nbsp;<em>You clicked menu item 1!</em>');
-            }
+            onAction: () => editor.insertContent('&nbsp;<em>You clicked menu item 1!</em>')
           },
           {
             type: 'nestedmenuitem',
             text: 'Menu item 2',
             icon: 'user',
-            getSubmenuItems: function () {
-              return [
-                {
-                  type: 'menuitem',
-                  text: 'Sub menu item 1',
-                  icon: 'unlock',
-                  onAction: function () {
-                    editor.insertContent('&nbsp;<em>You clicked Sub menu item 1!</em>');
-                  }
-                },
-                {
-                  type: 'menuitem',
-                  text: 'Sub menu item 2',
-                  icon: 'lock',
-                  onAction: function () {
-                    editor.insertContent('&nbsp;<em>You clicked Sub menu item 2!</em>');
-                  }
-                }
-              ];
-            }
+            getSubmenuItems: () => [
+              {
+                type: 'menuitem',
+                text: 'Sub menu item 1',
+                icon: 'unlock',
+                onAction: () => editor.insertContent('&nbsp;<em>You clicked Sub menu item 1!</em>')
+              },
+              {
+                type: 'menuitem',
+                text: 'Sub menu item 2',
+                icon: 'lock',
+                onAction: () => editor.insertContent('&nbsp;<em>You clicked Sub menu item 2!</em>')
+              }
+            ]
           },
           {
             type: 'togglemenuitem',
             text: 'Toggle menu item',
-            onAction: function () {
+            onAction: () => {
               toggleState = !toggleState;
               editor.insertContent('&nbsp;<em>You toggled a menuitem ' + (toggleState ? 'on' : 'off') + '</em>');
             },
-            onSetup: function (api) {
+            onSetup: (api) => {
               api.setActive(toggleState);
-              return function() {};
+              return () => {};
             }
           }
         ];

--- a/modules/ROOT/examples/live-demos/custom-toolbar-split-button/index.js
+++ b/modules/ROOT/examples/live-demos/custom-toolbar-split-button/index.js
@@ -2,19 +2,15 @@ tinymce.init({
   selector: 'textarea#custom-toolbar-split-button',
   toolbar: 'myButton',
   menubar: false,
-  setup: function (editor) {
+  setup: (editor) => {
     editor.ui.registry.addSplitButton('myButton', {
       text: 'My Button',
       icon: 'info',
       tooltip: 'This is an example split-button',
-      onAction: function () {
-        editor.insertContent('<p>You clicked the main button</p>');
-      },
-      onItemAction: function (api, value) {
-        editor.insertContent(value);
-      },
-      fetch: function (callback) {
-        var items = [
+      onAction: () => editor.insertContent('<p>You clicked the main button</p>'),
+      onItemAction: (api, value) => editor.insertContent(value),
+      fetch: (callback) => {
+        const items = [
           {
             type: 'choiceitem',
             icon: 'notice',

--- a/modules/ROOT/examples/live-demos/custom-toolbar-toggle-button/index.js
+++ b/modules/ROOT/examples/live-demos/custom-toolbar-toggle-button/index.js
@@ -1,10 +1,10 @@
 tinymce.init({
   selector: 'textarea#custom-toolbar-toggle-button',
   toolbar: 'customStrikethrough customToggleStrikethrough',
-  setup: function (editor) {
+  setup: (editor) => {
     editor.ui.registry.addToggleButton('customStrikethrough', {
       text: 'Strikethrough',
-      onAction: function (api) {
+      onAction: (api) => {
         editor.execCommand('mceToggleFormat', false, 'strikethrough');
         api.setActive(!api.isActive());
       }
@@ -12,13 +12,11 @@ tinymce.init({
 
     editor.ui.registry.addToggleButton('customToggleStrikethrough', {
       icon: 'strike-through',
-      onAction: function (_) {
-        editor.execCommand('mceToggleFormat', false, 'strikethrough');
-      },
-      onSetup: function (api) {
-        editor.formatter.formatChanged('strikethrough', function (state) {
-          api.setActive(state);
-        });
+      onAction: (_) => editor.execCommand('mceToggleFormat', false, 'strikethrough'),
+      onSetup: (api) => {
+        api.setActive(editor.formatter.match('strikethrough'));
+        const changed = editor.formatter.formatChanged('strikethrough', (state) => api.setActive(state));
+        return () => changed.unbind();
       }
     });
   },

--- a/modules/ROOT/examples/live-demos/dialog-pet-machine/index.js
+++ b/modules/ROOT/examples/live-demos/dialog-pet-machine/index.js
@@ -1,5 +1,5 @@
 /* example dialog that inserts the name of a Pet into the editor content */
-var dialogConfig =  {
+const dialogConfig =  {
   title: 'Pet Name Machine',
   body: {
     type: 'panel',
@@ -33,11 +33,11 @@ var dialogConfig =  {
     catdata: 'initial Cat',
     isdog: false
   },
-  onSubmit: function (api) {
-    var data = api.getData();
-    var pet = data.isdog ? 'dog' : 'cat';
+  onSubmit: (api) => {
+    const data = api.getData();
+    const pet = data.isdog ? 'dog' : 'cat';
 
-    tinymce.activeEditor.execCommand('mceInsertContent', false, '<p>My ' + pet +'\'s name is: <strong>' + data.catdata + '</strong></p>');
+    tinymce.activeEditor.execCommand('mceInsertContent', false, `<p>My ${pet}'s name is: <strong>${data.catdata}</strong></p>`);
     api.close();
   }
 };
@@ -45,12 +45,10 @@ var dialogConfig =  {
 tinymce.init({
   selector: 'textarea#dialog-pet-machine',
   toolbar: 'dialog-example-btn',
-  setup: function (editor) {
+  setup: (editor) => {
     editor.ui.registry.addButton('dialog-example-btn', {
       icon: 'code-sample',
-      onAction: function () {
-        editor.windowManager.open(dialogConfig)
-      }
+      onAction: () => editor.windowManager.open(dialogConfig)
     })
   },
   content_style: 'body { font-family:Helvetica,Arial,sans-serif; font-size:16px }'

--- a/modules/ROOT/examples/live-demos/notifications/index.js
+++ b/modules/ROOT/examples/live-demos/notifications/index.js
@@ -1,44 +1,42 @@
-function createSuccessNotification() {
+const createSuccessNotification = () => {
   tinymce.activeEditor.notificationManager.open({
     text: 'This is an success notification.<br/>TinyMCE loaded Successfully!',
     type: 'success'
   });
-}
+};
 
-function createInformationNotification() {
+const createInformationNotification = () => {
   tinymce.activeEditor.notificationManager.open({
     text: 'This is an informational notification.',
     type: 'info'
   });
-}
+};
 
-function createWarningNotification() {
+const createWarningNotification = () => {
   tinymce.activeEditor.notificationManager.open({
     text: 'This is a warning notification.',
     type: 'warning'
   });
-}
+};
 
-function createErrorNotification() {
+const createErrorNotification = () => {
   tinymce.activeEditor.notificationManager.open({
     text: 'This is an error... notification.',
     type: 'error'
   });
-}
+};
 
 tinymce.init({
   selector: 'textarea#notifications',
   height: 500,
   menubar: false,
-  plugins: [
-    'lists link image fullscreen table help'
-  ],
+  plugins: 'lists link image fullscreen table help',
   toolbar: 'undo redo | formatselect | ' +
   'bold italic backcolor | alignleft aligncenter ' +
   'alignright alignjustify | bullist numlist outdent indent | ' +
   'removeformat | help',
-  setup: function(editor) {
-    editor.on('skinLoaded', function(e) {
+  setup: (editor) => {
+    editor.on('SkinLoaded', (e) => {
       createSuccessNotification();
       createInformationNotification();
       createWarningNotification();

--- a/modules/ROOT/examples/live-demos/redial-demo/index.js
+++ b/modules/ROOT/examples/live-demos/redial-demo/index.js
@@ -1,4 +1,4 @@
-var page1Config = {
+const page1Config = {
   title: 'Redial Demo',
   body: {
     type: 'panel',
@@ -31,13 +31,12 @@ var page1Config = {
       disabled: true
     }
   ],
-  onChange: function (dialogApi, details) {
-    var data = dialogApi.getData();
+  onChange: (dialogApi, details) => {
+    const data = dialogApi.getData();
     /* Example of enabling and disabling a button, based on the checkbox state. */
-    var toggle = data.anyterms ? dialogApi.enable : dialogApi.disable;
-    toggle('uniquename');
+    dialogApi.setEnabled('uniquename', data.anyterms);
   },
-  onAction: function (dialogApi, details) {
+  onAction: (dialogApi, details) => {
     if (details.name === 'uniquename') {
       dialogApi.redial(page2Config);
     } else if (details.name === 'doesnothing') {
@@ -46,7 +45,7 @@ var page1Config = {
   }
 };
 
-var page2Config = {
+const page2Config = {
   title: 'Redial Demo - Page 2',
   body: {
     type: 'panel',
@@ -78,12 +77,12 @@ var page2Config = {
   initialData: {
     choosydata: ''
   },
-  onAction: function (dialogApi, details) {
-    var data = dialogApi.getData();
+  onAction: (dialogApi, details) => {
+    const data = dialogApi.getData();
 
-    var result = 'You chose wisely: ' + data.choosydata;
+    const result = 'You chose wisely: ' + data.choosydata;
     console.log(result);
-    tinymce.activeEditor.execCommand('mceInsertContent', false, '<p>' + result + '</p>');
+    tinymce.activeEditor.execCommand('mceInsertContent', false, `<p>${result}</p>`);
 
     dialogApi.close();
   }
@@ -93,12 +92,10 @@ tinymce.init({
   selector: 'textarea#redial-demo',
   toolbar: 'wizardExample',
   height: '900px',
-  setup: function (editor) {
+  setup: (editor) => {
     editor.ui.registry.addButton('wizardExample', {
       icon: 'code-sample',
-      onAction: function () {
-        editor.windowManager.open(page1Config)
-      }
+      onAction: () => editor.windowManager.open(page1Config)
     })
   },
   content_style: 'body { font-family:Helvetica,Arial,sans-serif; font-size:16px }'

--- a/modules/ROOT/examples/live-demos/toolbar-button/index.js
+++ b/modules/ROOT/examples/live-demos/toolbar-button/index.js
@@ -1,26 +1,18 @@
 tinymce.init({
   selector: 'textarea#toolbar-button',
   toolbar: 'basicDateButton selectiveDateButton toggleDateButton splitDateButton menuDateButton',
-  setup: function (editor) {
+  setup: (editor) => {
 
     /* Helper functions */
-    var toDateHtml = function (date) {
-      return '<time datetime="' + date.toString() + '">' + date.toDateString() + '</time>';
-    };
-    var toGmtHtml = function (date) {
-      return '<time datetime="' + date.toString() + '">' + date.toGMTString() + '</time>';
-    };
-    var toIsoHtml = function (date) {
-      return '<time datetime="' + date.toString() + '">' + date.toISOString() + '</time>';
-    };
+    const toDateHtml = (date) => `<time datetime="${date.toString()}">${date.toDateString()}</time>`;
+    const toGmtHtml = (date) => `<time datetime="${date.toString()}">${date.toGMTString()}</time>`;
+    const toIsoHtml = (date) => `<time datetime="${date.toString()}">${date.toISOString()}</time>`;
 
     /* Basic button that just inserts the date */
     editor.ui.registry.addButton('basicDateButton', {
       text: 'Insert Date',
       tooltip: 'Insert Current Date',
-      onAction: function (_) {
-        editor.insertContent(toDateHtml(new Date()));
-      }
+      onAction: (_) => editor.insertContent(toDateHtml(new Date()))
     });
 
     /* Basic button that inserts the date, but only if the cursor isn't currently in a "time" element */
@@ -28,17 +20,13 @@ tinymce.init({
       icon: 'insert-time',
       tooltip: 'Insert Current Date',
       disabled: true,
-      onAction: function (_) {
-        editor.insertContent(toDateHtml(new Date()));
-      },
-      onSetup: function (buttonApi) {
-        var editorEventCallback = function (eventApi) {
-          buttonApi.setDisabled(eventApi.element.nodeName.toLowerCase() === 'time');
+      onAction: (_) => editor.insertContent(toDateHtml(new Date())),
+      onSetup: (buttonApi) => {
+        const editorEventCallback = (eventApi) => {
+          buttonApi.setEnabled(eventApi.element.nodeName.toLowerCase() !== 'time');
         };
         editor.on('NodeChange', editorEventCallback);
-        return function (buttonApi) {
-          editor.off('NodeChange', editorEventCallback);
-        }
+        return () => editor.off('NodeChange', editorEventCallback);
       }
     });
 
@@ -47,31 +35,23 @@ tinymce.init({
     editor.ui.registry.addToggleButton('toggleDateButton', {
       icon: 'insert-time',
       tooltip: 'Insert Current Date',
-      onAction: function (_) {
-        editor.insertContent(toDateHtml(new Date()));
-      },
-      onSetup: function (buttonApi) {
-        var editorEventCallback = function (eventApi) {
+      onAction: (_) => editor.insertContent(toDateHtml(new Date())),
+      onSetup: (buttonApi) => {
+        const editorEventCallback = (eventApi) => {
           buttonApi.setActive(eventApi.element.nodeName.toLowerCase() === 'time');
         };
         editor.on('NodeChange', editorEventCallback);
-        return function (buttonApi) {
-          editor.off('NodeChange', editorEventCallback);
-        }
+        return () => editor.off('NodeChange', editorEventCallback);
       }
     });
 
     /* Split button that lists 3 formats, and inserts the date in the selected format when clicked */
     editor.ui.registry.addSplitButton('splitDateButton', {
       text: 'Insert Date',
-      onAction: function (_) {
-        editor.insertContent('<p>Its Friday!</p>')
-      },
-      onItemAction: function (buttonApi, value) {
-        editor.insertContent(value);
-      },
-      fetch: function (callback) {
-        var items = [
+      onAction: (_) => editor.insertContent('<p>Its Friday!</p>'),
+      onItemAction: (buttonApi, value) => editor.insertContent(value),
+      fetch: (callback) => {
+        const items = [
           {
             type: 'choiceitem',
             text: 'Insert Date',
@@ -96,36 +76,28 @@ tinymce.init({
     /* Clicking the first menu item or one of the submenu items inserts the date in the selected format. */
     editor.ui.registry.addMenuButton('menuDateButton', {
       text: 'Date',
-      fetch: function (callback) {
-        var items = [
+      fetch: (callback) => {
+        const items = [
           {
             type: 'menuitem',
             text: 'Insert Date',
-            onAction: function (_) {
-              editor.insertContent(toDateHtml(new Date()));
-            }
+            onAction: (_) => editor.insertContent(toDateHtml(new Date()))
           },
           {
             type: 'nestedmenuitem',
             text: 'Other formats',
-            getSubmenuItems: function () {
-              return [
-                {
-                  type: 'menuitem',
-                  text: 'GMT',
-                  onAction: function (_) {
-                    editor.insertContent(toGmtHtml(new Date()));
-                  }
-                },
-                {
-                  type: 'menuitem',
-                  text: 'ISO',
-                  onAction: function (_) {
-                    editor.insertContent(toIsoHtml(new Date()));
-                  }
-                }
-              ];
-            }
+            getSubmenuItems: () => [
+              {
+                type: 'menuitem',
+                text: 'GMT',
+                onAction: (_) => editor.insertContent(toGmtHtml(new Date()))
+              },
+              {
+                type: 'menuitem',
+                text: 'ISO',
+                onAction: (_) => editor.insertContent(toIsoHtml(new Date()))
+              }
+            ]
           }
         ];
         callback(items);

--- a/modules/ROOT/examples/live-demos/url-dialog/example.js
+++ b/modules/ROOT/examples/live-demos/url-dialog/example.js
@@ -2,17 +2,15 @@ tinymce.init({
   selector: 'textarea#url-dialog',
   toolbar: 'urldialog',
   height: 300,
-  setup: function (editor) {
+  setup: (editor) => {
     editor.ui.registry.addButton('urldialog', {
       icon: 'code-sample',
-      onAction: function () {
-        editor.windowManager.openUrl({
-          title: 'URL Dialog Demo',
-          url: '../../demo/url-dialog-demo/external-page.html',
-          height: 640,
-          width: 640
-        });
-      }
+      onAction: () => editor.windowManager.openUrl({
+        title: 'URL Dialog Demo',
+        url: 'external-page.html',
+        height: 640,
+        width: 640
+      })
     })
   },
   content_style: 'body { font-family:Helvetica,Arial,sans-serif; font-size:16px }'

--- a/modules/ROOT/examples/live-demos/url-dialog/index.js
+++ b/modules/ROOT/examples/live-demos/url-dialog/index.js
@@ -2,17 +2,15 @@ tinymce.init({
   selector: 'textarea#url-dialog',
   toolbar: 'urldialog',
   height: 300,
-  setup: function (editor) {
+  setup: (editor) => {
     editor.ui.registry.addButton('urldialog', {
       icon: 'code-sample',
-      onAction: function () {
-        editor.windowManager.openUrl({
-          title: 'URL Dialog Demo',
-          url: '../../demo/url-dialog-demo/external-page.html',
-          height: 640,
-          width: 640
-        });
-      }
+      onAction: () => editor.windowManager.openUrl({
+        title: 'URL Dialog Demo',
+        url: '{{attachmentsdir}}/url-dialog-demo/external-page.html',
+        height: 640,
+        width: 640
+      })
     })
   },
   content_style: 'body { font-family:Helvetica,Arial,sans-serif; font-size:16px }'

--- a/modules/ROOT/pages/annotations.adoc
+++ b/modules/ROOT/pages/annotations.adoc
@@ -19,15 +19,15 @@ To configure the annotate button on your toolbar:
 
 [source,js]
 ----
-setup: function(ed) {
-  ed.ui.registry.addButton('annotate-alpha', {
+setup: (editor) => {
+  editor.ui.registry.addButton('annotate-alpha', {
     text: 'Annotate',
-    onAction: function() {
-      var comment = prompt('Comment with?');
-      ed.annotator.annotate('alpha', {
+    onAction: () => {
+      const comment = prompt('Comment with?');
+      editor.annotator.annotate('alpha', {
         comment
       });
-      ed.focus();
+      editor.focus();
     }
   })
 }
@@ -40,17 +40,15 @@ The annotator API supports multiple annotation functions. Each annotation functi
 
 [source,js]
 ----
-ed.on('init', function() {
+editor.on('init', () => {
   editor.annotator.register('alpha', {
     persistent: true,
-    decorate: function (uid, data) {
-      return {
-        attributes: {
-          'data-mce-comment': data.comment ? data.comment : '',
-          'data-mce-author': data.author ? data.author : 'anonymous'
-        }
-      };
-    }
+    decorate: (uid, data) => ({
+      attributes: {
+        'data-mce-comment': data.comment ? data.comment : '',
+        'data-mce-author': data.author ? data.author : 'anonymous'
+      }
+    })
   });
 });
 ----
@@ -89,10 +87,10 @@ Example of specifying your own `+uid+`:
 
 [source,js]
 ----
-  editor.annotator.annotate('alpha', {
-    uid: 'use-this-id-instead-of-your-random-one-annotator!',
-    author: 'me'
-  });
+editor.annotator.annotate('alpha', {
+  uid: 'use-this-id-instead-of-your-random-one-annotator!',
+  author: 'me'
+});
 ----
 
 [[listening-to-selection-events]]
@@ -102,12 +100,12 @@ The Annotator API notifies the user when the selection cursor moves in or out of
 
 [source,js]
 ----
-editor.annotator.annotationChanged('alpha', function (state, name, obj) {
+editor.annotator.annotationChanged('alpha', (state, name, obj) => {
   if (state === false) {
     // NOTE: name will be 'alpha' here
-    console.log('We are no longer in a ' + name + ' area');
+    console.log(`We are no longer in a ${name} area`);
   } else {
-    console.log('We are now in comment: ' + obj.uid);
+    console.log(`We are now in comment: ${obj.uid}`);
   }
 });
 ----
@@ -144,8 +142,8 @@ The Annotator API allows retrieving an object of all of the uids for a particula
 
 [source,js]
 ----
-var annotations = editor.annotator.getAll('alpha');
-var nodesInFirstUid = annotations['first-uid'];
+const annotations = editor.annotator.getAll('alpha');
+const nodesInFirstUid = annotations['first-uid'];
 ----
 
 Assuming that there is a uid called `+first-uid+`, the above code shows how to access the nodes used for making that annotation. The full API is:

--- a/modules/ROOT/pages/creating-a-plugin.adoc
+++ b/modules/ROOT/pages/creating-a-plugin.adoc
@@ -39,16 +39,14 @@ Optionally, the function passed to `+PluginManager.add()+` can return an object 
 
 [source,js]
 ----
-tinymce.PluginManager.add('pluginId', function(editor, url) {
+tinymce.PluginManager.add('pluginId', (editor, url) => {
   // add plugin code here
 
   return {
-    getMetadata: function () {
-      return {
-        name: 'Custom plugin',
-        url: 'https://example.com/docs/customplugin'
-      };
-    }
+    getMetadata: () => ({
+      name: 'Custom plugin',
+      url: 'https://example.com/docs/customplugin'
+    })
   }
 });
 ----
@@ -118,7 +116,7 @@ tinymce.addI18n('es_ES', {
 [source,js]
 ----
 // Register the custom plugin
-tinymce.PluginManager.add('pluginId', function(editor, url) {
+tinymce.PluginManager.add('pluginId', (editor, url) => {
   // add plugin code here
 });
 // Load the required translation files

--- a/modules/ROOT/pages/creating-custom-menu-items.adoc
+++ b/modules/ROOT/pages/creating-custom-menu-items.adoc
@@ -13,9 +13,9 @@
 
 The methods for adding custom menu items are in the UI Registry part of the editor API editor.ui.registry. The API has three methods for adding menu items:
 
-* `+editor.ui.registry.addMenuItem+`(identifier, configuration)
-* `+editor.ui.registry.addNestedMenuItem+`(identifier, configuration)
-* `+editor.ui.registry.addToggleMenuItem+`(identifier, configuration)
+* `+editor.ui.registry.addMenuItem(identifier, configuration)+`
+* `+editor.ui.registry.addNestedMenuItem(identifier, configuration)+`
+* `+editor.ui.registry.addToggleMenuItem(identifier, configuration)+`
 
 The two arguments these methods take are:
 
@@ -34,12 +34,10 @@ tinymce.init({
     custom: { title: 'Custom Menu', items: 'undo redo myCustomMenuItem' }
   },
   menubar: 'file edit custom',
-  setup: function(editor) {
+  setup: (editor) => {
     editor.ui.registry.addMenuItem('myCustomMenuItem', {
       text: 'My Custom Menu Item',
-      onAction: function() {
-        alert('Menu item clicked');
-      }
+      onAction: () => alert('Menu item clicked')
     });
   }
 });

--- a/modules/ROOT/pages/creating-custom-notifications.adoc
+++ b/modules/ROOT/pages/creating-custom-notifications.adoc
@@ -86,7 +86,7 @@ Set the `+progressBar+` property type to `+True+` to display a progress bar to t
 
 [source,js]
 ----
-var notification = editor.notificationManager.open({
+const notification = editor.notificationManager.open({
   text: 'A test notification that contains a progress bar.',
   progressBar: true
 });
@@ -104,5 +104,5 @@ To close the last shown notification, `+call+` the following method:
 [source,js]
 ----
 // Close the last shown notification.
-top.tinymce.activeEditor.notificationManager.close();
+editor.notificationManager.close();
 ----

--- a/modules/ROOT/pages/custom-basic-menu-items.adoc
+++ b/modules/ROOT/pages/custom-basic-menu-items.adoc
@@ -41,12 +41,10 @@ tinymce.init({
   },
   menubar: 'file edit custom',
 
-  setup: function(editor) {
+  setup: (editor) => {
     editor.ui.registry.addMenuItem('basicitem', {
       text: 'My basic menu item',
-      onAction: function() {
-        alert('Menu item clicked');
-      }
+      onAction: () => alert('Menu item clicked')
     });
   }
 });

--- a/modules/ROOT/pages/custom-nested-menu-items.adoc
+++ b/modules/ROOT/pages/custom-nested-menu-items.adoc
@@ -37,22 +37,16 @@ tinymce.init({
     custom: { title: 'Custom Menu', items: 'undo redo nesteditem' }
   },
   menubar: 'file edit custom',
-
-  setup: function(editor) {
+  setup: (editor) => {
     editor.ui.registry.addNestedMenuItem('nesteditem', {
       text: 'My nested menu item',
-      getSubmenuItems: function() {
-        return [{
-          type: 'menuitem',
-          text: 'My submenu item',
-          onAction: function() {
-            alert('Submenu item clicked');
-          }
-        }];
-      }
+      getSubmenuItems: () => [{
+        type: 'menuitem',
+        text: 'My submenu item',
+        onAction: () => alert('Submenu item clicked')
+      }]
     });
   }
-
 });
 ----
 

--- a/modules/ROOT/pages/custom-toggle-menu-items.adoc
+++ b/modules/ROOT/pages/custom-toggle-menu-items.adoc
@@ -38,7 +38,7 @@ include::partial$misc/admon_predefined_icons_only.adoc[]
 ----
 // Menu items are recreated when the menu is closed and opened, so we need
 // a variable to store the toggle menu item state.
-var toggleState = false;
+let toggleState = false;
 
 tinymce.init({
   selector: 'textarea',
@@ -46,18 +46,17 @@ tinymce.init({
     custom: { title: 'Custom Menu', items: 'undo redo toggleitem' }
   },
   menubar: 'file edit custom',
-
-  setup: function(editor) {
+  setup: (editor) => {
     editor.ui.registry.addToggleMenuItem('toggleitem', {
       text: 'My toggle menu item',
       icon: 'home',
-      onAction: function() {
+      onAction: () => {
         toggleState = !toggleState;
         alert('Toggle menu item clicked');
       },
-      onSetup: function(api) {
+      onSetup: (api) => {
         api.setActive(toggleState);
-        return function() {};
+        return () => {};
       }
     });
   }

--- a/modules/ROOT/pages/custom-toolbarbuttons.adoc
+++ b/modules/ROOT/pages/custom-toolbarbuttons.adoc
@@ -35,12 +35,10 @@ To create a custom toolbar button, define and register the button within the `+s
 tinymce.init({
   selector: '#editor',
   toolbar: 'myCustomToolbarButton',
-  setup: function (editor) {
+  setup: (editor) => {
     editor.ui.registry.addButton('myCustomToolbarButton', {
       text: 'My Custom Button',
-      onAction: function () {
-        alert('Button clicked!');
-      }
+      onAction: () => alert('Button clicked!')
     });
   }
 });

--- a/modules/ROOT/pages/customsidebar.adoc
+++ b/modules/ROOT/pages/customsidebar.adoc
@@ -69,18 +69,18 @@ The `+element():HTMLElement+` function returns the root element of the sidebar p
 tinymce.init({
   ...
   toolbar: 'mysidebar',
-  setup: function (editor) {
+  setup: (editor) => {
     editor.ui.registry.addSidebar('mysidebar', {
       tooltip: 'My sidebar',
       icon: 'comment',
-      onSetup: function (api) {
+      onSetup: (api) => {
         console.log('Render panel', api.element());
       },
-      onShow: function (api) {
+      onShow: (api) => {
         console.log('Show panel', api.element());
         api.element().innerHTML = 'Hello world!';
       },
-      onHide: function (api) {
+      onHide: (api) => {
         console.log('Hide panel', api.element());
       }
     });
@@ -92,18 +92,18 @@ tinymce.init({
 
 [source,js]
 ----
-tinymce.PluginManager.add('myplugin', function (editor) {
+tinymce.PluginManager.add('myplugin', (editor) => {
   editor.ui.registry.addSidebar('mysidebar', {
     tooltip: 'My sidebar',
     icon: 'comment',
-    onSetup: function (api) {
+    onSetup: (api) => {
       console.log('Render panel', api.element());
     },
-    onShow: function (api) {
+    onShow: (api) => {
       console.log('Show panel', api.element());
       api.element().innerHTML = 'Hello world!';
     },
-    onHide: function (api) {
+    onHide: (api) => {
       console.log('Hide panel', api.element());
     }
   });

--- a/modules/ROOT/pages/dialog-components.adoc
+++ b/modules/ROOT/pages/dialog-components.adoc
@@ -75,7 +75,7 @@ const dialogConfig = {
     tabs: [ ... ] // array of panel configurations
   },
   buttons: [],
-  onTabChange: function (dialogApi, details) {
+  onTabChange: (dialogApi, details) => {
     // log the contents of details
     console.log(details.newTabName);
     console.log(details.oldTabName);

--- a/modules/ROOT/pages/events.adoc
+++ b/modules/ROOT/pages/events.adoc
@@ -17,8 +17,8 @@ The following example uses a function to create a console log entry when the edi
 ----
 tinymce.init({
   selector: 'textarea',
-  setup: function(editor) {
-    editor.on('init', function(e) {
+  setup: (editor) => {
+    editor.on('init', (e) => {
       console.log('The Editor has initialized.');
     });
   }
@@ -31,9 +31,9 @@ The following example uses a function to create a console log entry when a comma
 ----
 tinymce.init({
   selector: 'textarea',
-  init_instance_callback: function(editor) {
-    editor.on('ExecCommand', function(e) {
-      console.log('The ' + e.command + ' command was fired.');
+  init_instance_callback: (editor) => {
+    editor.on('ExecCommand', (e) => {
+      console.log(`The ${e.command} command was fired.`);
     });
   }
 });
@@ -394,7 +394,7 @@ The following events are used for editor management. These events are handled us
 .AddEditor
 [source,js]
 ----
-tinymce.on('AddEditor', function(e) {
+tinymce.on('AddEditor', (e) => {
   console.log('Added editor with id: ' + e.editor.id);
 });
 ----
@@ -402,7 +402,7 @@ tinymce.on('AddEditor', function(e) {
 .RemoveEditor
 [source,js]
 ----
-tinymce.on('RemoveEditor', function(e) {
+tinymce.on('RemoveEditor', (e) => {
   console.log('Removed editor with id: ' + e.editor.id);
 });
 ----

--- a/modules/ROOT/pages/urldialog.adoc
+++ b/modules/ROOT/pages/urldialog.adoc
@@ -15,8 +15,8 @@ The configuration for a basic URL dialog might look like this:
 [source,js]
 ----
 tinymce.activeEditor.windowManager.openUrl({
-   title: 'Just a title',
-   url: 'http://www.tiny.cloud/example.html'
+  title: 'Just a title',
+  url: 'http://www.tiny.cloud/example.html'
 });
 ----
 
@@ -114,7 +114,7 @@ Similarly, to send messages from {productname} back to the external page, the `+
 
 [source,js]
 ----
-window.addEventListener('message', function (event) {
+window.addEventListener('message', (event) => {
   var data = event.data;
 
   // Do something with the data received here

--- a/modules/ROOT/partials/misc/onSetup.adoc
+++ b/modules/ROOT/partials/misc/onSetup.adoc
@@ -7,10 +7,10 @@ To clarify, in code `+onSetup+` may look like this:
 
 [source,js]
 ----
-onSetup: function (api) {
+onSetup: (api) => {
   // Do something here on component render, like set component properties or bind an event listener
 
-  return function (api) {
+  return (api) => {
     // Do something here on teardown, like unbind an event listener
   };
 };
@@ -20,6 +20,6 @@ To bind a callback function to an editor event use `+editor.on(eventName, callba
 
 [NOTE]
 --
-* The callback function for `+editor.off()+` should be the same function passed to `+editor.on()+`. For example, if a `+editorEventCallback+` function is bound to the `+NodeChange+` event when the button is created, `+onSetup+` should return `+function (api) { editor.off('NodeChange', editorEventCallback) }+`.
-* If `+onSetup+` does not have any event listeners or only listens to the `+init+` event, `+onSetup+` can return an empty function e.g. `+return function () {};+`.
+* The callback function for `+editor.off()+` should be the same function passed to `+editor.on()+`. For example, if a `+editorEventCallback+` function is bound to the `+NodeChange+` event when the button is created, `+onSetup+` should return `+(api) => editor.off('NodeChange', editorEventCallback)+`.
+* If `+onSetup+` does not have any event listeners or only listens to the `+init+` event, `+onSetup+` can return an empty function e.g. `+return () => {};+`.
 --


### PR DESCRIPTION
Related Ticket: DOC-1577

Description of Changes:

Updated the code samples/snippets/live demos to use newer JavaScript syntax and to make the samples work with TinyMCE 6 changes. Also added back the missing `external-page.html` file used for the URL dialogs that somehow got lost in the migration.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
