### PR TITLE
DOC-1567: Updated the editor commands documentation

### DIFF
--- a/modules/ROOT/pages/editor-command-identifiers.adoc
+++ b/modules/ROOT/pages/editor-command-identifiers.adoc
@@ -46,7 +46,7 @@ The commands on the following table are provided by the {productname} editor and
 |Bold |Toggles bold formatting to selection.
 |Italic |Toggles italic formatting to selection.
 |Underline |Toggles underline formatting to selection.
-|Strikethrough |Toggles strikethough formatting to selection.
+|Strikethrough |Toggles strikethrough formatting to selection.
 |Superscript |Toggles superscript formatting to selection.
 |Subscript |Toggles subscript formatting to selection.
 |Cut |Cuts the selected contents and puts in into users clipboard.
@@ -54,6 +54,7 @@ The commands on the following table are provided by the {productname} editor and
 |Lang |Sets the language of the current selection. The value passed in should be a language spec described in xref:content-localization.adoc#content_langs[Content appearance options - `+content_langs+`].
 |Paste |Pastes the current clipboard contents into the editor.
 |mceInsertLink |Inserts a link at the current selection. The value is the URL to add to the link(s).
+|createLink |Inserts a link at the current selection. The value is the URL to add to the link(s). NOTE: This is an alias for the `mceInsertLink` command.
 |Unlink |Removes any links from the current selection.
 |JustifyLeft |Left aligns the current text block/image.
 |JustifyCenter |Center aligns the current text block/image.
@@ -62,6 +63,7 @@ The commands on the following table are provided by the {productname} editor and
 |JustifyNone |Removes any alignment to the selected text.
 |ForeColor |Changes the text color of the text. The value passed in should be the color.
 |HiliteColor |Changes the background color of the text. The value passed in should be the color.
+|BackColor |Changes the background color of the text. The value passed in should be the color. NOTE: This is an alias for the `HiliteColor` command.
 |FontName |Font name to apply to the text. The value passed in should be the font family name.
 |FontSize |Font size of the text. The value passed in should be a valid CSS font size.
 |LineHeight |Sets the line height of the text. The value passed in should be a valid CSS line height.
@@ -79,9 +81,12 @@ The commands on the following table are provided by the {productname} editor and
 |Indent |Indents the current selection.
 |Outdent |Outdents the current selection.
 |InsertHorizontalRule |Inserts a horizontal rule at the cursor location or inplace of the current selection.
-|InsertLineBreak |Adds a line break `+<br/>+` at the current cursor or selection.
+|InsertLineBreak |Adds a line break `+<br>+` at the current cursor or selection.
+|InsertParagraph |Inserts a new line at the current cursor or selection.
+|InsertText |Inserts the passed value as plain text at the current cursor or selection.
+|InsertHTML |Inserts the passed value as HTML at the current cursor or selection.
+|InsertImage |Adds an image `+<img src="...">+` at the current cursor or selection.
 |mceInsertNewLine |Adds a new line at the current cursor or selection, such as splitting the current paragraph element.
-|mceInsertRawHTML |Inserts the RAW HTML passed as a value, overwriting the current selection or at the cursor position. *Warning*: This command allows dangerous `+<script>+` elements to be added to and executed in the editor.
 |mceToggleVisualAid |Toggles the visual aids for: tables without borders and anchors.
 |SelectAll |Selects all content in the editor.
 |Delete |Deletes the current selection from the editor.
@@ -99,6 +104,8 @@ The commands on the following table are provided by the {productname} editor and
 |mcePrint |Opens the browser's print dialog for the current page.
 |mceInsertClipboardContent |Triggers a paste event at the cursor location or over the current selection. The command requires an object with: `+html+` containing the HTML content, or `+text+` containing plain text.
 |mceTogglePlainTextPaste |Toggles paste as plain text.
+|mceAutocompleterClose |Closes any active autocompleter menu.
+|mceAutocompleterReload |Reloads the autocompleter menu with new items. For the data to provide, see the xref:autocompleter.adoc#api[Autocompleter reload API].
 |===
 
 .Examples
@@ -114,6 +121,7 @@ tinymce.activeEditor.execCommand('Cut');
 tinymce.activeEditor.execCommand('Copy');
 tinymce.activeEditor.execCommand('Paste');
 tinymce.activeEditor.execCommand('mceInsertLink', false, 'https://www.tiny.cloud');
