### PR TITLE
Feature/tinymce5update 3 releases 6 to 5.10

### DIFF
--- a/_new_content_templates/blank_releasenotes.adoc
+++ b/_new_content_templates/blank_releasenotes.adoc
@@ -115,6 +115,7 @@ Add description here.
 
 For information on using premium skins and icon packs, see: link:{baseurl}/enterprise/premium-skins-and-icon-packs/[Premium Skins and Icon Packs].
 
+[[accompanyingpremiumself-hostedserver-sidecomponentchanges]]
 == Accompanying Premium self-hosted server-side component changes
 
 The {productname} vnumtxt release includes accompanying changes affecting the {productname} *self-hosted* services for the following plugins:

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -3,9 +3,7 @@
 :description: The history of TinyMCE releases.
 :keywords: changelog
 
-____
-This is the {productname} Community version changelog. For information about the latest {cloudname} or {enterpriseversion} Release, see: xref:release-notes/index.adoc[{productname} Release Notes].
-____
+NOTE: This is the {productname} Community version changelog. For information about the latest {cloudname} or {enterpriseversion} Release, see: xref:release-notes/index.adoc[{productname} Release Notes].
 
 == 5.10.2 - 2021-11-17
 
@@ -246,10 +244,7 @@ ____
 * Fixed a regression in the `tinymce.create()` API that caused issues when multiple objects were created.
 * Fixed the `LineHeight` command causing the `change` event to be fired inconsistently.
 
-// Note: The below anchor is matches a historical changelog format and is not needed for new versions in the changelog.
-
-+++<a class="anchor" id="version571march172021">++++++</a>+++
-
+[[version571march172021]]
 == 5.7.1 - 2021-03-17
 
 === Fixed
@@ -261,8 +256,7 @@ ____
 * Fixed context menu items lacking support for the `disabled` and `shortcut` properties.
 * Fixed a regression where the width and height were incorrectly set when embedding content using the `media` dialog.
 
-+++<a class="anchor" id="version570february102021">++++++</a>+++
-
+[[version570february102021]]
 == 5.7.0 - 2021-02-10
 
 === Added
@@ -316,16 +310,14 @@ ____
 * Fixed an issue where file extensions with uppercase characters were treated as invalid.
 * Fixed dialog block messages were not passed through TinyMCE's translation system.
 
-+++<a class="anchor" id="version562december82020">++++++</a>+++
-
+[[version562december82020]]
 == 5.6.2 - 2020-12-08
 
 === Fixed
 
 * Fixed a UI rendering regression when the document body is using `display: flex`.
 
-+++<a class="anchor" id="version561november252020">++++++</a>+++
-
+[[version561november252020]]
 == 5.6.1 - 2020-11-25
 
 === Fixed
@@ -335,8 +327,7 @@ ____
 * Fixed an issue where copying and pasting table columns resulted in invalid HTML when using colgroups.
 * Fixed an issue where the toolbar would render with the wrong width for inline editors in some situations.
 
-+++<a class="anchor" id="version560november182020">++++++</a>+++
-
+[[version560november182020]]
 == 5.6.0 - 2020-11-18
 
 === Added
@@ -389,8 +380,7 @@ ____
 * Fixed a regression that caused the selection to be difficult to see in tables with backgrounds.
 * Fixed content pasted multiple times in the editor when using Microsoft Internet Explorer 11. Patch contributed by mattford.
 
-+++<a class="anchor" id="version551october12020">++++++</a>+++
-
+[[version551october12020]]
 == 5.5.1 - 2020-10-01
 
 === Fixed
@@ -398,8 +388,7 @@ ____
 * Fixed pressing the down key near the end of a document incorrectly raising an exception.
 * Fixed incorrect Typescript types for the `Tools` API.
 
-+++<a class="anchor" id="version550september292020">++++++</a>+++
-
+[[version550september292020]]
 == 5.5.0 - 2020-09-29
 
 === Added
@@ -459,8 +448,7 @@ ____
 * Fixed `editor.selection.setCursorLocation` incorrectly placing the cursor outside `pre` elements in some circumstances.
 * Fixed an exception being thrown when pressing the enter key inside pre elements while `br_in_pre` setting is false.
 
-+++<a class="anchor" id="version542august172020">++++++</a>+++
-
+[[version542august172020]]
 == 5.4.2 - 2020-08-17
 
 === Fixed
@@ -479,8 +467,7 @@ ____
 * Fixed the list type style not retained when copying list items.
 * Fixed the Paste plugin converting tabs in plain text to a single space character. A `paste_tab_spaces` option has been included for setting the number of spaces used to replace a tab character.
 
-+++<a class="anchor" id="version541july82020">++++++</a>+++
-
+[[version541july82020]]
 == 5.4.1 - 2020-07-08
 
 === Fixed
@@ -492,8 +479,7 @@ ____
 * Fixed Oxide checklist styles not showing when printing.
 * Fixed bug with `scope` attribute not being added to the cells of header rows.
 
-+++<a class="anchor" id="version540june302020">++++++</a>+++
-
+[[version540june302020]]
 == 5.4.0 - 2020-06-30
 
 === Added
@@ -539,16 +525,14 @@ ____
 * Fixed the `link` plugin now suggest `mailto:` when the text contains an '@' and no slashes (`/`).
 * Fixed the `valid_children` check of custom elements now allows a wider range of characters in names.
 
-+++<a class="anchor" id="version532june102020">++++++</a>+++
-
+[[version532june102020]]
 == 5.3.2 - 2020-06-10
 
 === Fixed
 
 * Fixed a regression introduced in 5.3.0, where `images_dataimg_filter` was no-longer called.
 
-+++<a class="anchor" id="version531may272020">++++++</a>+++
-
+[[version531may272020]]
 == 5.3.1 - 2020-05-27
 
 === Fixed
@@ -556,8 +540,7 @@ ____
 * Fixed the image upload error alert also incorrectly closing the image dialog.
 * Fixed editor content scrolling incorrectly on focus in Firefox by reverting default content CSS html and body heights added in 5.3.0.
 
-+++<a class="anchor" id="version530may212020">++++++</a>+++
-
+[[version530may212020]]
 == 5.3.0 - 2020-05-21
 
 === Added
@@ -604,8 +587,7 @@ ____
 * Fixed a regression introduced in 5.2.0 whereby the desktop `toolbar_mode` setting would incorrectly override the mobile default setting.
 * Fixed an issue where deleting all content in a single cell table would delete the entire table.
 
-+++<a class="anchor" id="version522april232020">++++++</a>+++
-
+[[version522april232020]]
 == 5.2.2 - 2020-04-23
 
 === Fixed
@@ -616,8 +598,7 @@ ____
 * Fixed the floating toolbar drawer height collapsing when the editor is rendered in modal dialogs or floating containers.
 * Fixed `media` embed content not processing safely in some cases.
 
-+++<a class="anchor" id="version521march252020">++++++</a>+++
-
+[[version521march252020]]
 == 5.2.1 - 2020-03-25
 
 === Fixed
@@ -641,8 +622,7 @@ ____
 * Fixed an issue where removing the background color of text did not always work.
 * Fixed an issue where new rows and columns in a table did not retain the style of the previous row or column.
 
-+++<a class="anchor" id="version520february132020">++++++</a>+++
-
+[[version520february132020]]
 == 5.2.0 - 2020-02-13
 
 === Added
@@ -703,8 +683,7 @@ ____
 * Fixed keyboard flicker when opening a context menu on mobile.
 * Fixed issue where plus icon svg contained strokes.
 
-+++<a class="anchor" id="version516january282020">++++++</a>+++
-
+[[version516january282020]]
 == 5.1.6 - 2020-01-28
 
 === Fixed
@@ -717,8 +696,7 @@ ____
 * Fixed the `image` plugin not respecting the `automatic_uploads` setting when uploading local images.
 * Fixed security issue related to parsing HTML comments and CDATA.
 
-+++<a class="anchor" id="version515december192019">++++++</a>+++
-
+[[version515december192019]]
 == 5.1.5 - 2019-12-19
 
 === Fixed
@@ -728,8 +706,7 @@ ____
 * Fixed an exception being raised when inserting content if the caret was directly before or after a `contenteditable="false"` element.
 * Fixed a bug with pasting image URLs when paste as text is enabled.
 
-+++<a class="anchor" id="version514december112019">++++++</a>+++
-
+[[version514december112019]]
 == 5.1.4 - 2019-12-11
 
 === Fixed
@@ -741,8 +718,7 @@ ____
 * Fixed an issue with the `paste` plugin not sanitizing content in some cases.
 * Fixed HTML comments incorrectly being parsed in certain cases.
 
-+++<a class="anchor" id="version513december42019">++++++</a>+++
-
+[[version513december42019]]
 == 5.1.3 - 2019-12-04
 
 === Fixed
@@ -755,8 +731,7 @@ ____
 * Fixed search and replace dialog disappearing when finding offscreen matches on iOS devices.
 * Fixed performance issues where sticky toolbar was jumping while scrolling on slower browsers.
 
-+++<a class="anchor" id="version512november192019">++++++</a>+++
-
+[[version512november192019]]
 == 5.1.2 - 2019-11-19
 
 === Fixed
@@ -778,8 +753,7 @@ ____
 * Fixed quickbars quickimage picker not working on mobile.
 * Fixed fullscreen not resizing in an iOS WKWebView component.
 
-+++<a class="anchor" id="version511october282019">++++++</a>+++
-
+[[version511october282019]]
 == 5.1.1 - 2019-10-28
 
 === Fixed
@@ -789,8 +763,7 @@ ____
 * Fixed clicking outside a modal dialog focusing on the document body.
 * Fixed the context toolbar not hiding when scrolled out of view.
 
-+++<a class="anchor" id="version510october172019">++++++</a>+++
-
+[[version510october172019]]
 == 5.1.0 - 2019-10-17
 
 === Added
@@ -845,8 +818,7 @@ ____
 * Fixed the autocompleter not activating immediately after a `br` or `contenteditable=false` element.
 * Fixed an issue where the autocompleter would incorrectly close on IE 11 in certain edge cases.
 
-+++<a class="anchor" id="version5016september242019">++++++</a>+++
-
+[[version5016september242019]]
 == 5.0.16 - 2019-09-24
 
 === Added
@@ -864,8 +836,7 @@ ____
 * Fixed notifications appearing on top of the toolbar when scrolled in inline mode.
 * Fixed notifications displaying incorrectly on IE 11.
 
-+++<a class="anchor" id="version5015september22019">++++++</a>+++
-
+[[version5015september22019]]
 == 5.0.15 - 2019-09-02
 
 === Added
