### PR TITLE
feature(Plugins/Premium Plugins/Export): Update docs for the Export p…

### DIFF
--- a/modules/ROOT/pages/plugins/premium/export.adoc
+++ b/modules/ROOT/pages/plugins/premium/export.adoc
@@ -6,23 +6,24 @@
 :pluginname: Export
 :plugincode: export
 
-include::partial$misc/requires_5_5v.adoc[] +
+include::partial$misc/requires_5_5v.adoc[]
+
 include::partial$misc/premiumplugin.adoc[]
 
-The {pluginname} plugin adds the ability to export content from the editor to a user's local machine in various formats. For a list of available exporters and information on what they support, see the <<exporters,Exporters section>>.
+The {pluginname} plugin adds the ability to export content from the editor to a user's local machine in various formats. For a list of available exporters and information on what they support, see the xref:exporters[Exporters section].
 
 == Interactive example
 
 To export the editor content, either:
 
 * From the _File_ menu, click _Export_ and select _PDF_.
-* Click the Export toolbar button (image:{baseurl}/images/icons/export.svg[Export icon: A page with an arrow from the center of the page to the right of the page]) and select _PDF_.
+* Click the Export toolbar button (image:icons/export.svg[Export icon: A page with an arrow from the center of the page to the right of the page]) and select _PDF_.
 
 liveDemo::export[]
 
 == Basic setup
 
-To add the {pluginname} plugin to the editor, add `+{plugincode}+` to the `plugins` option in the editor configuration.
+To add the {pluginname} plugin to the editor, add `{plugincode}` to the `plugins` option in the editor configuration.
 
 For example:
 
@@ -36,12 +37,14 @@ tinymce.init({
 });
 ----
 
+[[exporters]]
 == Exporters
 
 The {pluginname} plugin provides the following exporters:
 
-* <<client-side-pdf,Client-side PDF (`clientpdf`)>>
+* xref:client-side-pdf[Client-side PDF (`clientpdf`)]
 
+[[client-side-pdf]]
 === Client-side PDF (`clientpdf`)
 
 The client-side PDF exporter converts the editor content to a PDF without the need for server-side components. This exporter will resize the content to fit on A4 pages, add page breaks, take a snapshot of the HTML, and embed the snapshot image within the exported PDF.
@@ -51,20 +54,20 @@ This exporter has a few limitations or known issues that should be noted:
 * The text content in the PDF cannot be selected or copied.
 * A single line of content sliced horizontally and distributed across separate pages.
 * Due to browser limitations, there is a limit on the number of pages that can be rendered. The number of pages varies between browsers.
-* Remote images require an image proxy to render due to browser limitations. For information on proxying remote images, see the <<export_image_proxy,export_image_proxy>> option.
+* Remote images require an image proxy to render due to browser limitations. For information on proxying remote images, see the xref:export_image_proxy[export_image_proxy] option.
 * Right-to-left languages that use cursive scripts (such as Arabic) may not render correctly due to an issue with how the image of the HTML content is rendered.
-* The link:{baseurl}/plugins/premium/checklist/[Checklist plugin] icons will not render for Internet Explorer 11 users due to browser limitations.
+* The xref:plugins/premium/checklist.adoc[Checklist plugin] icons will not render for Internet Explorer 11 users due to browser limitations.
 
 The following plugins are not supported:
 
-* link:{baseurl}/plugins/opensource/bbcode/[BBCode]
-* link:{baseurl}/plugins/premium/comments/[Comments]
-* link:{baseurl}/plugins/premium/mediaembed/[Enhanced Media Embed]
-* link:{baseurl}/plugins/opensource/fullpage/[Fullpage]
-* link:{baseurl}/plugins/opensource/legacyoutput/[Legacy Output]
-* link:{baseurl}/plugins/opensource/media/[Media]
-* link:{baseurl}/plugins/premium/pageembed/[Page Embed]
-* link:{baseurl}/plugins/opensource/toc/[Table of Contents]
+* xref:plugins/opensource/bbcode.adoc[BBCode]
+* xref:plugins/premium/comments/index.adoc[Comments]
+* xref:plugins/premium/mediaembed.adoc[Enhanced Media Embed]
+* xref:plugins/opensource/fullpage.adoc[Fullpage]
+* xref:plugins/opensource/legacyoutput.adoc[Legacy Output]
+* xref:plugins/opensource/media.adoc[Media]
+* xref:plugins/premium/pageembed.adoc[Page Embed]
+* xref:plugins/opensource/toc.adoc[Table of Contents]
 
 == Configuration Options
 