+tinymce.activeEditor.execCommand('createLink', false, 'https://www.tiny.cloud');
 tinymce.activeEditor.execCommand('Unlink');
 tinymce.activeEditor.execCommand('JustifyLeft');
 tinymce.activeEditor.execCommand('JustifyCenter');
@@ -122,6 +130,7 @@ tinymce.activeEditor.execCommand('JustifyFull');
 tinymce.activeEditor.execCommand('JustifyNone');
 tinymce.activeEditor.execCommand('ForeColor', false, '#FF0000');
 tinymce.activeEditor.execCommand('HiliteColor', false, '#FF0000');
+tinymce.activeEditor.execCommand('BackColor', false, '#FF0000');
 tinymce.activeEditor.execCommand('FontName', false, 'courier new');
 tinymce.activeEditor.execCommand('FontSize', false, '30px');
 tinymce.activeEditor.execCommand('LineHeight', false, '1.4');
@@ -141,8 +150,11 @@ tinymce.activeEditor.execCommand('Indent');
 tinymce.activeEditor.execCommand('Outdent');
 tinymce.activeEditor.execCommand('InsertHorizontalRule');
 tinymce.activeEditor.execCommand('InsertLineBreak');
+tinymce.activeEditor.execCommand('InsertParagraph');
+tinymce.activeEditor.execCommand('InsertText', false, 'My text content');
+tinymce.activeEditor.execCommand('InsertHTML', false, 'My HTML content');
+tinymce.activeEditor.execCommand('InsertImage', false, 'https://www.example.com/image.png');
 tinymce.activeEditor.execCommand('mceInsertNewLine');
-tinymce.activeEditor.execCommand('mceInsertRawHTML', false, '<p>Hello, World!</p>');
 tinymce.activeEditor.execCommand('mceToggleVisualAid');
 tinymce.activeEditor.execCommand('SelectAll');
 tinymce.activeEditor.execCommand('Delete');
@@ -163,7 +175,10 @@ tinymce.activeEditor.execCommand('mceInsertClipboardContent', false, {
   html: '<p>Hello, World!</p>'
 });
 tinymce.activeEditor.execCommand('mceTogglePlainTextPaste');
-
+tinymce.activeEditor.execCommand('mceAutocompleterClose');
+tinymce.activeEditor.execCommand('mceAutocompleterReload', false, {
+  fetchOptions: {}
+});
 ----
 
 [[plugincommands]]

--- a/modules/ROOT/pages/editor-command-identifiers.adoc
+++ b/modules/ROOT/pages/editor-command-identifiers.adoc
@@ -40,7 +40,7 @@ tinymce.activeEditor.editorCommands.commands.exec;
 
 ==== Supported browser-native commands
 
-The commands on the following table are provided by the {productname} editor and provide the same or similar functionality to the https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand#commands[native browser commands].
+The commands in the following table are provided by the {productname} editor and provide the same or similar functionality to the https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand#commands[native browser commands].
 
 [cols="1,3",options="header"]
 |===
@@ -121,7 +121,7 @@ tinymce.activeEditor.execCommand('Undo');
 
 ==== Additional core editor commands
 
-The commands on the following table are provided by the {productname} editor and provide additional functionality that do not require any plugins to be enabled.
+The commands in the following table are provided by the {productname} editor and provide additional functionality that does not require any plugins to be enabled.
 
 [cols="1,3",options="header"]
 |===

--- a/modules/ROOT/pages/editor-command-identifiers.adoc
+++ b/modules/ROOT/pages/editor-command-identifiers.adoc
@@ -28,7 +28,7 @@ The following tables show the existing editor commands. These commands are provi
 [[listingcoreandplugineditorcommands]]
 === Listing core and plugin editor commands
 
-To retrieve a list of avaliable commands from the active editor, run the following command from the browser console:
+To retrieve a list of available commands from the active editor, run the following command from the browser console:
 
 [source,js]
 ----
@@ -38,7 +38,9 @@ tinymce.activeEditor.editorCommands.commands.exec;
 [[coreeditorcommands]]
 === Core Editor commands
 
-The commands on the following table are provided by the {productname} editor and do not require any plugins to be enabled.
+==== Supported browser-native commands
+
+The commands on the following table are provided by the {productname} editor and provide the same or similar functionality to the https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand#commands[native browser commands].
 
 [cols="1,3",options="header"]
 |===
