### PR TITLE
DOC-1573: Updated PowerPaste command documentation

### DIFF
--- a/modules/ROOT/pages/powerpaste-commands-events-apis.adoc
+++ b/modules/ROOT/pages/powerpaste-commands-events-apis.adoc
@@ -10,7 +10,7 @@
 
 == Commands
 
-The PowerPaste plugin provides the following {productname} command.
+The PowerPaste plugin provides the following {productname} commands.
 
 include::partial$commands/powerpaste-cmds.adoc[]
 

--- a/modules/ROOT/partials/commands/powerpaste-cmds.adoc
+++ b/modules/ROOT/partials/commands/powerpaste-cmds.adoc
@@ -1,7 +1,7 @@
 [cols="1,3",options="header"]
 |===
 |Command |Description
-|mceInsertClipboardContent |Triggers a paste event to detect Word, Google Docs, or standard HTML content in the clipboard, and use the relevant paste path at the cursor location or over the current selection. The command requires an object with: `+html+` containing the HTML content, or `+text+` containing plain text.
+|mceInsertClipboardContent |Triggers a paste event at the cursor location or over the current selection. HTML content will be automatically detected as Word, Google Docs, or standard HTML content and use the relevant paste path. The command requires an object with: `+html+` containing the HTML content, or `+text+` containing plain text.
 |mceTogglePlainTextPaste |Toggles paste as plain text.
 |===
 

--- a/modules/ROOT/partials/commands/powerpaste-cmds.adoc
+++ b/modules/ROOT/partials/commands/powerpaste-cmds.adoc
@@ -1,7 +1,7 @@
 [cols="1,3",options="header"]
 |===
 |Command |Description
-|mceInsertClipboardContent |Triggers a paste event at the cursor location or over the current selection. The command requires an object with: `+html+` containing the HTML content, or `+text+` containing plain text.
+|mceInsertClipboardContent |Triggers a paste event to detect Word, Google Docs, or standard HTML content in the clipboard, and use the relevant paste path at the cursor location or over the current selection. The command requires an object with: `+html+` containing the HTML content, or `+text+` containing plain text.
 |mceTogglePlainTextPaste |Toggles paste as plain text.
 |===
 

--- a/modules/ROOT/partials/commands/powerpaste-cmds.adoc
+++ b/modules/ROOT/partials/commands/powerpaste-cmds.adoc
@@ -1,11 +1,15 @@
 [cols="1,3",options="header"]
 |===
 |Command |Description
+|mceInsertClipboardContent |Triggers a paste event at the cursor location or over the current selection. The command requires an object with: `+html+` containing the HTML content, or `+text+` containing plain text.
 |mceTogglePlainTextPaste |Toggles paste as plain text.
 |===
 
 .Example
 [source,js]
 ----
+tinymce.activeEditor.execCommand('mceInsertClipboardContent', false, {
+  html: '<p>Hello, World!</p>'
+});
 tinymce.activeEditor.execCommand('mceTogglePlainTextPaste');
 ----


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Added mceInsertClipboardContent command to list of PowerPaste commands
* Updated command description to describe paste path for PowerPaste, and replaced term content with html
* Updated PowerPaste commands description to be plural

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
