### PR TITLE
DOC-1601: Upgrade to the latest moxiedoc version and fix the feature branch deploy paths

### DIFF
--- a/.github/workflows/feature_6_docs.yml
+++ b/.github/workflows/feature_6_docs.yml
@@ -55,7 +55,7 @@ jobs:
         fi
 
     - name: (deploy) Upload website to S3
-      run: aws s3 sync --acl=public-read --delete ./build/site $(cat S3_BUCKET)
+      run: aws s3 sync --acl=public-read --delete ./build/site $(cat S3_BUCKET)/docs
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@antora/cli": "^3.0.1",
     "@antora/site-generator-default": "^3.0.1",
-    "@tinymce/moxiedoc": "^0.2.0-rc.20220310010105103.sha4bab33b",
+    "@tinymce/moxiedoc": "^0.2.0-rc.20220322005335934.sha73e058f",
     "dotenv": "^16.0.0",
     "ecstatic": "^4.1.4",
     "http-server": "^0.12.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -210,10 +210,10 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@tinymce/moxiedoc@^0.2.0-rc.20220310010105103.sha4bab33b":
-  version "0.2.0-rc.20220310010105103.sha4bab33b"
-  resolved "https://registry.yarnpkg.com/@tinymce/moxiedoc/-/moxiedoc-0.2.0-rc.20220310010105103.sha4bab33b.tgz#c8df2e8ea13d33b3525cd89e1a2dd1fcfeab01b2"
-  integrity sha512-LGiDjxvQ7z0wibY4M4wG8eJk8TQ17MBAYdiSw16SAepBqRjXFwrwQsEwlwNSZOHnw8nMhoHzV6q4luHl+ryRYA==
+"@tinymce/moxiedoc@^0.2.0-rc.20220322005335934.sha73e058f":
+  version "0.2.0-rc.20220322005335934.sha73e058f"
+  resolved "https://registry.yarnpkg.com/@tinymce/moxiedoc/-/moxiedoc-0.2.0-rc.20220322005335934.sha73e058f.tgz#473df8950a9ef68958046bc570f86dd534309597"
+  integrity sha512-pYQJR4HW5YGFRE3HxUMsOsai6X3+YZLbXlgMpCw0ETJiU3X7lhgBNvA17N6n8fREbbPx45LqwiWu0O/n6fvO+g==
   dependencies:
     cli-color "^2.0.0"
     commander "^7.0.0"


### PR DESCRIPTION
Related Ticket: DOC-1601

Description of Changes:
* Upgrade to the latest moxiedoc version to pull in the fix to use `xref` macros for linking
* Update the feature branch git workflow to upload to the `/docs/` prefix

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