@@ -51,49 +53,97 @@ The commands on the following table are provided by the {productname} editor and
 |Subscript |Toggles subscript formatting to selection.
 |Cut |Cuts the selected contents and puts in into users clipboard.
 |Copy |Copies the selected contents and puts in into users clipboard.
-|Lang |Sets the language of the current selection. The value passed in should be a language spec described in xref:content-localization.adoc#content_langs[Content appearance options - `+content_langs+`].
 |Paste |Pastes the current clipboard contents into the editor.
-|mceInsertLink |Inserts a link at the current selection. The value is the URL to add to the link(s).
-|createLink |Inserts a link at the current selection. The value is the URL to add to the link(s). NOTE: This is an alias for the `mceInsertLink` command.
-|Unlink |Removes any links from the current selection.
+|ForeColor |Changes the text color of the text. The value passed in should be the color.
+|BackColor |Changes the background color of the text. The value passed in should be the color.
 |JustifyLeft |Left aligns the current text block/image.
 |JustifyCenter |Center aligns the current text block/image.
 |JustifyRight |Right aligns the current text block/image.
 |JustifyFull |Full aligns the current text block/image.
-|JustifyNone |Removes any alignment to the selected text.
-|ForeColor |Changes the text color of the text. The value passed in should be the color.
-|HiliteColor |Changes the background color of the text. The value passed in should be the color.
-|BackColor |Changes the background color of the text. The value passed in should be the color. NOTE: This is an alias for the `HiliteColor` command.
 |FontName |Font name to apply to the text. The value passed in should be the font family name.
 |FontSize |Font size of the text. The value passed in should be a valid CSS font size.
+|FormatBlock |Toggles the format of the current selection. The value passed in should be the format name. If no format is specified, the paragraph (`+<p>+`) format will be toggled. For a list of options, see: xref:content-formatting.adoc#built-informats[Content formatting options - Built-in formats].
+|RemoveFormat |Removes any formats from the current selection.
+|Indent |Indents the current selection.
+|Outdent |Outdents the current selection.
+|CreateLink |Inserts a link at the current selection. The value is the URL to add to the link(s).
+|Unlink |Removes any links from the current selection.
+|InsertHorizontalRule |Inserts a horizontal rule at the cursor location or inplace of the current selection.
+|InsertParagraph |Inserts a new paragraph or new line at the current cursor or selection.
+|InsertText |Inserts the passed value as plain text at the current cursor or selection.
+|InsertHTML |Inserts the passed value as HTML at the current cursor or selection.
+|InsertImage |Adds an image `+<img src="...">+` at the current cursor or selection.
+|SelectAll |Selects all content in the editor.
+|Delete |Deletes the current selection from the editor.
+|ForwardDelete |Deletes the current selection or the character to the right of the cursor for a collapsed selection.
+|Redo |Redoes the last change to the editor.
+|Undo |Undoes the last change to the editor.
+|===
+
+
+.Examples
+[source,js]
+----
+tinymce.activeEditor.execCommand('Bold');
+tinymce.activeEditor.execCommand('Italic');
+tinymce.activeEditor.execCommand('Underline');
+tinymce.activeEditor.execCommand('Strikethrough');
+tinymce.activeEditor.execCommand('Superscript');
+tinymce.activeEditor.execCommand('Subscript');
+tinymce.activeEditor.execCommand('Cut');
+tinymce.activeEditor.execCommand('Copy');
+tinymce.activeEditor.execCommand('Paste');
+tinymce.activeEditor.execCommand('JustifyLeft');
+tinymce.activeEditor.execCommand('JustifyCenter');
+tinymce.activeEditor.execCommand('JustifyRight');
+tinymce.activeEditor.execCommand('JustifyFull');
+tinymce.activeEditor.execCommand('ForeColor', false, '#FF0000');
+tinymce.activeEditor.execCommand('BackColor', false, '#FF0000');
+tinymce.activeEditor.execCommand('FontName', false, 'courier new');
+tinymce.activeEditor.execCommand('FontSize', false, '30px');
+tinymce.activeEditor.execCommand('FormatBlock', false, 'bold');
+tinymce.activeEditor.execCommand('RemoveFormat');
+tinymce.activeEditor.execCommand('Indent');
+tinymce.activeEditor.execCommand('Outdent');
+tinymce.activeEditor.execCommand('CreateLink', false, 'https://www.tiny.cloud');
+tinymce.activeEditor.execCommand('Unlink');
+tinymce.activeEditor.execCommand('InsertHorizontalRule');
+tinymce.activeEditor.execCommand('InsertParagraph');
+tinymce.activeEditor.execCommand('InsertText', false, 'My text content');
+tinymce.activeEditor.execCommand('InsertHTML', false, 'My HTML content');
+tinymce.activeEditor.execCommand('InsertImage', false, 'https://www.example.com/image.png');
+tinymce.activeEditor.execCommand('SelectAll');
+tinymce.activeEditor.execCommand('Delete');
+tinymce.activeEditor.execCommand('ForwardDelete');
+tinymce.activeEditor.execCommand('Redo');
+tinymce.activeEditor.execCommand('Undo');
+----
+
+==== Additional core editor commands
+
+The commands on the following table are provided by the {productname} editor and provide additional functionality that do not require any plugins to be enabled.
+
+[cols="1,3",options="header"]
+|===
+|Command |Description
+|Lang |Sets the language of the current selection. The value passed in should be a language spec described in xref:content-localization.adoc#content_langs[Content appearance options - `+content_langs+`].
+|mceInsertLink |Inserts a link at the current selection. The value is the URL to add to the link(s). NOTE: This is an alias for the `CreateLink` command.
+|JustifyNone |Removes any alignment to the selected text.
+|HiliteColor |Changes the background color of the text. The value passed in should be the color. NOTE: This is an alias for the `BackColor` command.
 |LineHeight |Sets the line height of the text. The value passed in should be a valid CSS line height.
 |mceApplyTextcolor |Applies text color or background color to the current selection. Requires an argument of either `+'hilitecolor'+` or `+'forecolor'+`, and the value of the color.
 |mceRemoveTextcolor |Removes the text color or background color from the current selection. Requires an argument of either `+'hilitecolor'+` or `+'forecolor'+`.