@@ -882,8 +853,7 @@ ____
 * Fixed `onChange` callback not firing for the colorinput dialog component.
 * Fixed context toolbars not showing in fullscreen mode.
 
-+++<a class="anchor" id="version5014august192019">++++++</a>+++
-
+[[version5014august192019]]
 == 5.0.14 - 2019-08-19
 
 === Added
@@ -903,8 +873,7 @@ ____
 
 * Removed Oxide variable `@menubar-select-disabled-border-color` and replaced it with `@menubar-select-disabled-border`.
 
-+++<a class="anchor" id="version5013august62019">++++++</a>+++
-
+[[version5013august62019]]
 == 5.0.13 - 2019-08-06
 
 === Changed
@@ -928,8 +897,7 @@ ____
 * Fixed dialogs being able to be dragged outside the window viewport.
 * Fixed inline dialogs appearing above modal dialogs.
 
-+++<a class="anchor" id="version5012july182019">++++++</a>+++
-
+[[version5012july182019]]
 == 5.0.12 - 2019-07-18
 
 === Added
@@ -953,8 +921,7 @@ ____
 * Fixed the context toolbar overlapping the toolbar in various conditions.
 * Fixed IE11 edge case where items were being inserted into the wrong location.
 
-+++<a class="anchor" id="version5011july42019">++++++</a>+++
-
+[[version5011july42019]]
 == 5.0.11 - 2019-07-04
 
 === Fixed
@@ -963,8 +930,7 @@ ____
 * Fixed the customeditor component not able to get data from the dialog api.
 * Fixed collection component tooltips not being translated.
 
-+++<a class="anchor" id="version5010july22019">++++++</a>+++
-
+[[version5010july22019]]
 == 5.0.10 - 2019-07-02
 
 === Added
@@ -996,16 +962,14 @@ ____
 * Fixed exception being thrown when creating relative URIs.
 * Fixed focus is no longer set to the editor content during mode changes unless the editor already had focus.
 
-+++<a class="anchor" id="version509june262019">++++++</a>+++
-
+[[version509june262019]]
 == 5.0.9 - 2019-06-26
 
 === Fixed
 
 * Fixed print plugin not working in Firefox.
 
-+++<a class="anchor" id="version508june182019">++++++</a>+++
-
+[[version508june182019]]
 == 5.0.8 - 2019-06-18
 
 === Added
@@ -1034,8 +998,7 @@ ____
 * Fixed native context menu not showing with images in IE11.
 * Fixed inconsistent browser context menu image selection.
 
-+++<a class="anchor" id="version507june52019">++++++</a>+++
-
+[[version507june52019]]
 == 5.0.7 - 2019-06-05
 
 === Added
@@ -1067,8 +1030,7 @@ ____
 * Fixed the autocompleter menu showing up after a selection had been made.
 * Fixed an exception being thrown when a file or number input has focus during initialization. Patch contributed by t00.
 
-+++<a class="anchor" id="version506may222019">++++++</a>+++
-
+[[version506may222019]]
 == 5.0.6 - 2019-05-22
 
 === Added
@@ -1093,8 +1055,7 @@ ____
 * Fixed `mceInsertLink` command inserting spaces instead of url encoded characters.
 * Fixed text content floating on top of dialogs in IE11.
 
-+++<a class="anchor" id="version505may92019">++++++</a>+++
-
+[[version505may92019]]
 == 5.0.5 - 2019-05-09
 
 === Added
@@ -1113,8 +1074,7 @@ ____
 
 * Removed unused and hidden validation icons to avoid displaying phantom tooltips.
 
-+++<a class="anchor" id="version504april232019">++++++</a>+++
-
+[[version504april232019]]
 == 5.0.4 - 2019-04-23
 
 === Added
@@ -1144,8 +1104,7 @@ ____
 
 * Removed redundant mobile wrapper.
 
-+++<a class="anchor" id="version503march192019">++++++</a>+++
-
+[[version503march192019]]
 == 5.0.3 - 2019-03-19
 
 === Changed
@@ -1169,8 +1128,7 @@ ____
 * Fixed the `link` plugin context toolbar missing the open link button.
 * Fixed inconsistent dialog component spacing.
 
-+++<a class="anchor" id="version502march52019">++++++</a>+++
-
+[[version502march52019]]
 == 5.0.2 - 2019-03-05
 
 === Added
@@ -1202,8 +1160,7 @@ ____
 * Fixed the resize icon floating left when all status bar elements were disabled.
 * Fixed the resize handle to not show in fullscreen mode.
 
-+++<a class="anchor" id="version501february212019">++++++</a>+++
-
+[[version501february212019]]
 == 5.0.1 - 2019-02-21
 
 === Added
@@ -1236,8 +1193,7 @@ ____
 
 * Removed paste as text notification banner and paste_plaintext_inform setting.
 
-+++<a class="anchor" id="version500february42019">++++++</a>+++
-
+[[version500february42019]]
 == 5.0.0 - 2019-02-04
 
 Full documentation for the version 5 features and changes is available at \https://www.tiny.cloud/docs/release-notes/
@@ -1262,8 +1218,7 @@ Full documentation for the version 5 features and changes is available at \https
 * Fixed charmap and emoticons dialogs not having a primary button.
 * Fixed an issue where resizing wouldn't work correctly depending on the box-sizing model.
 
-+++<a class="anchor" id="version500-rc-2january222019">++++++</a>+++
-
+[[version500-rc-2january222019]]
 == 5.0.0-rc-2 - 2019-01-22
 
 === Added
@@ -1289,8 +1244,7 @@ Full documentation for the version 5 features and changes is available at \https
 
 * Removed unnecessary 'flex' and unused 'colspan' properties from the new dialog APIs.
 
-+++<a class="anchor" id="version500-rc-1january82019">++++++</a>+++
-
+[[version500-rc-1january82019]]
 == 5.0.0-rc-1 - 2019-01-08
 
 === Added
@@ -1318,8 +1272,7 @@ Full documentation for the version 5 features and changes is available at \https
 * Fixed an issue where preview wouldn't show anything in Edge under certain circumstances.
 * Fixed the height being incorrectly calculated for the autoresize plugin.
 
-+++<a class="anchor" id="version500-beta-1november302018">++++++</a>+++
-
+[[version500-beta-1november302018]]
 == 5.0.0-beta-1 - 2018-11-30
 
 === Added
@@ -1349,8 +1302,7 @@ Full documentation for the version 5 features and changes is available at \https
 
 * Removed compat3x plugin.
 
-+++<a class="anchor" id="version500-preview-4november122018">++++++</a>+++
-
+[[version500-preview-4november122018]]
 == 5.0.0-preview-4 - 2018-11-12
 
 === Added
@@ -1395,8 +1347,7 @@ Full documentation for the version 5 features and changes is available at \https
 
 * Removed the tox-custom-editor class that was added to the wrapping element of codemirror.
 
-+++<a class="anchor" id="version500-preview-3october182018">++++++</a>+++
-
+[[version500-preview-3october182018]]
 == 5.0.0-preview-3 - 2018-10-18
 
 === Changed
@@ -1416,8 +1367,7 @@ Full documentation for the version 5 features and changes is available at \https
 * Fixed vertical alignment of toolbar icons.
 * Fixed toolbar icons not appearing on IE11.
 
-+++<a class="anchor" id="version500-preview-2october102018">++++++</a>+++
-
+[[version500-preview-2october102018]]
 == 5.0.0-preview-2 - 2018-10-10
 
 === Added
@@ -1445,8 +1395,7 @@ Full documentation for the version 5 features and changes is available at \https
 * Removed `colorpicker` plugin, it is now in the theme.
 * Removed `textcolor` plugin, it is now in the theme.
 
-+++<a class="anchor" id="version500-preview-1october12018">++++++</a>+++
-
+[[version500-preview-1october12018]]
 == 5.0.0-preview-1 - 2018-10-01
 
 Developer preview 1

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -4,7 +4,7 @@
 :keywords: changelog
 
 ____
-This is the {productname} Community version changelog. For information about the latest {cloudname} or {enterpriseversion} Release, see: link:{baseurl}/release-notes/[{productname} Release Notes].
+This is the {productname} Community version changelog. For information about the latest {cloudname} or {enterpriseversion} Release, see: xref:release-notes/index.adoc[{productname} Release Notes].
 ____
 
 == 5.10.2 - 2021-11-17

--- a/modules/ROOT/pages/enterprise/server/configure.adoc
+++ b/modules/ROOT/pages/enterprise/server/configure.adoc
@@ -442,6 +442,7 @@ include::partial$misc/custom-dictionaries-path.adoc[]
 
 include::partial$misc/dynamic-custom-dictionaries.adoc[]
 
+[[num-incorrect-words-in-suggestions-request-limitoptional]]
 ==== `num-incorrect-words-in-suggestions-request-limit` (optional)
 
 include::partial$misc/num-incorrect-words-in-suggestions-request-limit.adoc[]

--- a/modules/ROOT/pages/plugins/premium/tinymcespellchecker.adoc
+++ b/modules/ROOT/pages/plugins/premium/tinymcespellchecker.adoc
@@ -117,6 +117,7 @@ tinymce.init({
 });
 ----
 
+[[spellcheckerignoreallevent]]
 === SpellcheckerIgnoreAll event
 
 This event triggers when the user selects *Ignore All* on a misspelled word.

--- a/modules/ROOT/pages/release-notes/6.0-upcoming-changes.adoc
+++ b/modules/ROOT/pages/release-notes/6.0-upcoming-changes.adoc
@@ -7,12 +7,13 @@ This page lists the upcoming changes planned and announced for {productname} 6.0
 
 Contents:
 
-* <<disablingthedeprecationwarning,Disabling the deprecation warning>>
-* <<themes,Themes>>
-* <<plugins,Plugins>>
-* <<options,Options>>
-* <<apis,APIs>>
+* xref:disablingthedeprecationwarning[Disabling the deprecation warning]
+* xref:themes[Themes]
+* xref:plugins[Plugins]
+* xref:options[Options]
+* xref:apis[APIs]
 
+[[disablingthedeprecationwarning]]
 == Disabling the deprecation warning
 
 To disable the {productname} 6.0 deprecation warning, set the `deprecation_warnings` option to `false`.
@@ -29,23 +30,25 @@ tinymce.init({
 });
 ----
 
+[[themes]]
 == Themes
 
 The `mobile` theme:: The dedicated `mobile` theme, sometimes referred to as the *legacy mobile theme* was deprecated with the release of {productname} 5.1 and will be removed in {productname} 6.0. The `silver` theme was updated in {productname} 5.1 to provide an improved mobile experience.
 
+[[plugins]]
 == Plugins
 
 The following plugins will be removed in {productname} 6.0 and will need to be removed from the `plugins` option when upgrading:
 
