### PR TITLE
DOC-1579: Updated the snippets and demos in the Getting started section

### DIFF
--- a/modules/ROOT/examples/live-demos/web-component/example.html
+++ b/modules/ROOT/examples/live-demos/web-component/example.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8"/>
+    <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body>

--- a/modules/ROOT/pages/editor-command-identifiers.adoc
+++ b/modules/ROOT/pages/editor-command-identifiers.adoc
@@ -74,7 +74,7 @@ The commands on the following table are provided by the {productname} editor and
 |mceReplaceContent |Replaces the current selection. The value passed in should be the new content.
 |mceSetContent |Sets the contents of the editor. The value is the contents to set as the editor contents.
 |mceToggleFormat |Toggles a specified format by name. The value is the name of the format to toggle. For a list of options, see: xref:content-formatting.adoc#built-informats[Content formatting options - Built-in formats].
-|ToggleSidebar |Closes the current sidebar, or toggles the sidebar if the sidebar name is provided as a value (_`+<sidebar-name>+`_).
+|ToggleSidebar |Closes the current sidebar, or toggles the sidebar if the sidebar name is provided as a value (`_<sidebar-name>_`).
 |ToggleToolbarDrawer |Toggles the Toolbar Drawer. For information on toolbars, see: xref:toolbar-configuration-options.adoc#toolbar[User interface options - Toolbar].
 |Indent |Indents the current selection.
 |Outdent |Outdents the current selection.

--- a/modules/ROOT/partials/install/basic-quickstart-base.adoc
+++ b/modules/ROOT/partials/install/basic-quickstart-base.adoc
@@ -145,21 +145,19 @@ For example:
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
+    <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <script src="{scriptsource}" referrerpolicy="origin"></script>
-
     <script>
       tinymce.init({
         selector: '#mytextarea'
       });
     </script>
-
   </head>
 
   <body>
-  <h1>{productname} Quick Start Guide</h1>
+    <h1>{productname} Quick Start Guide</h1>
     <form method="post">
       <textarea id="mytextarea">Hello, World!</textarea>
     </form>

--- a/modules/ROOT/partials/install/upgrading-info.adoc
+++ b/modules/ROOT/partials/install/upgrading-info.adoc
@@ -99,7 +99,7 @@ tinymce/
 └── themes/
 ----
 . Download the latest version of {productname}.
-* For the {productname} Community Version, download `{prodnamecode}_<VERSION>.zip` from link:{gettiny}/self-hosted/[Get {productname} - Self-hosted releases], where _`+<VERSION>+`_ is the latest version of {productname}.
+* For the {productname} Community Version, download `{prodnamecode}_<VERSION>.zip` from link:{gettiny}/self-hosted/[Get {productname} - Self-hosted releases], where `_<VERSION>_` is the latest version of {productname}.
 * For the {productname} Enterprise Version, download the *{productname} Enterprise Bundle* from link:{accountpageurl}/downloads/[{accountpage} > Downloads]. The downloaded file will be named `+enterprise_latest.zip+`.
 . Extract the downloaded `+.zip+` file to a temporary location.
 . (If required) Install the latest language packs from link:{gettiny}/language-packages/[Get {productname} - Language Packages].