-|RemoveFormat |Removes any formats from the current selection.
 |mceBlockQuote |Wraps the selected text blocks into a block quote.
-|FormatBlock |Toggles the format of the current selection. The value passed in should be the format name. If no format is specified, the paragraph (<`+p+`>) format will be toggled. For a list of options, see: xref:content-formatting.adoc#built-informats[Content formatting options - Built-in formats].
 |mceInsertContent |Inserts contents at the current selection. The value passed in should be the contents to be inserted.
 |mceReplaceContent |Replaces the current selection. The value passed in should be the new content.
 |mceSetContent |Sets the contents of the editor. The value is the contents to set as the editor contents.
 |mceToggleFormat |Toggles a specified format by name. The value is the name of the format to toggle. For a list of options, see: xref:content-formatting.adoc#built-informats[Content formatting options - Built-in formats].
 |ToggleSidebar |Closes the current sidebar, or toggles the sidebar if the sidebar name is provided as a value (`_<sidebar-name>_`).
 |ToggleToolbarDrawer |Toggles the Toolbar Drawer. For information on toolbars, see: xref:toolbar-configuration-options.adoc#toolbar[User interface options - Toolbar].
-|Indent |Indents the current selection.
-|Outdent |Outdents the current selection.
-|InsertHorizontalRule |Inserts a horizontal rule at the cursor location or inplace of the current selection.
 |InsertLineBreak |Adds a line break `+<br>+` at the current cursor or selection.
-|InsertParagraph |Inserts a new line at the current cursor or selection.
-|InsertText |Inserts the passed value as plain text at the current cursor or selection.
-|InsertHTML |Inserts the passed value as HTML at the current cursor or selection.
-|InsertImage |Adds an image `+<img src="...">+` at the current cursor or selection.
-|mceInsertNewLine |Adds a new line at the current cursor or selection, such as splitting the current paragraph element.
+|mceInsertNewLine |Adds a new line at the current cursor or selection, such as splitting the current paragraph element. NOTE: This is an alias for the `InsertParagraph` command.
 |mceToggleVisualAid |Toggles the visual aids for: tables without borders and anchors.
-|SelectAll |Selects all content in the editor.
-|Delete |Deletes the current selection from the editor.
-|ForwardDelete |Deletes the current selection or the character to the right of the cursor for a collapsed selection.
 |mceNewDocument |Removes all contents of the editor.
-|Redo |Redoes the last change to the editor.
-|Undo |Undoes the last change to the editor.
 |mceAddUndoLevel |Adds an undo level.
 |mceEndUndoLevel |Adds an undo level.
 |mceCleanup |Copies the current editor content and sets the content using the copy.