--- a/modules/ROOT/pages/plugins/premium/export.adoc
+++ b/modules/ROOT/pages/plugins/premium/export.adoc
@@ -27,7 +27,7 @@ To add the {pluginname} plugin to the editor, add `{plugincode}` to the `plugins
 
 For example:
 
-[source, js]
+[source, js, subs="attributes+"]
 ----
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML

--- a/modules/ROOT/pages/plugins/premium/mediaembed.adoc
+++ b/modules/ROOT/pages/plugins/premium/mediaembed.adoc
@@ -9,14 +9,14 @@ The *Enhanced Media Embed* plugin is a link:{pricingpage}[premium {productname} 
 
 == Installation
 
-For the moment the *Enhanced Media Embed* plugin has to be used in conjunction with the link:{baseurl}/plugins/opensource/media/[media] plugin, so:
+For the moment the *Enhanced Media Embed* plugin has to be used in conjunction with the xref:plugins/opensource/media.adoc[media] plugin, so:
 
 . Make sure you have the `media` plugin added to the `plugins` list.
 . Add the `mediaembed` plugin to the `plugins` list.
 
 === Example Cloud Configuration
 
-The service URL is already configured with link:{baseurl}/cloud-deployment-guide/editor-and-features/[{cloudname}].
+The service URL is already configured with xref:cloud-deployment-guide/editor-and-features.adoc[{cloudname}].
 Simply specify the `media` and `mediaembed` plugins, and optionally a `mediaembed_max_width`
 
 [source, js]
@@ -65,4 +65,4 @@ include::partial$configuration/mediaembed_max_width.adoc[]
 
 == Downloading Enhanced Media Embed plugin
 
-A link:{pricingpage}[{enterpriseversion} subscription] includes the ability to download and install the *Media Embed* plugin and a *WAR* file to access the service backend. Please follow these link:{baseurl}/enterprise/server/#step6setupeditorclientinstancestousetheserver-sidefunctionality[instructions] to configure the *WAR* file.
+A link:{pricingpage}[{enterpriseversion} subscription] includes the ability to download and install the *Media Embed* plugin and a *WAR* file to access the service backend. Please follow these xref:enterprise/server/index.adoc#step6setupeditorclientinstancestousetheserver-sidefunctionality[instructions] to configure the *WAR* file.

--- a/modules/ROOT/partials/configuration/export_ignore_elements.adoc
+++ b/modules/ROOT/partials/configuration/export_ignore_elements.adoc
@@ -9,7 +9,7 @@ This option takes an array of HTML element names and allows specific HTML elemen
 [discrete]
 ===== Example: `export_ignore_elements`
 
-[source, js]
+[source, js, subs="attributes+"]
 ----
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML

--- a/modules/ROOT/partials/configuration/image_cors_hosts.adoc
+++ b/modules/ROOT/partials/configuration/image_cors_hosts.adoc
@@ -3,6 +3,7 @@ ifeval::["{plugincode}" == "export"]
 === `export_cors_hosts`
 endif::[]
 ifeval::["{plugincode}" != "export"]
+[[imagetools_cors_hosts]]
 === `imagetools_cors_hosts`
 endif::[]
 

--- a/modules/ROOT/partials/configuration/image_cors_hosts.adoc
+++ b/modules/ROOT/partials/configuration/image_cors_hosts.adoc
@@ -1,23 +1,23 @@
-ifeval::[{plugincode} == "export"]
+ifeval::["{plugincode}" == "export"]
 === `export_cors_hosts`
 endif::[]
-ifeval::[{plugincode} != "export"]
+ifeval::["{plugincode}" != "export"]
 === `imagetools_cors_hosts`
 endif::[]
 
 The {pluginname} plugin cannot work with images from another domains due to security measures imposed by browsers on so called cross-origin HTTP requests. To overcome these constraints, Cross-Origin Resource Sharing (CORS) must be explicitly enabled on the specified domain(s) (for more information check https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS[HTTP access control]).
 
-An array of supported domains for the images (with CORS enabled on them) can be supplied to {productname} via the `+{plugincode}_cors_hosts+` option.
+An array of supported domains for the images (with CORS enabled on them) can be supplied to {productname} via the `{plugincode}_cors_hosts` option.
 
 NOTE: Each string in the array _must_ be in the format of `mydomain.com`. Do not include protocols (`http://, https://`) or any trailing slashes in your domains.
 
-NOTE: `+{plugincode}_cors_hosts+` is *not* required when enabling this plugin via link:{baseurl}/cloud-deployment-guide/editor-and-features/[{cloudname}].
+NOTE: `{plugincode}_cors_hosts` is *not* required when enabling this plugin via xref:cloud-deployment-guide/editor-and-features.adoc[{cloudname}].
 
 *Type:* `String[]`
 
 *Default Value:* `[]`
 
-==== Example: `+{plugincode}_cors_hosts+`
+==== Example: `{plugincode}_cors_hosts`
 
 [source, js,subs='attributes+']
 ----

--- a/modules/ROOT/partials/configuration/image_cors_hosts.adoc
+++ b/modules/ROOT/partials/configuration/image_cors_hosts.adoc
@@ -1,4 +1,5 @@
 ifeval::["{plugincode}" == "export"]