-BBCode (`bbcode`):: The BBCode plugin (`bbcode`) was deprecated with the release of {productname} 5.9. For details, see link:{baseurl}/release-notes/release-notes59/#thebbcodebbcodeplugin[the BBCode plugin deprecation notice]. The BBCode plugin will be removed in {productname} 6.0.
+BBCode (`bbcode`):: The BBCode plugin (`bbcode`) was deprecated with the release of {productname} 5.9. For details, see xref:release-notes/release-notes59.adoc#thebbcodebbcodeplugin[the BBCode plugin deprecation notice]. The BBCode plugin will be removed in {productname} 6.0.
 
-Full Page (`fullpage`):: The Full Page plugin (`fullpage`) was deprecated with the release of {productname} 5.9. For details, see link:{baseurl}/release-notes/release-notes59/#thefullpagefullpageplugin[the Full Page plugin deprecation notice]. The Full Page plugin will be removed in {productname} 6.0.
+Full Page (`fullpage`):: The Full Page plugin (`fullpage`) was deprecated with the release of {productname} 5.9. For details, see xref:release-notes/release-notes59.adoc#thefullpagefullpageplugin[the Full Page plugin deprecation notice]. The Full Page plugin will be removed in {productname} 6.0.
 
 Image Tools (`imagetools`):: {productname} {productminorversion} will include the final release of the Image Tools plugin (`imagetools`) as an open source plugin. The Image Tools plugin will be removed from the open source bundle and be available as a premium plugin for {productname} 6.0.
 
-Legacy Output (`legacyoutput`):: The Legacy Output plugin (`legacyoutput`) was deprecated with the release of {productname} 5.9. For details, see link:{baseurl}/release-notes/release-notes59/#thelegacyoutputlegacyoutputplugin[the Legacy Output plugin deprecation notice]. The Legacy Output plugin will be removed in {productname} 6.0.
+Legacy Output (`legacyoutput`):: The Legacy Output plugin (`legacyoutput`) was deprecated with the release of {productname} 5.9. For details, see xref:release-notes/release-notes59.adoc#thelegacyoutputlegacyoutputplugin[the Legacy Output plugin deprecation notice]. The Legacy Output plugin will be removed in {productname} 6.0.
 
-Spell Checker (`spellchecker`):: The *free* {productname} Spell Checker plugin (`spellchecker`) was deprecated with the release of {productname} 5.4. For details, see link:{baseurl}/release-notes/release-notes54/#thefreetinymcespellcheckerplugin[the free {productname} Spell Checker plugin deprecation notice]. The free Spell Checker plugin will be removed in {productname} 6.0.
+Spell Checker (`spellchecker`):: The *free* {productname} Spell Checker plugin (`spellchecker`) was deprecated with the release of {productname} 5.4. For details, see xref:release-notes/release-notes54.adoc#thefreetinymcespellcheckerplugin[the free {productname} Spell Checker plugin deprecation notice]. The free Spell Checker plugin will be removed in {productname} 6.0.
 
 Table of Contents (`toc`):: {productname} {productminorversion} will include the final release of the Table of Contents (`toc`) as an open source plugin. The Table of Contents plugin will be removed from the open source bundle and be available as a premium plugin for {productname} 6.0.
 