@@ -111,34 +161,15 @@ The commands on the following table are provided by the {productname} editor and
 .Examples
 [source,js]
 ----
-tinymce.activeEditor.execCommand('Bold');
-tinymce.activeEditor.execCommand('Italic');
-tinymce.activeEditor.execCommand('Underline');
-tinymce.activeEditor.execCommand('Strikethrough');
-tinymce.activeEditor.execCommand('Superscript');
-tinymce.activeEditor.execCommand('Subscript');
-tinymce.activeEditor.execCommand('Cut');
-tinymce.activeEditor.execCommand('Copy');
-tinymce.activeEditor.execCommand('Paste');
+tinymce.activeEditor.execCommand('Lang', false, { code: 'en_US' });  /* OR */
+tinymce.activeEditor.execCommand('Lang', false, { code: 'en_US', customCode: 'en-us-medical' });
 tinymce.activeEditor.execCommand('mceInsertLink', false, 'https://www.tiny.cloud');
-tinymce.activeEditor.execCommand('createLink', false, 'https://www.tiny.cloud');
-tinymce.activeEditor.execCommand('Unlink');
-tinymce.activeEditor.execCommand('JustifyLeft');
-tinymce.activeEditor.execCommand('JustifyCenter');
-tinymce.activeEditor.execCommand('JustifyRight');
-tinymce.activeEditor.execCommand('JustifyFull');
 tinymce.activeEditor.execCommand('JustifyNone');
-tinymce.activeEditor.execCommand('ForeColor', false, '#FF0000');
 tinymce.activeEditor.execCommand('HiliteColor', false, '#FF0000');
-tinymce.activeEditor.execCommand('BackColor', false, '#FF0000');
-tinymce.activeEditor.execCommand('FontName', false, 'courier new');
-tinymce.activeEditor.execCommand('FontSize', false, '30px');
 tinymce.activeEditor.execCommand('LineHeight', false, '1.4');
 tinymce.activeEditor.execCommand('mceApplyTextcolor', 'hilitecolor', '#FF0000');
 tinymce.activeEditor.execCommand('mceRemoveTextcolor', 'hilitecolor');
-tinymce.activeEditor.execCommand('RemoveFormat');
 tinymce.activeEditor.execCommand('mceBlockQuote');
-tinymce.activeEditor.execCommand('FormatBlock', false, 'bold');
 tinymce.activeEditor.execCommand('mceInsertContent', false, 'My new content');
 tinymce.activeEditor.execCommand('mceReplaceContent', false, 'My replacement content');
 tinymce.activeEditor.execCommand('mceSetContent', false, 'My content');
@@ -146,22 +177,10 @@ tinymce.activeEditor.execCommand('mceToggleFormat', false, 'bold');
 tinymce.activeEditor.execCommand('ToggleSidebar');  /* OR */
 tinymce.activeEditor.execCommand('ToggleSidebar', false, '<sidebar-name>');
 tinymce.activeEditor.execCommand('ToggleToolbarDrawer');
-tinymce.activeEditor.execCommand('Indent');
-tinymce.activeEditor.execCommand('Outdent');
-tinymce.activeEditor.execCommand('InsertHorizontalRule');
 tinymce.activeEditor.execCommand('InsertLineBreak');
-tinymce.activeEditor.execCommand('InsertParagraph');
-tinymce.activeEditor.execCommand('InsertText', false, 'My text content');
-tinymce.activeEditor.execCommand('InsertHTML', false, 'My HTML content');
-tinymce.activeEditor.execCommand('InsertImage', false, 'https://www.example.com/image.png');
 tinymce.activeEditor.execCommand('mceInsertNewLine');
 tinymce.activeEditor.execCommand('mceToggleVisualAid');
-tinymce.activeEditor.execCommand('SelectAll');
-tinymce.activeEditor.execCommand('Delete');
-tinymce.activeEditor.execCommand('ForwardDelete');
 tinymce.activeEditor.execCommand('mceNewDocument');
-tinymce.activeEditor.execCommand('Redo');
-tinymce.activeEditor.execCommand('Undo');
 tinymce.activeEditor.execCommand('mceAddUndoLevel');
 tinymce.activeEditor.execCommand('mceEndUndoLevel');
 tinymce.activeEditor.execCommand('mceCleanup');


### PR DESCRIPTION
Related Ticket: DOC-1567

Description of Changes:
* Added autocompleter commands
* Added native commands that were re-implemented in core
* Removed the `mceInsertRawHTML` command

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