+[[export_cors_hosts]]
 === `export_cors_hosts`
 endif::[]
 ifeval::["{plugincode}" != "export"]

--- a/modules/ROOT/partials/configuration/image_proxy.adoc
+++ b/modules/ROOT/partials/configuration/image_proxy.adoc
@@ -5,6 +5,7 @@ ifeval::["{plugincode}" == "export"]
 endif::[]
 ifeval::["{plugincode}" != "export"]
 :proxy_setting_name: imagetools_proxy
+[[imagetools_proxy]]
 === `imagetools_proxy`
 endif::[]
 

--- a/modules/ROOT/partials/configuration/image_proxy.adoc
+++ b/modules/ROOT/partials/configuration/image_proxy.adoc
@@ -1,21 +1,22 @@
-ifeval::[{plugincode} == "export"]
+ifeval::["{plugincode}" == "export"]
 :proxy_setting_name: export_image_proxy
+[[export_image_proxy]]
 === `export_image_proxy`
 endif::[]
-ifeval::[{plugincode} != "export"]
+ifeval::["{plugincode}" != "export"]
 :proxy_setting_name: imagetools_proxy
 === `imagetools_proxy`
 endif::[]
 
 This option can be used as a way of getting images across domains using a local server-side proxy. A proxy is basically a script, that will retrieve a remote image and pipe it back to {productname}, as if it was a local image. An example of such a proxy (written in PHP) can be found below.
 
-link:{pricingpage}[Paid TinyMCE subscriptions] also includes a proxy service written in Java. Check the link:{baseurl}/enterprise/server/[Install Server-side Components] guide for details.
+link:{pricingpage}[Paid TinyMCE subscriptions] also includes a proxy service written in Java. Check the xref:enterprise/server/index.adoc[Install Server-side Components] guide for details.
 
-NOTE: `+{proxy_setting_name}+` is *not* required when enabling this plugin via link:{baseurl}/cloud-deployment-guide/editor-and-features/[{cloudname}].
+NOTE: `{proxy_setting_name}` is *not* required when enabling this plugin via xref:cloud-deployment-guide/editor-and-features.adoc[{cloudname}].
 
 *Type:* `String`
 
-==== Example: Using `+{proxy_setting_name}+`
+==== Example: Using `{proxy_setting_name}`
 
 [source, js,subs='attributes+']
 ----

--- a/modules/ROOT/partials/configuration/mediaembed_service_url.adoc
+++ b/modules/ROOT/partials/configuration/mediaembed_service_url.adoc
@@ -1,6 +1,6 @@
 === `mediaembed_service_url`
 
-This option specifies the URL to the service that will handle your requests and return the embeddable snippets used by the *Media Embed* plugin. Please follow these link:{baseurl}/enterprise/server/#step6setupeditorclientinstancestousetheserver-sidefunctionality[instructions] to configure the *WAR* file that you will get as a part of your link:{pricingpage}[{enterpriseversion} subscription].
-This option is not required for link:{baseurl}/cloud-deployment-guide/editor-and-features/[{cloudname}].
+This option specifies the URL to the service that will handle your requests and return the embeddable snippets used by the *Media Embed* plugin. Please follow these xref:enterprise/server/index.adoc#step6setupeditorclientinstancestousetheserver-sidefunctionality[instructions] to configure the *WAR* file that you will get as a part of your link:{pricingpage}[{enterpriseversion} subscription].
+This option is not required for xref:cloud-deployment-guide/editor-and-features.adoc[{cloudname}].
 
 *Type:* `String`

--- a/modules/ROOT/partials/events/export-events.adoc
+++ b/modules/ROOT/partials/events/export-events.adoc
@@ -1,4 +1,4 @@
-The following event are provided by the link:{baseurl}/plugins/premium/export/[Export plugin].
+The following event are provided by the xref:plugins/premium/export.adoc[Export plugin].
 
 |===
 | Name | Data | Description

--- a/modules/ROOT/partials/menu-item-ids/export-menu-items.adoc
+++ b/modules/ROOT/partials/menu-item-ids/export-menu-items.adoc
@@ -1,5 +1,5 @@
 |===
-| Menu item identifier | link:{baseurl}/configure/editor-appearance/#examplethetinymcedefaultmenuitems[Default Menu Location] | Description
+| Menu item identifier | xref:configure/editor-appearance.adoc#examplethetinymcedefaultmenuitems[Default Menu Location] | Description
 
 | `export`
 | File


### PR DESCRIPTION
…remium plugin page

Related Ticket: TINY-8595

Description of Changes:
This PR fixes the docs of the Export premium plugin page. This PR tries to be as contained as possible and not cause conflict with other PRs, so the changes are made to the files being rendered only in the /plugins/premium/export.html url
Worth noting that some xrefs might be broken (e.g: the one that link to configure/something.adoc ) as well as some Jekyll syntax that did not get update because it is taken care of in other PRs.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
