### PR TITLE
Feature/tinymce5update 3 releases 5.7.1 to 5.6

### DIFF
--- a/modules/ROOT/pages/advanced/events.adoc
+++ b/modules/ROOT/pages/advanced/events.adoc
@@ -82,6 +82,7 @@ tinymce.init({
 * https://developer.mozilla.org/en-US/docs/Web/API/Element/touchstart_event[touchstart]
 * https://developer.mozilla.org/en-US/docs/Web/API/Element/wheel_event[wheel]
 
+[[editorcoreevents]]
 == Editor core events
 
 The following events are provided by the {productname} editor.

--- a/modules/ROOT/pages/plugins/opensource/table.adoc
+++ b/modules/ROOT/pages/plugins/opensource/table.adoc
@@ -150,6 +150,7 @@ include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 tinymce.activeEditor.plugins.table.insertTable(2, 3);
 ----
 
+[[events]]
 == Events
 
 include::partial$events/table-events.adoc[]

--- a/modules/ROOT/pages/plugins/premium/tinymcespellchecker.adoc
+++ b/modules/ROOT/pages/plugins/premium/tinymcespellchecker.adoc
@@ -87,6 +87,7 @@ include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
+[[commands]]
 == Commands
 
 The Spell Checker Pro plugin provides the following commands.
@@ -221,6 +222,7 @@ tinymce.init({
 });
 ----
 
+[[apis]]
 == APIs
 
 The {pluginname} plugin provides the following APIs.

--- a/modules/ROOT/pages/plugins/premium/tinymcespellchecker.adoc
+++ b/modules/ROOT/pages/plugins/premium/tinymcespellchecker.adoc
@@ -94,6 +94,7 @@ The Spell Checker Pro plugin provides the following commands.
 
 include::partial$commands/tinymcespellchecker-cmds.adoc[]
 
+[[events]]
 == Events
 
 include::partial$events/tinymcespellchecker-events.adoc[]

--- a/modules/ROOT/pages/release-notes/release-notes56.adoc
+++ b/modules/ROOT/pages/release-notes/release-notes56.adoc
@@ -163,7 +163,7 @@ The {productname} 5.6 release includes an accompanying release of the *PowerPast
 *PowerPaste* 5.4.0 also provides the following bug fixes:
 
 * Fixed the `Cut` menu item not working in the latest version of Firefox.
-* Fixed two Cross-Site Scripting (XSS) vulnerability issues. For more information, see: xref:security-fixes[Security fixes].
+* Fixed two Cross-Site Scripting (XSS) vulnerability issues. For more information, see: xref:securityfixes[Security fixes].
 
 For information on the PowerPaste plugin, see: xref:plugins/premium/powerpaste.adoc[PowerPaste plugin].
 

--- a/modules/ROOT/pages/release-notes/release-notes56.adoc
+++ b/modules/ROOT/pages/release-notes/release-notes56.adoc
@@ -34,7 +34,7 @@ For information on the `images_file_types` option, see: xref:configure/file-imag
 
 A new `emojiimages` database has been added to the Emoticons plugin. This database uses images provided by the Twitter Emoji (twemoji) project to render emojis in the content.
 
-:feature: ``emojiimages`` database
+:feature: pass:q[``emojiimages`` database]
 :third_party_product: Twitter Emoji (Twemoji) graphics
 :license_agreement_name: CC-BY 4.0
 include::partial$misc/under-license.adoc[]

--- a/modules/ROOT/pages/release-notes/release-notes56.adoc
+++ b/modules/ROOT/pages/release-notes/release-notes56.adoc
@@ -7,15 +7,16 @@
 
 {productname} 5.6 was released for {enterpriseversion} and {cloudname} on Tuesday, December 8^th^, 2020. It includes {productname} 5.6.1 and additional changes to premium plugins. These release notes provide an overview of the changes for {productname} 5.6, including:
 
-* <<newfeatures,New features>>
-* <<enhancements,Enhancements>>
-* <<accompanyingpremiumpluginchanges,Accompanying Premium Plugin changes>>
-* <<generalbugfixes,General bug fixes>>
-* <<securityfixes,Security fixes>>
-* <<upgradingtothelatestversionoftinymce5,Upgrading to the latest version of TinyMCE 5>>
+* xref:newfeatures[New features]
+* xref:enhancements[Enhancements]
+* xref:accompanyingpremiumpluginchanges[Accompanying Premium Plugin changes]
+* xref:generalbugfixes[General bug fixes]
+* xref:securityfixes[Security fixes]
+* xref:upgradingtothelatestversionoftinymce5[Upgrading to the latest version of TinyMCE 5]
 
 include::partial$misc/releasenotes_for_stable.adoc[]
 
+[[newfeatures]]
 == New features
 
 The following new features were added for the {productname} 5.6 release.
@@ -27,7 +28,7 @@ The new `images_file_types` option allows different image file extensions to be 
 * Smart Paste's image URL to embedded image functionality.
 * Allowed file extensions for the Image plugin.
 
-For information on the `images_file_types` option, see: link:{baseurl}/configure/file-image-upload/#images_file_types[Image & file options - images_file_types].
+For information on the `images_file_types` option, see: xref:configure/file-image-upload.adoc#images_file_types[Image & file options - images_file_types].
 
 === New image emoji database for the Emoticons plugin
 
@@ -42,14 +43,14 @@ A new `emoticons_database` option has been added to specify which built-in emoji
 
 For information on:
 
-* The `emojiimages` database and `emoticons_database` option, see: link:{baseurl}/plugins/opensource/emoticons/#emoticons_database[Emoticons plugin - `emoticons_database`].
-* The `emoticons_images_url` option, see: link:{baseurl}/plugins/opensource/emoticons/#emoticons_images_url[Emoticons plugin - `emoticons_images_url`].
+* The `emojiimages` database and `emoticons_database` option, see: xref:plugins/opensource/emoticons.adoc#emoticons_database[Emoticons plugin - `emoticons_database`].
+* The `emoticons_images_url` option, see: xref:plugins/opensource/emoticons.adoc#emoticons_images_url[Emoticons plugin - `emoticons_images_url`].
 
 === New `format_empty_lines` option for content formatting
 
 A new `format_empty_lines` option allows empty lines to be formatted for multi-line selections when applying an "inline" format such as bold (`<strong>`).
 
-For information on the `format_empty_lines` option, see: link:{baseurl}/configure/content-formatting/#format_empty_lines[Content Formatting - `format_empty_lines`].
+For information on the `format_empty_lines` option, see: xref:configure/content-formatting.adoc#format_empty_lines[Content Formatting - `format_empty_lines`].
 
 === New editor events
 
@@ -60,14 +61,14 @@ For information on the `format_empty_lines` option, see: link:{baseurl}/configur
 
 For information on:
 
-* The `TableModified` event, see: link:{baseurl}/plugins/opensource/table/#events[Table plugin - `events`].
-* Core editor events, see: link:{baseurl}/advanced/events/#editorcoreevents[Editor core events].
+* The `TableModified` event, see: xref:plugins/opensource/table.adoc#events[Table plugin - `events`].
+* Core editor events, see: xref:advanced/events.adoc#editorcoreevents[Editor core events].
 
 === New card menu item for the autocompleter
 
 A new card menu item has been added to the autocompleter, allowing for greater customization of the autocompleter results displayed to the user.
 
-For information on customizing autocompleter results with `CardMenuItem`, see: link:{baseurl}/ui-components/autocompleter/#cardmenuitem[UI components - Autocompleter - `CardMenuItem`].
+For information on customizing autocompleter results with `CardMenuItem`, see: xref:ui-components/autocompleter.adoc#cardmenuitem[UI components - Autocompleter - `CardMenuItem`].
 
 === Additional new features
 
@@ -76,6 +77,7 @@ For information on customizing autocompleter results with `CardMenuItem`, see: l
 * Added new user interface `enable`, `disable`, and `isDisabled` methods.
 * Added new `closest` formatter API to get the closest matching selection format from a set of formats.
 
+[[enhancements]]
 == Enhancements
 
 The following enhancements were made for the {productname} 5.6 release.
@@ -88,8 +90,9 @@ Clicking links when the editor is in `readonly` mode will open the URL in a new 
 
 A new optional `name` field that sets a specific name to the format when it's being registered using the `style_formats` option.
 
-For information on the `name` field, see: link:{baseurl}/configure/editor-appearance/#style_formats[User interface - `style_formats`].
+For information on the `name` field, see: xref:configure/editor-appearance.adoc#style_formats[User interface - `style_formats`].
 
+[[accompanyingpremiumpluginchanges]]
 == Accompanying Premium Plugin changes
 
 The following premium plugin updates were released alongside {productname} 5.6.
@@ -100,7 +103,7 @@ The {productname} 5.6 release includes an accompanying release of the *Accessibi
 
 *Accessibility Checker* 2.3.1 fixes an issue where internal {productname} elements were not ignored.
 
-For information on the Accessibility Checker plugin, see: link:{baseurl}/plugins/premium/a11ychecker/[Accessibility Checker plugin].
+For information on the Accessibility Checker plugin, see: xref:plugins/premium/a11ychecker.adoc[Accessibility Checker plugin].
 
 === Advanced Code Editor 2.3.0
 
@@ -115,7 +118,7 @@ The {productname} 5.6 release includes an accompanying release of the *Advanced 
 * Fixed the code view not using monospace fonts.
 * Fixed an issue where non-breaking spaces were inserted instead of regular spaces on Safari.
 
-For information on the Advanced Code Editor plugin, see: link:{baseurl}/plugins/premium/advcode/[Advanced Code Editor plugin].
+For information on the Advanced Code Editor plugin, see: xref:plugins/premium/advcode.adoc[Advanced Code Editor plugin].
 
 === Comments 2.3.0
 
@@ -131,7 +134,7 @@ The {productname} 5.6 release includes an accompanying release of the *Comments*
 * Fixed long comments getting cut off.
 * Fixed a scrollbar appearing in the textarea when writing a comment.
 
-For information on the Comments plugin, see: link:{baseurl}/plugins/premium/comments/[Comments plugin].
+For information on the Comments plugin, see: xref:plugins/premium/comments/index.adoc[Comments plugin].
 
 === Mentions 2.2.0
 
@@ -147,7 +150,7 @@ The {productname} 5.6 release includes an accompanying release of the *Mentions*
 
 * Fixed mentions not converted to `contenteditable=false` elements when set using `editor.setContent()`
 
-For information on the Mentions plugin, see: link:{baseurl}/plugins/premium/mentions/[Mentions plugin].
+For information on the Mentions plugin, see: xref:plugins/premium/mentions.adoc[Mentions plugin].
 
 === PowerPaste 5.4.0
 
@@ -160,9 +163,9 @@ The {productname} 5.6 release includes an accompanying release of the *PowerPast
 *PowerPaste* 5.4.0 also provides the following bug fixes:
 
 * Fixed the `Cut` menu item not working in the latest version of Firefox.
-* Fixed two Cross-Site Scripting (XSS) vulnerability issues. For more information, see: <<security-fixes,Security fixes>>.
+* Fixed two Cross-Site Scripting (XSS) vulnerability issues. For more information, see: xref:security-fixes[Security fixes].
 
-For information on the PowerPaste plugin, see: link:{baseurl}/plugins/premium/powerpaste/[PowerPaste plugin].
+For information on the PowerPaste plugin, see: xref:plugins/premium/powerpaste.adoc[PowerPaste plugin].
 
 === Spell Checker Pro 2.2.0
 
@@ -179,8 +182,9 @@ The {productname} 5.6 release includes an accompanying release of the *Spell Che
 * Fixed the spellchecker dialog not checking incorrect words outside of the window viewport.
 * Fixed the spellchecker as-you-type functionality interfering with the dialog.
 
-For information on the Spell Checker Pro plugin, see: link:{baseurl}/plugins/premium/tinymcespellchecker/[Spell Checker Pro plugin].
+For information on the Spell Checker Pro plugin, see: xref:plugins/premium/tinymcespellchecker.adoc[Spell Checker Pro plugin].
 
+[[generalbugfixes]]
 == General bug fixes
 
 {productname} 5.6 provides fixes for the following bugs:
@@ -216,6 +220,7 @@ For information on the Spell Checker Pro plugin, see: link:{baseurl}/plugins/pre
 * Fixed the `mceTableRowType` and `mceTableCellType` commands were not firing the `newCell` event.
 * Fixed the HTML5 `s` element was not recognized when editing or clearing text formatting.
 
+[[securityfixes]]
 == Security fixes
 
 {productname} 5.6 provides fixes for the following security issues:

--- a/modules/ROOT/pages/release-notes/release-notes562.adoc
+++ b/modules/ROOT/pages/release-notes/release-notes562.adoc
@@ -7,12 +7,13 @@
 
 {productname} 5.6.2 was released for {enterpriseversion} and {cloudname} on Wednesday, December 9^th^, 2020. It includes {productname} 5.6.2 and additional changes to premium plugins. These release notes provide an overview of the changes for {productname} 5.6.2, including:
 
-* <<accompanyingpremiumchanges,Accompanying Premium changes>>
-* <<generalbugfixes,General bug fixes>>
-* <<upgradingtothelatestversionoftinymce5,Upgrading to the latest version of TinyMCE 5>>
+* xref:accompanyingpremiumchanges[Accompanying Premium changes]
+* xref:generalbugfixes[General bug fixes]
+* xref:upgradingtothelatestversionoftinymce5[Upgrading to the latest version of TinyMCE 5]
 
 include::partial$misc/releasenotes_for_stable.adoc[]
 
+[[accompanyingpremiumchanges]]
 == Accompanying Premium changes
 
 The following premium updates were released alongside {productname} 5.6.2.
@@ -25,8 +26,9 @@ The *Enterprise language packs* include the following bug fix:
 
 * Fixes Swedish translations (`sv_SE`).
 
-For information on the Enterprise language packs, see: link:{baseurl}/configure/localization/#language[Localization options - `language`].
+For information on the Enterprise language packs, see: xref:configure/localization.adoc#language[Localization options - `language`].
 
+[[generalbugfixes]]
 == General bug fixes
 
 {productname} 5.6.2 provides fixes for the following bugs:

--- a/modules/ROOT/pages/release-notes/release-notes57.adoc
+++ b/modules/ROOT/pages/release-notes/release-notes57.adoc
@@ -7,18 +7,19 @@
 
 {productname} 5.7 was released for {enterpriseversion} and {cloudname} on Wednesday, February 24 ^th^, 2021. It includes {productname} 5.7 and additional changes to premium plugins. These release notes provide an overview of the changes for {productname} 5.7, including:
 
-* <<newfeatures,New features>>
-* <<enhancements,Enhancements>>
-* <<accompanyingpremiumpluginchanges,Accompanying Premium Plugin changes>>
-* <<accompanyingpremiumskinsandiconpackschanges,Accompanying Premium Skins and Icon Packs changes>>
-* <<accompanyingpremiumself-hostedserver-sidecomponentchanges,Accompanying Premium self-hosted server-side component changes>>
-* <<generalbugfixes,General bug fixes>>
-* <<deprecatedfeatures,Deprecated features>>
-* <<knownissues,Known issues>>
-* <<upgradingtothelatestversionoftinymce5,Upgrading to the latest version of TinyMCE 5>>
+* xref:newfeatures[New features]
+* xref:enhancements[Enhancements]
+* xref:accompanyingpremiumpluginchanges[Accompanying Premium Plugin changes]
+* xref:accompanyingpremiumskinsandiconpackschanges[Accompanying Premium Skins and Icon Packs changes]
+* xref:accompanyingpremiumself-hostedserver-sidecomponentchanges[Accompanying Premium self-hosted server-side component changes]
+* xref:generalbugfixes[General bug fixes]
+* xref:deprecatedfeatures[Deprecated features]
+* xref:knownissues[Known issues]
+* xref:upgradingtothelatestversionoftinymce5[Upgrading to the latest version of TinyMCE 5]
 
 include::partial$misc/releasenotes_for_stable.adoc[]
 
+[[newfeatures]]
 == New features
 
 The following new features were added for the {productname} 5.7 release.
@@ -30,14 +31,15 @@ When inserting or deleting table columns, the resizing behavior will now respect
 * `table_column_resizing: 'preservetable'` - The columns will resize to fit the width of the table.
 * `table_column_resizing: 'resizetable'` - The table will resize to fit the width of the columns.
 
-For information on the `table_column_resizing` option, see: link:{baseurl}/plugins/opensource/table/#table_column_resizing[Table plugin - `table_column_resizing`].
+For information on the `table_column_resizing` option, see: xref:plugins/opensource/table.adoc#table_column_resizing[Table plugin - `table_column_resizing`].
 
 === Added new `font_css` option
 
 The `font_css` option loads the specified font CSS files into both the editable area and the webpage {productname} is rendered in. This is useful for ensuring that {productname} UI uses the correct fonts for font family examples and for content that uses those fonts, or for ensuring {productname} content and content outside the editor that should use the same fonts renders correctly.
 
-For information on the `font_css` option, see: link:{baseurl}/configure/content-appearance/#font-css[Content Appearance - `font_css`].
+For information on the `font_css` option, see: xref:configure/content-appearance.adoc#font-css[Content Appearance - `font_css`].
 
+[[enhancements]]
 == Enhancements
 
 The following enhancements were made for the {productname} 5.7 release.
@@ -49,7 +51,7 @@ Notifications opened with the Notifications API will now remain visible when the
 For information on:
 
 * The {productname} `setProgress()` API, see xref:apis/tinymce.editor.adoc#setProgressState[Editor API - `setProgressState`].
-* The Notifications API, see link:{baseurl}/advanced/creating-custom-notifications[Create custom notifications].
+* The Notifications API, see xref:advanced/creating-custom-notifications.adoc[Create custom notifications].
 
 === Table widths are now retained when copying and pasting tables
 
@@ -66,13 +68,13 @@ The `lists` plugin has been updated to improve toggling lists on content contain
 
 The `media_live_embeds` option now supports rendering live embeds of `audio` and `video` elements while editing content. The elements can now also be resized without having to open a dialog to manually change the size.
 
-For information on the `media_live_embeds` option, see: link:{baseurl}/plugins/opensource/media/#media_live_embeds[Media plugin - `media_live_embeds`].
+For information on the `media_live_embeds` option, see: xref:plugins/opensource/media.adoc#media_live_embeds[Media plugin - `media_live_embeds`].
 
 === Enhanced `TableModified` event data
 
 The `TableModified` event now contains additional data which specifies whether the table structure, style, or both were modified.
 
-For information on the `TableModified` event, see: link:{baseurl}/plugins/opensource/table/#events[Table plugin - Events].
+For information on the `TableModified` event, see: xref:plugins/opensource/table.adoc#events[Table plugin - Events].
 
 === Added IPv6 URI parsing support
 
@@ -93,6 +95,7 @@ For information on the `URI` API, see: xref:apis/tinymce.util.uri.adoc[URI].
 * Changed the type signature for `editor.selection.getRng()` incorrectly returning `null`.
 * Changed some `SaxParser` regular expressions to improve performance.
 
+[[accompanyingpremiumpluginchanges]]
 == Accompanying Premium Plugin changes
 
 The following premium plugin updates were released alongside {productname} 5.7.
@@ -103,7 +106,7 @@ The {productname} 5.7 release includes an accompanying release of the *Advanced 
 
 *Advanced Tables* 1.0.2 fixes an issue where the `TableModified` event was not fired when sorting a table.
 
-For information on the `TableModified` event, see: link:{baseurl}/plugins/opensource/table/#events[Table plugin - Events].
+For information on the `TableModified` event, see: xref:plugins/opensource/table.adoc#events[Table plugin - Events].
 
 === Mentions 2.2.1
 
@@ -114,7 +117,7 @@ The {productname} 5.7 release includes an accompanying release of the *Mentions*
 * Fixed hover cards not being visible in fullscreen mode.
 * Fixed hover card not positioned correctly if the editor has scrolled.
 
-For information on the Mentions plugin, see: link:{baseurl}/plugins/premium/mentions/[Mentions plugin].
+For information on the Mentions plugin, see: xref:plugins/premium/mentions.adoc[Mentions plugin].
 
 === PowerPaste 5.4.1
 
@@ -122,7 +125,7 @@ The {productname} 5.7 release includes an accompanying release of the *PowerPast
 
 *PowerPaste* 5.4.1 fixes an issue where file extensions with uppercase characters were treated as invalid.
 
-For information on the PowerPaste plugin, see: link:{baseurl}/plugins/premium/powerpaste/[PowerPaste plugin].
+For information on the PowerPaste plugin, see: xref:plugins/premium/powerpaste.adoc[PowerPaste plugin].
 
 === Spell Checker Pro 2.3.0
 
@@ -140,7 +143,7 @@ The {productname} 5.7 release includes an accompanying release of the *Spell Che
 * `getLanguage`
 * `setLanguage`
 
-For information on the Spell Checker Pro API, see: link:{baseurl}/plugins/premium/tinymcespellchecker/#apis[Spell Checker Pro - APIs].
+For information on the Spell Checker Pro API, see: xref:plugins/premium/tinymcespellchecker.adoc#apis[Spell Checker Pro - APIs].
 
 ===== New Spell Checker Pro Commands
 
@@ -151,13 +154,13 @@ For information on the Spell Checker Pro API, see: link:{baseurl}/plugins/premiu
 * `mceSpellcheckDialog`
 * `mceSpellcheckDialogClose`
 
-For information on the Spell Checker Pro Commands, see: link:{baseurl}/plugins/premium/tinymcespellchecker/#commands[Spell Checker Pro - Commands].
+For information on the Spell Checker Pro Commands, see: xref:plugins/premium/tinymcespellchecker.adoc#commands[Spell Checker Pro - Commands].
 
 ===== New Spell Checker Pro Event
 
 *Spell Checker Pro* introduces a new `SpellcheckerLanguageChanged` event which is fired when the active language is changed.
 
-For information on the Spell Checker Pro Events, see: link:{baseurl}/plugins/premium/tinymcespellchecker/#events[Spell Checker Pro - `Events`].
+For information on the Spell Checker Pro Events, see: xref:plugins/premium/tinymcespellchecker.adoc#events[Spell Checker Pro - `Events`].
 
 ==== Spell Checker Pro - Enhancements
 
@@ -165,9 +168,9 @@ For information on the Spell Checker Pro Events, see: link:{baseurl}/plugins/pre
 
 ===== The `spellchecker_ignore_list` option now accepts arrays of words for specific languages
 
-*Spell Checker Pro* 2.3.0 introduces enhancements to the `spellchecker_ignore_list` (formerly `spellchecker_whitelist`, see: <<thespellchecker_whitelistoptionhasbeenrenamed,The `spellchecker_whitelist` option has been renamed>>).
+*Spell Checker Pro* 2.3.0 introduces enhancements to the `spellchecker_ignore_list` (formerly `spellchecker_whitelist`, see: xref:thespellchecker_whitelistoptionhasbeenrenamed[The `spellchecker_whitelist` option has been renamed]).
 
-It is now possible to specify arrays of words for specific languages to be ignored by the Spell Checker Pro plugin using the `spellchecker_ignore_list` option, see: link:{baseurl}/plugins/premium/tinymcespellchecker/#spellchecker_ignore_list[Spell Checker Pro - `spellchecker_ignore_list`].
+It is now possible to specify arrays of words for specific languages to be ignored by the Spell Checker Pro plugin using the `spellchecker_ignore_list` option, see: xref:plugins/premium/tinymcespellchecker.adoc#spellchecker_ignore_list[Spell Checker Pro - `spellchecker_ignore_list`].
 
 ==== Spell Checker Pro - Bug fixes
 
@@ -177,8 +180,9 @@ It is now possible to specify arrays of words for specific languages to be ignor
 * Fixed a regression that caused errors to be thrown if the editor was destroyed while spellchecking.
 * Fixed an issue where the spellchecker would incorrectly check content inside of special elements such as `style`.
 
-For information on the Spell Checker Pro plugin, see: link:{baseurl}/plugins/premium/tinymcespellchecker/[Spell Checker Pro].
+For information on the Spell Checker Pro plugin, see: xref:plugins/premium/tinymcespellchecker.adoc[Spell Checker Pro].
 
+[[accompanyingpremiumskinsandiconpackschanges]]
 == Accompanying Premium Skins and Icon Packs changes
 
 The {productname} 5.7 release includes an accompanying release of the *Premium Skins and Icon Packs*.
@@ -187,7 +191,7 @@ The {productname} 5.7 release includes an accompanying release of the *Premium S
 
 A new `bootstrap` icon pack is now available that provides https://icons.getbootstrap.com/[Bootstrap icons] for {productname}.
 
-For information on using premium skins and icon packs, see: link:{baseurl}/enterprise/premium-skins-and-icon-packs/[Premium Skins and Icon Packs].
+For information on using premium skins and icon packs, see: xref:enterprise/premium-skins-and-icon-packs/index.adoc[Premium Skins and Icon Packs].
 
 === Premium Skins and Icon Packs - Bug fixes
 
@@ -196,8 +200,9 @@ The *Premium Skins and Icon Packs* release includes the following bug fixes:
 * Fixes an issue where the Snow skin had a transparent inline and sticky toolbar, as well as a transparent toolbar in fullscreen mode.
 * Fixes an issue where the Snow skin special characters and emoticons dialog icons disappeared on hover.
 
-For information on using premium skins and icon packs, see: link:{baseurl}/enterprise/premium-skins-and-icon-packs/[Premium Skins and Icon Packs].
+For information on using premium skins and icon packs, see: xref:enterprise/premium-skins-and-icon-packs/index.adoc[Premium Skins and Icon Packs].
 
+[[accompanyingpremiumself-hostedserver-sidecomponentchanges]]
 == Accompanying Premium self-hosted server-side component changes
 
 The {productname} 5.7 release includes accompanying changes affecting the {productname} *self-hosted* services for the following plugins:
@@ -213,12 +218,13 @@ This version upgraded and replaced internal dependencies to provide upstream bug
 
 For information on:
 
-* The Spell Checker Pro plugin, see: link:{baseurl}/plugins/premium/tinymcespellchecker/[Spell Checker Pro plugin].
-* The Link Checker plugin, see: link:{baseurl}/plugins/premium/linkchecker/[Link Checker plugin].
-* The Image Tools plugin, see: link:{baseurl}/plugins/opensource/imagetools/[Image Tools plugin].
-* The Enhanced Media Embed plugin, see: link:{baseurl}/plugins/premium/mediaembed/[Enhanced Media Embed plugin].
-* Deploying the server-side components, see: link:{baseurl}/enterprise/server/[Server-side component installation].
+* The Spell Checker Pro plugin, see: xref:plugins/premium/tinymcespellchecker.adoc[Spell Checker Pro plugin].
+* The Link Checker plugin, see: xref:plugins/premium/linkchecker.adoc[Link Checker plugin].
+* The Image Tools plugin, see: xref:plugins/opensource/imagetools.adoc[Image Tools plugin].
+* The Enhanced Media Embed plugin, see: xref:plugins/premium/mediaembed.adoc[Enhanced Media Embed plugin].
+* Deploying the server-side components, see: xref:enterprise/server/index.adoc[Server-side component installation].
 
+[[generalbugfixes]]
 == General bug fixes
 
 {productname} 5.7 provides fixes for the following bugs:
@@ -249,26 +255,30 @@ For information on:
 * Fixed an issue where file extensions with uppercase characters were treated as invalid.
 * Fixed dialog block messages were not passed through TinyMCE's translation system.
 
+[[deprecatedfeatures]]
 == Deprecated features
 
 The following features have been deprecated with the release of {productname} 5.7:
 
-* <<thespellchecker_whitelistoptionhasbeenrenamed,The `spellchecker_whitelist` option has been renamed>>.
+* xref:thespellchecker_whitelistoptionhasbeenrenamed[The `spellchecker_whitelist` option has been renamed].
 
+[[thespellchecker_whitelistoptionhasbeenrenamed]]
 === The `spellchecker_whitelist` option has been renamed
 
 With the release of {productname} 5.7, the `spellchecker_whitelist` option has been renamed to `spellchecker_ignore_list`.
 
-For information on the `spellchecker_ignore_list` option, see: link:{baseurl}/plugins/premium/tinymcespellchecker/#spellchecker_ignore_list[Spell Checker Pro - `spellchecker_ignore_list`].
+For information on the `spellchecker_ignore_list` option, see: xref:plugins/premium/tinymcespellchecker.adoc#spellchecker_ignore_list[Spell Checker Pro - `spellchecker_ignore_list`].
 
+[[knownissues]]
 == Known issues
 
 This section describes issues that users of {productname} 5.7 may encounter and possible workarounds for these issues.
 
 *Outline*
 
-* <<rowsortingnotworkingfortableswithcolgroupelements,Row sorting not working for tables with `colgroup` elements>>
+* xref:rowsortingnotworkingfortableswithcolgroupelements[Row sorting not working for tables with `colgroup` elements]
 
+[[rowsortingnotworkingfortableswithcolgroupelements]]
 === Row sorting not working for tables with `colgroup` elements
 
 *Issue*: This issue affects the row sorting functionality provided by the *Advanced Tables* plugin. If a row sort is performed on a table containing colgroups, the editor will return invalid HTML.

--- a/modules/ROOT/pages/release-notes/release-notes571.adoc
+++ b/modules/ROOT/pages/release-notes/release-notes571.adoc
@@ -7,13 +7,14 @@
 
 {productname} 5.7.1 was released for {enterpriseversion} and {cloudname} on Wednesday, March 24^th^, 2021. It includes {productname} 5.7.1 and additional changes to premium plugins. These release notes provide an overview of the changes for {productname} 5.7.1, including:
 
-* <<accompanyingpremiumpluginchanges,Accompanying Premium Plugin changes>>
-* <<generalbugfixes,General bug fixes>>
-* <<securityfixes,Security fixes>>
-* <<upgradingtothelatestversionoftinymce5,Upgrading to the latest version of TinyMCE 5>>
+* xref:accompanyingpremiumpluginchanges[Accompanying Premium Plugin changes]
+* xref:generalbugfixes[General bug fixes]
+* xref:securityfixes[Security fixes]
+* xref:upgradingtothelatestversionoftinymce5[Upgrading to the latest version of TinyMCE 5]
 
 include::partial$misc/releasenotes_for_stable.adoc[]
 
+[[accompanyingpremiumpluginchanges]]
 == Accompanying Premium Plugin changes
 
 The following premium plugin updates were released alongside {productname} 5.7.1.
@@ -26,8 +27,9 @@ The {productname} 5.7.1 release includes an accompanying release of the *PowerPa
 
 * Fixed a security issue where dragging and dropping content wasn't correctly sanitized in some cases.
 
-For information on the PowerPaste plugin, see: link:{baseurl}/plugins/premium/powerpaste/[PowerPaste plugin].
+For information on the PowerPaste plugin, see: xref:plugins/premium/powerpaste.adoc[PowerPaste plugin].
 
+[[generalbugfixes]]
 == General bug fixes
 
 {productname} 5.7.1 provides fixes for the following bugs:
@@ -38,6 +40,7 @@ For information on the PowerPaste plugin, see: link:{baseurl}/plugins/premium/po
 * Fixed context menu items lacking support for the `disabled` and `shortcut` properties.
 * Fixed a regression where the width and height were incorrectly set when embedding content using the `media` dialog.
 
+[[securityfixes]]
 == Security fixes
 
 {productname} 5.7.1 provides fixes for the following security issues.

--- a/modules/ROOT/pages/ui-components/autocompleter.adoc
+++ b/modules/ROOT/pages/ui-components/autocompleter.adoc
@@ -108,6 +108,7 @@ This is the standard item for the autocompleter. If no type is specified, autoco
 }
 ----
 
+[[cardmenuitem]]
 ==== CardMenuItem
 
 include::partial$misc/requires_5_6v.adoc[]

--- a/modules/ROOT/partials/configuration/emoticons_database.adoc
+++ b/modules/ROOT/partials/configuration/emoticons_database.adoc
@@ -1,3 +1,4 @@
+[[emoticons_database]]
 === `emoticons_database`
 
 include::partial$misc/requires_5_6v.adoc[]

--- a/modules/ROOT/partials/configuration/emoticons_images_url.adoc
+++ b/modules/ROOT/partials/configuration/emoticons_images_url.adoc
@@ -1,3 +1,4 @@
+[[emoticons_images_url]]
 === `emoticons_images_url`
 
 include::partial$misc/requires_5_6v.adoc[]

--- a/modules/ROOT/partials/configuration/font_css.adoc
+++ b/modules/ROOT/partials/configuration/font_css.adoc
@@ -1,3 +1,4 @@
+[[font-css]]
 == font_css
 
 The `font_css` option loads the specified font CSS files into both the editable area and the webpage {productname} is rendered in.

--- a/modules/ROOT/partials/configuration/font_css.adoc
+++ b/modules/ROOT/partials/configuration/font_css.adoc
@@ -1,5 +1,5 @@
 [[font-css]]
-== font_css
+== `font_css`
 
 The `font_css` option loads the specified font CSS files into both the editable area and the webpage {productname} is rendered in.
 

--- a/modules/ROOT/partials/configuration/images_file_types.adoc
+++ b/modules/ROOT/partials/configuration/images_file_types.adoc
@@ -1,3 +1,4 @@
+[[images_file_types]]
 === `images_file_types`
 
 include::partial$misc/requires_5_6v.adoc[]

--- a/modules/ROOT/partials/configuration/media_live_embeds.adoc
+++ b/modules/ROOT/partials/configuration/media_live_embeds.adoc
@@ -1,3 +1,4 @@
+[[media_live_embeds]]
 === `media_live_embeds`
 
 When you enable this option users will see a live preview of embedded video content within the editable area, rather than a placeholder image. This means that users can play a video clip, such as YouTube, within the editor.

--- a/modules/ROOT/partials/configuration/spellchecker_ignore_list.adoc
+++ b/modules/ROOT/partials/configuration/spellchecker_ignore_list.adoc
@@ -1,3 +1,4 @@
+[[spellchecker_ignore_list]]
 === `spellchecker_ignore_list`
 
 This option specifies which words should be ignored by the spell checker. If an array of words is provided, the specified words will be ignored for all languages. If an object containing an array of words per language is provided, the specified words will be ignored for the specified languages.

--- a/modules/ROOT/partials/configuration/table_column_resizing.adoc
+++ b/modules/ROOT/partials/configuration/table_column_resizing.adoc
@@ -1,3 +1,4 @@
+[[table_column_resizing]]
 === `table_column_resizing`
 
 include::partial$misc/requires_5_5v.adoc[]

--- a/modules/ROOT/partials/misc/releasenotes_for_stable.adoc
+++ b/modules/ROOT/partials/misc/releasenotes_for_stable.adoc
@@ -1,1 +1,1 @@
-NOTE: This is the Tiny Cloud and TinyMCE Enterprise release notes. For information on the latest community version of TinyMCE, see: link:https://www.tiny.cloud/docs/changelog/[TinyMCE Changelog].
+NOTE: This is the Tiny Cloud and TinyMCE Enterprise release notes. For information on the latest community version of TinyMCE, see: xref:changelog.adoc[TinyMCE Changelog].

--- a/modules/ROOT/partials/misc/releasenotes_for_stable.adoc
+++ b/modules/ROOT/partials/misc/releasenotes_for_stable.adoc
@@ -1,1 +1,1 @@
-NOTE: This is the Tiny Cloud and TinyMCE Enterprise release notes. For information on the latest community version of TinyMCE, see: [TinyMCE Changelog](https://www.tiny.cloud/docs/changelog/).
+NOTE: This is the Tiny Cloud and TinyMCE Enterprise release notes. For information on the latest community version of TinyMCE, see: link:https://www.tiny.cloud/docs/changelog/[TinyMCE Changelog].


### PR DESCRIPTION
Related Ticket: 

Description of Changes, it covers:

- Release TinyMCE 5.7.1
- Release TinyMCE 5.7
- Release TinyMCE 5.6.2
- Release TinyMCE 5.6


Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