--- a/modules/ROOT/partials/integrations/bootstrap-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/bootstrap-quick-start.adoc
@@ -73,7 +73,7 @@ $(document).on('focusin', function(e) {
 ----
 // Prevent Bootstrap dialog from blocking focusin
 document.addEventListener('focusin', (e) => {
-  if (e.target.closest(".tox-tinymce-aux, .moxman-window, .tam-assetmanager-root") !== null) {
+  if (e.target.closest(".tox-tinymce, .tox-tinymce-aux, .moxman-window, .tam-assetmanager-root") !== null) {
     e.stopImmediatePropagation();
   }
 });

--- a/modules/ROOT/partials/integrations/expressjs-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/expressjs-quick-start.adoc
@@ -103,8 +103,9 @@ For example:
 ----
 <!DOCTYPE html> <!-- Required for TinyMCE to function as intended -->
 <html>
-
   <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{productname} Demo</title>
     <link rel="stylesheet" href="/stylesheets/style.css">
   </head>
@@ -113,12 +114,12 @@ For example:
     <h1>{productname} Demo</h1>
     <!-- Text area matching the selector specified in the TinyMCE configuration -->
     <textarea id="my-expressjs-{prodnamecode}-app">Hello, World!</textarea>
-  </body>
 
-  <!-- Script element sourcing TinyMCE -->
-  <script type="application/javascript" src= "/tinymce/tinymce.min.js"></script>
-  <!-- Script element sourcing the TinyMCE configuration -->
-  <script type="application/javascript" src= "/javascripts/my-{prodnamecode}-config.js"></script>
+    <!-- Script element sourcing TinyMCE -->
+    <script type="application/javascript" src= "/tinymce/tinymce.min.js"></script>
+    <!-- Script element sourcing the TinyMCE configuration -->
+    <script type="application/javascript" src= "/javascripts/my-{prodnamecode}-config.js"></script>
+  </body>
 </html>
 ----
 . Test the application using the Node.js development server.

--- a/modules/ROOT/partials/integrations/laravel-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/laravel-quick-start.adoc
@@ -162,7 +162,7 @@ _File:_ `+resources/views/welcome.blade.php+`
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
   <head>
-    <meta charset="utf-8">
+    <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>TinyMCE in Laravel</title>
     <!-- Insert the blade containing the TinyMCE configuration and source script -->

--- a/modules/ROOT/partials/integrations/rails-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/rails-quick-start.adoc
@@ -17,7 +17,7 @@ include::partial$integrations/rails-basic-proj.adoc[]
 ----
 . Create a `+<textarea>+` with the initial content `+Hello, World!+` for {productname} by adding the following lines to `+app/views/welcome/index.html.erb+`:
 +
-[source,html]
+[source,erb]
 ----
 <%= text_area_tag :content, "Hello, World!", :class => "tinymce" %>
 ----
@@ -49,7 +49,7 @@ include::partial$integrations/rails-basic-proj.adoc[]
 ----
 . Create a `+<textarea>+` with the initial content `+Hello, World!+` for {productname} by adding the following lines to `+app/views/welcome/index.html.erb+`:
 +
-[source,html]
+[source,erb]
 ----
 <%= text_area_tag :content, "Hello, World!", :class => "tinymce" %>
 ----
@@ -105,14 +105,14 @@ plugins:
 ----
 . Add the following lines within the `+<head>+` element of `+app/views/layouts/application.html.erb+` to automatically include {productname} on pages using the `+application+` layout:
 +
-[source,html]
+[source,erb]
 ----
 <%= tinymce_assets %>
 <script type="text/javascript" src="/assets/tinymce.js"></script>
 ----
 . Create a `+<textarea>+` with the initial content `+Hello, World!+` for {productname} by adding the following lines to `+app/views/welcome/index.html.erb+`:
 +
-[source,html]
+[source,erb]
 ----
 <%= text_area_tag :content, "Hello, World!", :class => "tinymce" %>
 <%= tinymce %>

--- a/modules/ROOT/partials/integrations/svelte-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/svelte-quick-start.adoc
@@ -81,7 +81,7 @@ export default {
   plugins: [
     copy({
       targets: [
-        { src: 'node_modules/tinymce/*', dest: 'public/tinymce'}
+        { src: 'node_modules/tinymce/*', dest: 'public/tinymce' }
       ]
     }),
     /* More existing configuration... */

--- a/modules/ROOT/partials/integrations/swing-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/swing-quick-start.adoc
@@ -82,7 +82,7 @@ Or by passing Javascript that returns a {productname} configuration object.
     ].join(''),
     images_reuse_filename: true
   };
-})()
+})();
 ----
 
 Snippet of *Edit.java*:

--- a/modules/ROOT/partials/integrations/webcomponent-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/webcomponent-quick-start.adoc
@@ -19,7 +19,7 @@ The `+DOCTYPE+` declaration is required for the editor to function correctly.
 [source,html]
 ----
 <head>
-  <meta charset="utf-8"/>
+  <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 ----


### PR DESCRIPTION
Related Ticket: DOC-1579

Description of Changes:

This is largely just some further fixes/enhancements for things I found to what was already done in https://github.com/tinymce/tinymce-docs/pull/2292. It turns out the content used between the `Getting started` and `How-to guides` section is exactly the same as they both link to the same URLs.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