@@ -55,39 +58,40 @@ The functionality of following plugins was moved to the {productname} core in {p
 * Context Menu
 * Text Color
 
+[[options]]
 == Options
 
 The following options will be changed in {productname} 6.0:
 
-toolbar_mode:: The link:{baseurl}/configure/editor-appearance/#toolbar_mode[`toolbar_mode`] option will no-longer accept the `false` value in {productname} 6.0, which was retained for backwards compatibility with the `toolbar_drawer` option. Use `'wrap'` instead to keep the same functionality as `false`.
+toolbar_mode:: The xref:configure/editor-appearance.adoc#toolbar_mode[`toolbar_mode`] option will no-longer accept the `false` value in {productname} 6.0, which was retained for backwards compatibility with the `toolbar_drawer` option. Use `'wrap'` instead to keep the same functionality as `false`.
 
-forced_root_block:: The link:{baseurl}/configure/content-filtering/#forced_root_block[`forced_root_block`] option will no-longer accept the `false` value or an empty string value in {productname} 6.0. Setting `forced_root_block` to `false` is not compatible with Real-time Collaboration. It also blocks various editor functions from working correctly and causes non-semantic HTML to be generated.
+forced_root_block:: The xref:configure/content-filtering.adoc#forced_root_block[`forced_root_block`] option will no-longer accept the `false` value or an empty string value in {productname} 6.0. Setting `forced_root_block` to `false` is not compatible with Real-time Collaboration. It also blocks various editor functions from working correctly and causes non-semantic HTML to be generated.
 
 The following options have been deprecated in {productname} 5.10 or earlier and will be removed in {productname} 6.0.
 
-autoresize_on_init:: The link:{baseurl}/plugins/opensource/autoresize/#autoresize_on_init[`autoresize_on_init`] option does not affect the autoresize behavior in {productname} 5, as the editor will always resize regardless of this option. This option would only forcibly resize at short intervals after the editor has initialized, which is no longer required and as such will be removed.
+autoresize_on_init:: The xref:plugins/opensource/autoresize.adoc#autoresize_on_init[`autoresize_on_init`] option does not affect the autoresize behavior in {productname} 5, as the editor will always resize regardless of this option. This option would only forcibly resize at short intervals after the editor has initialized, which is no longer required and as such will be removed.
 
-convert_fonts_to_spans:: The link:{baseurl}/configure/content-filtering/#convert_fonts_to_spans[`convert_fonts_to_spans`] option would convert `font` elements to `span` styles to assist with the migration to newer HTML standards. Font elements were included in HTML 3 or earlier standards and have since been deprecated or removed.
+convert_fonts_to_spans:: The xref:configure/content-filtering.adoc#convert_fonts_to_spans[`convert_fonts_to_spans`] option would convert `font` elements to `span` styles to assist with the migration to newer HTML standards. Font elements were included in HTML 3 or earlier standards and have since been deprecated or removed.
 
-gecko_spellcheck:: The link:{baseurl}/configure/spelling/#gecko_spellcheck[`gecko_spellcheck`] option was deprecated and replaced by the link:{baseurl}/configure/spelling/#browser_spellcheck[`browser_spellcheck`] option in {productname} 4.3.
+gecko_spellcheck:: The xref:configure/spelling.adoc#gecko_spellcheck[`gecko_spellcheck`] option was deprecated and replaced by the xref:configure/spelling.adoc#browser_spellcheck[`browser_spellcheck`] option in {productname} 4.3.
 
-images_dataimg_filter:: The link:{baseurl}configure/file-image-upload/#images_dataimg_filter[`images_dataimg_filter`] option was deprecated in {productname} 5.3. This option can be used for an unintended use-case and is not compatible with Real-time Collaboration.
+images_dataimg_filter:: The xref:configure/file-image-upload.adoc#images_dataimg_filter[`images_dataimg_filter`] option was deprecated in {productname} 5.3. This option can be used for an unintended use-case and is not compatible with Real-time Collaboration.
 
-media_scripts:: The link:{baseurl}/plugins/opensource/media/#media_scripts[`media_scripts`] option is no longer useful in the modern web and did not work in most cases. As such it has been deprecated in {productname} 5.10.
+media_scripts:: The xref:plugins/opensource/media.adoc#media_scripts[`media_scripts`] option is no longer useful in the modern web and did not work in most cases. As such it has been deprecated in {productname} 5.10.
 
-paste_convert_word_fake_lists:: The Microsoft Word specific paste handling functionality will be removed from the `paste` plugin. As a result, the link:{baseurl}/plugins/opensource/paste/#paste_convert_word_fake_lists[`paste_convert_word_fake_lists`] option will be removed in {productname} 6.0.
+paste_convert_word_fake_lists:: The Microsoft Word specific paste handling functionality will be removed from the `paste` plugin. As a result, the xref:plugins/opensource/paste.adoc#paste_convert_word_fake_lists[`paste_convert_word_fake_lists`] option will be removed in {productname} 6.0.
 
-paste_retain_style_properties:: The Microsoft Word specific paste handling functionality will be removed from the `paste` plugin. As a result, the link:{baseurl}/plugins/opensource/paste/#paste_retain_style_properties[`paste_retain_style_properties`] option will be removed in {productname} 6.0.
+paste_retain_style_properties:: The Microsoft Word specific paste handling functionality will be removed from the `paste` plugin. As a result, the xref:plugins/opensource/paste.adoc#paste_retain_style_properties[`paste_retain_style_properties`] option will be removed in {productname} 6.0.
 
-paste_word_valid_elements:: The Microsoft Word specific paste handling functionality will be removed from the `paste` plugin. As a result, the link:{baseurl}/plugins/opensource/paste/#paste_word_valid_elements[`paste_word_valid_elements`] option will be removed in {productname} 6.0.
+paste_word_valid_elements:: The Microsoft Word specific paste handling functionality will be removed from the `paste` plugin. As a result, the xref:plugins/opensource/paste.adoc#paste_word_valid_elements[`paste_word_valid_elements`] option will be removed in {productname} 6.0.
 
-spellchecker_select_languages:: The link:{baseurl}/plugins/premium/tinymcespellchecker/#spellchecker_select_languages[`spellchecker_select_languages`] option was deprecated and replaced by the link:{baseurl}/configure/localization/#content_langs[`content_langs`] option in {productname} 5.9. The new option provides better support for the BCP47 standard used for `lang` attributes and increased configuration capabilities.
+spellchecker_select_languages:: The xref:plugins/premium/tinymcespellchecker.adoc#spellchecker_select_languages[`spellchecker_select_languages`] option was deprecated and replaced by the xref:configure/localization.adoc#content_langs[`content_langs`] option in {productname} 5.9. The new option provides better support for the BCP47 standard used for `lang` attributes and increased configuration capabilities.
 
-spellchecker_whitelist:: The `spellchecker_whitelist` option was deprecated and replaced by the link:{baseurl}/plugins/premium/tinymcespellchecker/#spellchecker_ignore_list[`spellchecker_ignore_list`] option in {productname} 5.7. The new option provides additional functionality and avoids insensitive naming.
+spellchecker_whitelist:: The `spellchecker_whitelist` option was deprecated and replaced by the xref:plugins/premium/tinymcespellchecker.adoc#spellchecker_ignore_list[`spellchecker_ignore_list`] option in {productname} 5.7. The new option provides additional functionality and avoids insensitive naming.
 
-table_responsive_width:: The `table_responsive_width` option was deprecated and replaced by the link:{baseurl}/plugins/opensource/table/#table_sizing_mode[`table_sizing_mode`] option in {productname} 5.4. Use the `'relative'` or `'fixed'` sizing modes to keep the same functionality.
+table_responsive_width:: The `table_responsive_width` option was deprecated and replaced by the xref:plugins/opensource/table.adoc#table_sizing_mode[`table_sizing_mode`] option in {productname} 5.4. Use the `'relative'` or `'fixed'` sizing modes to keep the same functionality.
 
-toolbar_drawer:: The `toolbar_drawer` option was deprecated and replaced by the link:{baseurl}/configure/editor-appearance/#toolbar_mode[`toolbar_mode`] option in {productname} 5.2. This change was made to reflect the range of settings available for this option.
+toolbar_drawer:: The `toolbar_drawer` option was deprecated and replaced by the xref:configure/editor-appearance.adoc#toolbar_mode[`toolbar_mode`] option in {productname} 5.2. This change was made to reflect the range of settings available for this option.
 
 The following undocumented or unsupported legacy options will be removed in {productname} 6.0.
 
@@ -97,23 +101,23 @@ boolean_attributes:: The `boolean_attributes` option could override the built-in
 
 content_editable_state:: The `content_editable_state` option controlled the initial state of the `contenteditable` attribute on the editor body. This caused issues. Once set, there was no way to change the state back later using the editor APIs and left the editor in an half-broken state.
 
-editor_deselector:: The `editor_deselector` option is a legacy initialization option from {productname} 3 that allowed developers to specify a class to control which textareas should not be initialized as an editor. It was deprecated and replaced by the link:{baseurl}/configure/integration-and-setup/#selector[`selector`] or link:{baseurl}/configure/integration-and-setup/#target[`target`] options in {productname} 4.
+editor_deselector:: The `editor_deselector` option is a legacy initialization option from {productname} 3 that allowed developers to specify a class to control which textareas should not be initialized as an editor. It was deprecated and replaced by the xref:configure/integration-and-setup.adoc#selector[`selector`] or xref:configure/integration-and-setup.adoc#target[`target`] options in {productname} 4.
 
-editor_selector:: The `editor_selector` option is a legacy initialization option from {productname} 3 that allowed developers to specify a class to control which textareas should be initialized as an editor. It was deprecated and replaced by the link:{baseurl}/configure/integration-and-setup/#selector[`selector`] or link:{baseurl}/configure/integration-and-setup/#target[`target`] options in {productname} 4.
+editor_selector:: The `editor_selector` option is a legacy initialization option from {productname} 3 that allowed developers to specify a class to control which textareas should be initialized as an editor. It was deprecated and replaced by the xref:configure/integration-and-setup.adoc#selector[`selector`] or xref:configure/integration-and-setup.adoc#target[`target`] options in {productname} 4.
 
-elements:: The `elements` option is a legacy initialization option from {productname} 3 that allowed specifying a list of element ids for elements that should be initialized as an editor. It was deprecated and replaced by the link:{baseurl}/configure/integration-and-setup/#selector[`selector`] or link:{baseurl}/configure/integration-and-setup/#target[`target`] options in {productname} 4.
+elements:: The `elements` option is a legacy initialization option from {productname} 3 that allowed specifying a list of element ids for elements that should be initialized as an editor. It was deprecated and replaced by the xref:configure/integration-and-setup.adoc#selector[`selector`] or xref:configure/integration-and-setup.adoc#target[`target`] options in {productname} 4.
 
-file_browser_callback_types:: The `file_browser_callback_types` option was deprecated and replaced by the link:{baseurl}/configure/file-image-upload/#file_picker_types[`file_picker_types`] option in {productname} 5.0.
+file_browser_callback_types:: The `file_browser_callback_types` option was deprecated and replaced by the xref:configure/file-image-upload.adoc#file_picker_types[`file_picker_types`] option in {productname} 5.0.
 
 filepicker_validator_handler:: The `filepicker_validator_handler` option was deprecated and replaced by the `file_picker_validator_handler` option in {productname} 5.0.15 due to inconsistent naming.
 
 force_hex_style_colors:: The `force_hex_style_colors` option was deprecated in {productname} 5.0. This option was used to force color styles stored as hexadecimal values instead of RGB strings.
 
-force_p_newlines:: The `force_p_newlines` option was deprecated and replaced by the link:{baseurl}/configure/content-filtering/#forced_root_block[`forced_root_block`] option in {productname} 3.5. This option had been kept as an undocumented fallback.
+force_p_newlines:: The `force_p_newlines` option was deprecated and replaced by the xref:configure/content-filtering.adoc#forced_root_block[`forced_root_block`] option in {productname} 3.5. This option had been kept as an undocumented fallback.
 
 inline_styles:: The `inline_styles` option was primarily used for assisting with the migration to newer HTML standards. It enabled converting some deprecated HTML 3 or earlier elements to inline styles, such as `font` and `strike`.
 
-mode:: The `mode` option is a legacy initialization option from {productname} 3 that allowed controlling which mode was used to initialize the editor (`exact` or `textareas`). It was deprecated and replaced by the link:{baseurl}/configure/integration-and-setup/#selector[`selector`] or link:{baseurl}/configure/integration-and-setup/#target[`target`] options in {productname} 4.
+mode:: The `mode` option is a legacy initialization option from {productname} 3 that allowed controlling which mode was used to initialize the editor (`exact` or `textareas`). It was deprecated and replaced by the xref:configure/integration-and-setup.adoc#selector[`selector`] or xref:configure/integration-and-setup.adoc#target[`target`] options in {productname} 4.
 
 move_caret_before_on_enter_elements:: The `move_caret_before_on_enter_elements` option allowed developers to override the built-in HTML schema to specify which elements the selection should be moved "in front of" when pressing enter on the keyboard. Using this option can break the editor and requires the default to be repeated with any desired changes.
 
@@ -127,16 +131,17 @@ short_ended_elements:: The `short_ended_elements` option allowed developers to o
 
 special:: The `special` option allowed developers to override the built-in HTML schema to specify which elements should be treated as special and content inside should be treated as text when parsing HTML. Using this option can break the editor and requires the default to be repeated with any desired changes. Additionally, browsers can't be changed to parse differently, so this setting was not useful.
 
-tab_focus:: The `tab_focus` option was deprecated and replaced by the link:{baseurl}/plugins/opensource/tabfocus/#tabfocus_elements[`tabfocus_elements`] option in {productname} 3.2. This option had been kept as an undocumented fallback.
+tab_focus:: The `tab_focus` option was deprecated and replaced by the xref:plugins/opensource/tabfocus.adoc#tabfocus_elements[`tabfocus_elements`] option in {productname} 3.2. This option had been kept as an undocumented fallback.
 
 text_block_elements:: The `text_block_elements` option allowed developers to override the built-in HTML schema to specify which elements should be treated as block text elements (such as those used for formatting). Using this option can break the editor and requires the default to be repeated with any desired changes.
 
 text_inline_elements:: The `text_inline_elements` option allowed developers to override the built-in HTML schema to specify which elements should be treated as inline text elements (such as those used for formatting). Using this option can break the editor and requires the default to be repeated with any desired changes.
 
-types:: The `types` option is a legacy initialization option from {productname} 3 that allowed developers to specify which type of elements should be initialized as an editor. It was deprecated and replaced by the link:{baseurl}/configure/integration-and-setup/#selector[`selector`] or link:{baseurl}/configure/integration-and-setup/#target[`target`] options in {productname} 4.
+types:: The `types` option is a legacy initialization option from {productname} 3 that allowed developers to specify which type of elements should be initialized as an editor. It was deprecated and replaced by the xref:configure/integration-and-setup.adoc#selector[`selector`] or xref:configure/integration-and-setup.adoc#target[`target`] options in {productname} 4.
 
 whitespace_elements:: The `whitespace_elements` option allowed developers to override the built-in HTML schema to specify which elements should be treated as rendering content as verbatim content. Using this option can break the editor and requires the default to be repeated with any desired changes. Additionally, browsers can't be changed to parse differently, so this was only useful to add custom elements.
 
+[[apis]]
 == APIs
 
 The following API classes, methods, or properties have been deprecated in {productname} 5.10 or earlier and will be removed in {productname} 6.0.
@@ -171,7 +176,7 @@ tinymce.html.Schema API methods:: The `getSpecialElements` method has been depre
 
 tinymce.html.Styles API methods:: The `toHex` method has been deprecated in {productname} 5.10. For information on the `toHex` method, see: xref:apis/tinymce.html.styles.adoc#toHex[tinymce.html.Styles - tohex].
 
-tinymce API properties:: The `editors` and `settings` (undocumented) properties have been deprecated in {productname} 5.10. For information on the deprecated properties, see: link:{baseurl}/api/tinymce/root_tinymce/#properties[tinymce - properties].
+tinymce API properties:: The `editors` and `settings` (undocumented) properties have been deprecated in {productname} 5.10. For information on the deprecated properties, see: xref:apis/tinymce.root.adoc#properties[tinymce - properties].
 
 tinymce.AddOnManager API methods:: The `addComponents` and `dependencies` (undocumented) methods have been deprecated in {productname} 5.10. For information on the deprecated methods, see: xref:apis/tinymce.addonmanager.adoc[tinymce.AddOnManager].
 

--- a/modules/ROOT/pages/release-notes/release-notes510.adoc
+++ b/modules/ROOT/pages/release-notes/release-notes510.adoc
@@ -7,18 +7,19 @@
 
 {productname} 5.10 was released for {enterpriseversion} and {cloudname} on Wednesday, October 20^th^, 2021. It includes {productname} 5.10 and additional changes to premium plugins. These release notes provide an overview of the changes for {productname} 5.10, including:
 
-* <<newfeatures,New features>>
-* <<enhancements,Enhancements>>
-* <<functionalitychanges,Functionality changes>>
-* <<accompanyingpremiumpluginchanges,Accompanying Premium Plugin changes>>
-* <<accompanyingpremiumself-hostedserver-sidecomponentchanges,Accompanying Premium self-hosted server-side component changes>>
-* <<generalbugfixes,General bug fixes>>
-* <<securityfixes,Security fixes>>
-* <<deprecatedfeatures,Deprecated features>>
-* <<upgradingtothelatestversionoftinymce5,Upgrading to the latest version of TinyMCE 5>>
+* xref:newfeatures[New features]
+* xref:enhancements[Enhancements]
+* xref:functionalitychanges[Functionality changes]
+* xref:accompanyingpremiumpluginchanges[Accompanying Premium Plugin changes]
+* xref:accompanyingpremiumself-hostedserver-sidecomponentchanges[Accompanying Premium self-hosted server-side component changes]
+* xref:generalbugfixes[General bug fixes]
+* xref:securityfixes[Security fixes]
+* xref:deprecatedfeatures[Deprecated features]
+* xref:upgradingtothelatestversionoftinymce5[Upgrading to the latest version of TinyMCE 5]
 
 include::partial$misc/releasenotes_for_stable.adoc[]
 
+[[newfeatures]]
 == New features
 
 {productname} 5.10 introduces the following minor new features:
@@ -27,12 +28,14 @@ include::partial$misc/releasenotes_for_stable.adoc[]
 * Added the `ESC` key code constant to the `VK` API.
 * Added a new `deprecation_warnings` setting for turning off deprecation console warning messages.
 
+[[enhancements]]
 == Enhancements
 
 {productname} 5.10 introduces the following minor enhancements:
 
 * The `element` argument of the `editor.selection.scrollIntoView()` API is now optional, and if it is not provided the current selection will be scrolled into view.
 
+[[functionalitychanges]]
 == Functionality changes
 
 The following functionality changes were made for the {productname} 5.10 release:
@@ -40,6 +43,7 @@ The following functionality changes were made for the {productname} 5.10 release
 * The deprecated `scope` attribute is no longer added to `td` cells when converting a row to a header row.
 * The number of `col` elements is normalized to match the number of columns in a table after a table action.
 
+[[accompanyingpremiumpluginchanges]]
 == Accompanying Premium Plugin changes
 
 The following premium plugin updates were released alongside {productname} 5.10.
@@ -50,13 +54,13 @@ The {productname} 5.10 release includes an accompanying release of the *Advanced
 
 *Advanced Tables* 1.2.0 introduces the following enhancements:
 
-* Added `getRowType` property to the series generator `info` argument. For details, see link:{baseurl}/plugins/premium/advtable/#generatorinfo[`GeneratorInfo`].
+* Added `getRowType` property to the series generator `info` argument. For details, see xref:plugins/premium/advtable.adoc#generatorinfo[`GeneratorInfo`].
 
 *Advanced Tables* 1.2.0 provides the following bug fixes:
 
 * The selection could be placed in an invalid location when a row numbering column was updated.
 
-For information on the Advanced Tables plugin, see: link:{baseurl}/plugins/premium/advtable/[Advanced Tables plugin].
+For information on the Advanced Tables plugin, see: xref:plugins/premium/advtable.adoc[Advanced Tables plugin].
 
 === Real-time Collaboration 1.1.1
 
@@ -64,9 +68,9 @@ The {productname} 5.10 release includes an accompanying release of the *RTC* pre
 
 *RTC* 1.1.1 adds the following new features:
 
-* Added support for the link:{baseurl}/configure/content-formatting/#indent_use_margin[`indent_use_margin`] option.
-* Added validation of document and role JWT claims. For details, see: link:{baseurl}/rtc/configuration/rtc-options-required/#optionaljwtclaims[`Optional JWT claims`].
-* Added support for the link:{baseurl}/configure/content-filtering/#allow_unsafe_link_target[`allow_unsafe_link_target`] and link:{baseurl}/plugins/opensource/link/#rel_list[`rel_list`] options.
+* Added support for the xref:configure/content-formatting.adoc#indent_use_margin[`indent_use_margin`] option.
+* Added validation of document and role JWT claims. For details, see: xref:rtc/configuration/rtc-options-required.adoc#optionaljwtclaims[`Optional JWT claims`].
+* Added support for the xref:configure/content-filtering.adoc#allow_unsafe_link_target[`allow_unsafe_link_target`] and xref:plugins/opensource/link.adoc#rel_list[`rel_list`] options.
 * RTC will now automatically recover from temporary network connection issues. If the network issues are persistent it will show a disconnected notification after 30 seconds.
 
 *RTC* 1.1.1 introduces the following enhancements:
@@ -83,7 +87,7 @@ The {productname} 5.10 release includes an accompanying release of the *RTC* pre
 * Clear Formatting did not work on collapsed selections.
 * Disconnect was not clean if the page unloaded without removing the editor.
 
-For information on the RTC plugin, see: link:{baseurl}/rtc/[RTC plugin].
+For information on the RTC plugin, see: xref:rtc/index.adoc[RTC plugin].
 
 === Spell Checker Pro 2.5.0
 
@@ -91,14 +95,15 @@ The {productname} 5.10 release includes an accompanying release of the *Spell Ch
 
 *Spell Checker Pro* 2.5.0 introduces the following enhancements:
 
-* The `SpellcheckerIgnoreAll` event now includes a `language` property. For details, see link:{baseurl}/plugins/premium/tinymcespellchecker/#spellcheckerignoreallevent[Spell Checker Pro - SpellcheckerIgnoreAll Event].
+* The `SpellcheckerIgnoreAll` event now includes a `language` property. For details, see xref:plugins/premium/tinymcespellchecker.adoc#spellcheckerignoreallevent[Spell Checker Pro - SpellcheckerIgnoreAll Event].
 
 *Spell Checker Pro* 2.5.0 provides the following bug fixes:
 
 * The "Ignore all" action would incorrectly affect words that were in a different language to the selected word, if they were spelled the same.
 
-For information on the Spell Checker Pro plugin, see: link:{baseurl}/plugins/premium/tinymcespellchecker/[Spell Checker Pro plugin].
+For information on the Spell Checker Pro plugin, see: xref:plugins/premium/tinymcespellchecker.adoc[Spell Checker Pro plugin].
 
+[[accompanyingpremiumself-hostedserver-sidecomponentchanges]]
 == Accompanying Premium self-hosted server-side component changes
 
 The {productname} 5.10 release includes accompanying changes affecting the {productname} *self-hosted* services for the following plugins:
@@ -115,11 +120,11 @@ The Java server-side components have been updated to the following versions:
 * `ephox-hyperlinking.war`: 2.105.5
 * `ephox-image-proxy.war`: 2.105.4
 
-These versions require Java 8 or higher. For information on the removal of Java 7 support, see: link:{baseurl}/release-notes/release-notes53/#removalofjava7support[Removal of Java 7 support for TinyMCE 5.3 and later].
+These versions require Java 8 or higher. For information on the removal of Java 7 support, see: xref:release-notes/release-notes53.adoc#removalofjava7support[Removal of Java 7 support for TinyMCE 5.3 and later].
 
 === New Server-side component features
 
-The Spelling service now includes a new configuration option, allowing the server to reject spelling requests that contain too many incorrect words. For details, see: link:{baseurl}/enterprise/server/configure/#num-incorrect-words-in-suggestions-request-limitoptional[Configure server-side components: `num-incorrect-words-in-suggestions-request-limit`].
+The Spelling service now includes a new configuration option, allowing the server to reject spelling requests that contain too many incorrect words. For details, see: xref:enterprise/server/configure.adoc#num-incorrect-words-in-suggestions-request-limitoptional[Configure server-side components: `num-incorrect-words-in-suggestions-request-limit`].
 
 === Image Proxy service patch release
 
@@ -131,11 +136,11 @@ Version 2.105.5 of the hyperlinking service includes a fix to send `Accept` head
 
 For information on:
 
-* The Spell Checker Pro plugin, see: link:{baseurl}/plugins/premium/tinymcespellchecker/[Spell Checker Pro plugin].
-* The Link Checker plugin, see: link:{baseurl}/plugins/premium/linkchecker/[Link Checker plugin].
-* The Image Tools plugin, see: link:{baseurl}/plugins/opensource/imagetools/[Image Tools plugin].
-* The Enhanced Media Embed plugin, see: link:{baseurl}/plugins/premium/mediaembed/[Enhanced Media Embed plugin].
-* Deploying the server-side components, see: link:{baseurl}/enterprise/server/[Server-side component installation].
+* The Spell Checker Pro plugin, see: xref:plugins/premium/tinymcespellchecker.adoc[Spell Checker Pro plugin].
+* The Link Checker plugin, see: xref:plugins/premium/linkchecker.adoc[Link Checker plugin].
+* The Image Tools plugin, see: xref:plugins/opensource/imagetools.adoc[Image Tools plugin].
+* The Enhanced Media Embed plugin, see: xref:plugins/premium/mediaembed.adoc[Enhanced Media Embed plugin].
+* Deploying the server-side components, see: xref:enterprise/server/index.adoc[Server-side component installation].
 
 === Updating the self-hosted server-side components
 
@@ -152,9 +157,10 @@ The new versions of the server-side services provide updates for the Java-based 
 
 For information on:
 
-* Deploying the server-side components, see: link:{baseurl}/enterprise/server/[Server-side component installation].
-* Deploying the server-side components using Docker, see: link:{baseurl}/enterprise/server/dockerservices/[Containerized service deployments].
+* Deploying the server-side components, see: xref:enterprise/server/index.adoc[Server-side component installation].
+* Deploying the server-side components using Docker, see: xref:enterprise/server/dockerservices.adoc[Containerized service deployments].
 
+[[generalbugfixes]]
 == General bug fixes
 
 {productname} 5.10 provides fixes for the following bugs:
@@ -182,50 +188,55 @@ For information on:
 * `video` and `audio` elements were unable to be played when the `media` plugin live embeds were enabled in some cases.
 * Pasting images would throw an exception if the clipboard `items` were not files (for example, screenshots taken from gnome-software). Patch contributed by cedric-anne.
 
+[[securityfixes]]
 == Security fixes
 
 {productname} 5.10 provides fixes for the following security issues.
 
 Fixed URLs not cleaned correctly in some cases in the `link` and `image` plugins. This caused a medium severity Cross Site Scripting (XSS) vulnerability. Tiny Technologies would like to thank Yakir6 for discovering this vulnerability.
 
+[[deprecatedfeatures]]
 == Deprecated features
 
-For a full list of the features deprecated since the release of {productname} 5.0, see: link:{baseurl}/release-notes/6.0-upcoming-changes/[List of upcoming changes for {productname} 6].
+For a full list of the features deprecated since the release of {productname} 5.0, see: xref:release-notes/6.0-upcoming-changes.adoc[List of upcoming changes for {productname} 6].
 
 The following features have been deprecated with the release of {productname} 5.10:
 
-* <<plugins,Plugins>>
-* <<options,Options>>
-* <<apis,APIs>>
+* xref:plugins[Plugins]
+* xref:options[Options]
+* xref:apis[APIs]
 
+[[plugins]]
 === Plugins
 
 Image Tools (`imagetools`):: {productname} {productminorversion} includes the final release of the Image Tools plugin (`imagetools`) as an open source plugin. The Image Tools plugin will be removed from the open source bundle and be available as a premium plugin from {productname} 6.0.
 
 Table of Contents (`toc`):: {productname} {productminorversion} includes the final release of the Table of Contents (`toc`) as an open source plugin. The Table of Contents plugin will be removed from the open source bundle and be available as a premium plugin from {productname} 6.0.
 
+[[options]]
 === Options
 
 The following settings are not being deprecated, but a supported value or behavior will be removed in {productname} 6.0.
 
-toolbar_mode:: The link:{baseurl}/configure/editor-appearance/#toolbar_mode[`toolbar_mode`] option will no-longer accept the `false` value in {productname} 6.0, which was retained for backwards compatibility with the `toolbar_drawer` option. Use `'wrap'` instead to keep the same functionality as `false`.
+toolbar_mode:: The xref:configure/editor-appearance.adoc#toolbar_mode[`toolbar_mode`] option will no-longer accept the `false` value in {productname} 6.0, which was retained for backwards compatibility with the `toolbar_drawer` option. Use `'wrap'` instead to keep the same functionality as `false`.
 
-forced_root_block:: The link:{baseurl}/configure/content-filtering/#forced_root_block[`forced_root_block`] option will no-longer accept the `false` value or an empty string value in {productname} 6.0. Setting `forced_root_block` to `false` is not compatible with Real-time Collaboration. It also blocks various editor functions from working correctly and causes non-semantic HTML to be generated.
+forced_root_block:: The xref:configure/content-filtering.adoc#forced_root_block[`forced_root_block`] option will no-longer accept the `false` value or an empty string value in {productname} 6.0. Setting `forced_root_block` to `false` is not compatible with Real-time Collaboration. It also blocks various editor functions from working correctly and causes non-semantic HTML to be generated.
 
 The following options have been deprecated in {productname} 5.10.
 
-autoresize_on_init:: The link:{baseurl}/plugins/opensource/autoresize/#autoresize_on_init[`autoresize_on_init`] option does not affect the autoresize behavior in {productname} 5, as the editor will always resize regardless of this option. This option would only forcibly resize at short intervals after the editor has initialized, which is no longer required and as such will be removed.
+autoresize_on_init:: The xref:plugins/opensource/autoresize.adoc#autoresize_on_init[`autoresize_on_init`] option does not affect the autoresize behavior in {productname} 5, as the editor will always resize regardless of this option. This option would only forcibly resize at short intervals after the editor has initialized, which is no longer required and as such will be removed.
 
-convert_fonts_to_spans:: The link:{baseurl}/configure/content-filtering/#convert_fonts_to_spans[`convert_fonts_to_spans`] option would convert `font` elements to `span` styles to assist with the migration to newer HTML standards. Font elements were included in HTML 3 or earlier standards and have since been deprecated or removed.
+convert_fonts_to_spans:: The xref:configure/content-filtering.adoc#convert_fonts_to_spans[`convert_fonts_to_spans`] option would convert `font` elements to `span` styles to assist with the migration to newer HTML standards. Font elements were included in HTML 3 or earlier standards and have since been deprecated or removed.
 
-media_scripts:: The link:{baseurl}/plugins/opensource/media/#media_scripts[`media_scripts`] option is no longer useful in the modern web and did not work in most cases. As such it has been deprecated in {productname} 5.10.
+media_scripts:: The xref:plugins/opensource/media.adoc#media_scripts[`media_scripts`] option is no longer useful in the modern web and did not work in most cases. As such it has been deprecated in {productname} 5.10.
 
-paste_convert_word_fake_lists:: The Microsoft Word specific paste handling functionality will be removed from the `paste` plugin. As a result, the link:{baseurl}/plugins/opensource/paste/#paste_convert_word_fake_lists[`paste_convert_word_fake_lists`] option will be removed in {productname} 6.0.
+paste_convert_word_fake_lists:: The Microsoft Word specific paste handling functionality will be removed from the `paste` plugin. As a result, the xref:plugins/opensource/paste.adoc#paste_convert_word_fake_lists[`paste_convert_word_fake_lists`] option will be removed in {productname} 6.0.
 
-paste_retain_style_properties:: The Microsoft Word specific paste handling functionality will be removed from the `paste` plugin. As a result, the link:{baseurl}/plugins/opensource/paste/#paste_retain_style_properties[`paste_retain_style_properties`] option will be removed in {productname} 6.0.
+paste_retain_style_properties:: The Microsoft Word specific paste handling functionality will be removed from the `paste` plugin. As a result, the xref:plugins/opensource/paste.adoc#paste_retain_style_properties[`paste_retain_style_properties`] option will be removed in {productname} 6.0.
 
-paste_word_valid_elements:: The Microsoft Word specific paste handling functionality will be removed from the `paste` plugin. As a result, the link:{baseurl}/plugins/opensource/paste/#paste_word_valid_elements[`paste_word_valid_elements`] option will be removed in {productname} 6.0.
+paste_word_valid_elements:: The Microsoft Word specific paste handling functionality will be removed from the `paste` plugin. As a result, the xref:plugins/opensource/paste.adoc#paste_word_valid_elements[`paste_word_valid_elements`] option will be removed in {productname} 6.0.
 
+[[apis]]
 === APIs
 
 The following API classes, methods, or properties have been deprecated in {productname} 5.10.
@@ -242,7 +253,7 @@ tinymce.html.Schema API methods:: The `getSpecialElements` method has been depre
 
 tinymce.html.Styles API methods:: The `toHex` method has been deprecated in {productname} 5.10. For information on the `toHex` method, see: xref:apis/tinymce.html.styles.adoc#toHex[tinymce.html.Styles - tohex].
 
-tinymce API properties:: The `editors` and `settings` (undocumented) properties have been deprecated in {productname} 5.10. For information on the deprecated properties, see: link:{baseurl}/api/tinymce/root_tinymce/#properties[tinymce - properties].
+tinymce API properties:: The `editors` and `settings` (undocumented) properties have been deprecated in {productname} 5.10. For information on the deprecated properties, see: xref:apis/tinymce.root.adoc#properties[tinymce - properties].
 
 tinymce.AddOnManager API methods:: The `addComponents` and `dependencies` (undocumented) methods have been deprecated in {productname} 5.10. For information on the deprecated methods, see: xref:apis/tinymce.addonmanager.adoc[tinymce.AddOnManager].
 

--- a/modules/ROOT/pages/release-notes/release-notes5101.adoc
+++ b/modules/ROOT/pages/release-notes/release-notes5101.adoc
@@ -7,14 +7,15 @@
 
 {productname} 5.10.1 was released for {enterpriseversion} and {cloudname} on Wednesday, November 10^th^, 2021. It includes {productname} 5.10.1 and additional changes to premium plugins. These release notes provide an overview of the changes for {productname} 5.10.1, including:
 
-* <<accompanyingpremiumpluginchanges,Accompanying Premium Plugin changes>>
-* <<accompanyingpremiumself-hostedserver-sidecomponentchanges,Accompanying Premium self-hosted server-side component changes>>
-* <<generalbugfixes,General bug fixes>>
-* <<securityfixes,Security fixes>>
-* <<upgradingtothelatestversionoftinymce5,Upgrading to the latest version of TinyMCE 5>>
+* xref:accompanyingpremiumpluginchanges[Accompanying Premium Plugin changes]
+* xref:accompanyingpremiumself-hostedserver-sidecomponentchanges[Accompanying Premium self-hosted server-side component changes]
+* xref:generalbugfixes[General bug fixes]
+* xref:securityfixes[Security fixes]
+* xref:upgradingtothelatestversionoftinymce5[Upgrading to the latest version of TinyMCE 5]
 
 include::partial$misc/releasenotes_for_stable.adoc[]
 
+[[accompanyingpremiumpluginchanges]]
 == Accompanying Premium Plugin changes
 
 The following premium plugin updates were released alongside {productname} 5.10.1.
@@ -25,7 +26,7 @@ The {productname} 5.10.1 release includes an accompanying release of the *Advanc
 
 *Advanced Code* 2.3.2 fixes an exception getting thrown for hints when the editor was rendered in a shadow root.
 
-For information on the Advanced Code plugin, see: link:{baseurl}/plugins/premium/advcode/[Advanced Code plugin].
+For information on the Advanced Code plugin, see: xref:plugins/premium/advcode.adoc[Advanced Code plugin].
 
 === PowerPaste 5.6.1
 
@@ -33,8 +34,9 @@ The {productname} 5.10.1 release includes an accompanying release of the *PowerP
 
 *PowerPaste* 5.6.1 fixes a bug where pasting text content with multiple items on the clipboard did not work.
 
-For information on the PowerPaste plugin, see: link:{baseurl}/plugins/premium/powerpaste/[PowerPaste plugin].
+For information on the PowerPaste plugin, see: xref:plugins/premium/powerpaste.adoc[PowerPaste plugin].
 
+[[accompanyingpremiumself-hostedserver-sidecomponentchanges]]
 == Accompanying Premium self-hosted server-side component changes
 
 The {productname} 5.10.1 release includes accompanying changes affecting the {productname} *self-hosted* services for the following plugins:
@@ -51,21 +53,21 @@ The Java server-side components have been updated to the following versions:
 * `ephox-hyperlinking.war`: 2.105.6
 * `ephox-image-proxy.war`: 2.105.5
 
-This version requires Java 8 or higher. For information on the removal of Java 7 support, see: link:{baseurl}/release-notes/release-notes53/#removalofjava7support[Removal of Java 7 support for TinyMCE 5.3 and later].
+This version requires Java 8 or higher. For information on the removal of Java 7 support, see: xref:release-notes/release-notes53.adoc#removalofjava7support[Removal of Java 7 support for TinyMCE 5.3 and later].
 
 For information on:
 
-* The Spell Checker Pro plugin, see: link:{baseurl}/plugins/premium/tinymcespellchecker/[Spell Checker Pro plugin].
-* The Link Checker plugin, see: link:{baseurl}/plugins/premium/linkchecker/[Link Checker plugin].
-* The Image Tools plugin, see: link:{baseurl}/plugins/opensource/imagetools/[Image Tools plugin].
-* The Enhanced Media Embed plugin, see: link:{baseurl}/plugins/premium/mediaembed/[Enhanced Media Embed plugin].
-* Deploying the server-side components, see: link:{baseurl}/enterprise/server/[Server-side component installation].
+* The Spell Checker Pro plugin, see: xref:plugins/premium/tinymcespellchecker.adoc[Spell Checker Pro plugin].
+* The Link Checker plugin, see: xref:plugins/premium/linkchecker.adoc[Link Checker plugin].
+* The Image Tools plugin, see: xref:plugins/opensource/imagetools.adoc[Image Tools plugin].
+* The Enhanced Media Embed plugin, see: xref:plugins/premium/mediaembed.adoc[Enhanced Media Embed plugin].
+* Deploying the server-side components, see: xref:enterprise/server/index.adoc[Server-side component installation].
 
 === Security related dependency update for all 3 server-side services
 
 IMPORTANT: During further scans, some vulnerable dependencies were missed in this release. As such, these security issues have not been resolved in the 5.10.1 release and will be resolved in an upcoming release. Note that no details of the security vulnerabilities have been publicly disclosed at the time of release.
 
-~~All 3 server-side components have been updated to include dependency updates addressing security issues. This includes _High_ severity vulnerability fixes.~~
++++<del>+++All 3 server-side components have been updated to include dependency updates addressing security issues. This includes _High_ severity vulnerability fixes.+++</del>+++
 
 === Fixed Link Checker highlighting for unresolvable hosts
 
@@ -86,9 +88,10 @@ The new versions of the server-side services provide updates for the Java-based 
 
 For information on:
 
-* Deploying the server-side components, see: link:{baseurl}/enterprise/server/[Server-side component installation].
-* Deploying the server-side components using Docker, see: link:{baseurl}/enterprise/server/dockerservices/[Containerized service deployments].
+* Deploying the server-side components, see: xref:enterprise/server/index.adoc[Server-side component installation].
+* Deploying the server-side components using Docker, see: xref:enterprise/server/dockerservices.adoc[Containerized service deployments].
 
+[[generalbugfixes]]
 == General bug fixes
 
 {productname} 5.10.1 provides fixes for the following bugs:
@@ -104,15 +107,16 @@ For information on:
 * The insert table grid menu displayed an incorrect size when re-opening the grid.
 * The word count plugin was treating the zero width space character (`+&#8203;+`) as a word.
 
+[[securityfixes]]
 == Security fixes
 
 {productname} 5.10.1 provides fixes for the following security issues:
 
 IMPORTANT: During further scans, some vulnerable dependencies were missed in this release. As such, these security issues have not been resolved in the 5.10.1 release and will be resolved in an upcoming release. Note that no details of the security vulnerabilities have been publicly disclosed at the time of release.
 
-~~All 3 server-side components have been updated to include dependency updates addressing security issues. This includes _High_ severity vulnerability fixes.~~
++++<del>+++All 3 server-side components have been updated to include dependency updates addressing security issues. This includes _High_ severity vulnerability fixes.+++</del>+++
 
-~~For information on the server-side components updates, see: <<accompanyingpremiumself-hostedserver-sidecomponentchanges,Accompanying Premium self-hosted server-side component changes>>.~~
++++<del>+++For information on the server-side components updates, see: xref:accompanyingpremiumself-hostedserver-sidecomponentchanges[Accompanying Premium self-hosted server-side component changes].+++</del>+++
 
 :enterprise: true
 

--- a/modules/ROOT/pages/release-notes/release-notes5101.adoc
+++ b/modules/ROOT/pages/release-notes/release-notes5101.adoc
@@ -67,7 +67,8 @@ For information on:
 
 IMPORTANT: During further scans, some vulnerable dependencies were missed in this release. As such, these security issues have not been resolved in the 5.10.1 release and will be resolved in an upcoming release. Note that no details of the security vulnerabilities have been publicly disclosed at the time of release.
 
-+++<del>+++All 3 server-side components have been updated to include dependency updates addressing security issues. This includes _High_ severity vulnerability fixes.+++</del>+++
+[.line-through]
+All 3 server-side components have been updated to include dependency updates addressing security issues. This includes _High_ severity vulnerability fixes.
 
 === Fixed Link Checker highlighting for unresolvable hosts
 
@@ -114,9 +115,11 @@ For information on:
 
 IMPORTANT: During further scans, some vulnerable dependencies were missed in this release. As such, these security issues have not been resolved in the 5.10.1 release and will be resolved in an upcoming release. Note that no details of the security vulnerabilities have been publicly disclosed at the time of release.
 
-+++<del>+++All 3 server-side components have been updated to include dependency updates addressing security issues. This includes _High_ severity vulnerability fixes.+++</del>+++
+[.line-through]
+All 3 server-side components have been updated to include dependency updates addressing security issues. This includes _High_ severity vulnerability fixes.
 
-+++<del>+++For information on the server-side components updates, see: xref:accompanyingpremiumself-hostedserver-sidecomponentchanges[Accompanying Premium self-hosted server-side component changes].+++</del>+++
+[.line-through]
+For information on the server-side components updates, see: xref:accompanyingpremiumself-hostedserver-sidecomponentchanges[Accompanying Premium self-hosted server-side component changes].
 
 :enterprise: true
 

--- a/modules/ROOT/pages/release-notes/release-notes5102.adoc
+++ b/modules/ROOT/pages/release-notes/release-notes5102.adoc
@@ -7,14 +7,15 @@
 
 {productname} 5.10.2 was released for {enterpriseversion} and {cloudname} on Monday, November 22^nd^, 2021. It includes {productname} 5.10.2 and additional changes to premium plugins. These release notes provide an overview of the changes for {productname} 5.10.2, including:
 
-* <<accompanyingpremiumpluginchanges,Accompanying Premium Plugin changes>>
-* <<accompanyingpremiumself-hostedserver-sidecomponentchanges,Accompanying Premium self-hosted server-side component changes>>
-* <<generalbugfixes,General bug fixes>>
-* <<securityfixes,Security fixes>>
-* <<upgradingtothelatestversionoftinymce5,Upgrading to the latest version of TinyMCE 5>>
+* xref:accompanyingpremiumpluginchanges[Accompanying Premium Plugin changes]
+* xref:accompanyingpremiumself-hostedserver-sidecomponentchanges[Accompanying Premium self-hosted server-side component changes]
+* xref:generalbugfixes[General bug fixes]
+* xref:securityfixes[Security fixes]
+* xref:upgradingtothelatestversionoftinymce5[Upgrading to the latest version of TinyMCE 5]
 
 include::partial$misc/releasenotes_for_stable.adoc[]
 
+[[accompanyingpremiumpluginchanges]]
 == Accompanying Premium Plugin changes
 
 The following premium plugin updates were released alongside {productname} 5.10.2.
@@ -25,7 +26,7 @@ The {productname} 5.10.2 release includes an accompanying release of the *Enhanc
 
 *Enhanced Media Embed* 2.2.6 fixes the `mediaembed` content CSS loading incorrectly, which caused it to not display in previews.
 
-For information on the Enhanced Media Embed plugin, see: link:{baseurl}/plugins/premium/mediaembed/[Enhanced Media Embed plugin].
+For information on the Enhanced Media Embed plugin, see: xref:plugins/premium/mediaembed.adoc[Enhanced Media Embed plugin].
 
 === Page Embed 1.1.1
 
@@ -33,8 +34,9 @@ The {productname} 5.10.2 release includes an accompanying release of the *Page E
 
 *Page Embed* 1.1.1 fixes a bug where the wrong media type was used in the source URL dialog field.
 
-For information on the Page Embed plugin, see: link:{baseurl}/plugins/premium/pageembed/[Page Embed plugin].
+For information on the Page Embed plugin, see: xref:plugins/premium/pageembed.adoc[Page Embed plugin].
 
+[[accompanyingpremiumself-hostedserver-sidecomponentchanges]]
 == Accompanying Premium self-hosted server-side component changes
 
 The {productname} 5.10.2 release includes accompanying changes affecting the {productname} *self-hosted* services for the following plugins:
@@ -51,15 +53,15 @@ The Java server-side components have been updated to the following versions:
 * `ephox-hyperlinking.war`: 2.105.7
 * `ephox-image-proxy.war`: 2.105.6
 
-This version requires Java 8 or higher. For information on the removal of Java 7 support, see: link:{baseurl}/release-notes/release-notes53/#removalofjava7support[Removal of Java 7 support for TinyMCE 5.3 and later].
+This version requires Java 8 or higher. For information on the removal of Java 7 support, see: xref:release-notes/release-notes53.adoc#removalofjava7support[Removal of Java 7 support for TinyMCE 5.3 and later].
 
 For information on:
 
-* The Spell Checker Pro plugin, see: link:{baseurl}/plugins/premium/tinymcespellchecker/[Spell Checker Pro plugin].
-* The Link Checker plugin, see: link:{baseurl}/plugins/premium/linkchecker/[Link Checker plugin].
-* The Image Tools plugin, see: link:{baseurl}/plugins/opensource/imagetools/[Image Tools plugin].
-* The Enhanced Media Embed plugin, see: link:{baseurl}/plugins/premium/mediaembed/[Enhanced Media Embed plugin].
-* Deploying the server-side components, see: link:{baseurl}/enterprise/server/[Server-side component installation].
+* The Spell Checker Pro plugin, see: xref:plugins/premium/tinymcespellchecker.adoc[Spell Checker Pro plugin].
+* The Link Checker plugin, see: xref:plugins/premium/linkchecker.adoc[Link Checker plugin].
+* The Image Tools plugin, see: xref:plugins/opensource/imagetools.adoc[Image Tools plugin].
+* The Enhanced Media Embed plugin, see: xref:plugins/premium/mediaembed.adoc[Enhanced Media Embed plugin].
+* Deploying the server-side components, see: xref:enterprise/server/index.adoc[Server-side component installation].
 
 === Security related dependency update for all 3 server-side services
 
@@ -80,22 +82,24 @@ The new versions of the server-side services provide updates for the Java-based 
 
 For information on:
 
-* Deploying the server-side components, see: link:{baseurl}/enterprise/server/[Server-side component installation].
-* Deploying the server-side components using Docker, see: link:{baseurl}/enterprise/server/dockerservices/[Containerized service deployments].
+* Deploying the server-side components, see: xref:enterprise/server/index.adoc[Server-side component installation].
+* Deploying the server-side components using Docker, see: xref:enterprise/server/dockerservices.adoc[Containerized service deployments].
 
+[[generalbugfixes]]
 == General bug fixes
 
 {productname} 5.10.2 provides fixes for the following bugs:
 
 * Internal selectors were appearing in the style list when using the `importcss` plugin.
 
+[[securityfixes]]
 == Security fixes
 
 {productname} 5.10.2 provides fixes for the following security issues:
 
 All 3 server-side components have been updated to include dependency updates addressing security issues. This includes _High_ severity vulnerability fixes.
 
-For information on the server-side components updates, see: <<accompanyingpremiumself-hostedserver-sidecomponentchanges,Accompanying Premium self-hosted server-side component changes>>.
+For information on the server-side components updates, see: xref:accompanyingpremiumself-hostedserver-sidecomponentchanges[Accompanying Premium self-hosted server-side component changes].
 
 :enterprise: true
 

--- a/modules/ROOT/pages/release-notes/release-notes53.adoc
+++ b/modules/ROOT/pages/release-notes/release-notes53.adoc
@@ -159,6 +159,7 @@ For information on:
 * The Enhanced Media Embed plugin, see: link:{baseurl}/plugins/premium/mediaembed/[Enhanced Media Embed plugin].
 * Deploying the server-side components, see: link:{baseurl}/enterprise/server/[Server-side component installation].
 
+[[removalofjava7support]]
 === Removal of Java 7 support
 
 Java 7 support has been removed with this release. The {productname} Java server-side components now require a minimum of Java 8. From the {productname} 5.3 release, the `.war` files provided in the self-hosted bundles will not be compatible with Java 7. This change resolves security issues present in the older versions of these services. The following plugins are affected by this change:

--- a/modules/ROOT/pages/release-notes/release-notes59.adoc
+++ b/modules/ROOT/pages/release-notes/release-notes59.adoc
@@ -385,6 +385,7 @@ With the release of {productname} 5.9, the `spellchecker_select_languages` optio
 
 For information on the `content_langs` option, see: link:{baseurl}/plugins/premium/tinymcespellchecker/#content_langs[Spell Checker Pro - `content_langs`].
 
+[[thebbcodebbcodeplugin]]
 === The BBCode (`bbcode`) plugin
 
 The BBCode plugin (`bbcode`) has been deprecated and will be removed in the 6.0 release of {productname}.
@@ -398,6 +399,7 @@ The Full Page plugin (`fullpage`) has been deprecated and will be removed in the
 
 To develop and maintain a new Full Page plugin based on the {productname} Full Page plugin, you can create a fork using the https://github.com/tinymce/tinymce-dist/tree/5.8.2/plugins/fullpage[Full Page plugin source code in the TinyMCE distribution repository].
 
+[[thelegacyoutputlegacyoutputplugin]]
 === The Legacy Output (`legacyoutput`) plugin
 
 The Legacy Output plugin (`legacyoutput`) has been deprecated and will be removed in the 6.0 release of {productname}.

--- a/modules/ROOT/partials/configuration/advtable_value_series.adoc
+++ b/modules/ROOT/partials/configuration/advtable_value_series.adoc
@@ -79,6 +79,7 @@ The `generator` is a callback function used to specify how a table cell of a val
 
 If the "state" of the series needs to be kept between generator iterations, additional properties can be added to the generator result. The state can be accessed through the `prev` property of the `info` parameter. For details, see: <<generatorinfo,GeneratorInfo>>.
 
+[[generatorinfo]]
 ===== GeneratorInfo
 
 An object with the following properties is passed to the generator callback function as the `info` parameter.

--- a/modules/ROOT/partials/configuration/autoresize_on_init.adoc
+++ b/modules/ROOT/partials/configuration/autoresize_on_init.adoc
@@ -1,3 +1,4 @@
+[[autoresize_on_init]]
 === `autoresize_on_init`
 
 include::partial$DEPRECATED/generic-5_10.adoc[]

--- a/modules/ROOT/partials/configuration/convert_fonts_to_spans.adoc
+++ b/modules/ROOT/partials/configuration/convert_fonts_to_spans.adoc
@@ -1,5 +1,5 @@
 [[convert_fonts_to_spans]]
-== convert_fonts_to_spans
+== `convert_fonts_to_spans`
 
 include::partial$DEPRECATED/generic-5_10.adoc[]
 

--- a/modules/ROOT/partials/configuration/convert_fonts_to_spans.adoc
+++ b/modules/ROOT/partials/configuration/convert_fonts_to_spans.adoc
@@ -1,3 +1,4 @@
+[[convert_fonts_to_spans]]
 == convert_fonts_to_spans
 
 include::partial$DEPRECATED/generic-5_10.adoc[]

--- a/modules/ROOT/partials/configuration/file_picker_types.adoc
+++ b/modules/ROOT/partials/configuration/file_picker_types.adoc
@@ -1,3 +1,4 @@
+[[file_picker_types]]
 == `file_picker_types`
 
 This option enables you to specify what types of file pickers you need by a space or comma separated list of type names. There are currently three valid types: `file`, `image` and `media`.

--- a/modules/ROOT/partials/configuration/media_scripts.adoc
+++ b/modules/ROOT/partials/configuration/media_scripts.adoc
@@ -1,3 +1,4 @@
+[[media_scripts]]
 === `media_scripts`
 
 include::partial$DEPRECATED/generic-5_10.adoc[]

--- a/modules/ROOT/partials/configuration/paste_convert_word_fake_lists.adoc
+++ b/modules/ROOT/partials/configuration/paste_convert_word_fake_lists.adoc
@@ -1,3 +1,4 @@
+[[paste_convert_word_fake_lists]]
 === `paste_convert_word_fake_lists`
 
 include::partial$DEPRECATED/generic-5_10.adoc[]

--- a/modules/ROOT/partials/configuration/paste_retain_style_properties.adoc
+++ b/modules/ROOT/partials/configuration/paste_retain_style_properties.adoc
@@ -1,3 +1,4 @@
+[[paste_retain_style_properties]]
 === `paste_retain_style_properties`
 
 include::partial$DEPRECATED/generic-5_10.adoc[]

--- a/modules/ROOT/partials/configuration/paste_word_valid_elements.adoc
+++ b/modules/ROOT/partials/configuration/paste_word_valid_elements.adoc
@@ -1,3 +1,4 @@
+[[paste_word_valid_elements]]
 === `paste_word_valid_elements`
 
 include::partial$DEPRECATED/generic-5_10.adoc[]

--- a/modules/ROOT/partials/configuration/rtc_token_provider.adoc
+++ b/modules/ROOT/partials/configuration/rtc_token_provider.adoc
@@ -55,6 +55,7 @@ Return data::
 | A timestamp indicating the token expiry date and time.
 |===
 
+[[optionaljwtclaims]]
 === Optional JWT claims
 
 [cols=",^,"]

--- a/modules/ROOT/partials/configuration/spellchecker_ignore_list.adoc
+++ b/modules/ROOT/partials/configuration/spellchecker_ignore_list.adoc
@@ -1,3 +1,4 @@
+[[spellchecker_ignore_list]]
 === `spellchecker_ignore_list`
 
 This option specifies which words should be ignored by the spell checker. If an array of words is provided, the specified words will be ignored for all languages. If an object containing an array of words per language is provided, the specified words will be ignored for the specified languages.

--- a/modules/ROOT/partials/configuration/spellchecker_select_languages.adoc
+++ b/modules/ROOT/partials/configuration/spellchecker_select_languages.adoc
@@ -1,3 +1,4 @@
+[[spellchecker_select_languages]]
 === `spellchecker_select_languages`
 
 IMPORTANT: This option will be removed in {productname} 6.0.

--- a/modules/ROOT/partials/configuration/tabfocus_elements.adoc
+++ b/modules/ROOT/partials/configuration/tabfocus_elements.adoc
@@ -1,3 +1,4 @@
+[[tabfocus_elements]]
 === `tabfocus_elements`
 
 This option enables you to specify an element `ID` to focus when the user presses the tab key inside the editor. You can also use the special `":prev"` and `":next"` values. It will then place the focus on either the previous or next input element placed before/after the {productname} instance in the DOM.

--- a/modules/ROOT/partials/configuration/target.adoc
+++ b/modules/ROOT/partials/configuration/target.adoc
@@ -1,3 +1,4 @@
+[[target]]
 == `target`
 
 Sometimes there might be already a reference to a DOM element at hand, for example when element is created dynamically. In such case initialising editor on it by link:{baseurl}/configure/integration-and-setup/#selector[selector] might seem irrational (since selector - _id_ or _class_ should be created first). In such cases you can supply that element directly via `target` option.

--- a/modules/ROOT/partials/install/upgrading-info.adoc
+++ b/modules/ROOT/partials/install/upgrading-info.adoc
@@ -85,18 +85,18 @@ Customizations for {productname} are typically stored in the following directori
 +
 [source, sh]
 ----
- tinymce/
- ├── icons/
- ├── langs/
- ├── plugins/
- ├── skins/
- │   ├── content/
- │   └── ui/
- └── themes/
+tinymce/
+├── icons/
+├── langs/
+├── plugins/
+├── skins/
+│   ├── content/
+│   └── ui/
+└── themes/
 ----
 
 . Download the latest version of {productname}.
- ** For the {productname} Community Version, download `{prodnamecode}_<VERSION>.zip` from link:{gettiny}/self-hosted/[Get {productname} - Self-hosted releases], where _`<VERSION>`_ is the latest version of {productname}.
+ ** For the {productname} Community Version, download `{prodnamecode}_<VERSION>.zip` from link:{gettiny}/self-hosted/[Get {productname} - Self-hosted releases], where `_<VERSION>_` is the latest version of {productname}.
  ** For the {productname} Enterprise Version, download the *{productname} Enterprise Bundle* from link:{accountpageurl}/downloads/[{accountpage} > Downloads]. The downloaded file will be named `enterprise_latest.zip`.
 . Extract the downloaded `.zip` file to a temporary location.
 . (If required) Install the latest language packs from link:{gettiny}/language-packages/[Get {productname} - Language Packages].

--- a/modules/ROOT/partials/install/upgrading-info.adoc
+++ b/modules/ROOT/partials/install/upgrading-info.adoc
@@ -1,3 +1,4 @@
+[[upgradingtothelatestversionoftinymce5]]
 == Upgrading to the latest version of TinyMCE 5
 
 The procedure for upgrading to the latest version of {productname} {productmajorversion} depends on the deployment type.

--- a/modules/ROOT/partials/misc/releasenotes_for_stable.adoc
+++ b/modules/ROOT/partials/misc/releasenotes_for_stable.adoc
@@ -1,1 +1,1 @@
-NOTE: This is the Tiny Cloud and TinyMCE Enterprise release notes. For information on the latest community version of TinyMCE, see: link:https://www.tiny.cloud/docs/changelog/[TinyMCE Changelog].
+NOTE: This is the Tiny Cloud and TinyMCE Enterprise release notes. For information on the latest community version of TinyMCE, see: xref:changelog.adoc[TinyMCE Changelog].

--- a/modules/ROOT/partials/misc/releasenotes_for_stable.adoc
+++ b/modules/ROOT/partials/misc/releasenotes_for_stable.adoc
@@ -1,1 +1,1 @@
-NOTE: This is the Tiny Cloud and TinyMCE Enterprise release notes. For information on the latest community version of TinyMCE, see: [TinyMCE Changelog](https://www.tiny.cloud/docs/changelog/).
+NOTE: This is the Tiny Cloud and TinyMCE Enterprise release notes. For information on the latest community version of TinyMCE, see: link:https://www.tiny.cloud/docs/changelog/[TinyMCE Changelog].


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
It covers:

- Changelog
- Release TinyMCE 6.0
- Release TinyMCE 5.10.2
- Release TinyMCE 5.10.1
- Release TinyMCE 5.10

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
