### PR TITLE
DOC-1616: Various maintenance fixes or improvements

### DIFF
--- a/_new_content_templates/pluginpage.adoc
+++ b/_new_content_templates/pluginpage.adoc
@@ -1,6 +1,6 @@
 = <Plugin Name> plugin
 
-:title_nav: <Plugin Name>
+:navtitle: <Plugin Name>
 :description: <What does this plugin do? What is the benefit? (One sentence description)>.
 :description_short: <Like description, but shorter (if possible)>.
 :keywords: plugin <plugincode> etc.

--- a/_new_content_templates/releasenotes_blank/x_y_z-release-notes-core-changes.adoc
+++ b/_new_content_templates/releasenotes_blank/x_y_z-release-notes-core-changes.adoc
@@ -4,7 +4,7 @@ Replace vnumtxt with the version number such as: X.Y.Z
 
 = New features, enhancements, and changes for TinyMCE vnumtxt core and core plugins
 
-:title_nav: Core improvements
+:navtitle: Core improvements
 :description: New features, enhancements, and functionality changes for TinyMCE vnumtxt
 :keywords: releasenotes bugfixes
 

--- a/_new_content_templates/releasenotes_blank/x_y_z-release-notes-core-fixes.adoc
+++ b/_new_content_templates/releasenotes_blank/x_y_z-release-notes-core-fixes.adoc
@@ -4,7 +4,7 @@ Replace vnumtxt with the version number such as: X.Y.Z
 
 = vnumtxt Core and core plugin bug fixes
 
-:title_nav: Core bug fixes
+:navtitle: Core bug fixes
 :description: Bug fixes for TinyMCE vnumtxt
 :keywords: releasenotes bugfixes
 

--- a/_new_content_templates/releasenotes_blank/x_y_z-release-notes-core-security-fixes.adoc
+++ b/_new_content_templates/releasenotes_blank/x_y_z-release-notes-core-security-fixes.adoc
@@ -4,7 +4,7 @@ Replace vnumtxt with the version number such as: X.Y.Z
 
 = vnumtxt Security fixes
 
-:title_nav: Security fixes
+:navtitle: Security fixes
 :description: Security fixes in TinyMCE vnumtxt
 :keywords: releasenotes bugfixes security
 

--- a/_new_content_templates/releasenotes_blank/x_y_z-release-notes-deprecated-features.adoc
+++ b/_new_content_templates/releasenotes_blank/x_y_z-release-notes-deprecated-features.adoc
@@ -4,7 +4,7 @@ Replace vnumtxt with the version number such as: X.Y.Z
 
 = vnumtxt Deprecated features
 
-:title_nav: Deprecated features
+:navtitle: Deprecated features
 :description: Features deprecated in TinyMCE vnumtxt
 :keywords: releasenotes deprecations deprecated deprecate remove removed
 

--- a/_new_content_templates/releasenotes_blank/x_y_z-release-notes-known-issues.adoc
+++ b/_new_content_templates/releasenotes_blank/x_y_z-release-notes-known-issues.adoc
@@ -4,7 +4,7 @@ Replace vnumtxt with the version number such as: X.Y.Z
 
 = vnumtxt Known issues
 
-:title_nav: Known issues
+:navtitle: Known issues
 :description: Known issues for TinyMCE vnumtxt
 :keywords: releasenotes issues
 

--- a/_new_content_templates/releasenotes_blank/x_y_z-release-notes-overview.adoc
+++ b/_new_content_templates/releasenotes_blank/x_y_z-release-notes-overview.adoc
@@ -16,7 +16,7 @@ The following "list" should be added to `data/nav.yml`
 
 = TinyMCE vnumtxt
 
-:title_nav: TinyMCE vnumtxt
+:navtitle: TinyMCE vnumtxt
 :description: Release notes overview for TinyMCE vnumtxt
 :keywords: releasenotes new changes bugfixes
 

--- a/_new_content_templates/releasenotes_blank/x_y_z-release-notes-premium-changes.adoc
+++ b/_new_content_templates/releasenotes_blank/x_y_z-release-notes-premium-changes.adoc
@@ -5,7 +5,7 @@ Replace vnumcode with the version number without points, such as XYZ
 
 = Accompanying premium feature changes
 
-:title_nav: Premium Features
+:navtitle: Premium Features
 :description: Premium feature changes accompanying TinyMCE vnumtxt
 :keywords: releasenotes premium bugfixes
 

--- a/extensions/live-demo.js
+++ b/extensions/live-demo.js
@@ -131,7 +131,6 @@ const loadContent = (engine, catalog, id, docAttrs) => {
     if (catalogFile !== undefined) {
       data[type] = engine.parseAndRenderSync(catalogFile, {
         baseurl: `${docAttrs['site-url']}/${ctx.component}/${ctx.version}`,
-        baseimagesurl: `${docAttrs['site-url']}/${ctx.component}/${ctx.version}/${docAttrs['imagesdir']}`,
         ...docAttrs
       });
       data[hasKey] = true;

--- a/modules/ROOT/examples/live-demos/drive-plugin-browse/index.js
+++ b/modules/ROOT/examples/live-demos/drive-plugin-browse/index.js
@@ -1,5 +1,5 @@
 tinymce.init({
-  tinydrive_demo_files_url: '{{baseimagesurl}}/tiny-drive-demo/demo_files.json',
+  tinydrive_demo_files_url: '{{imagesdir}}/tiny-drive-demo/demo_files.json',
   tinydrive_token_provider: (success) => {
     success({ token: 'fake-token' });
   },

--- a/modules/ROOT/examples/live-demos/live-demo.adoc.liquid
+++ b/modules/ROOT/examples/live-demos/live-demo.adoc.liquid
@@ -2,9 +2,9 @@
 {% comment %} Add cloud script(s) {% endcomment %}
 {%- if liveDemo.script.include -%}
 <script src="{{ liveDemo.script.url }}" referrerpolicy="origin"></script>
-{%- if liveDemo.type == 'tinydrive' -%}
+{%- if liveDemo.css.size > 0 -%}
 <style>
-{% include 'tinydrive.css' %}
+{{ liveDemo.css }}
 </style>
 {%- endif -%}
 {%- endif -%}

--- a/modules/ROOT/examples/live-demos/open-source-plugins/style.css
+++ b/modules/ROOT/examples/live-demos/open-source-plugins/style.css
@@ -1,4 +1,4 @@
-/* For other boilerplate styles, see: {{baseurl}}/editor-content-css.html */
+/* For other boilerplate styles, see: {{baseurl}}/editor-content-css/ */
 /*
 * For rendering images inserted using the image plugin.
 * Includes image captions using the HTML5 figure element.

--- a/modules/ROOT/pages/6_0_0-release-notes-core-changes.adoc
+++ b/modules/ROOT/pages/6_0_0-release-notes-core-changes.adoc
@@ -1,6 +1,6 @@
 = New features, enhancements, and changes for TinyMCE 6.0 core and core plugins
 
-:title_nav: Core improvements
+:navtitle: Core improvements
 :description: New features, enhancements, and functionality changes for TinyMCE 6.0
 :keywords: releasenotes bugfixes
 

--- a/modules/ROOT/pages/6_0_0-release-notes-core-fixes.adoc
+++ b/modules/ROOT/pages/6_0_0-release-notes-core-fixes.adoc
@@ -1,6 +1,6 @@
 = 6.0 Core and core plugin bug fixes
 
-:title_nav: Core bug fixes
+:navtitle: Core bug fixes
 :description: Bug fixes for TinyMCE 6.0
 :keywords: releasenotes bugfixes
 

--- a/modules/ROOT/pages/6_0_0-release-notes-core-security-fixes.adoc
+++ b/modules/ROOT/pages/6_0_0-release-notes-core-security-fixes.adoc
@@ -1,6 +1,6 @@
 = 6.0 Security fixes
 
-:title_nav: Security fixes
+:navtitle: Security fixes
 :description: Security fixes in TinyMCE 6.0
 :keywords: releasenotes bugfixes security
 

--- a/modules/ROOT/pages/6_0_0-release-notes-deprecated-features.adoc
+++ b/modules/ROOT/pages/6_0_0-release-notes-deprecated-features.adoc
@@ -1,6 +1,6 @@
 = 6.0 Deprecated features
 
-:title_nav: Deprecated features
+:navtitle: Deprecated features
 :description: Features deprecated in TinyMCE 6.0
 :keywords: releasenotes deprecations deprecated deprecate remove removed
 

--- a/modules/ROOT/pages/6_0_0-release-notes-known-issues.adoc
+++ b/modules/ROOT/pages/6_0_0-release-notes-known-issues.adoc
@@ -1,6 +1,6 @@
 = 6.0 Known issues
 
-:title_nav: Known issues
+:navtitle: Known issues
 :description: Known issues for TinyMCE 6.0
 :keywords: releasenotes issues
 

--- a/modules/ROOT/pages/6_0_0-release-notes-overview.adoc
+++ b/modules/ROOT/pages/6_0_0-release-notes-overview.adoc
@@ -1,6 +1,6 @@
 = Overview
 
-:title_nav: Overview
+:navtitle: Overview
 :description: Release notes overview for TinyMCE 6.0
 :keywords: releasenotes new changes bugfixes breaking changes
 

--- a/modules/ROOT/pages/6_0_0-release-notes-premium-changes.adoc
+++ b/modules/ROOT/pages/6_0_0-release-notes-premium-changes.adoc
@@ -1,6 +1,6 @@
 = Accompanying premium feature changes
 
-:title_nav: Premium Features
+:navtitle: Premium Features
 :description: Premium feature changes accompanying TinyMCE 6.0
 :keywords: releasenotes premium bugfixes
 

--- a/modules/ROOT/pages/a11ychecker.adoc
+++ b/modules/ROOT/pages/a11ychecker.adoc
@@ -15,7 +15,7 @@ The `+a11ychecker+` premium plugin allows you to check the HTML in the editor fo
 
 == Interactive example
 
-liveDemo::a11ychecker[ ]
+liveDemo::a11ychecker[]
 
 include::partial$misc/purchase-premium-plugins.adoc[]
 

--- a/modules/ROOT/pages/a11ychecker.adoc
+++ b/modules/ROOT/pages/a11ychecker.adoc
@@ -1,6 +1,6 @@
 = Accessibility Checker plugin
 
-:title_nav: Accessibility Checker
+:navtitle: Accessibility Checker
 :description: Checks the contents of the editor for WCAG & Section 508 accessibility problems.
 :keywords: a11y accessibility WCAG
 :pluginname: Accessibility Checker

--- a/modules/ROOT/pages/a11ychecker.adoc
+++ b/modules/ROOT/pages/a11ychecker.adoc
@@ -5,7 +5,6 @@
 :keywords: a11y accessibility WCAG
 :pluginname: Accessibility Checker
 :plugincode: a11ychecker
-:altplugincode: nil
 :pluginminimumplan: tierthree
 :includedSection: a11yPlugin
 

--- a/modules/ROOT/pages/accessibility.adoc
+++ b/modules/ROOT/pages/accessibility.adoc
@@ -1,6 +1,6 @@
 = Accessibility options
 
-:title_nav: Accessibility
+:navtitle: Accessibility
 :description_short: Configure the accessibility of TinyMCE.
 :description: Configure the accessibility of TinyMCE.
 

--- a/modules/ROOT/pages/add-css-options.adoc
+++ b/modules/ROOT/pages/add-css-options.adoc
@@ -1,6 +1,6 @@
 = Adding or changing the editor content CSS
 
-:title_nav: Add CSS
+:navtitle: Add CSS
 :description: Options for changing the editor content CSS.
 
 == Add CSS and styles to the editor

--- a/modules/ROOT/pages/advcode.adoc
+++ b/modules/ROOT/pages/advcode.adoc
@@ -1,6 +1,6 @@
 = Advanced Code Editor plugin
 
-:title_nav: Advanced Code Editor
+:navtitle: Advanced Code Editor
 :description: How to setup TinyMCE's Advanced Code Editor plugin.
 :keywords: code advcode codemirror
 :controls: toolbar button, menu item

--- a/modules/ROOT/pages/advcode.adoc
+++ b/modules/ROOT/pages/advcode.adoc
@@ -21,7 +21,7 @@ The xref:advcode.adoc[Advanced Code Editor] plugin (`+advcode+`) brings a more a
 
 == The difference between the Code and Advanced Code Editor plugins
 
-liveDemo::advcode[ ]
+liveDemo::advcode[]
 
 include::partial$misc/purchase-premium-plugins.adoc[]
 

--- a/modules/ROOT/pages/advlist.adoc
+++ b/modules/ROOT/pages/advlist.adoc
@@ -1,6 +1,6 @@
 = Advanced List plugin
 
-:title_nav: Advanced List
+:navtitle: Advanced List
 :description: Create styled number and bulleted lists.
 :keywords: advlist advlist_bullet_styles advlist_number_styles
 :plugincode: advlist

--- a/modules/ROOT/pages/advlist.adoc
+++ b/modules/ROOT/pages/advlist.adoc
@@ -4,7 +4,6 @@
 :description: Create styled number and bulleted lists.
 :keywords: advlist advlist_bullet_styles advlist_number_styles
 :plugincode: advlist
-:altplugincode: nil
 
 The `+advlist+` plugin extends the core `+bullist+` and `+numlist+` toolbar controls by adding CSS `+list-style-type+` styled number formats and bullet types to the controls.
 

--- a/modules/ROOT/pages/advtable.adoc
+++ b/modules/ROOT/pages/advtable.adoc
@@ -17,7 +17,7 @@ The `+advtable+` plugin is a premium plugin that extends the core xref:table.ado
 
 == Try our Advanced Tables Demo
 
-liveDemo::advtable[ ]
+liveDemo::advtable[]
 
 include::partial$misc/purchase-premium-plugins.adoc[]
 

--- a/modules/ROOT/pages/advtable.adoc
+++ b/modules/ROOT/pages/advtable.adoc
@@ -1,6 +1,6 @@
 = Advanced Tables plugin
 
-:title_nav: Advanced Tables
+:navtitle: Advanced Tables
 :description: Add advanced functionality to tables.
 :keywords: sort rownumbering series tables advanced advtable premium
 :pluginname: Advanced Tables

--- a/modules/ROOT/pages/advtable.adoc
+++ b/modules/ROOT/pages/advtable.adoc
@@ -5,7 +5,6 @@
 :keywords: sort rownumbering series tables advanced advtable premium
 :pluginname: Advanced Tables
 :plugincode: advtable
-:altplugincode: nil
 :plugincategory: premium
 :pluginminimumplan: tierthree
 

--- a/modules/ROOT/pages/anchor.adoc
+++ b/modules/ROOT/pages/anchor.adoc
@@ -5,7 +5,6 @@
 :controls: toolbar button, menu item
 :pluginname: Anchor
 :plugincode: anchor
-:altplugincode: nil
 
 This plugin adds an anchor/bookmark button to the toolbar that inserts an anchor at the editor's cursor insertion point. It also adds the menu item `+anchor+` under the `+Insert+` menu.
 

--- a/modules/ROOT/pages/anchor.adoc
+++ b/modules/ROOT/pages/anchor.adoc
@@ -1,6 +1,6 @@
 = Anchor plugin
 
-:title_nav: Anchor
+:navtitle: Anchor
 :description: Insert anchors (sometimes referred to as a bookmarks).
 :controls: toolbar button, menu item
 :pluginname: Anchor

--- a/modules/ROOT/pages/angular-cloud.adoc
+++ b/modules/ROOT/pages/angular-cloud.adoc
@@ -1,6 +1,6 @@
 = Using TinyMCE from the Tiny Cloud CDN with the Angular framework
 
-:title_nav: Angular
+:navtitle: Angular
 :description: A guide on integrating TinyMCE from the Tiny Cloud into the Angular framework.
 :keywords: integration integrate angular
 :productSource: cloud

--- a/modules/ROOT/pages/angular-pm.adoc
+++ b/modules/ROOT/pages/angular-pm.adoc
@@ -1,6 +1,6 @@
 = Using the TinyMCE package with the Angular framework
 
-:title_nav: Using a package manager
+:navtitle: Using a package manager
 :description: A guide on integrating the TinyMCE package into the Angular framework.
 :keywords: integration integrate angular
 :productSource: package-manager

--- a/modules/ROOT/pages/angular-ref.adoc
+++ b/modules/ROOT/pages/angular-ref.adoc
@@ -1,6 +1,6 @@
 = TinyMCE Angular integration technical reference
 
-:title_nav: Technical reference
+:navtitle: Technical reference
 :description: Technical reference for the TinyMCE Angular integration
 :keywords: integration integrate angular
 

--- a/modules/ROOT/pages/angular-zip.adoc
+++ b/modules/ROOT/pages/angular-zip.adoc
@@ -1,6 +1,6 @@
 = Using the TinyMCE .zip package with the Angular framework
 
-:title_nav: Using a .zip package
+:navtitle: Using a .zip package
 :description: A guide on integrating a .zip version of TinyMCE into the Angular framework.
 :keywords: integration integrate angular
 :productSource: zip

--- a/modules/ROOT/pages/annotations.adoc
+++ b/modules/ROOT/pages/annotations.adoc
@@ -134,7 +134,7 @@ annotationChanged: (name: string, callback): void
 
 Use the following example to create the Annotate API:
 
-liveDemo::annotations[ height="750" ]
+liveDemo::annotations[height="750"]
 
 == Retrieving All Annotations for a Particular Annotation Name
 

--- a/modules/ROOT/pages/autocompleter.adoc
+++ b/modules/ROOT/pages/autocompleter.adoc
@@ -1,6 +1,6 @@
 = Autocompleter
 
-:title_nav: Autocompleter
+:navtitle: Autocompleter
 :description: Add a custom autocompleter to TinyMCE 6.
 :keywords: autocomplete
 

--- a/modules/ROOT/pages/autocompleter.adoc
+++ b/modules/ROOT/pages/autocompleter.adoc
@@ -193,10 +193,10 @@ The following examples show how to create a special characters autocompleters.
 
 This example uses the standard autocompleter item and will show when user types the colon (`+:+`) character and at least one additional character.
 
-liveDemo::autocompleter-autocompleteitem[ height="300" tab="js" ]
+liveDemo::autocompleter-autocompleteitem[height="300", tab="js"]
 
 === Example: Using `+CardMenuItems+` in the Autocompleter
 
 This example uses xref:cardmenuitem[CardMenuItems] and will show when a user types a hyphen (`+-+`) character and at least one additional character.
 
-liveDemo::autocompleter-cardmenuitem[ height="300" tab="js" ]
+liveDemo::autocompleter-cardmenuitem[height="300", tab="js"]

--- a/modules/ROOT/pages/autolink.adoc
+++ b/modules/ROOT/pages/autolink.adoc
@@ -4,7 +4,6 @@
 :description: Automatically create hyperlinks.
 :keywords: link url urls
 :plugincode: autolink
-:altplugincode: nil
 
 The Autolink plugin automatically creates hyperlinks when a user types a valid, complete URL. For example `+www.example.com+` is converted to `+http://www.example.com+`.
 

--- a/modules/ROOT/pages/autolink.adoc
+++ b/modules/ROOT/pages/autolink.adoc
@@ -1,6 +1,6 @@
 = Autolink plugin
 
-:title_nav: Autolink
+:navtitle: Autolink
 :description: Automatically create hyperlinks.
 :keywords: link url urls
 :plugincode: autolink

--- a/modules/ROOT/pages/autoresize.adoc
+++ b/modules/ROOT/pages/autoresize.adoc
@@ -6,7 +6,6 @@
 :keywords: height width max_height min_height autoresize_overflow_padding autoresize_overflow_padding
 :pluginname: Autoresize
 :plugincode: autoresize
-:altplugincode: nil
 
 This plugin automatically resizes the editor to the content inside it. It is typically used to prevent the editor from expanding infinitely as a user types into the editable area. For example, by giving the `+max_height+` option a value the editor will stop resizing when the set value is reached.
 

--- a/modules/ROOT/pages/autoresize.adoc
+++ b/modules/ROOT/pages/autoresize.adoc
@@ -1,6 +1,6 @@
 = Autoresize plugin
 
-:title_nav: Autoresize
+:navtitle: Autoresize
 :description_short:
 :description: Automatically resize TinyMCE to fit content.
 :keywords: height width max_height min_height autoresize_overflow_padding autoresize_overflow_padding

--- a/modules/ROOT/pages/autosave.adoc
+++ b/modules/ROOT/pages/autosave.adoc
@@ -1,6 +1,6 @@
 = Autosave plugin
 
-:title_nav: Autosave
+:navtitle: Autosave
 :description: Automatically save content in your local browser.
 :controls: toolbar button, menu item
 :keywords: autosave_ask_before_unload autosave_interval autosave_prefix autosave_prefix autosave_restore_when_empty autosave_retention

--- a/modules/ROOT/pages/autosave.adoc
+++ b/modules/ROOT/pages/autosave.adoc
@@ -6,7 +6,6 @@
 :keywords: autosave_ask_before_unload autosave_interval autosave_prefix autosave_prefix autosave_restore_when_empty autosave_retention
 :pluginname: Autosave
 :plugincode: autosave
-:altplugincode: nil
 
 The autosave plugin gives the user a warning if they have unsaved changes in the editor and either:
 

--- a/modules/ROOT/pages/available-menu-items.adoc
+++ b/modules/ROOT/pages/available-menu-items.adoc
@@ -1,6 +1,6 @@
 = Menu Items Available for TinyMCE
 
-:title_nav: Available Menu Items
+:navtitle: Available Menu Items
 :description_short: Complete list of menu items available for the menu bar and context menus.
 :description: Complete list of menu items available for the menu bar and context menus.
 :keywords: menuitems menu menubar

--- a/modules/ROOT/pages/available-menu-items.adoc
+++ b/modules/ROOT/pages/available-menu-items.adoc
@@ -24,7 +24,6 @@ include::partial$menu-item-ids/core-menu-items.adoc[]
 :plugincategory: premium
 :pluginname: A11yChecker
 :plugincode: a11ychecker
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: premium
@@ -32,59 +31,51 @@ include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 :plugincode: advcode
 :altplugincode: code
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
+:!altplugincode:
 
 :plugincategory: premium
 :pluginname: Advanced Tables
 :plugincode: advtable
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Anchor
 :plugincode: anchor
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Autosave
 :plugincode: autosave
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: premium
 :pluginname: Case Change
 :plugincode: casechange
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Character Map
 :plugincode: charmap
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: premium
 :pluginname: Checklist
 :plugincode: checklist
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Code
 :plugincode: code
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Code Sample
 :plugincode: codesample
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: premium
 :pluginname: Comments
 :plugincode: comments
-:altplugincode: nil
 :pluginpage: introduction-to-tiny-comments.adoc
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 :!pluginpage:
@@ -92,91 +83,76 @@ include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 :plugincategory: opensource
 :pluginname: Emoticons
 :plugincode: emoticons
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: premium
 :pluginname: Export
 :plugincode: export
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Full Screen
 :plugincode: fullscreen
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Help
 :plugincode: help
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Image
 :plugincode: image
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Insert Date/Time
 :plugincode: insertdatetime
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Link
 :plugincode: link
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Media
 :plugincode: media
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Nonbreaking Space
 :plugincode: nonbreaking
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Page Break
 :plugincode: pagebreak
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: premium
 :pluginname: Page Embed
 :plugincode: pageembed
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: premium
 :pluginname: Permanent Pen
 :plugincode: permanentpen
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Preview
 :plugincode: preview
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Search and Replace
 :plugincode: searchreplace
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: premium
 :pluginname: Spell Checker Pro
 :plugincode: tinymcespellchecker
-:altplugincode: nil
 :pluginpage: introduction-to-tiny-spellchecker.adoc
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 :!pluginpage:
@@ -184,25 +160,21 @@ include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 :plugincategory: opensource
 :pluginname: Table
 :plugincode: table
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: premium
 :pluginname: Table of Contents
 :plugincode: tableofcontents
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Template
 :plugincode: template
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: premium
 :pluginname: {cloudfilemanager}
 :plugincode: tinydrive
-:altplugincode: nil
 :pluginpage: tinydrive-introduction.adoc
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 :!pluginpage:
@@ -210,17 +182,14 @@ include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 :plugincategory: opensource
 :pluginname: Visual Blocks
 :plugincode: visualblocks
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Visual Characters
 :plugincode: visualchars
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Word Count
 :plugincode: wordcount
-:altplugincode: nil
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]

--- a/modules/ROOT/pages/available-toolbar-buttons.adoc
+++ b/modules/ROOT/pages/available-toolbar-buttons.adoc
@@ -24,7 +24,6 @@ include::partial$toolbar-button-ids/core-toolbar-buttons.adoc[]
 :plugincategory: premium
 :pluginname: A11yChecker
 :plugincode: a11ychecker
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
@@ -32,59 +31,51 @@ include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 :plugincode: advcode
 :altplugincode: code
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
+:!altplugincode:
 
 :plugincategory: premium
 :pluginname: Advanced Tables
 :plugincode: advtable
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Anchor
 :plugincode: anchor
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Autosave
 :plugincode: autosave
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
 :pluginname: Case Change
 :plugincode: casechange
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Character Map
 :plugincode: charmap
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
 :pluginname: Checklist
 :plugincode: checklist
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Code
 :plugincode: code
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Code Sample
 :plugincode: codesample
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
 :pluginname: Comments
 :plugincode: comments
-:altplugincode: nil
 :pluginpage: introduction-to-tiny-comments.adoc
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 :!pluginpage:
@@ -92,127 +83,106 @@ include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 :plugincategory: opensource
 :pluginname: Directionality
 :plugincode: directionality
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
 :pluginname: Edit Image
 :plugincode: editimage
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Emoticons
 :plugincode: emoticons
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
 :pluginname: Export
 :plugincode: export
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
 :pluginname: Format Painter
 :plugincode: formatpainter
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Full Screen
 :plugincode: fullscreen
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Help
 :plugincode: help
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Image
 :plugincode: image
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Insert Date/Time
 :plugincode: insertdatetime
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Link
 :plugincode: link
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Lists
 :plugincode: lists
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Media
 :plugincode: media
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Nonbreaking Space
 :plugincode: nonbreaking
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Page Break
 :plugincode: pagebreak
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
 :pluginname: Page Embed
 :plugincode: pageembed
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
 :pluginname: Permanent Pen
 :plugincode: permanentpen
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Preview
 :plugincode: preview
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Quick Toolbars
 :plugincode: quickbars
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Save
 :plugincode: save
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Search and Replace
 :plugincode: searchreplace
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
 :pluginname: Spell Checker Pro
 :plugincode: tinymcespellchecker
-:altplugincode: nil
 :pluginpage: introduction-to-tiny-spellchecker.adoc
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 :!pluginpage:
@@ -220,25 +190,21 @@ include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 :plugincategory: opensource
 :pluginname: Table
 :plugincode: table
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
 :pluginname: Table of Contents
 :plugincode: tableofcontents
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Template
 :plugincode: template
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
 :pluginname: {cloudfilemanager}
 :plugincode: tinydrive
-:altplugincode: nil
 :pluginpage: tinydrive-introduction.adoc
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 :!pluginpage:
@@ -246,17 +212,14 @@ include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 :plugincategory: opensource
 :pluginname: Visual Blocks
 :plugincode: visualblocks
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Visual Characters
 :plugincode: visualchars
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Word Count
 :plugincode: wordcount
-:altplugincode: nil
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]

--- a/modules/ROOT/pages/available-toolbar-buttons.adoc
+++ b/modules/ROOT/pages/available-toolbar-buttons.adoc
@@ -1,6 +1,6 @@
 = Toolbar Buttons Available for TinyMCE
 
-:title_nav: Available Toolbar Buttons
+:navtitle: Available Toolbar Buttons
 :description_short: Complete list of toolbar buttons available for the toolbar and quick toolbars.
 :description: Complete list of toolbar buttons available for the toolbar and quick toolbars.
 :keywords: toolbar button tool bar

--- a/modules/ROOT/pages/basic-example.adoc
+++ b/modules/ROOT/pages/basic-example.adoc
@@ -1,6 +1,6 @@
 = Basic example
 
-:title_nav: Basic example
+:navtitle: Basic example
 :description_short: See how we built a commonly used TinyMCE instance.
 :description: This example contains the plugins needed for the most common use cases.
 :keywords: example demo custom common standard normal typical

--- a/modules/ROOT/pages/basic-example.adoc
+++ b/modules/ROOT/pages/basic-example.adoc
@@ -9,4 +9,4 @@
 
 This example contains the plugins needed for the most common use cases.
 
-liveDemo::basic-example[ ]
+liveDemo::basic-example[]

--- a/modules/ROOT/pages/basic-setup.adoc
+++ b/modules/ROOT/pages/basic-setup.adoc
@@ -1,6 +1,6 @@
 = Basic setup
 
-:title_nav: Basic setup
+:navtitle: Basic setup
 :description_short: The three most important configuration settings, with examples.
 :description: TinyMCE provides a range of configuration options that allow you to integrate it into your application.
 :keywords: selector plugin toolbar configuration configure

--- a/modules/ROOT/pages/basic-setup.adoc
+++ b/modules/ROOT/pages/basic-setup.adoc
@@ -63,7 +63,7 @@ tinymce.init({
 
 Providing a {productname} editor with the default configuration, such as:
 
-liveDemo::default[ ]
+liveDemo::default[]
 
 The selector can target most block elements when the editor is used in xref:use-tinymce-inline.adoc[inline editing mode]. Inline mode edits the content in place, instead of replacing the element with an `+iframe+`.
 
@@ -139,7 +139,7 @@ tinymce.init({
 });
 ----
 
-liveDemo::menubar[ ]
+liveDemo::menubar[]
 
 To create an `+Edit+` menu that only contains the _Undo_, _Redo_, and _Select all_ items.
 
@@ -153,7 +153,7 @@ tinymce.init({
 });
 ----
 
-liveDemo::menu1[ ]
+liveDemo::menu1[]
 
 To create a menu titled "Happy", provide an identifier for the menu and an object with the `+title+` and `+items+` for the menu.
 
@@ -171,7 +171,7 @@ tinymce.init({
 });
 ----
 
-liveDemo::menu2[ ]
+liveDemo::menu2[]
 
 === Default menu controls
 
@@ -283,7 +283,7 @@ Sets the styling of the editable area using `+content_css+`.
 content_css: 'css/content.css',
 ----
 
-liveDemo::basic-conf[ ]
+liveDemo::basic-conf[]
 
 === Additional information
 

--- a/modules/ROOT/pages/blazor-cloud.adoc
+++ b/modules/ROOT/pages/blazor-cloud.adoc
@@ -1,7 +1,7 @@
 = Using TinyMCE from the Tiny Cloud CDN with the Blazor framework
 
 :description: A guide on integrating TinyMCE from the Tiny Cloud into the Blazor framework.
-:title_nav: Blazor
+:navtitle: Blazor
 :keywords: integration integrate blazor blazorapp
 :productSource: cloud
 

--- a/modules/ROOT/pages/blazor-pm.adoc
+++ b/modules/ROOT/pages/blazor-pm.adoc
@@ -1,6 +1,6 @@
 = Using the TinyMCE package with the Blazor framework
 
-:title_nav: Using a package manager
+:navtitle: Using a package manager
 :description: A guide on integrating the TinyMCE package into the Blazor framework.
 :keywords: integration integrate blazor blazorapp
 :productSource: package-manager

--- a/modules/ROOT/pages/blazor-ref.adoc
+++ b/modules/ROOT/pages/blazor-ref.adoc
@@ -1,6 +1,6 @@
 = TinyMCE Blazor integration technical reference
 
-:title_nav: Technical reference
+:navtitle: Technical reference
 :description: Technical reference for the TinyMCE Blazor integration
 :keywords: integration integrate blazor blazorapp
 

--- a/modules/ROOT/pages/blazor-zip.adoc
+++ b/modules/ROOT/pages/blazor-zip.adoc
@@ -1,6 +1,6 @@
 = Using the TinyMCE .zip package with the Blazor framework
 
-:title_nav: Using a .zip package
+:navtitle: Using a .zip package
 :description: A guide on integrating a .zip version of TinyMCE into the Blazor framework.
 :keywords: integration integrate blazor blazorapp
 :productSource: zip

--- a/modules/ROOT/pages/bootstrap-cloud.adoc
+++ b/modules/ROOT/pages/bootstrap-cloud.adoc
@@ -1,6 +1,6 @@
 = Using TinyMCE from the Tiny Cloud CDN with the Bootstrap framework
 
-:title_nav: Bootstrap
+:navtitle: Bootstrap
 :description: A guide on integrating TinyMCE from the Tiny Cloud into the Bootstrap framework.
 :keywords: integration integrate bootstrap
 :productSource: cloud

--- a/modules/ROOT/pages/bootstrap-demo.adoc
+++ b/modules/ROOT/pages/bootstrap-demo.adoc
@@ -1,6 +1,6 @@
 = Bootstrap skin demo
 
-:title_nav: Bootstrap Demo
+:navtitle: Bootstrap Demo
 :description: Bootstrap Demo
 :keywords: skin skins icon icons bootstrap customize theme
 

--- a/modules/ROOT/pages/bootstrap-demo.adoc
+++ b/modules/ROOT/pages/bootstrap-demo.adoc
@@ -8,4 +8,4 @@ This demo shows an example form using Bootstrap together with {productname} and 
 
 NOTE: The focus outline on the editor is not part of the skin. Take a look in the JS tab below for inspiration on how to add it.
 
-liveDemo::premiumskinsandicons-bootstrap[ ]
+liveDemo::premiumskinsandicons-bootstrap[]

--- a/modules/ROOT/pages/bootstrap-zip.adoc
+++ b/modules/ROOT/pages/bootstrap-zip.adoc
@@ -1,7 +1,7 @@
 = Using the TinyMCE .zip package with the Bootstrap framework
 
 :description: A guide on integrating a .zip version of TinyMCE into the Bootstrap framework.
-:title_nav: Bootstrap
+:navtitle: Bootstrap
 :keywords: integration integrate bootstrap
 :productSource: zip
 

--- a/modules/ROOT/pages/borderless-demo.adoc
+++ b/modules/ROOT/pages/borderless-demo.adoc
@@ -1,6 +1,6 @@
 = Borderless skin demo
 
-:title_nav: Borderless Demo
+:navtitle: Borderless Demo
 :description: Borderless Demo
 :keywords: skin skins icon icons borderless customize theme
 

--- a/modules/ROOT/pages/borderless-demo.adoc
+++ b/modules/ROOT/pages/borderless-demo.adoc
@@ -6,4 +6,4 @@
 
 This demo uses the borderless skin. It's the default {productname} skin but without the outer border. This is useful if you want to use the editor "fullscreen" like a word processor or if you want to provide your own outer borders.
 
-liveDemo::premiumskinsandicons-borderless[ ]
+liveDemo::premiumskinsandicons-borderless[]

--- a/modules/ROOT/pages/bower-projects.adoc
+++ b/modules/ROOT/pages/bower-projects.adoc
@@ -1,6 +1,6 @@
 = Installing TinyMCE with Bower
 
-:title_nav: Bower projects
+:navtitle: Bower projects
 :description: Learn how to install TinyMCE using Bower.
 :keywords: bower javascript install
 :productSource: bower

--- a/modules/ROOT/pages/browserify-cjs-download.adoc
+++ b/modules/ROOT/pages/browserify-cjs-download.adoc
@@ -1,6 +1,6 @@
 = Bundling a .zip version of TinyMCE with CommonJS and Browserify
 
-:title_nav: CommonJS and a .zip archive
+:navtitle: CommonJS and a .zip archive
 :description_short: Bundling a .zip archive version of TinyMCE in a project using CommonJS and Browserify
 :description: Bundling a .zip archive version of TinyMCE in a project using CommonJS and Browserify
 :keywords: browserify commonjs cjs zip modules tinymce

--- a/modules/ROOT/pages/browserify-cjs-npm.adoc
+++ b/modules/ROOT/pages/browserify-cjs-npm.adoc
@@ -1,6 +1,6 @@
 = Bundling an npm version of TinyMCE with CommonJS and Browserify
 
-:title_nav: CommonJS and npm
+:navtitle: CommonJS and npm
 :description_short: Bundling an npm version of TinyMCE in a project using CommonJS and Browserify
 :description: Bundling an npm version of TinyMCE in a project using CommonJS and Browserify
 :keywords: browserify commonjs cjs npm modules tinymce

--- a/modules/ROOT/pages/bundle-hyperlinking-container.adoc
+++ b/modules/ROOT/pages/bundle-hyperlinking-container.adoc
@@ -1,6 +1,6 @@
 = Premium self-hosted bundle - Hyperlinking service container
 
-:title_nav: Hyperlinking service
+:navtitle: Hyperlinking service
 :description: How-to deploy the Hyperlinking service from the self-hosted bundle as a docker image.
 :shbundledockerfiles: true
 

--- a/modules/ROOT/pages/bundle-imageproxy-container.adoc
+++ b/modules/ROOT/pages/bundle-imageproxy-container.adoc
@@ -1,6 +1,6 @@
 = Premium self-hosted bundle - Image Proxy service container
 
-:title_nav: Image Proxy service
+:navtitle: Image Proxy service
 :description: How-to deploy the Image Proxy service from the self-hosted bundle as a docker image.
 :shbundledockerfiles: true
 

--- a/modules/ROOT/pages/bundle-intro-setup.adoc
+++ b/modules/ROOT/pages/bundle-intro-setup.adoc
@@ -1,6 +1,6 @@
 = Introduction and initial setup for containerized server-side services from the premium self-hosted bundle
 
-:title_nav: Introduction and initial setup
+:navtitle: Introduction and initial setup
 :description: The containerized server-side components for premium plugins.
 
 The {enterpriseversion} server-side components can be deployed on Docker orchestration applications such as https://kubernetes.io/[Kubernetes], https://docs.docker.com/engine/swarm/[Docker Swarm], or https://www.openshift.com/[OpenShift]. {companyname} provides packages containing pre-configured https://docs.docker.com/engine/reference/builder/[`+Dockerfiles+`] for building and deploying the {enterpriseversion} server-side components using Docker.

--- a/modules/ROOT/pages/bundle-spelling-container.adoc
+++ b/modules/ROOT/pages/bundle-spelling-container.adoc
@@ -1,6 +1,6 @@
 = Premium self-hosted bundle - Spelling service container
 
-:title_nav: Spelling service
+:navtitle: Spelling service
 :description: How-to deploy the Spelling service from the self-hosted bundle as a docker image.
 :shbundledockerfiles: true
 

--- a/modules/ROOT/pages/bundling-content-css.adoc
+++ b/modules/ROOT/pages/bundling-content-css.adoc
@@ -1,6 +1,6 @@
 = Bundling TinyMCE content CSS using module loading
 
-:title_nav: Content CSS
+:navtitle: Content CSS
 :description_short: Information on bundling the editor content CSS
 :description: Information on bundling the editor content CSS using module loading
 

--- a/modules/ROOT/pages/bundling-icons.adoc
+++ b/modules/ROOT/pages/bundling-icons.adoc
@@ -1,6 +1,6 @@
 = Bundling TinyMCE icon packs using module loading
 
-:title_nav: Icons
+:navtitle: Icons
 :description_short: Information on bundling icon packs
 :description: Information on bundling TinyMCE icon packs using module loading
 

--- a/modules/ROOT/pages/bundling-localization.adoc
+++ b/modules/ROOT/pages/bundling-localization.adoc
@@ -1,6 +1,6 @@
 = Bundling the User Interface localizations for TinyMCE
 
-:title_nav: UI localizations
+:navtitle: UI localizations
 :description_short: Information on bundling User Interface localizations
 :description: Information on bundling User Interface localizations
 

--- a/modules/ROOT/pages/bundling-plugins.adoc
+++ b/modules/ROOT/pages/bundling-plugins.adoc
@@ -1,6 +1,6 @@
 = Bundling TinyMCE plugins using module loading
 
-:title_nav: Plugins
+:navtitle: Plugins
 :description_short: Information on bundling plugins
 :description: Information on bundling TinyMCE plugins using module loading
 

--- a/modules/ROOT/pages/bundling-skins.adoc
+++ b/modules/ROOT/pages/bundling-skins.adoc
@@ -1,6 +1,6 @@
 = Bundling TinyMCE skins using module loading
 
-:title_nav: Skins
+:navtitle: Skins
 :description_short: Information on bundling TinyMCE skins
 :description: Information on bundling TinyMCE skins using module loading
 

--- a/modules/ROOT/pages/bundling-themes.adoc
+++ b/modules/ROOT/pages/bundling-themes.adoc
@@ -1,6 +1,6 @@
 = Bundling TinyMCE themes using module loading
 
-:title_nav: Themes
+:navtitle: Themes
 :description_short: Information on bundling themes
 :description: Information on bundling TinyMCE themes using module loading
 

--- a/modules/ROOT/pages/casechange.adoc
+++ b/modules/ROOT/pages/casechange.adoc
@@ -15,7 +15,7 @@ The *Case Change* plugin is a time saving and handy extension that allows changi
 
 == Try our Case Change demo
 
-liveDemo::casechange[ ]
+liveDemo::casechange[]
 
 include::partial$misc/purchase-premium-plugins.adoc[]
 

--- a/modules/ROOT/pages/casechange.adoc
+++ b/modules/ROOT/pages/casechange.adoc
@@ -1,6 +1,6 @@
 = Case Change
 
-:title_nav: Case Change
+:navtitle: Case Change
 :description: Change the case of text.
 :keywords: case capitalization capitalize lowercase uppercase
 :controls: toolbar button, menu item

--- a/modules/ROOT/pages/casechange.adoc
+++ b/modules/ROOT/pages/casechange.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button, menu item
 :pluginname: Case Change
 :plugincode: casechange
-:altplugincode: nil
 :pluginminimumplan: tiertwo
 
 

--- a/modules/ROOT/pages/charmap.adoc
+++ b/modules/ROOT/pages/charmap.adoc
@@ -1,6 +1,6 @@
 = Character Map plugin
 
-:title_nav: Character Map
+:navtitle: Character Map
 :description: Insert special characters into TinyMCE.
 :keywords: charmap symbols
 :controls: toolbar button, menu item

--- a/modules/ROOT/pages/charmap.adoc
+++ b/modules/ROOT/pages/charmap.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button, menu item
 :pluginname: Character Map
 :plugincode: charmap
-:altplugincode: nil
 
 This plugin adds a dialog to the editor with a map of special unicode characters, which cannot be added directly from the keyboard. The dialog can be invoked via a toolbar button - `+charmap+` - or a dedicated menu item added as `+Insert > Special character+`.
 

--- a/modules/ROOT/pages/checklist.adoc
+++ b/modules/ROOT/pages/checklist.adoc
@@ -1,6 +1,6 @@
 = Checklist plugin
 
-:title_nav: Checklist
+:navtitle: Checklist
 :description: Add checklists to your content.
 :keywords: lists todo checklist
 :controls: toolbar button

--- a/modules/ROOT/pages/checklist.adoc
+++ b/modules/ROOT/pages/checklist.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button
 :pluginname: Checklist
 :plugincode: checklist
-:altplugincode: nil
 :pluginminimumplan: tiertwo
 
 

--- a/modules/ROOT/pages/checklist.adoc
+++ b/modules/ROOT/pages/checklist.adoc
@@ -17,7 +17,7 @@ The *Checklist* plugin allows the user to add checkbox lists to their content fo
 
 In the {productname} editor, checklists are presented as lists with small checkboxes beside the list items. After the item has been completed, a small tick or check mark is drawn in the box by clicking on it.
 
-liveDemo::checklist[ ]
+liveDemo::checklist[]
 
 include::partial$misc/purchase-premium-plugins.adoc[]
 

--- a/modules/ROOT/pages/classic.adoc
+++ b/modules/ROOT/pages/classic.adoc
@@ -1,6 +1,6 @@
 = Classic editor example
 
-:title_nav: Classic editor mode
+:navtitle: Classic editor mode
 :description_short: Configure TinyMCE classic editor.
 :description: This example shows you how to use TinyMCE classic editor.
 :keywords: example demo classic editor

--- a/modules/ROOT/pages/classic.adoc
+++ b/modules/ROOT/pages/classic.adoc
@@ -9,4 +9,4 @@
 
 This example shows you how to use {productname} Classic Editor.
 
-liveDemo::classic[ ]
+liveDemo::classic[]

--- a/modules/ROOT/pages/cloud-quick-start.adoc
+++ b/modules/ROOT/pages/cloud-quick-start.adoc
@@ -1,6 +1,6 @@
 = Quick start
 
-:title_nav: Quick start
+:navtitle: Quick start
 :description_short: Setup a basic TinyMCE 6 editor using the Tiny Cloud.
 :description: Get an instance of TinyMCE 6 up and running using the Tiny Cloud.
 :keywords: tinymce script textarea

--- a/modules/ROOT/pages/code.adoc
+++ b/modules/ROOT/pages/code.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button, menu item
 :pluginname: Code
 :plugincode: code
-:altplugincode: nil
 
 This plugin adds a toolbar button that allows a user to edit the HTML code hidden by the WYSIWYG view. It also adds the menu item `+Source code+` under the `+Tools+` menu.
 

--- a/modules/ROOT/pages/code.adoc
+++ b/modules/ROOT/pages/code.adoc
@@ -1,6 +1,6 @@
 = Code plugin
 
-:title_nav: Code
+:navtitle: Code
 :description: Edit your content's HTML source.
 :keywords: wysiwyg source html edit
 :controls: toolbar button, menu item

--- a/modules/ROOT/pages/codesample.adoc
+++ b/modules/ROOT/pages/codesample.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button
 :pluginname: Code Sample
 :plugincode: codesample
-:altplugincode: nil
 
 
 The Code Sample plugin (`+codesample+`) lets a user insert and embed syntax color highlighted code snippets into the editable area. It also adds a button to the toolbar which on click will open a dialog box to accept raw code input.

--- a/modules/ROOT/pages/codesample.adoc
+++ b/modules/ROOT/pages/codesample.adoc
@@ -1,6 +1,6 @@
 = Code Sample plugin
 
-:title_nav: Code Sample
+:navtitle: Code Sample
 :description: Insert and embed syntax highlighted code snippets.
 :keywords: syntax highlight codesample code contenteditable codesample_languages
 :controls: toolbar button

--- a/modules/ROOT/pages/codesample.adoc
+++ b/modules/ROOT/pages/codesample.adoc
@@ -42,7 +42,7 @@ You need to add `+prism.js+` and `+prism.css+` to your page in order to get the 
 
 == Interactive example
 
-liveDemo::codesample[ ]
+liveDemo::codesample[]
 
 == Options
 

--- a/modules/ROOT/pages/comments-callback-mode.adoc
+++ b/modules/ROOT/pages/comments-callback-mode.adoc
@@ -1,6 +1,6 @@
 = Configuring the Comments plugin in callback mode
 
-:title_nav: Callback mode
+:navtitle: Callback mode
 :description: Information on configuring the Comments plugin in callback mode
 :keywords: comments commenting tinycomments callback
 :pluginname: Comments

--- a/modules/ROOT/pages/comments-callback-mode.adoc
+++ b/modules/ROOT/pages/comments-callback-mode.adoc
@@ -13,7 +13,7 @@
 
 The following example uses a simulated server (provided by https://netflix.github.io/pollyjs/[Polly.js]) which has been hidden from the example javascript to keep the example code concise. The interactions between TinyMCE and Polly.js are visible in the browser console.
 
-liveDemo::comments-callback[ ]
+liveDemo::comments-callback[]
 
 === How the comments plugin works in callback mode
 

--- a/modules/ROOT/pages/comments-commands-events-apis.adoc
+++ b/modules/ROOT/pages/comments-commands-events-apis.adoc
@@ -5,7 +5,6 @@
 :keywords: comments commenting tinycomments
 :pluginname: Comments
 :plugincode: comments
-:altplugincode: nil
 
 
 == Commands

--- a/modules/ROOT/pages/comments-commands-events-apis.adoc
+++ b/modules/ROOT/pages/comments-commands-events-apis.adoc
@@ -1,6 +1,6 @@
 = Commands for the comments plugin
 
-:title_nav: Commands
+:navtitle: Commands
 :description: Information on the commands provided with the comments plugin.
 :keywords: comments commenting tinycomments
 :pluginname: Comments

--- a/modules/ROOT/pages/comments-embedded-mode.adoc
+++ b/modules/ROOT/pages/comments-embedded-mode.adoc
@@ -26,7 +26,7 @@ This is the minimum recommended setup for the Comments plugin in embedded mode. 
 
 == Interactive example
 
-liveDemo::comments-embedded[ ]
+liveDemo::comments-embedded[]
 
 == Configuration options
 

--- a/modules/ROOT/pages/comments-embedded-mode.adoc
+++ b/modules/ROOT/pages/comments-embedded-mode.adoc
@@ -5,7 +5,6 @@
 :keywords: comments commenting tinycomments embedded mode
 :pluginname: Comments
 :plugincode: comments
-:altplugincode: nil
 
 
 == Add the Comments plugin in embedded mode

--- a/modules/ROOT/pages/comments-embedded-mode.adoc
+++ b/modules/ROOT/pages/comments-embedded-mode.adoc
@@ -1,6 +1,6 @@
 = Configuring the Comments plugin in embedded mode
 
-:title_nav: Embedded mode
+:navtitle: Embedded mode
 :description: Information on configuring the Comments plugin in embedded mode
 :keywords: comments commenting tinycomments embedded mode
 :pluginname: Comments

--- a/modules/ROOT/pages/comments-toolbars-menus.adoc
+++ b/modules/ROOT/pages/comments-toolbars-menus.adoc
@@ -5,7 +5,6 @@
 :keywords: comments commenting tinycomments
 :pluginname: Comments
 :plugincode: comments
-:altplugincode: nil
 
 
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]

--- a/modules/ROOT/pages/comments-toolbars-menus.adoc
+++ b/modules/ROOT/pages/comments-toolbars-menus.adoc
@@ -1,6 +1,6 @@
 = Toolbar buttons and menu items for the Comments plugin
 
-:title_nav: Toolbar buttons and menu items
+:navtitle: Toolbar buttons and menu items
 :description: Details of the toolbar buttons and menu items provided for the Comments plugin.
 :keywords: comments commenting tinycomments
 :pluginname: Comments

--- a/modules/ROOT/pages/comments-using-comments.adoc
+++ b/modules/ROOT/pages/comments-using-comments.adoc
@@ -5,7 +5,6 @@
 :keywords: comments commenting tinycomments
 :pluginname: Comments
 :plugincode: comments
-:altplugincode: nil
 
 
 I'm trying to:

--- a/modules/ROOT/pages/comments-using-comments.adoc
+++ b/modules/ROOT/pages/comments-using-comments.adoc
@@ -1,6 +1,6 @@
 = Using TinyMCE Comments
 
-:title_nav: Using Comments
+:navtitle: Using Comments
 :description: How to add, edit, resolve, and remove comments in TinyMCE
 :keywords: comments commenting tinycomments
 :pluginname: Comments

--- a/modules/ROOT/pages/configure-common-settings-services.adoc
+++ b/modules/ROOT/pages/configure-common-settings-services.adoc
@@ -1,6 +1,6 @@
 = Common server-side component settings
 
-:title_nav: Optional common settings
+:navtitle: Optional common settings
 :description: Settings that affect all premium server-side components.
 
 The following settings for the premium server-side components are optional and will apply to all services using the configuration file. These settings should be added to the `+application.conf+` file described in xref:configure-required-services.adoc[Required configuration for the server-side components].

--- a/modules/ROOT/pages/configure-required-services.adoc
+++ b/modules/ROOT/pages/configure-required-services.adoc
@@ -1,6 +1,6 @@
 = Required configuration for the server-side components
 
-:title_nav: Required configuration
+:navtitle: Required configuration
 :description: Configuration options for premium server-side components.
 
 == Creating a configuration file

--- a/modules/ROOT/pages/content-appearance.adoc
+++ b/modules/ROOT/pages/content-appearance.adoc
@@ -1,6 +1,6 @@
 = Content appearance options
 
-:title_nav: Content appearance
+:navtitle: Content appearance
 :description: Configure the appearance of content inside TinyMCE's editable area.
 
 == Showing for "hidden" elements

--- a/modules/ROOT/pages/content-behavior-options.adoc
+++ b/modules/ROOT/pages/content-behavior-options.adoc
@@ -1,6 +1,6 @@
 = Editor content behaviors
 
-:title_nav: Behaviors
+:navtitle: Behaviors
 :description: Options for changing the behavior of editor content.
 
 include::partial$configuration/custom_undo_redo_levels.adoc[]

--- a/modules/ROOT/pages/content-filtering.adoc
+++ b/modules/ROOT/pages/content-filtering.adoc
@@ -1,6 +1,6 @@
 = Content filtering options
 
-:title_nav: Content filtering
+:navtitle: Content filtering
 :description_short: Learn how to create clean, maintainable and readable content.
 :description: These settings change the way the editor handles the input and output of content. This will help you to create clean, maintainable and readable content.
 

--- a/modules/ROOT/pages/content-formatting.adoc
+++ b/modules/ROOT/pages/content-formatting.adoc
@@ -1,6 +1,6 @@
 = Content formatting options
 
-:title_nav: Content formats
+:navtitle: Content formats
 :description: These options change the way the editor handles the input and output of content. This will help you to create clean, maintainable and readable content.
 
 include::partial$configuration/formats.adoc[]

--- a/modules/ROOT/pages/content-localization.adoc
+++ b/modules/ROOT/pages/content-localization.adoc
@@ -1,6 +1,6 @@
 = Content localization options
 
-:title_nav: Localization
+:navtitle: Localization
 :description_short: Localize TinyMCE for your language, including directionality.
 :description: These settings configure TinyMCE's language capabilities, including right-to-left support.
 

--- a/modules/ROOT/pages/contextform.adoc
+++ b/modules/ROOT/pages/contextform.adoc
@@ -114,6 +114,6 @@ Both `+contextformbutton+` and `+contextformtogglebutton+` are passed `+formApi+
 
 This example shows how the link plugin adds the standard link context form. The context form will show whenever any content is selected.
 
-liveDemo::context-form[ height="400" tab="js" ]
+liveDemo::context-form[height="400", tab="js"]
 
 include::partial$context/priority.adoc[]

--- a/modules/ROOT/pages/contextform.adoc
+++ b/modules/ROOT/pages/contextform.adoc
@@ -1,6 +1,6 @@
 = Context forms
 
-:title_nav: Context forms
+:navtitle: Context forms
 :description: Creating custom context forms for TinyMCE 6
 :keywords: contextforms context forms contextformsbarapi
 :contextItemType: form

--- a/modules/ROOT/pages/contextmenu.adoc
+++ b/modules/ROOT/pages/contextmenu.adoc
@@ -1,6 +1,6 @@
 = Context menus
 
-:title_nav: Context menus
+:navtitle: Context menus
 :description: Creating custom context menus for TinyMCE 6
 :keywords: contextmenu context menu contextmenuapi
 

--- a/modules/ROOT/pages/contextmenu.adoc
+++ b/modules/ROOT/pages/contextmenu.adoc
@@ -10,7 +10,7 @@ The context menu supports both individual menu items and dynamic context menu se
 
 == Interactive example
 
-liveDemo::context-menu[ ]
+liveDemo::context-menu[]
 
 == Options
 
@@ -77,4 +77,4 @@ When creating a dynamic menu, the structure `+type+` properties are used in orde
 
 This example shows how the image plugin dynamically adds the standard image menu section to the context menu. The image context menu section is empty unless the selected element is an image.
 
-liveDemo::contextmenu-section[ height="600" tab="js" ]
+liveDemo::contextmenu-section[height="600", tab="js"]

--- a/modules/ROOT/pages/contexttoolbar.adoc
+++ b/modules/ROOT/pages/contexttoolbar.adoc
@@ -26,7 +26,7 @@ include::partial$context/positioning.adoc[]
 
 This example shows how the quickbars plugin adds the standard selection context toolbar and an example of a custom toolbar for image alignment. The context toolbar will show whenever any content is selected.
 
-liveDemo::context-toolbar[ height="600" tab="js" ]
+liveDemo::context-toolbar[height="600", tab="js"]
 
 == Launching a context toolbar programmatically
 

--- a/modules/ROOT/pages/contexttoolbar.adoc
+++ b/modules/ROOT/pages/contexttoolbar.adoc
@@ -1,6 +1,6 @@
 = Context toolbar
 
-:title_nav: Context toolbar
+:navtitle: Context toolbar
 :description: Creating custom context toolbars for TinyMCE 6
 :keywords: contexttoolbar context toolbar contexttoolbarapi
 :contextItemType: toolbar

--- a/modules/ROOT/pages/copy-and-paste.adoc
+++ b/modules/ROOT/pages/copy-and-paste.adoc
@@ -1,6 +1,6 @@
 = Copy & paste options
 
-:title_nav: Copy and paste options
+:navtitle: Copy and paste options
 :description: TinyMCE copy and paste
 
 == {productname} PowerPaste plugin

--- a/modules/ROOT/pages/creating-a-plugin.adoc
+++ b/modules/ROOT/pages/creating-a-plugin.adoc
@@ -1,6 +1,6 @@
 = Create a plugin for TinyMCE
 
-:title_nav: Create a plugin
+:navtitle: Create a plugin
 :description_short: Introducing plugin creation, with an example.
 :description: A short introduction to creating plugins for TinyMCE along with an example plugin.
 :keywords: plugin plugin.js plugin.min.js tinymce.js

--- a/modules/ROOT/pages/creating-a-plugin.adoc
+++ b/modules/ROOT/pages/creating-a-plugin.adoc
@@ -127,4 +127,4 @@ tinymce.PluginManager.requireLangPack('pluginId', 'es_ES,de_AT');
 
 This example plugin demonstrates how to add a simple toolbar button and menu item. This button opens a dialog that allows a title to be entered into the editor. The menu item will open the same dialog as the button.
 
-liveDemo::custom-plugin[ tab="js" ]
+liveDemo::custom-plugin[tab="js"]

--- a/modules/ROOT/pages/creating-a-skin.adoc
+++ b/modules/ROOT/pages/creating-a-skin.adoc
@@ -1,6 +1,6 @@
 = Create a skin for TinyMCE
 
-:title_nav: Create a skin
+:navtitle: Create a skin
 :description_short: Introducing skin creation.
 :description: Introducing skin creation, less and icon modification.
 :keywords: create creator skin icon

--- a/modules/ROOT/pages/creating-an-icon-pack.adoc
+++ b/modules/ROOT/pages/creating-an-icon-pack.adoc
@@ -1,6 +1,6 @@
 = Create an icon pack for TinyMCE
 
-:title_nav: Create an icon pack
+:navtitle: Create an icon pack
 :description_short: Introducing icon pack creation.
 :description: How to make your own icon pack.
 :keywords: create creator skin icon

--- a/modules/ROOT/pages/creating-custom-menu-items.adoc
+++ b/modules/ROOT/pages/creating-custom-menu-items.adoc
@@ -1,6 +1,6 @@
 = Creating custom menu items
 
-:title_nav: Creating custom menu items
+:navtitle: Creating custom menu items
 :description: This section demonstrates different types of menu items.
 :keywords: menu menuitem menuitems
 

--- a/modules/ROOT/pages/creating-custom-menu-items.adoc
+++ b/modules/ROOT/pages/creating-custom-menu-items.adoc
@@ -49,4 +49,4 @@ NOTE: The identifier used to create the menu item must be included in the xref:m
 
 This example shows you how to add some simple menu items to a new "custom" menu.
 
-liveDemo::custom-menu-item[ ]
+liveDemo::custom-menu-item[]

--- a/modules/ROOT/pages/creating-custom-notifications.adoc
+++ b/modules/ROOT/pages/creating-custom-notifications.adoc
@@ -1,6 +1,6 @@
 = Create custom notifications
 
-:title_nav: Notifications
+:navtitle: Notifications
 :description_short: Learn how to make custom notifications.
 :description: Learn how to make custom dialogs with NotificationManager.
 :keywords: custom notification notifications cdn notificationmanager

--- a/modules/ROOT/pages/creating-custom-notifications.adoc
+++ b/modules/ROOT/pages/creating-custom-notifications.adoc
@@ -9,7 +9,7 @@
 
 == Interactive example
 
-liveDemo::notifications[ ]
+liveDemo::notifications[]
 
 == Text
 

--- a/modules/ROOT/pages/custom-basic-menu-items.adoc
+++ b/modules/ROOT/pages/custom-basic-menu-items.adoc
@@ -1,6 +1,6 @@
 = Custom Basic menu items
 
-:title_nav: Custom Basic menu items
+:navtitle: Custom Basic menu items
 :description: How to create custom basic menu items.
 :keywords: menu menuitem menuitems
 

--- a/modules/ROOT/pages/custom-basic-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-basic-toolbar-button.adoc
@@ -1,6 +1,6 @@
 = Creating custom Basic toolbar buttons
 
-:title_nav: Basic toolbar button
+:navtitle: Basic toolbar button
 :description: Creating custom Basic toolbar buttons for TinyMCE
 :keywords: toolbar toolbarbuttons buttons toolbarbuttonsapi
 

--- a/modules/ROOT/pages/custom-basic-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-basic-toolbar-button.adoc
@@ -33,7 +33,7 @@ include::partial$misc/admon_predefined_icons_only.adoc[]
 
 The following example adds two buttons to the toolbar:
 
-liveDemo::custom-toolbar-button[ tab="js" ]
+liveDemo::custom-toolbar-button[tab="js"]
 
 The first button inserts "It's my button!" into the editor when clicked. The second button is an example of how `+onSetup+` works. This button inserts a `+time+` element containing the current date into the editor using a `+toTimeHtml()+` helper function - a simplified version of {productname}'s xref:insertdatetime.adoc[insertdatetime] plugin.
 

--- a/modules/ROOT/pages/custom-group-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-group-toolbar-button.adoc
@@ -34,7 +34,7 @@ include::partial$misc/admon_predefined_icons_only.adoc[]
 
 The following is a simple group toolbar button example:
 
-liveDemo::custom-toolbar-group-button[ tab="js" ]
+liveDemo::custom-toolbar-group-button[tab="js"]
 
 The example above configures a custom *alignment* group toolbar button. When clicked the button will show a floating shelf containing the align left, center, right and justify toolbar buttons.
 

--- a/modules/ROOT/pages/custom-group-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-group-toolbar-button.adoc
@@ -1,6 +1,6 @@
 = Creating custom Group toolbar buttons
 
-:title_nav: Group toolbar button
+:navtitle: Group toolbar button
 :description: Creating custom Group toolbar buttons for TinyMCE
 :keywords: toolbar toolbarbuttons buttons toolbarbuttonsapi
 

--- a/modules/ROOT/pages/custom-menu-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-menu-toolbar-button.adoc
@@ -34,7 +34,7 @@ include::partial$misc/admon_predefined_icons_only.adoc[]
 
 The following is a simple toolbar menu button example:
 
-liveDemo::custom-toolbar-menu-button[ tab="js" ]
+liveDemo::custom-toolbar-menu-button[tab="js"]
 
 This example configures a toolbar menu button with the label `+My Button+` that opens the specified menu when clicked. The top-level menu contains two items. The first menu item inserts content when clicked and the second menu item opens a submenu containing two menu items which insert content when clicked.
 

--- a/modules/ROOT/pages/custom-menu-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-menu-toolbar-button.adoc
@@ -1,6 +1,6 @@
 = Creating custom Menu toolbar buttons
 
-:title_nav: Menu toolbar button
+:navtitle: Menu toolbar button
 :description: Creating custom Menu toolbar buttons for TinyMCE
 :keywords: toolbar toolbarbuttons buttons toolbarbuttonsapi
 

--- a/modules/ROOT/pages/custom-nested-menu-items.adoc
+++ b/modules/ROOT/pages/custom-nested-menu-items.adoc
@@ -1,6 +1,6 @@
 = Custom Nested menu items
 
-:title_nav: Custom Nested menu items
+:navtitle: Custom Nested menu items
 :description: How to create custom Nested menu items.
 :keywords: menu menuitem menuitems
 

--- a/modules/ROOT/pages/custom-split-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-split-toolbar-button.adoc
@@ -1,6 +1,6 @@
 = Creating custom Split toolbar buttons
 
-:title_nav: Split toolbar button
+:navtitle: Split toolbar button
 :description: Creating custom Split toolbar buttons for TinyMCE
 :keywords: toolbar toolbarbuttons buttons toolbarbuttonsapi
 

--- a/modules/ROOT/pages/custom-split-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-split-toolbar-button.adoc
@@ -38,7 +38,7 @@ include::partial$misc/admon_predefined_icons_only.adoc[]
 
 The following example sets up a split button with a text label and a static dropdown menu.
 
-liveDemo::custom-toolbar-split-button[ tab="js" ]
+liveDemo::custom-toolbar-split-button[tab="js"]
 
 A split button is similar to a basic button in that they both require an `+onAction+` callback. The `+onAction+` callback function should take the button's API and return nothing. It is called when the basic button section is clicked. In this example, `+onAction+` calls `+editor.insertContent(value)+` which inserts the given content into the editor.
 

--- a/modules/ROOT/pages/custom-toggle-menu-items.adoc
+++ b/modules/ROOT/pages/custom-toggle-menu-items.adoc
@@ -1,6 +1,6 @@
 = Custom Toggle menu items
 
-:title_nav: Custom Toggle menu items
+:navtitle: Custom Toggle menu items
 :description: How to create custom Toggle menu items.
 :keywords: menu menuitem menuitems
 

--- a/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
@@ -1,6 +1,6 @@
 = Creating custom Toggle toolbar buttons
 
-:title_nav: Toggle toolbar button
+:navtitle: Toggle toolbar button
 :description: Creating custom Toggle toolbar buttons for TinyMCE
 :keywords: toolbar toolbarbuttons buttons toolbarbuttonsapi
 

--- a/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
@@ -34,7 +34,7 @@ include::partial$misc/admon_predefined_icons_only.adoc[]
 
 == Toggle button example and explanation
 
-liveDemo::custom-toolbar-toggle-button[ tab="js" ]
+liveDemo::custom-toolbar-toggle-button[tab="js"]
 
 The example above adds two custom *strikethrough* buttons with the same `+onAction+` configuration. The configuration uses `+editor.execCommand(command, ui, args)+` to execute `+mceToggleFormat+`. This editor method toggles the specified format on and off, but only works for xref:content-formatting.adoc#formats[formats] that are already registered with the editor. In this example, `+strikethrough+` is the registered format.
 

--- a/modules/ROOT/pages/custom-toolbarbuttons.adoc
+++ b/modules/ROOT/pages/custom-toolbarbuttons.adoc
@@ -1,6 +1,6 @@
 = Toolbar buttons
 
-:title_nav: Toolbar buttons
+:navtitle: Toolbar buttons
 :description: Add a custom buttons to the TinyMCE 6 toolbar.
 :keywords: toolbar toolbarbuttons buttons toolbarbuttonsapi
 

--- a/modules/ROOT/pages/custom-toolbarbuttons.adoc
+++ b/modules/ROOT/pages/custom-toolbarbuttons.adoc
@@ -49,4 +49,4 @@ tinymce.init({
 
 The following example creates different types of toolbar buttons.
 
-liveDemo::toolbar-button[ height="400" ]
+liveDemo::toolbar-button[height="400"]

--- a/modules/ROOT/pages/customize-ui.adoc
+++ b/modules/ROOT/pages/customize-ui.adoc
@@ -1,6 +1,6 @@
 = Customizing the editor UI
 
-:title_nav: Customizing the UI
+:navtitle: Customizing the UI
 :description: Learn how to change the appearance of TinyMCE.
 :keywords: themes skins statusbar
 

--- a/modules/ROOT/pages/customsidebar.adoc
+++ b/modules/ROOT/pages/customsidebar.adoc
@@ -1,6 +1,6 @@
 = Custom sidebar
 
-:title_nav: Sidebars
+:navtitle: Sidebars
 :description_short: Introducing sidebar panel creation.
 :description: A short introduction to creating sidebars.
 :keywords: sidebar

--- a/modules/ROOT/pages/dialog-apis.adoc
+++ b/modules/ROOT/pages/dialog-apis.adoc
@@ -1,6 +1,6 @@
 = APIs for custom dialogs
 
-:title_nav: APIs
+:navtitle: APIs
 :description: APIs for custom TinyMCE dialogs
 :keywords: dialog dialogapi api
 

--- a/modules/ROOT/pages/dialog-components.adoc
+++ b/modules/ROOT/pages/dialog-components.adoc
@@ -1,6 +1,6 @@
 = Custom dialog body components
 
-:title_nav: Body components
+:navtitle: Body components
 :description: A reference list of all TinyMCE dialog components.
 :keywords: dialog dialogapi
 

--- a/modules/ROOT/pages/dialog-configuration.adoc
+++ b/modules/ROOT/pages/dialog-configuration.adoc
@@ -1,6 +1,6 @@
 = Configuring custom dialogs
 
-:title_nav: Basic configuration
+:navtitle: Basic configuration
 :description: How to create a basic dialog for TinyMCE.
 :keywords: dialog dialogapi api
 

--- a/modules/ROOT/pages/dialog-examples.adoc
+++ b/modules/ROOT/pages/dialog-examples.adoc
@@ -1,6 +1,6 @@
 = Interactive examples of custom dialogs
 
-:title_nav: Interactive examples
+:navtitle: Interactive examples
 :description: Interactive examples of custom dialogs for TinyMCE.
 :keywords: dialog dialogapi api
 

--- a/modules/ROOT/pages/dialog-examples.adoc
+++ b/modules/ROOT/pages/dialog-examples.adoc
@@ -9,7 +9,7 @@
 
 The following example demonstrates how data flows through the dialog and how buttons are configured. This is an interactive dialog that inserts the name of a cat into the editor content on submit.
 
-liveDemo::dialog-pet-machine[ height="150" tab="js" ]
+liveDemo::dialog-pet-machine[height="150", tab="js"]
 
 The dialog in this example contains two interactive components - an input component named `+catdata+` and a checkbox component named `+isdog+`. These names are used in the `+initialdata+` configuration property to set the initial values for these components. In this case, when the dialog loads the input will contain the text _initial Cat_ and the checkbox will not be checked.
 
@@ -26,7 +26,7 @@ The following example demonstrates one way of implementing a multipage form dial
 
 To see the output of the code, click on the {productname} tab on the fiddle below.
 
-liveDemo::redial-demo[ height="900" tab="js" ]
+liveDemo::redial-demo[height="900", tab="js"]
 
 The example JavaScript code contains two dialog configurations - `+page1Config+` and `+page2Config+`. The {productname} initialization code adds a button to the editor that when clicked calls `+editor.windowManager.open(page1Config)+` to open a dialog using the first configuration.
 

--- a/modules/ROOT/pages/dialog-footer-buttons.adoc
+++ b/modules/ROOT/pages/dialog-footer-buttons.adoc
@@ -1,6 +1,6 @@
 = Custom dialog footer buttons
 
-:title_nav: Footer buttons
+:navtitle: Footer buttons
 :description: Reference for adding footer buttons to custom TinyMCE dialogs.
 :keywords: dialog dialogapi
 

--- a/modules/ROOT/pages/dialog.adoc
+++ b/modules/ROOT/pages/dialog.adoc
@@ -1,6 +1,6 @@
 = Creating custom dialogs
 
-:title_nav: Creating custom dialogs
+:navtitle: Creating custom dialogs
 :description: An overview of TinyMCE dialogs and how to create custom dialogs.
 :keywords: dialog dialogapi api
 

--- a/modules/ROOT/pages/directionality.adoc
+++ b/modules/ROOT/pages/directionality.adoc
@@ -1,6 +1,6 @@
 = Directionality plugin
 
-:title_nav: Directionality
+:navtitle: Directionality
 :description: Toolbar buttons for setting the left-to-right or right-to-left direction of content.
 :keywords: rtl, ltr, internationalization, internationalisation, localization, localisation, international
 :controls: toolbar button

--- a/modules/ROOT/pages/directionality.adoc
+++ b/modules/ROOT/pages/directionality.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button
 :pluginname: Directionality
 :plugincode: directionality
-:altplugincode: nil
 
 
 This plugin adds directionality controls to the toolbar, enabling {productname} to better handle languages written from right to left. It also adds a toolbar button for each of its values, `+ltr+` for left-to-right text and `+rtl+` for right-to-left text.

--- a/modules/ROOT/pages/django-cloud.adoc
+++ b/modules/ROOT/pages/django-cloud.adoc
@@ -1,6 +1,6 @@
 = Using TinyMCE from the Tiny Cloud CDN with the Django framework
 
-:title_nav: Django
+:navtitle: Django
 :description: A guide on integrating TinyMCE from the Tiny Cloud into the Django framework.
 :keywords: integration integrate Django django django-tinymce python
 :productSource: cloud

--- a/modules/ROOT/pages/django-zip.adoc
+++ b/modules/ROOT/pages/django-zip.adoc
@@ -1,6 +1,6 @@
 = Using the TinyMCE .zip package with the Django framework
 
-:title_nav: Django
+:navtitle: Django
 :description: A guide on integrating a .zip version of TinyMCE into the Django framework.
 :keywords: integration integrate Django django django-tinymce python
 :productSource: zip

--- a/modules/ROOT/pages/dotnet-projects.adoc
+++ b/modules/ROOT/pages/dotnet-projects.adoc
@@ -1,6 +1,6 @@
 = Installing TinyMCE for .NET
 
-:title_nav: .NET projects
+:navtitle: .NET projects
 :description: Learn how to install TinyMCE from NuGet.
 :keywords: nuget .net install
 :productSource: nuget

--- a/modules/ROOT/pages/editimage.adoc
+++ b/modules/ROOT/pages/editimage.adoc
@@ -5,7 +5,6 @@
 :keywords: edit image rotate rotateleft rotateright flip flipv fliph editimage imageoptions
 :pluginname: Edit Image
 :plugincode: editimage
-:altplugincode: nil
 :pluginminimumplan: tierone
 
 Edit Image (`+editimage+`) plugin adds a contextual editing toolbar to the images in the editor. If toolbar is not appearing on image click, it might be that you need to enable `+editimage_cors_hosts+` or `+editimage_proxy_service_url+` (see below).

--- a/modules/ROOT/pages/editimage.adoc
+++ b/modules/ROOT/pages/editimage.adoc
@@ -11,7 +11,7 @@ Edit Image (`+editimage+`) plugin adds a contextual editing toolbar to the image
 
 == Interactive example
 
-liveDemo::edit-image[ ]
+liveDemo::edit-image[]
 
 include::partial$misc/admon_svg_not_supported.adoc[]
 

--- a/modules/ROOT/pages/editimage.adoc
+++ b/modules/ROOT/pages/editimage.adoc
@@ -1,6 +1,6 @@
 = Edit Image
 
-:title_nav: Edit Image
+:navtitle: Edit Image
 :description: Image editing features for TinyMCE.
 :keywords: edit image rotate rotateleft rotateright flip flipv fliph editimage imageoptions
 :pluginname: Edit Image

--- a/modules/ROOT/pages/editor-command-identifiers.adoc
+++ b/modules/ROOT/pages/editor-command-identifiers.adoc
@@ -1,6 +1,6 @@
 = Commands Available for TinyMCE
 
-:title_nav: Available Commands
+:navtitle: Available Commands
 :description_short: Complete list of editor commands.
 :description: The complete list of exposed editor commands.
 :keywords: editorcommands editorcommand execcommand Bold Italic Underline Strikethrough Superscript Subscript Cut Copy Paste Unlink JustifyLeft JustifyCenter JustifyRight JustifyFull JustifyNone InsertUnorderedList InsertOrderedList ForeColor HiliteColor FontName FontSize RemoveFormat mceBlockQuote FormatBlock mceInsertContent mceToggleFormat mceSetContent Indent Outdent InsertHorizontalRule mceToggleVisualAid mceInsertLink selectAll delete mceNewDocument Undo Redo mceAutoResize mceShowCharmap mceCodeEditor mceDirectionLTR mceDirectionRTL mceFullscreen mceImage mceInsertDate mceInsertTime mceInsertDefinitionList mceNonBreaking mcePageBreak mcePreview mcePrint mceSave SearchReplace mceInsertTemplate mceVisualBlocks mceVisualChars mceMedia mceAnchor mceTableSplitCells mceTableMergeCells mceTableInsertRowBefore mceTableInsertRowAfter mceTableInsertColBefore mceTableInsertColAfter mceTableDeleteCol mceTableDeleteRow mceTableCutRow mceTableCopyRow mceTablePasteRowBefore mceTablePasteRowAfter mceTableDelete mceInsertTable mceTableRowProps mceTableCellProps mceEditImage mceAddEditor mceRemoveEditor mceToggleEditor

--- a/modules/ROOT/pages/editor-content-css.adoc
+++ b/modules/ROOT/pages/editor-content-css.adoc
@@ -1,6 +1,6 @@
 = CSS for rendering TinyMCE content outside the editor
 
-:title_nav: CSS for rendering content
+:navtitle: CSS for rendering content
 :description: CSS for rendering TinyMCE content outside the editor, such as on a webpage.
 :keywords: css content_css
 

--- a/modules/ROOT/pages/editor-context-menu-identifiers.adoc
+++ b/modules/ROOT/pages/editor-context-menu-identifiers.adoc
@@ -1,6 +1,6 @@
 = Context Menu Items Available for TinyMCE
 
-:title_nav: Available Context Menu Items
+:navtitle: Available Context Menu Items
 :description_short: Complete list of available context menu sections.
 :description: Complete list of available context menu sections.
 :keywords: contextmenu

--- a/modules/ROOT/pages/editor-dfree.adoc
+++ b/modules/ROOT/pages/editor-dfree.adoc
@@ -1,6 +1,6 @@
 = Distraction-free editor example
 
-:title_nav: Distraction-free editor
+:navtitle: Distraction-free editor
 :description_short: Distraction-free editor.
 :description: Distraction-free editor
 :keywords: example distraction-free editor

--- a/modules/ROOT/pages/editor-dfree.adoc
+++ b/modules/ROOT/pages/editor-dfree.adoc
@@ -9,4 +9,4 @@
 
 This example shows you how to use {productname}'s Distraction-free editor.
 
-liveDemo::editor-dfree[ ]
+liveDemo::editor-dfree[]

--- a/modules/ROOT/pages/editor-icon-identifiers.adoc
+++ b/modules/ROOT/pages/editor-icon-identifiers.adoc
@@ -1,6 +1,6 @@
 = Icons Available for TinyMCE
 
-:title_nav: Available Icons
+:navtitle: Available Icons
 :description_short: Complete list of icon identifiers.
 :description: Complete list of icon identifiers.
 :keywords: icon icons identifier

--- a/modules/ROOT/pages/editor-icons.adoc
+++ b/modules/ROOT/pages/editor-icons.adoc
@@ -1,6 +1,6 @@
 = TinyMCE Icon options
 
-:title_nav: Icons
+:navtitle: Icons
 :description: Configure the editor's toolbar button and menu item icons.
 
 include::partial$misc/icons-or-icons_url.adoc[]

--- a/modules/ROOT/pages/editor-important-options.adoc
+++ b/modules/ROOT/pages/editor-important-options.adoc
@@ -1,6 +1,6 @@
 = Key editor options for adding TinyMCE to an application
 
-:title_nav: Integration options
+:navtitle: Integration options
 :description: Key editor options for integrating TinyMCE to an application
 :keywords:
 

--- a/modules/ROOT/pages/editor-save-and-submit.adoc
+++ b/modules/ROOT/pages/editor-save-and-submit.adoc
@@ -1,6 +1,6 @@
 = Editor save and submit options
 
-:title_nav: Save and submit
+:navtitle: Save and submit
 :description: Editor options related to saving or submitting editor content
 :keywords:
 

--- a/modules/ROOT/pages/editor-size-options.adoc
+++ b/modules/ROOT/pages/editor-size-options.adoc
@@ -1,6 +1,6 @@
 = Editor size and resize options
 
-:title_nav: Size
+:navtitle: Size
 :description: Options for setting the size of the editor and controling editor resizing
 :keywords:
 

--- a/modules/ROOT/pages/editor-skin.adoc
+++ b/modules/ROOT/pages/editor-skin.adoc
@@ -1,6 +1,6 @@
 = TinyMCE Skin options
 
-:title_nav: Skins
+:navtitle: Skins
 :description: Configure the editor's overall appearance.
 
 include::partial$misc/skin-or-skin_url.adoc[]

--- a/modules/ROOT/pages/editor-theme.adoc
+++ b/modules/ROOT/pages/editor-theme.adoc
@@ -1,6 +1,6 @@
 = TinyMCE Theme options
 
-:title_nav: Themes
+:navtitle: Themes
 :description: Configure the editor's theme.
 
 WARNING: {companyname} does not recommend creating custom themes. The default `+silver+` theme provides the editor user interface components such as buttons, dialogs, and menus. To change the editor appearance, customize the skin, icons, and other user interface elements such as the toolbar.

--- a/modules/ROOT/pages/emoticons.adoc
+++ b/modules/ROOT/pages/emoticons.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button
 :pluginname: Emoticons
 :plugincode: emoticons
-:altplugincode: nil
 
 This plugin adds a dialog to the editor lets users insert emoji into {productname}'s editable area. The dialog can be invoked via a toolbar button - `+emoticons+` - or a dedicated menu item added as `+Insert > Emoticons+`.
 

--- a/modules/ROOT/pages/emoticons.adoc
+++ b/modules/ROOT/pages/emoticons.adoc
@@ -28,7 +28,7 @@ tinymce.init({
 
 By default, the emoticon plugin inserts Unicode character codes, such as `+\ud83d\ude03+` for the smiley emoji. How emoji are rendered is dependent on the web browser and operating system of the user. As a result of this, some emoji may be rendered in black and white, or may not render. To ensure emoji render consistently across browsers and operating systems, {companyname} recommends adding an emoji-compatible web font to the default font-family using xref:add-css-options.adoc#content_css[`+content_css+`].
 
-liveDemo::emoticons[ ]
+liveDemo::emoticons[]
 
 == Options
 

--- a/modules/ROOT/pages/emoticons.adoc
+++ b/modules/ROOT/pages/emoticons.adoc
@@ -1,6 +1,6 @@
 = Emoticons plugin
 
-:title_nav: Emoticons
+:navtitle: Emoticons
 :description: Bring a smiley to your content.
 :keywords: smiley happy smiling emoji
 :controls: toolbar button

--- a/modules/ROOT/pages/events.adoc
+++ b/modules/ROOT/pages/events.adoc
@@ -1,6 +1,6 @@
 = Events Available for TinyMCE
 
-:title_nav: Available Events
+:navtitle: Available Events
 :description_short: List of common editor events
 :description: List of common editor events
 :keywords: Click DblClick MouseDown MouseUp MouseMove MouseOver MouseOut MouseEnter MouseLeave KeyDown KeyPress KeyUp ContextMenu Paste Init Focus Blur BeforeSetContent SetContent GetContent PreProcess PostProcess NodeChange Undo Redo Change Dirty Remove ExecCommand PastePreProcess PastePostProcess

--- a/modules/ROOT/pages/export.adoc
+++ b/modules/ROOT/pages/export.adoc
@@ -1,6 +1,6 @@
 = Export plugin
 
-:title_nav: Export
+:navtitle: Export
 :description: Export content from TinyMCE, into various formats.
 :keywords: plugin export pdf
 :pluginname: Export

--- a/modules/ROOT/pages/export.adoc
+++ b/modules/ROOT/pages/export.adoc
@@ -5,7 +5,6 @@
 :keywords: plugin export pdf
 :pluginname: Export
 :plugincode: export
-:altplugincode: nil
 :pluginminimumplan: tiertwo
 
 include::partial$misc/admon_premium_plugin.adoc[]

--- a/modules/ROOT/pages/export.adoc
+++ b/modules/ROOT/pages/export.adoc
@@ -18,7 +18,7 @@ To export the editor content, either:
 * From the _File_ menu, click _Export_ and select _PDF_.
 * Click the Export toolbar button (image:icons/export.svg[Export icon: A page with an arrow from the center of the page to the right of the page]) and select _PDF_.
 
-liveDemo::export[ ]
+liveDemo::export[]
 
 include::partial$misc/purchase-premium-plugins.adoc[]
 

--- a/modules/ROOT/pages/expressjs-pm.adoc
+++ b/modules/ROOT/pages/expressjs-pm.adoc
@@ -1,6 +1,6 @@
 = Integrating TinyMCE into an Express JS App
 
-:title_nav: Node.js + Express
+:navtitle: Node.js + Express
 :description: A quick start guide on integrating TinyMCE into an Express JS Application
 :keywords: integration integrate nodejs node.js express express.js expressjs
 

--- a/modules/ROOT/pages/fabric-demo.adoc
+++ b/modules/ROOT/pages/fabric-demo.adoc
@@ -6,4 +6,4 @@
 
 This demo uses the Fabric skin which follows the Microsoft design language. By default it has no border around the editor to make it easier to implement as a fullscreen editor. You can easily create your own border around the editor, look at the demo below for an example.
 
-liveDemo::premiumskinsandicons-fabric[ ]
+liveDemo::premiumskinsandicons-fabric[]

--- a/modules/ROOT/pages/fabric-demo.adoc
+++ b/modules/ROOT/pages/fabric-demo.adoc
@@ -1,6 +1,6 @@
 = Fabric skin demo
 
-:title_nav: Fabric Demo
+:navtitle: Fabric Demo
 :description: Fabric Demo
 :keywords: skin skins icon icons borderless fabric microsoft office word customize theme
 

--- a/modules/ROOT/pages/file-image-upload.adoc
+++ b/modules/ROOT/pages/file-image-upload.adoc
@@ -1,6 +1,6 @@
 = Image and file options
 
-:title_nav: Images and files
+:navtitle: Images and files
 :description: These settings affect TinyMCE's image and file handling capabilities.
 
 == Controlling or adjusting allowed image and file formats

--- a/modules/ROOT/pages/filter-content.adoc
+++ b/modules/ROOT/pages/filter-content.adoc
@@ -1,6 +1,6 @@
 = Filtering TinyMCE content
 
-:title_nav: Content filtering
+:navtitle: Content filtering
 :description: Learn how to create clean, maintainable and readable content.
 
 {productname} has comprehensive content filtering capabilities that change the way the editor handles the input and output of content. This capability ensures content is clean, maintainable, and readable.

--- a/modules/ROOT/pages/fluent-demo.adoc
+++ b/modules/ROOT/pages/fluent-demo.adoc
@@ -6,4 +6,4 @@
 
 This demo uses the Fluent skin which follows the Microsoft design language. By default it has no border around the editor to make it easier to implement as a fullscreen editor. You can easily create your own border around the editor, look at the demo below for an example.
 
-liveDemo::premiumskinsandicons-fluent[ ]
+liveDemo::premiumskinsandicons-fluent[]

--- a/modules/ROOT/pages/fluent-demo.adoc
+++ b/modules/ROOT/pages/fluent-demo.adoc
@@ -1,6 +1,6 @@
 = Fluent skin demo
 
-:title_nav: Fluent Demo
+:navtitle: Fluent Demo
 :description: Fluent Demo
 :keywords: skin skins icon icons borderless fluent microsoft office word customize theme
 

--- a/modules/ROOT/pages/formatpainter.adoc
+++ b/modules/ROOT/pages/formatpainter.adoc
@@ -1,6 +1,6 @@
 = Format Painter
 
-:title_nav: Format Painter
+:navtitle: Format Painter
 :description: Quickly apply formats to multiple pieces of text.
 :keywords: formats formatting edit formatpainter_removeformat formatpainter_tableformats formatpainter_ignored_formats format painter configuration
 :controls: toolbar button

--- a/modules/ROOT/pages/formatpainter.adoc
+++ b/modules/ROOT/pages/formatpainter.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button
 :pluginname: Format Painter
 :plugincode: formatpainter
-:altplugincode: nil
 :pluginminimumplan: tiertwo
 
 

--- a/modules/ROOT/pages/formatpainter.adoc
+++ b/modules/ROOT/pages/formatpainter.adoc
@@ -17,7 +17,7 @@ The Format Painter plugin allows a user to copy and paste formatting from one lo
 
 The format painter retains the formatting after application making it possible to apply the same formatting multiple times by using the `+Ctrl+Alt+V+` keyboard shortcut.
 
-liveDemo::format-painter[ ]
+liveDemo::format-painter[]
 
 include::partial$misc/purchase-premium-plugins.adoc[]
 

--- a/modules/ROOT/pages/fullscreen.adoc
+++ b/modules/ROOT/pages/fullscreen.adoc
@@ -1,6 +1,6 @@
 = Full Screen plugin
 
-:title_nav: Full Screen
+:navtitle: Full Screen
 :description: Zoom TinyMCE up to the whole screen.
 :keywords: fullscreen view
 :controls: toolbar button, menu item

--- a/modules/ROOT/pages/fullscreen.adoc
+++ b/modules/ROOT/pages/fullscreen.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button, menu item
 :pluginname: Full Screen
 :plugincode: fullscreen
-:altplugincode: nil
 
 This plugin adds full screen editing capabilities to {productname}. When the toolbar button is pressed the editable area will fill the browser's viewport. The plugin adds a toolbar button and a menu item `+Fullscreen+` under the `+View+` menu.
 

--- a/modules/ROOT/pages/generate-rsa-key-pairs.adoc
+++ b/modules/ROOT/pages/generate-rsa-key-pairs.adoc
@@ -1,6 +1,6 @@
 = Creating a private/public key pair for Tiny Cloud
 
-:title_nav: Generate public key pairs
+:navtitle: Generate public key pairs
 :description: Instructions on how to generate private/public key pairs for the Tiny Cloud
 :keywords: authentication rsa openssl keypair keys cryptographic
 

--- a/modules/ROOT/pages/help.adoc
+++ b/modules/ROOT/pages/help.adoc
@@ -1,6 +1,6 @@
 = Help plugin
 
-:title_nav: Help
+:navtitle: Help
 :description: Shows the help dialog.
 :keywords: help
 :controls: toolbar button, menu item

--- a/modules/ROOT/pages/help.adoc
+++ b/modules/ROOT/pages/help.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button, menu item
 :pluginname: Help
 :plugincode: help
-:altplugincode: nil
 
 The help plugin adds a button and/or menu item that opens a dialog showing two tabs:
 

--- a/modules/ROOT/pages/how-the-rtc-plugin-encrypts-content.adoc
+++ b/modules/ROOT/pages/how-the-rtc-plugin-encrypts-content.adoc
@@ -1,6 +1,6 @@
 = How the RTC plugin encryption works
 
-:title_nav: How RTC encrypts content
+:navtitle: How RTC encrypts content
 :description: Useful information for understanding how encryption is used with RTC
 :keywords: rtc encrypt decrypt key signature
 

--- a/modules/ROOT/pages/image.adoc
+++ b/modules/ROOT/pages/image.adoc
@@ -1,6 +1,6 @@
 = Image plugin
 
-:title_nav: Image
+:navtitle: Image
 :description: Insert an image into TinyMCE.
 :keywords: photo insert edit style format image_caption image_list image_advtab image_title image_class_list image_prepend_url image_description image_dimensions image_title image_prepend_url
 :pluginname: Image

--- a/modules/ROOT/pages/image.adoc
+++ b/modules/ROOT/pages/image.adoc
@@ -5,7 +5,6 @@
 :keywords: photo insert edit style format image_caption image_list image_advtab image_title image_class_list image_prepend_url image_description image_dimensions image_title image_prepend_url
 :pluginname: Image
 :plugincode: image
-:altplugincode: nil
 
 This plugin enables the user to insert an image into {productname}'s editable area. The plugin also adds a toolbar button and an `+Insert/edit image+` menu item under the `+Insert+` menu.
 

--- a/modules/ROOT/pages/importcss.adoc
+++ b/modules/ROOT/pages/importcss.adoc
@@ -1,6 +1,6 @@
 = Import CSS plugin
 
-:title_nav: Import CSS
+:navtitle: Import CSS
 :description: Automatically populate CSS class names into the Format dropdown.
 :keywords: importcss content_css importcss_append importcss_file_filter importcss_selector_filter importcss_groups importcss_merge_classes importcss_selector_converter importcss_exclusive
 :plugincode: importcss

--- a/modules/ROOT/pages/importcss.adoc
+++ b/modules/ROOT/pages/importcss.adoc
@@ -4,7 +4,6 @@
 :description: Automatically populate CSS class names into the Format dropdown.
 :keywords: importcss content_css importcss_append importcss_file_filter importcss_selector_filter importcss_groups importcss_merge_classes importcss_selector_converter importcss_exclusive
 :plugincode: importcss
-:altplugincode: nil
 
 The `+importcss+` plugin adds the ability to automatically import CSS classes from the CSS file specified in the xref:add-css-options.adoc#content_css[`+content_css+`] configuration setting.
 

--- a/modules/ROOT/pages/individual-hyperlinking-container.adoc
+++ b/modules/ROOT/pages/individual-hyperlinking-container.adoc
@@ -1,6 +1,6 @@
 = Deploy the TinyMCE Hyperlinking server-side component using Docker (individually licensed)
 
-:title_nav: Hyperlinking service
+:navtitle: Hyperlinking service
 :description: How-to deploy the TinyMCE Hyperlinking server-side component using Docker (individually licensed).
 :shbundledockerfiles: false
 

--- a/modules/ROOT/pages/individual-spelling-container.adoc
+++ b/modules/ROOT/pages/individual-spelling-container.adoc
@@ -1,6 +1,6 @@
 = Deploy the TinyMCE Spelling server-side component using Docker (individually licensed)
 
-:title_nav: Spelling service
+:navtitle: Spelling service
 :description: How-to deploy the TinyMCE Spelling server-side component using Docker (individually licensed).
 :shbundledockerfiles: false
 

--- a/modules/ROOT/pages/inline-editor-options.adoc
+++ b/modules/ROOT/pages/inline-editor-options.adoc
@@ -1,6 +1,6 @@
 = Inline editor options
 
-:title_nav: Inline editor options
+:navtitle: Inline editor options
 :description: Options for changing the editor to inline mode and working with inline mode.
 
 include::partial$configuration/inline.adoc[]

--- a/modules/ROOT/pages/inline.adoc
+++ b/modules/ROOT/pages/inline.adoc
@@ -1,6 +1,6 @@
 = Inline editor example
 
-:title_nav: Inline editor
+:navtitle: Inline editor
 :description_short: See how inline editor works.
 :description: This example shows you the inline editing capabilities of TinyMCE.
 :keywords: example demo custom inline

--- a/modules/ROOT/pages/inline.adoc
+++ b/modules/ROOT/pages/inline.adoc
@@ -7,4 +7,4 @@
 
 This example shows you the inline editing capabilities of {productname}.
 
-liveDemo::inline[ ]
+liveDemo::inline[]

--- a/modules/ROOT/pages/insertdatetime.adoc
+++ b/modules/ROOT/pages/insertdatetime.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button, menu item
 :pluginname: Insert Date/Time
 :plugincode: insertdatetime
-:altplugincode: nil
 
 The `+insertdatetime+` plugin provides a toolbar control and menu item `+Insert date/time+` (under the `+Insert+` menu) that lets a user easily insert the current date and/or time into the editable area at the cursor insertion point.
 

--- a/modules/ROOT/pages/insertdatetime.adoc
+++ b/modules/ROOT/pages/insertdatetime.adoc
@@ -1,6 +1,6 @@
 = Insert Date/Time plugin
 
-:title_nav: Insert Date/Time
+:navtitle: Insert Date/Time
 :description: Insert the current date and/or time into TinyMCE.
 :keywords: insertdatetime insertdatetime_dateformat insertdatetime_formats insertdatetime_timeformat insertdatetime_element dateformats
 :controls: toolbar button, menu item

--- a/modules/ROOT/pages/introduction-to-bundling-tinymce.adoc
+++ b/modules/ROOT/pages/introduction-to-bundling-tinymce.adoc
@@ -1,6 +1,6 @@
 = Introduction to bundling TinyMCE
 
-:title_nav: Introduction
+:navtitle: Introduction
 :description_short: Introduction to bundling TinyMCE using a module loader.
 :description: Introduction to bundling TinyMCE with Webpack, Rollup.js, or Browserify.
 :keywords: webpack browserify es6 rollup commonjs modules tinymce es2015

--- a/modules/ROOT/pages/introduction-to-mediaembed.adoc
+++ b/modules/ROOT/pages/introduction-to-mediaembed.adoc
@@ -1,6 +1,6 @@
 = Enhanced Media Embed plugin
 
-:title_nav: Enhanced Media Embed
+:navtitle: Enhanced Media Embed
 :description: Add rich media previews inside TinyMCE.
 :keywords: video youtube vimeo mp3 mp4 mov movie clip film spotify
 :pluginname: Enhanced Media Embed

--- a/modules/ROOT/pages/introduction-to-mediaembed.adoc
+++ b/modules/ROOT/pages/introduction-to-mediaembed.adoc
@@ -14,7 +14,7 @@ The *Enhanced Media Embed* plugin is a link:{pricingpage}/[premium {productname}
 
 == Interactive example
 
-liveDemo::mediaembed[ ]
+liveDemo::mediaembed[]
 
 include::partial$misc/purchase-premium-plugins.adoc[]
 

--- a/modules/ROOT/pages/introduction-to-mediaembed.adoc
+++ b/modules/ROOT/pages/introduction-to-mediaembed.adoc
@@ -5,7 +5,6 @@
 :keywords: video youtube vimeo mp3 mp4 mov movie clip film spotify
 :pluginname: Enhanced Media Embed
 :plugincode: mediaembed
-:altplugincode: nil
 :pluginminimumplan: tiertwo
 
 

--- a/modules/ROOT/pages/introduction-to-powerpaste.adoc
+++ b/modules/ROOT/pages/introduction-to-powerpaste.adoc
@@ -16,7 +16,7 @@ NOTE: Due to limitations in Microsoft Excel online (part of Office Live) PowerPa
 
 == Try our PowerPaste plugin demo
 
-liveDemo::paste-from-word[ ]
+liveDemo::paste-from-word[]
 
 include::partial$misc/purchase-premium-plugins.adoc[]
 

--- a/modules/ROOT/pages/introduction-to-powerpaste.adoc
+++ b/modules/ROOT/pages/introduction-to-powerpaste.adoc
@@ -5,7 +5,6 @@
 :keywords: enterprise powerpaste power microsoft word excel google docs
 :pluginname: PowerPaste
 :plugincode: powerpaste
-:altplugincode: nil
 :pluginminimumplan: tiertwo
 
 

--- a/modules/ROOT/pages/introduction-to-powerpaste.adoc
+++ b/modules/ROOT/pages/introduction-to-powerpaste.adoc
@@ -1,6 +1,6 @@
 = Introduction to PowerPaste
 
-:title_nav: Introduction
+:navtitle: Introduction
 :description: The PowerPaste plugin automatically cleans up content from Microsoft Word, Microsoft Excel, Google Docs, and HTML sources.
 :keywords: enterprise powerpaste power microsoft word excel google docs
 :pluginname: PowerPaste

--- a/modules/ROOT/pages/introduction-to-tiny-comments.adoc
+++ b/modules/ROOT/pages/introduction-to-tiny-comments.adoc
@@ -1,6 +1,6 @@
 = Introduction to Tiny Comments
 
-:title_nav: Introduction
+:navtitle: Introduction
 :description: Tiny Comments provides the ability to add comments to the content and collaborate with other users for content editing.
 :keywords: comments commenting tinycomments
 :pluginname: Comments

--- a/modules/ROOT/pages/introduction-to-tiny-comments.adoc
+++ b/modules/ROOT/pages/introduction-to-tiny-comments.adoc
@@ -43,7 +43,7 @@ The Comments plugin allows the user to perform the following functions:
 
 The following example shows how to configure the Comments plugin in *embedded* mode. For information on configuring the Comments plugin, see: xref:getting-started-with-the-comments-plugin-selecting-a-mode[Comments plugin Modes].
 
-liveDemo::comments-embedded[ ]
+liveDemo::comments-embedded[]
 
 include::partial$misc/purchase-premium-plugins.adoc[]
 

--- a/modules/ROOT/pages/introduction-to-tiny-comments.adoc
+++ b/modules/ROOT/pages/introduction-to-tiny-comments.adoc
@@ -5,7 +5,6 @@
 :keywords: comments commenting tinycomments
 :pluginname: Comments
 :plugincode: comments
-:altplugincode: nil
 :pluginminimumplan: enterprise
 
 

--- a/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
+++ b/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
@@ -5,7 +5,6 @@
 :keywords: tinymcespellchecker spellchecker_language spellchecker_languages spellchecker_rpc_url spellchecker_dialog ephox
 :pluginname: Spell Checker Pro
 :plugincode: tinymcespellchecker
-:altplugincode: nil
 :pluginminimumplan: tierthree
 
 include::partial$misc/admon_premium_plugin.adoc[]

--- a/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
+++ b/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
@@ -13,7 +13,7 @@ include::partial$misc/admon_premium_plugin.adoc[]
 
 == Interactive example
 
-liveDemo::spellcheckerpro[ ]
+liveDemo::spellcheckerpro[]
 
 include::partial$misc/purchase-premium-plugins.adoc[]
 

--- a/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
+++ b/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
@@ -1,6 +1,6 @@
 = Spell Checker Pro plugin
 
-:title_nav: Spell Checker Pro
+:navtitle: Spell Checker Pro
 :description: Check spelling as-you-type in TinyMCE.
 :keywords: tinymcespellchecker spellchecker_language spellchecker_languages spellchecker_rpc_url spellchecker_dialog ephox
 :pluginname: Spell Checker Pro

--- a/modules/ROOT/pages/introduction-to-tinydrive-apis.adoc
+++ b/modules/ROOT/pages/introduction-to-tinydrive-apis.adoc
@@ -1,6 +1,6 @@
 = Introduction to the Tiny Drive plugin APIs
 
-:title_nav: Introduction to the plugin APIs
+:navtitle: Introduction to the plugin APIs
 :description: Overview of the Tiny Drive plugin APIs
 :keywords: tinydrive configuration
 

--- a/modules/ROOT/pages/jam-demo.adoc
+++ b/modules/ROOT/pages/jam-demo.adoc
@@ -6,4 +6,4 @@
 
 This demo uses icons from the popular https://jam-icons.com[JAM icon library], here used with the Small skin.
 
-liveDemo::premiumskinsandicons-jam[ ]
+liveDemo::premiumskinsandicons-jam[]

--- a/modules/ROOT/pages/jam-demo.adoc
+++ b/modules/ROOT/pages/jam-demo.adoc
@@ -1,6 +1,6 @@
 = Jam icons pack demo
 
-:title_nav: Jam Icons Demo
+:navtitle: Jam Icons Demo
 :description: Jam Icons Demo
 :keywords: skin skins icon icons small jam customize theme
 

--- a/modules/ROOT/pages/jquery-cloud.adoc
+++ b/modules/ROOT/pages/jquery-cloud.adoc
@@ -1,6 +1,6 @@
 = TinyMCE jQuery integration quick start guide
 
-:title_nav: jQuery
+:navtitle: jQuery
 :description: Documentation for the official TinyMCE jQuery integration.
 :keywords: integration integrate jquery javascript
 :productSource: cloud

--- a/modules/ROOT/pages/jquery-pm.adoc
+++ b/modules/ROOT/pages/jquery-pm.adoc
@@ -1,6 +1,6 @@
 = TinyMCE jQuery integration quick start guide
 
-:title_nav: jQuery
+:navtitle: jQuery
 :description: Documentation for the official TinyMCE jQuery integration.
 :keywords: integration integrate jquery javascript
 :productSource: package-manager

--- a/modules/ROOT/pages/keyboard-shortcuts.adoc
+++ b/modules/ROOT/pages/keyboard-shortcuts.adoc
@@ -1,6 +1,6 @@
 = TinyMCE Keyboard shortcuts
 
-:title_nav: TinyMCE Keyboard shortcuts
+:navtitle: TinyMCE Keyboard shortcuts
 :description_short: Complete list of keyboard shortcuts.
 :description: Complete list of keyboard shortcuts.
 :keywords: keyboard shortcuts

--- a/modules/ROOT/pages/laravel-composer-install.adoc
+++ b/modules/ROOT/pages/laravel-composer-install.adoc
@@ -1,6 +1,6 @@
 = Using the TinyMCE composer package with the Laravel framework
 
-:title_nav: Using the Composer package
+:navtitle: Using the Composer package
 :description: A guide on integrating the TinyMCE Composer package into the Laravel framework.
 :keywords: integration integrate laravel php composer
 :productSource: composer

--- a/modules/ROOT/pages/laravel-tiny-cloud.adoc
+++ b/modules/ROOT/pages/laravel-tiny-cloud.adoc
@@ -1,6 +1,6 @@
 = Using TinyMCE from the Tiny Cloud CDN with the Laravel framework
 
-:title_nav: Laravel
+:navtitle: Laravel
 :description: A guide on integrating TinyMCE from the Tiny Cloud into the Laravel framework.
 :keywords: integration integrate laravel php composer
 :productSource: cloud

--- a/modules/ROOT/pages/laravel-zip-install.adoc
+++ b/modules/ROOT/pages/laravel-zip-install.adoc
@@ -1,6 +1,6 @@
 = Using the TinyMCE .zip package with the Laravel framework
 
-:title_nav: Using a .zip package
+:navtitle: Using a .zip package
 :description: A guide on integrating a .zip version of TinyMCE into the Laravel framework.
 :keywords: integration integrate laravel php composer
 :productSource: zip

--- a/modules/ROOT/pages/link.adoc
+++ b/modules/ROOT/pages/link.adoc
@@ -1,6 +1,6 @@
 = Link plugin
 
-:title_nav: Link
+:navtitle: Link
 :description: Add hyperlinks to content.
 :keywords: url urls insert edit link_default_target link_assume_external_targets link_class_list link_list link_target_list link_rel_list link_title
 :controls: toolbar button, menu item

--- a/modules/ROOT/pages/link.adoc
+++ b/modules/ROOT/pages/link.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button, menu item
 :pluginname: Link
 :plugincode: link
-:altplugincode: nil
 
 
 The *link* plugin allows a user to link external resources such as website URLs, to selected text in their document.

--- a/modules/ROOT/pages/linkchecker.adoc
+++ b/modules/ROOT/pages/linkchecker.adoc
@@ -1,6 +1,6 @@
 = Link Checker plugin
 
-:title_nav: Link Checker
+:navtitle: Link Checker
 :description: Validate links, as you type.
 :keywords: url urls link linkchecker_service_url linkchecker_content_css
 :pluginname: Link Checker

--- a/modules/ROOT/pages/linkchecker.adoc
+++ b/modules/ROOT/pages/linkchecker.adoc
@@ -16,7 +16,7 @@ The Link Checker plugin relies on HTTP response status codes to determine if a l
 
 == Interactive example
 
-liveDemo::linkchecker[ ]
+liveDemo::linkchecker[]
 
 include::partial$misc/purchase-premium-plugins.adoc[]
 

--- a/modules/ROOT/pages/linkchecker.adoc
+++ b/modules/ROOT/pages/linkchecker.adoc
@@ -5,7 +5,6 @@
 :keywords: url urls link linkchecker_service_url linkchecker_content_css
 :pluginname: Link Checker
 :plugincode: linkchecker
-:altplugincode: nil
 :pluginminimumplan: tierthree
 
 

--- a/modules/ROOT/pages/lists.adoc
+++ b/modules/ROOT/pages/lists.adoc
@@ -1,6 +1,6 @@
 = Lists plugin
 
-:title_nav: Lists
+:navtitle: Lists
 :description: Normalizes list behavior between browsers.
 :keywords: list lists browser normalize
 :pluginname: Lists

--- a/modules/ROOT/pages/lists.adoc
+++ b/modules/ROOT/pages/lists.adoc
@@ -5,7 +5,6 @@
 :keywords: list lists browser normalize
 :pluginname: Lists
 :plugincode: lists
-:altplugincode: nil
 
 
 The `+lists+` plugin allows you to add numbered and bulleted lists to {productname}. To enable advanced lists (e.g. alpha numbered lists, square bullets) you should also enable the xref:advlist.adoc[Advanced List] (`+advlist+`) plugin.

--- a/modules/ROOT/pages/localize-your-language.adoc
+++ b/modules/ROOT/pages/localize-your-language.adoc
@@ -1,6 +1,6 @@
 = Localize TinyMCE
 
-:title_nav: Localization
+:navtitle: Localization
 :description: Localize TinyMCE with global language capabilities.
 :keywords: internationalization localization languages
 

--- a/modules/ROOT/pages/material-classic-demo.adoc
+++ b/modules/ROOT/pages/material-classic-demo.adoc
@@ -1,6 +1,6 @@
 = Material Classic skin demo
 
-:title_nav: Material Classic Demo
+:navtitle: Material Classic Demo
 :description: Material Classic Demo
 :keywords: skin skins icon icons material customize theme
 

--- a/modules/ROOT/pages/material-classic-demo.adoc
+++ b/modules/ROOT/pages/material-classic-demo.adoc
@@ -6,4 +6,4 @@
 
 This demo shows an example form using the classical Material Design web components together with {productname} with the _Material Classic_ skin and _Material_ icon pack.
 
-liveDemo::premiumskinsandicons-material-classic[ ]
+liveDemo::premiumskinsandicons-material-classic[]

--- a/modules/ROOT/pages/material-outline-demo.adoc
+++ b/modules/ROOT/pages/material-outline-demo.adoc
@@ -1,6 +1,6 @@
 = Material Outline skin demo
 
-:title_nav: Material Outline Demo
+:navtitle: Material Outline Demo
 :description: Material Outline Demo
 :keywords: skin skins icon icons material customize theme
 

--- a/modules/ROOT/pages/material-outline-demo.adoc
+++ b/modules/ROOT/pages/material-outline-demo.adoc
@@ -6,4 +6,4 @@
 
 This demo shows an example form using the outlined version of Material Design web components together with {productname} with the _Material Outline_ skin and _Material_ icon pack.
 
-liveDemo::premiumskinsandicons-material-outline[ ]
+liveDemo::premiumskinsandicons-material-outline[]

--- a/modules/ROOT/pages/media.adoc
+++ b/modules/ROOT/pages/media.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button, menu item
 :pluginname: Media
 :plugincode: media
-:altplugincode: nil
 
 
 The `+media+` plugin adds the ability for users to be able to add HTML5 video and audio elements to the editable area. It also adds the item `+Insert/edit video+` under the `+Insert+` menu as well as a toolbar button.

--- a/modules/ROOT/pages/media.adoc
+++ b/modules/ROOT/pages/media.adoc
@@ -1,6 +1,6 @@
 = Media plugin
 
-:title_nav: Media
+:navtitle: Media
 :description: Add HTML5 video and audio elements.
 :keywords: video youtube vimeo mp3 mp4 mov movie clip film media_live_embeds audio_template_callback media_alt_source media_poster media_dimensions media_filter_html media_scripts video_template_callback
 :controls: toolbar button, menu item

--- a/modules/ROOT/pages/mentions.adoc
+++ b/modules/ROOT/pages/mentions.adoc
@@ -1,6 +1,6 @@
 = Mentions plugin
 
-:title_nav: Mentions
+:navtitle: Mentions
 :description: Enables @mention functionality.
 :keywords: mentions atmentions
 :pluginname: Mentions

--- a/modules/ROOT/pages/mentions.adoc
+++ b/modules/ROOT/pages/mentions.adoc
@@ -13,7 +13,7 @@ The mentions plugin will present a list of users when a user types the "@" symbo
 
 == Interactive example
 
-liveDemo::mentions[ height="400" ]
+liveDemo::mentions[height="400"]
 
 include::partial$misc/purchase-premium-plugins.adoc[]
 

--- a/modules/ROOT/pages/mentions.adoc
+++ b/modules/ROOT/pages/mentions.adoc
@@ -5,7 +5,6 @@
 :keywords: mentions atmentions
 :pluginname: Mentions
 :plugincode: mentions
-:altplugincode: nil
 :pluginminimumplan: enterprise
 
 include::partial$misc/admon_premium_plugin.adoc[]

--- a/modules/ROOT/pages/menus-configuration-options.adoc
+++ b/modules/ROOT/pages/menus-configuration-options.adoc
@@ -1,6 +1,6 @@
 = Options for customizing the editor's menus
 
-:title_nav: Options
+:navtitle: Options
 :description: Information on options for customizing TinyMCE's menus
 
 == Basic menu configuration options

--- a/modules/ROOT/pages/migration-from-5x.adoc
+++ b/modules/ROOT/pages/migration-from-5x.adoc
@@ -1,6 +1,6 @@
 = Migrating from TinyMCE 5 to TinyMCE 6
 
-:title_nav: Migrating from TinyMCE 5
+:navtitle: Migrating from TinyMCE 5
 :description: Guidance for migrating from TinyMCE 5 to TinyMCE 6
 :keywords: migration considerations premigration pre-migration
 

--- a/modules/ROOT/pages/migration-from-froala.adoc
+++ b/modules/ROOT/pages/migration-from-froala.adoc
@@ -1,6 +1,6 @@
 = Migrating from Froala to TinyMCE
 
-:title_nav: Migrating from Froala
+:navtitle: Migrating from Froala
 :description: Upgrading your rich text editor from Froala Editor v3 to TinyMCE 6.
 :keywords: migration considerations premigration pre-migration froala
 

--- a/modules/ROOT/pages/moxiemanager.adoc
+++ b/modules/ROOT/pages/moxiemanager.adoc
@@ -1,6 +1,6 @@
 = MoxieManager plugin
 
-:title_nav: MoxieManager
+:navtitle: MoxieManager
 :description: File and image management plugin and service
 :keywords: amazon azure premium pro enterprise tiny relative_urls
 

--- a/modules/ROOT/pages/multiple-editors.adoc
+++ b/modules/ROOT/pages/multiple-editors.adoc
@@ -1,6 +1,6 @@
 = Use multiple TinyMCE instances in a single page
 
-:title_nav: Multiple editors in a page
+:navtitle: Multiple editors in a page
 :keywords:
 
 This section is about adding multiple editor instances to a single page. This is a common use case when using {productname}'s `+inline+` mode. Breaking content into sections (e.g., titles, paragraphs) allows users to edit them individually.

--- a/modules/ROOT/pages/naked-demo.adoc
+++ b/modules/ROOT/pages/naked-demo.adoc
@@ -1,6 +1,6 @@
 = Naked skin demo
 
-:title_nav: Naked Demo
+:navtitle: Naked Demo
 :description: Naked Demo
 :keywords: skin skins icon icons customize theme
 

--- a/modules/ROOT/pages/naked-demo.adoc
+++ b/modules/ROOT/pages/naked-demo.adoc
@@ -8,4 +8,4 @@ This demo uses the Naked skin. The Naked skin completely removes outside borders
 
 The example below uses the small icon pack and a custom editor frame.
 
-liveDemo::premiumskinsandicons-naked[ ]
+liveDemo::premiumskinsandicons-naked[]

--- a/modules/ROOT/pages/nonbreaking.adoc
+++ b/modules/ROOT/pages/nonbreaking.adoc
@@ -1,6 +1,6 @@
 = Nonbreaking Space plugin
 
-:title_nav: Nonbreaking Space
+:navtitle: Nonbreaking Space
 :description: Insert a nonbreaking space.
 :keywords: nonbreaking nonbreaking_force_tab insert
 :controls: toolbar button, menu item

--- a/modules/ROOT/pages/nonbreaking.adoc
+++ b/modules/ROOT/pages/nonbreaking.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button, menu item
 :pluginname: Nonbreaking Space
 :plugincode: nonbreaking
-:altplugincode: nil
 
 This plugin adds a button for inserting nonbreaking space entities `+&nbsp;+` at the current caret location (cursor insert point). It also adds a menu item `+Nonbreaking space+` under the `+Insert+` menu dropdown and a toolbar button.
 

--- a/modules/ROOT/pages/npm-projects.adoc
+++ b/modules/ROOT/pages/npm-projects.adoc
@@ -1,6 +1,6 @@
 = Installing TinyMCE from NPM
 
-:title_nav: NPM projects
+:navtitle: NPM projects
 :description: Learn how to install TinyMCE from NPM using npm and Yarn.
 :keywords: yarn npm javascript install
 :productSource: npm

--- a/modules/ROOT/pages/os-full-featured.adoc
+++ b/modules/ROOT/pages/os-full-featured.adoc
@@ -7,7 +7,7 @@
 
 This example includes only non-premium plugins. These plugins are also used in the xref:premium-full-featured.adoc[Full featured demo: Including Premium Plugins].
 
-liveDemo::open-source-plugins[ ]
+liveDemo::open-source-plugins[]
 
 The following plugins are excluded from this example:
 

--- a/modules/ROOT/pages/os-full-featured.adoc
+++ b/modules/ROOT/pages/os-full-featured.adoc
@@ -1,6 +1,6 @@
 = Full featured demo: Non-Premium Plugins only
 
-:title_nav: Excluding premium features
+:navtitle: Excluding premium features
 :description_short: Open source TinyMCE in action.
 :description: An example with all of the non-premium features.
 :keywords: example demo custom wysiwyg full-power full-featured plugins non-premium

--- a/modules/ROOT/pages/outside-demo.adoc
+++ b/modules/ROOT/pages/outside-demo.adoc
@@ -1,6 +1,6 @@
 = Outside skin demo
 
-:title_nav: Outside Demo
+:navtitle: Outside Demo
 :description: Outside Demo
 :keywords: skin skins icon icons customize theme
 

--- a/modules/ROOT/pages/outside-demo.adoc
+++ b/modules/ROOT/pages/outside-demo.adoc
@@ -8,4 +8,4 @@ This demo uses the Outside skin. The Outside skin completely removes outside bor
 
 The example below uses the small icon pack.
 
-liveDemo::premiumskinsandicons-outside[ ]
+liveDemo::premiumskinsandicons-outside[]

--- a/modules/ROOT/pages/pagebreak.adoc
+++ b/modules/ROOT/pages/pagebreak.adoc
@@ -1,6 +1,6 @@
 = Page Break plugin
 
-:title_nav: Page Break
+:navtitle: Page Break
 :description: Add a page break.
 :keywords: pagebreak insert pagebreak_separator pagebreak_split_block
 :controls: toolbar button, menu item

--- a/modules/ROOT/pages/pagebreak.adoc
+++ b/modules/ROOT/pages/pagebreak.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button, menu item
 :pluginname: Page Break
 :plugincode: pagebreak
-:altplugincode: nil
 
 This plugin adds page break support and enables a user to insert page breaks in the editable area. This is useful where a CMS uses a special separator to break content into pages.
 

--- a/modules/ROOT/pages/pageembed.adoc
+++ b/modules/ROOT/pages/pageembed.adoc
@@ -1,6 +1,6 @@
 = Page Embed plugin
 
-:title_nav: Page Embed
+:navtitle: Page Embed
 :description: Easily inserts iframe into the content.
 :keywords: view Page Embed insert iframe
 :controls: toolbar button, menu item

--- a/modules/ROOT/pages/pageembed.adoc
+++ b/modules/ROOT/pages/pageembed.adoc
@@ -19,7 +19,7 @@ The *Page Embed* plugin embeds a page in the content using an iframe (Inline fra
 
 == Try our Page Embed plugin demo
 
-liveDemo::page-embed[ ]
+liveDemo::page-embed[]
 
 include::partial$misc/purchase-premium-plugins.adoc[]
 

--- a/modules/ROOT/pages/pageembed.adoc
+++ b/modules/ROOT/pages/pageembed.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button, menu item
 :pluginname: Page Embed
 :plugincode: pageembed
-:altplugincode: nil
 :pluginminimumplan: tiertwo
 
 

--- a/modules/ROOT/pages/permanentpen.adoc
+++ b/modules/ROOT/pages/permanentpen.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button, contextmenu, menu item
 :pluginname: Permanent Pen
 :plugincode: permanentpen
-:altplugincode: nil
 :pluginminimumplan: tiertwo
 
 

--- a/modules/ROOT/pages/permanentpen.adoc
+++ b/modules/ROOT/pages/permanentpen.adoc
@@ -35,7 +35,7 @@ For more information on {productname} formats, refer to the xref:content-formatt
 
 == Try our Permanent Pen demo
 
-liveDemo::permanent-pen[ ]
+liveDemo::permanent-pen[]
 
 include::partial$misc/purchase-premium-plugins.adoc[]
 

--- a/modules/ROOT/pages/permanentpen.adoc
+++ b/modules/ROOT/pages/permanentpen.adoc
@@ -1,6 +1,6 @@
 = Permanent Pen Plugin
 
-:title_nav: Permanent Pen
+:navtitle: Permanent Pen
 :description: Apply formats while typing.
 :keywords: permanent pen copy text format style
 :controls: toolbar button, contextmenu, menu item

--- a/modules/ROOT/pages/php-projects.adoc
+++ b/modules/ROOT/pages/php-projects.adoc
@@ -1,6 +1,6 @@
 = Installing TinyMCE with Composer
 
-:title_nav: PHP projects
+:navtitle: PHP projects
 :description: Learn how to install TinyMCE from Packagist using Composer.
 :keywords: php composer packagist install
 :productSource: composer

--- a/modules/ROOT/pages/php-upload-handler.adoc
+++ b/modules/ROOT/pages/php-upload-handler.adoc
@@ -1,6 +1,6 @@
 = PHP image upload handler
 
-:title_nav: PHP image upload handler
+:navtitle: PHP image upload handler
 :description_short: A server-side upload handler PHP script.
 :description: A server-side upload handler PHP script suitable for TinyMCE.
 :keywords: php_upload_handler php async image upload

--- a/modules/ROOT/pages/plugin-editor-version-compatibility.adoc
+++ b/modules/ROOT/pages/plugin-editor-version-compatibility.adoc
@@ -1,7 +1,6 @@
 = Version compatibility reference
 
 :description_short: Matrix of compatibility between TinyMCE editor versions and premium plugins.
-
 :description: Premium plugins compatibility with TinyMCE editor versions.
 :keywords: tinymce cloud script textarea apiKey
 

--- a/modules/ROOT/pages/powerpaste-commands-events-apis.adoc
+++ b/modules/ROOT/pages/powerpaste-commands-events-apis.adoc
@@ -5,7 +5,6 @@
 :keywords: enterprise powerpaste power paste microsoft word excel google docs
 :pluginname: PowerPaste
 :plugincode: PowerPaste
-:altplugincode: nil
 
 
 == Commands

--- a/modules/ROOT/pages/powerpaste-commands-events-apis.adoc
+++ b/modules/ROOT/pages/powerpaste-commands-events-apis.adoc
@@ -1,6 +1,6 @@
 = Commands and Events for the PowerPaste plugin
 
-:title_nav: Commands and Events
+:navtitle: Commands and Events
 :description: Information on the commands, events and API methods provided with the PowerPaste plugin.
 :keywords: enterprise powerpaste power paste microsoft word excel google docs
 :pluginname: PowerPaste

--- a/modules/ROOT/pages/powerpaste-options.adoc
+++ b/modules/ROOT/pages/powerpaste-options.adoc
@@ -1,6 +1,6 @@
 = Options for the PowerPaste plugin
 
-:title_nav: Options
+:navtitle: Options
 :description: Information on the options provided by the PowerPaste plugin.
 :keywords: enterprise powerpaste power paste microsoft word excel google docs
 :pluginname: PowerPaste

--- a/modules/ROOT/pages/powerpaste-options.adoc
+++ b/modules/ROOT/pages/powerpaste-options.adoc
@@ -5,7 +5,6 @@
 :keywords: enterprise powerpaste power paste microsoft word excel google docs
 :pluginname: PowerPaste
 :plugincode: powerpaste
-:altplugincode: nil
 
 == Configuration Options
 

--- a/modules/ROOT/pages/powerpaste-support.adoc
+++ b/modules/ROOT/pages/powerpaste-support.adoc
@@ -1,6 +1,6 @@
 = Supported functionality for the PowerPaste plugin
 
-:title_nav: Supported functionality
+:navtitle: Supported functionality
 :description: Information on the supported PowerPaste functionality.
 :keywords: enterprise powerpaste power paste microsoft word excel google docs
 

--- a/modules/ROOT/pages/powerpaste-troubleshooting.adoc
+++ b/modules/ROOT/pages/powerpaste-troubleshooting.adoc
@@ -1,6 +1,6 @@
 = Troubleshooting the PowerPaste plugin
 
-:title_nav: Troubleshooting
+:navtitle: Troubleshooting
 :description: Information on troubleshooting PowerPaste behavior.
 :keywords: enterprise powerpaste power paste microsoft word excel google docs
 

--- a/modules/ROOT/pages/premium-full-featured.adoc
+++ b/modules/ROOT/pages/premium-full-featured.adoc
@@ -1,6 +1,6 @@
 = Full featured demo: Including Premium Plugins
 
-:title_nav: Including premium features
+:navtitle: Including premium features
 :description_short: Every TinyMCE plugin in action.
 :description: These examples display all of the plugins available with TinyMCE Cloud premium subscriptions.
 :keywords: example demo custom wysiwyg full-featured plugins non-premium

--- a/modules/ROOT/pages/premium-full-featured.adoc
+++ b/modules/ROOT/pages/premium-full-featured.adoc
@@ -9,7 +9,7 @@ This example includes most of the available {productname} plugins, including plu
 
 Want to try it for yourself? link:{accountsignup}/[Get started with TinyMCE now on Cloud].
 
-liveDemo::full-featured[ ]
+liveDemo::full-featured[]
 
 The following plugins are excluded from this example:
 

--- a/modules/ROOT/pages/premium-skins-and-icons.adoc
+++ b/modules/ROOT/pages/premium-skins-and-icons.adoc
@@ -1,6 +1,6 @@
 = Tiny Skins and Icon Packs
 
-:title_nav: Tiny Skins and Icon Packs
+:navtitle: Tiny Skins and Icon Packs
 :description: Quickly give TinyMCE a new look.
 :keywords: skin skins icon icons material bootstrap customize theme
 

--- a/modules/ROOT/pages/preview.adoc
+++ b/modules/ROOT/pages/preview.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button, menu item
 :pluginname: Preview
 :plugincode: preview
-:altplugincode: nil
 
 This plugin adds a preview button to the toolbar. Pressing the button opens a dialog box showing the current content in a preview mode. It also adds a menu item `+Preview+` under the `+File+` and `+View+` menu dropdowns.
 

--- a/modules/ROOT/pages/preview.adoc
+++ b/modules/ROOT/pages/preview.adoc
@@ -1,6 +1,6 @@
 = Preview plugin
 
-:title_nav: Preview
+:navtitle: Preview
 :description: Shows a popup of the current content in read-only format.
 :keywords: view preview
 :controls: toolbar button, menu item

--- a/modules/ROOT/pages/quickbars.adoc
+++ b/modules/ROOT/pages/quickbars.adoc
@@ -1,6 +1,6 @@
 = Quick Toolbars plugin
 
-:title_nav: Quick Toolbars
+:navtitle: Quick Toolbars
 :description: User interface controls to create content faster.
 :keywords: plugin inlite quickbar
 :pluginname: Quick Toolbars

--- a/modules/ROOT/pages/quickbars.adoc
+++ b/modules/ROOT/pages/quickbars.adoc
@@ -5,7 +5,6 @@
 :keywords: plugin inlite quickbar
 :pluginname: Quick Toolbars
 :plugincode: quickbars
-:altplugincode: nil
 
 The Quick Toolbar plugin adds three context toolbars:
 

--- a/modules/ROOT/pages/quickbars.adoc
+++ b/modules/ROOT/pages/quickbars.adoc
@@ -20,7 +20,7 @@ This plugin also adds three new toolbar buttons:
 
 == Interactive example
 
-liveDemo::quickbars[ ]
+liveDemo::quickbars[]
 
 == Basic setup
 

--- a/modules/ROOT/pages/rails-cloud.adoc
+++ b/modules/ROOT/pages/rails-cloud.adoc
@@ -1,6 +1,6 @@
 = Using TinyMCE from the Tiny Cloud CDN with Ruby on Rails
 
-:title_nav: Ruby on Rails
+:navtitle: Ruby on Rails
 :description: A guide on integrating TinyMCE from the Tiny Cloud into Ruby on Rails.
 :keywords: integration integrate ruby rails
 :productSource: cloud

--- a/modules/ROOT/pages/rails-third-party.adoc
+++ b/modules/ROOT/pages/rails-third-party.adoc
@@ -1,6 +1,6 @@
 = Using the TinyMCE package with the Ruby on Rails framework
 
-:title_nav: Using a package manager
+:navtitle: Using a package manager
 :description: A guide on integrating TinyMCE into the Ruby on Rails framework.
 :keywords: integration integrate rails ruby
 :productSource: package-manager

--- a/modules/ROOT/pages/rails-zip.adoc
+++ b/modules/ROOT/pages/rails-zip.adoc
@@ -1,6 +1,6 @@
 = Using the TinyMCE .zip package with the Ruby on Rails framework
 
-:title_nav: Using a .zip package
+:navtitle: Using a .zip package
 :description: A guide on integrating a .zip version of TinyMCE into the Ruby on Rails framework.
 :keywords: integration integrate rails ruby
 :productSource: zip

--- a/modules/ROOT/pages/react-cloud.adoc
+++ b/modules/ROOT/pages/react-cloud.adoc
@@ -1,6 +1,6 @@
 = Using TinyMCE from the Tiny Cloud CDN with the React framework
 
-:title_nav: React
+:navtitle: React
 :description: A guide on integrating TinyMCE from the Tiny Cloud into the React framework.
 :keywords: integration integrate react reactjs create-react-app tinymce-react
 :productSource: cloud

--- a/modules/ROOT/pages/react-pm.adoc
+++ b/modules/ROOT/pages/react-pm.adoc
@@ -1,6 +1,6 @@
 = Using the TinyMCE package with the React framework
 
-:title_nav: Using a package manager
+:navtitle: Using a package manager
 :description: A guide on integrating the TinyMCE package into the React framework.
 :keywords: integration integrate react reactjs create-react-app tinymce-react
 :productSource: package-manager

--- a/modules/ROOT/pages/react-ref.adoc
+++ b/modules/ROOT/pages/react-ref.adoc
@@ -1,6 +1,6 @@
 = TinyMCE React integration technical reference
 
-:title_nav: Technical reference
+:navtitle: Technical reference
 :description: Technical reference for the TinyMCE React integration
 :keywords: integration integrate react reactapp
 

--- a/modules/ROOT/pages/react-zip.adoc
+++ b/modules/ROOT/pages/react-zip.adoc
@@ -1,6 +1,6 @@
 = Using the TinyMCE .zip package with the React framework
 
-:title_nav: Using a .zip package
+:navtitle: Using a .zip package
 :description: A guide on integrating a .zip version of TinyMCE into the React framework.
 :keywords: integration integrate react reactjs create-react-app tinymce-react
 :productSource: zip

--- a/modules/ROOT/pages/rollup-es6-download.adoc
+++ b/modules/ROOT/pages/rollup-es6-download.adoc
@@ -1,6 +1,6 @@
 = Bundling a .zip version of TinyMCE with ES6 and Rollup.js
 
-:title_nav: ES6 and a .zip archive
+:navtitle: ES6 and a .zip archive
 :description_short: Bundling a .zip archive version of TinyMCE in a project using ES6 and Rollup.js
 :description: Bundling a .zip archive version of TinyMCE in a project using ES6 and Rollup.js
 :keywords: rollupjs es6 es2015 zip modules tinymce

--- a/modules/ROOT/pages/rollup-es6-npm.adoc
+++ b/modules/ROOT/pages/rollup-es6-npm.adoc
@@ -1,6 +1,6 @@
 = Bundling an npm version of TinyMCE with ES6 and Rollup.js
 
-:title_nav: ES6 and npm
+:navtitle: ES6 and npm
 :description_short: Bundling an npm version of TinyMCE in a project using ES6 and Rollup.js
 :description: Bundling an npm version of TinyMCE in a project using ES6 and Rollup.js
 :keywords: rollupjs es6 es2015 npm modules tinymce

--- a/modules/ROOT/pages/rtc-encryption.adoc
+++ b/modules/ROOT/pages/rtc-encryption.adoc
@@ -5,7 +5,6 @@
 :keywords: rtc encrypt decrypt key rotate signature
 :pluginname: Real-Time Collaboration (RTC)
 :plugincode: rtc
-:altplugincode: nil
 
 {productname} {pluginname} uses encryption keys to encrypt content before sending it to collaborators through the RTC server to provide end-to-end encryption. This is different from the use of JWTs for RTC, which are used to verify that your servers have allowed the user to access and collaborate on the content.
 

--- a/modules/ROOT/pages/rtc-encryption.adoc
+++ b/modules/ROOT/pages/rtc-encryption.adoc
@@ -1,6 +1,6 @@
 = Real-Time Collaboration (RTC) Encryption Setup
 
-:title_nav: Encryption Setup
+:navtitle: Encryption Setup
 :description: Useful information for setting up encryption for RTC
 :keywords: rtc encrypt decrypt key rotate signature
 :pluginname: Real-Time Collaboration (RTC)

--- a/modules/ROOT/pages/rtc-events.adoc
+++ b/modules/ROOT/pages/rtc-events.adoc
@@ -1,6 +1,6 @@
 = Real-Time Collaboration (RTC) events
 
-:title_nav: RTC Events
+:navtitle: RTC Events
 :description: List of all available RTC specific events.
 :keywords: rtc events
 

--- a/modules/ROOT/pages/rtc-getting-started.adoc
+++ b/modules/ROOT/pages/rtc-getting-started.adoc
@@ -11,9 +11,9 @@
 This procedure will assist with setting up {productname} with real-time collaboration.
 
 [IMPORTANT]
---
+====
 include::partial$misc/secure-context.adoc[]
---
+====
 
 The steps required for setting up Real-Time Collaboration for {productname} are:
 

--- a/modules/ROOT/pages/rtc-getting-started.adoc
+++ b/modules/ROOT/pages/rtc-getting-started.adoc
@@ -1,6 +1,6 @@
 = Getting started with Real-Time Collaboration (RTC)
 
-:title_nav: Getting started with RTC
+:navtitle: Getting started with RTC
 :description: Getting started with RTC
 :keywords: rtc
 :pluginname: Real-Time Collaboration (RTC)

--- a/modules/ROOT/pages/rtc-introduction.adoc
+++ b/modules/ROOT/pages/rtc-introduction.adoc
@@ -1,6 +1,6 @@
 = Introduction to Real-Time Collaboration (RTC)
 
-:title_nav: Introduction
+:navtitle: Introduction
 :description: What is RTC and what can it do
 :keywords: rtc introduction overview
 

--- a/modules/ROOT/pages/rtc-introduction.adoc
+++ b/modules/ROOT/pages/rtc-introduction.adoc
@@ -10,7 +10,7 @@ include::partial$rtc/rtc-description.adoc[]
 
 The following example shows two editors that are collaborating using the {productname} Real-Time Collaboration plugin. All network requests made by these editors, real or simulated, are being logged to the browser console. To view the network requests, open the browser console using the *F12* keyboard key and navigate to the _Console_ tab.
 
-liveDemo::rtc[ ]
+liveDemo::rtc[]
 
 == Features of TinyMCE Real-Time Collaboration
 

--- a/modules/ROOT/pages/rtc-jwt-authentication.adoc
+++ b/modules/ROOT/pages/rtc-jwt-authentication.adoc
@@ -1,6 +1,6 @@
 = Real-Time Collaboration (RTC) JWT Authentication Setup
 
-:title_nav: JWT Authentication Setup
+:navtitle: JWT Authentication Setup
 :description: Guide on how to setup JWT Authentication for RTC
 :keywords: jwt authentication
 :pluginname: Real-Time Collaboration (RTC)

--- a/modules/ROOT/pages/rtc-options-optional.adoc
+++ b/modules/ROOT/pages/rtc-options-optional.adoc
@@ -1,6 +1,6 @@
 = Recommended and optional Real-Time Collaboration configuration options
 
-:title_nav: Recommended and optional configuration options
+:navtitle: Recommended and optional configuration options
 :description: List of all recommended and optional RTC configuration options.
 :keywords: rtc configuration
 :pluginname: Real-Time Collaboration (RTC)

--- a/modules/ROOT/pages/rtc-options-optional.adoc
+++ b/modules/ROOT/pages/rtc-options-optional.adoc
@@ -5,7 +5,6 @@
 :keywords: rtc configuration
 :pluginname: Real-Time Collaboration (RTC)
 :plugincode: rtc
-:altplugincode: nil
 
 This section covers the recommended and optional configuration options for the RTC plugin. None of these options are required but assist with creating a consistent user experience between your application and {productname} {pluginname}.
 

--- a/modules/ROOT/pages/rtc-options-overview.adoc
+++ b/modules/ROOT/pages/rtc-options-overview.adoc
@@ -5,7 +5,6 @@
 :keywords: rtc configuration
 :pluginname: Real-Time Collaboration (RTC)
 :plugincode: rtc
-:altplugincode: nil
 
 == Configuration style
 

--- a/modules/ROOT/pages/rtc-options-overview.adoc
+++ b/modules/ROOT/pages/rtc-options-overview.adoc
@@ -1,6 +1,6 @@
 = Overview of the Real-Time Collaboration configuration options
 
-:title_nav: Configuration options overview
+:navtitle: Configuration options overview
 :description: List of all available RTC configuration options.
 :keywords: rtc configuration
 :pluginname: Real-Time Collaboration (RTC)

--- a/modules/ROOT/pages/rtc-options-required.adoc
+++ b/modules/ROOT/pages/rtc-options-required.adoc
@@ -5,7 +5,6 @@
 :keywords: rtc configuration
 :pluginname: Real-Time Collaboration (RTC)
 :plugincode: rtc
-:altplugincode: nil
 
 The following options are required to use the Real-Time Collaboration (RTC) plugin:
 

--- a/modules/ROOT/pages/rtc-options-required.adoc
+++ b/modules/ROOT/pages/rtc-options-required.adoc
@@ -1,6 +1,6 @@
 = Required Real-Time Collaboration configuration options
 
-:title_nav: Required configuration options
+:navtitle: Required configuration options
 :description: List of all required RTC configuration options.
 :keywords: rtc configuration
 :pluginname: Real-Time Collaboration (RTC)

--- a/modules/ROOT/pages/rtc-supported-functionality.adoc
+++ b/modules/ROOT/pages/rtc-supported-functionality.adoc
@@ -1,6 +1,6 @@
 = Supported TinyMCE functionality for Real-Time Collaboration
 
-:title_nav: Supported Functionality
+:navtitle: Supported Functionality
 :description: Information on what TinyMCE functionality is, and is not, supported in Real-Time Collaboration
 :keywords: rtc support functionality
 :pluginname: Real-Time Collaboration (RTC)

--- a/modules/ROOT/pages/rtc-supported-functionality.adoc
+++ b/modules/ROOT/pages/rtc-supported-functionality.adoc
@@ -5,7 +5,6 @@
 :keywords: rtc support functionality
 :pluginname: Real-Time Collaboration (RTC)
 :plugincode: rtc
-:altplugincode: nil
 
 == Browser support
 

--- a/modules/ROOT/pages/rtc-troubleshooting.adoc
+++ b/modules/ROOT/pages/rtc-troubleshooting.adoc
@@ -1,6 +1,6 @@
 = Troubleshooting information for the Real-Time Collaboration (RTC) plugin
 
-:title_nav: RTC Troubleshooting
+:navtitle: RTC Troubleshooting
 :description: Useful information for troubleshooting issues with the RTC plugin.
 :keywords: rtc faq trouble troubleshoot troubleshooting bug
 

--- a/modules/ROOT/pages/save.adoc
+++ b/modules/ROOT/pages/save.adoc
@@ -1,6 +1,6 @@
 = Save plugin
 
-:title_nav: Save
+:navtitle: Save
 :description: Adds a save button to the TinyMCE toolbar.
 :keywords: submit save_enablewhendirty save_oncancelcallback save_onsavecallback
 :controls: toolbar button

--- a/modules/ROOT/pages/save.adoc
+++ b/modules/ROOT/pages/save.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button
 :pluginname: Save
 :plugincode: save
-:altplugincode: nil
 
 This plugin adds a save button to the {productname} toolbar, which will submit the form that the editor is within.
 

--- a/modules/ROOT/pages/searchreplace.adoc
+++ b/modules/ROOT/pages/searchreplace.adoc
@@ -1,6 +1,6 @@
 = Search and Replace plugin
 
-:title_nav: Search and Replace
+:navtitle: Search and Replace
 :description: Find and replace content in TinyMCE.
 :keywords: searchreplace edit
 :controls: toolbar button, menu item

--- a/modules/ROOT/pages/searchreplace.adoc
+++ b/modules/ROOT/pages/searchreplace.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button, menu item
 :pluginname: Search and Replace
 :plugincode: searchreplace
-:altplugincode: nil
 
 This plugin adds search/replace dialogs to {productname}. It also adds a toolbar button and the menu item `+Find and replace+` under the `+Edit+` menu dropdown.
 

--- a/modules/ROOT/pages/security.adoc
+++ b/modules/ROOT/pages/security.adoc
@@ -1,6 +1,6 @@
 = Security guide
 
-:title_nav: Security guide
+:navtitle: Security guide
 :description_short: Security information for TinyMCE.
 :description: Information on reporting security issues, what TinyMCE does to protect users, and what you can do to protect your users.
 :keywords: security xss scripting vulnerability hack hacker csp mitigation protection protect

--- a/modules/ROOT/pages/self-hosting-hunspell.adoc
+++ b/modules/ROOT/pages/self-hosting-hunspell.adoc
@@ -1,6 +1,6 @@
 = Add Hunspell dictionaries to Spell Checker Pro
 
-:title_nav: Spelling service - Using Hunspell dictionaries
+:navtitle: Spelling service - Using Hunspell dictionaries
 :description: Instructions for adding Hunspell dictionaries to TinyMCE Spell Checker Pro.
 :keywords: enterprise tinymcespellchecker hunspell spell check checker pro server configuration configure
 

--- a/modules/ROOT/pages/shortcuts.adoc
+++ b/modules/ROOT/pages/shortcuts.adoc
@@ -15,10 +15,10 @@ include::partial$misc/shortcut-os-mappings.adoc[]
 
 == Example: Custom keyboard shortcut
 
-liveDemo::custom-shortcut[ tab="js" ]
+liveDemo::custom-shortcut[tab="js"]
 
 == Example: Adding a custom shortcut for a menu item
 
 When adding a shortcut for a custom menu item, add both a custom shortcut and a custom menu item. To display the shortcut on a custom menu item, add the `+shortcut+` configuration option when creating the menu item.
 
-liveDemo::custom-shortcut-2[ tab="js" ]
+liveDemo::custom-shortcut-2[tab="js"]

--- a/modules/ROOT/pages/shortcuts.adoc
+++ b/modules/ROOT/pages/shortcuts.adoc
@@ -1,6 +1,6 @@
 = Custom Keyboard Shortcuts
 
-:title_nav: Keyboard Shortcuts
+:navtitle: Keyboard Shortcuts
 :description: How-to add custom keyboard shortcuts to TinyMCE 6.
 :keywords: shortcuts shortcut custom keyboard
 

--- a/modules/ROOT/pages/small-demo.adoc
+++ b/modules/ROOT/pages/small-demo.adoc
@@ -1,6 +1,6 @@
 = Small icons pack demo
 
-:title_nav: Small Icons Demo
+:navtitle: Small Icons Demo
 :description: Small Icons and Skin demo
 :keywords: skin skins icon icons small customize theme
 

--- a/modules/ROOT/pages/small-demo.adoc
+++ b/modules/ROOT/pages/small-demo.adoc
@@ -6,4 +6,4 @@
 
 This demo uses the smaller version of the default icons together with a small skin to make the buttons smaller. This is useful to save space if you are using many toolbar buttons.
 
-liveDemo::premiumskinsandicons-small[ ]
+liveDemo::premiumskinsandicons-small[]

--- a/modules/ROOT/pages/snow-demo.adoc
+++ b/modules/ROOT/pages/snow-demo.adoc
@@ -1,6 +1,6 @@
 = Snow skin demo
 
-:title_nav: Snow Demo
+:navtitle: Snow Demo
 :description: Snow Demo
 :keywords: skin skins icon icons customize theme
 

--- a/modules/ROOT/pages/snow-demo.adoc
+++ b/modules/ROOT/pages/snow-demo.adoc
@@ -6,4 +6,4 @@
 
 The Snow skin is designed as a modern and lightweight editor for web apps. It looks great together with the Thin icon pack.
 
-liveDemo::premiumskinsandicons-snow[ ]
+liveDemo::premiumskinsandicons-snow[]

--- a/modules/ROOT/pages/spell-checking.adoc
+++ b/modules/ROOT/pages/spell-checking.adoc
@@ -1,6 +1,6 @@
 = Check spelling in TinyMCE
 
-:title_nav: Spell checking
+:navtitle: Spell checking
 :keywords: spell checker spelling browser_spellcheck
 :descripton: {productname} provides several options to bring spell checking capabilities to your users.
 

--- a/modules/ROOT/pages/spelling.adoc
+++ b/modules/ROOT/pages/spelling.adoc
@@ -1,6 +1,6 @@
 = Spelling options
 
-:title_nav: Spelling options
+:navtitle: Spelling options
 :description: TinyMCE spell checking
 
 include::partial$misc/spell-checker-pro.adoc[]

--- a/modules/ROOT/pages/statusbar-configuration-options.adoc
+++ b/modules/ROOT/pages/statusbar-configuration-options.adoc
@@ -1,6 +1,6 @@
 = Options for customizing the editor's statusbar
 
-:title_nav: Statusbar
+:navtitle: Statusbar
 :description: Information on options for customizing TinyMCE's statusbar
 
 The options listed on this page affect the {productname} statusbar. The xref:statusbar[`+statusbar+` option] can be used to remove the statusbar from the editor.

--- a/modules/ROOT/pages/support.adoc
+++ b/modules/ROOT/pages/support.adoc
@@ -1,6 +1,6 @@
 = Support
 
-:title_nav: Support
+:navtitle: Support
 :description: Getting support and supported platforms
 :description_short: Getting support and supported platforms
 :keywords: browser compatibility safari firefox chrome edge mobile support supported browsers windows osx linux premium self-hosted selfhosted

--- a/modules/ROOT/pages/svelte-cloud.adoc
+++ b/modules/ROOT/pages/svelte-cloud.adoc
@@ -1,6 +1,6 @@
 = Using TinyMCE from the Tiny Cloud CDN with the Svelte framework
 
-:title_nav: Svelte
+:navtitle: Svelte
 :description: A guide on integrating TinyMCE from the Tiny Cloud into the Svelte framework.
 :keywords: integration integrate svelte sveltejs tinymce-svelte
 :productSource: cloud

--- a/modules/ROOT/pages/svelte-pm.adoc
+++ b/modules/ROOT/pages/svelte-pm.adoc
@@ -1,6 +1,6 @@
 = Using the TinyMCE package with the Svelte framework
 
-:title_nav: Using a package manager
+:navtitle: Using a package manager
 :description: A guide on integrating the TinyMCE package into the Svelte framework.
 :keywords: integration integrate svelte svelteapp
 :productSource: package-manager

--- a/modules/ROOT/pages/svelte-ref.adoc
+++ b/modules/ROOT/pages/svelte-ref.adoc
@@ -1,6 +1,6 @@
 = TinyMCE Svelte integration technical reference
 
-:title_nav: Technical reference
+:navtitle: Technical reference
 :keywords: integration integrate svelte sveltejs tinymce-svelte
 :description: Technical reference for the TinyMCE Svelte integration
 

--- a/modules/ROOT/pages/svelte-zip.adoc
+++ b/modules/ROOT/pages/svelte-zip.adoc
@@ -1,6 +1,6 @@
 = Using the TinyMCE .zip package with the Svelte framework
 
-:title_nav: Using a .zip package
+:navtitle: Using a .zip package
 :description: A guide on integrating a .zip version of TinyMCE into the Svelte framework.
 :keywords: integration integrate svelte svelteapp
 :productSource: zip

--- a/modules/ROOT/pages/swing.adoc
+++ b/modules/ROOT/pages/swing.adoc
@@ -1,6 +1,6 @@
 = TinyMCE for Java Swing integration
 
-:title_nav: Java Swing
+:navtitle: Java Swing
 :description: Seamlessly integrates TinyMCE into Java Swing applications.
 :keywords: integration integrate java swing
 

--- a/modules/ROOT/pages/table.adoc
+++ b/modules/ROOT/pages/table.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button, menu item
 :pluginname: Table
 :plugincode: table
-:altplugincode: nil
 
 The `+table+` plugin adds table management functionality to {productname}. It also adds a new menubar item `+Table+` with various options in its dropdown including `+Insert table+` and options to modify cells, rows and columns, and a toolbar button with the same functionality.
 

--- a/modules/ROOT/pages/table.adoc
+++ b/modules/ROOT/pages/table.adoc
@@ -1,6 +1,6 @@
 = Table plugin
 
-:title_nav: Table
+:navtitle: Table
 :description: Table editing features.
 :keywords: row cell column table_appearance_options table_clone_elements table_grid table_tab_navigation table_default_attributes table_default_styles table_class_list table_cell_class_list table_row_class_list table_advtab table_cell_advtab table_row_advtab
 :controls: toolbar button, menu item

--- a/modules/ROOT/pages/tableofcontents.adoc
+++ b/modules/ROOT/pages/tableofcontents.adoc
@@ -1,6 +1,6 @@
 = Table of Contents plugin
 
-:title_nav: Table of Contents
+:navtitle: Table of Contents
 :description: Insert a simple Table of Contents into TinyMCE editor
 :keywords: tableofcontents tableofcontents_depth tableofcontents_class tableofcontents_header toc
 :controls: toolbar button, menu item

--- a/modules/ROOT/pages/tableofcontents.adoc
+++ b/modules/ROOT/pages/tableofcontents.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button, menu item
 :pluginname: Table of Contents
 :plugincode: tableofcontents
-:altplugincode: nil
 :pluginminimumplan: tierone
 
 The `+tableofcontents+` plugin will generate basic _Table of Contents_ and insert it into the editor at the current cursor position. Items for the table will be taken from the headers found in the content.

--- a/modules/ROOT/pages/template.adoc
+++ b/modules/ROOT/pages/template.adoc
@@ -1,6 +1,6 @@
 = Template plugin
 
-:title_nav: Template
+:navtitle: Template
 :description: Custom templates for your content.
 :keywords: insert template_cdate_classes template_cdate_format template_mdate_classes template_mdate_format template_replace_values template_selected_content_classes template_preview_replace_values
 :controls: toolbar button, menu item

--- a/modules/ROOT/pages/template.adoc
+++ b/modules/ROOT/pages/template.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button, menu item
 :pluginname: Template
 :plugincode: template
-:altplugincode: nil
 
 The `+template+` plugin adds support for custom templates. It also adds a menu item `+Insert template+` under the `+Insert+` menu and a toolbar button.
 

--- a/modules/ROOT/pages/template.adoc
+++ b/modules/ROOT/pages/template.adoc
@@ -24,7 +24,7 @@ tinymce.init({
 
 This example shows how the template plugin can be used to insert custom templates with pre-defined markup and values.
 
-liveDemo::template[ tab="js" ]
+liveDemo::template[tab="js"]
 
 == Configuration Options
 

--- a/modules/ROOT/pages/tinydrive-browse.adoc
+++ b/modules/ROOT/pages/tinydrive-browse.adoc
@@ -9,7 +9,7 @@ The `+tinydrive.browse+` method allows users to browse the files stored in {clou
 
 == Interactive example: Using `+tinydrive.browse+`
 
-liveDemo::drive-plugin-browse[ ]
+liveDemo::drive-plugin-browse[]
 
 == Configuration options
 

--- a/modules/ROOT/pages/tinydrive-browse.adoc
+++ b/modules/ROOT/pages/tinydrive-browse.adoc
@@ -1,6 +1,6 @@
 = Tiny Drive Browse API
 
-:title_nav: The Browse API
+:navtitle: The Browse API
 :description: Using the Tiny Drive Browse API
 :keywords: tinydrive api browse
 :apiname: browse

--- a/modules/ROOT/pages/tinydrive-changelog.adoc
+++ b/modules/ROOT/pages/tinydrive-changelog.adoc
@@ -1,6 +1,6 @@
 = Tiny Drive Changelog
 
-:title_nav: Changelog
+:navtitle: Changelog
 :description: The history of Tiny Drive releases.
 :keywords: changelog class: changelog
 

--- a/modules/ROOT/pages/tinydrive-dotnet.adoc
+++ b/modules/ROOT/pages/tinydrive-dotnet.adoc
@@ -1,6 +1,6 @@
 = .Net Core
 
-:title_nav: .Net Core
+:navtitle: .Net Core
 :description: .Net Core
 :keywords: tinydrive .Net Core
 :keyurl: {accountpageurl}/key-manager/

--- a/modules/ROOT/pages/tinydrive-dropbox-integration.adoc
+++ b/modules/ROOT/pages/tinydrive-dropbox-integration.adoc
@@ -1,6 +1,6 @@
 = Dropbox integration
 
-:title_nav: Dropbox
+:navtitle: Dropbox
 :description: Guide for setting up Tiny Drive with Dropbox.
 :keywords: dropbox
 

--- a/modules/ROOT/pages/tinydrive-dropbox-integration.adoc
+++ b/modules/ROOT/pages/tinydrive-dropbox-integration.adoc
@@ -63,4 +63,4 @@ Read about other Dropbox options https://www.dropbox.com/guide/business[here].
 
 Here is an interactive example of Dropbox-enabled on {cloudfilemanager}.
 
-liveDemo::drive-demo-dropbox[ ]
+liveDemo::drive-demo-dropbox[]

--- a/modules/ROOT/pages/tinydrive-getting-started.adoc
+++ b/modules/ROOT/pages/tinydrive-getting-started.adoc
@@ -5,7 +5,6 @@
 :keywords: tinydrive starter projects
 :pluginname: Tiny Drive
 :plugincode: tinydrive
-:altplugincode: nil
 :numberedHeading: true
 
 To get started with {cloudfilemanager}, try one of the starter projects below, or follow our guide on xref:implementing-tiny-drive-with-your-system[Implementing Tiny Drive with your system].

--- a/modules/ROOT/pages/tinydrive-getting-started.adoc
+++ b/modules/ROOT/pages/tinydrive-getting-started.adoc
@@ -1,6 +1,6 @@
 = Getting started
 
-:title_nav: Getting started
+:navtitle: Getting started
 :description: Getting started with Tiny Drive
 :keywords: tinydrive starter projects
 :pluginname: Tiny Drive

--- a/modules/ROOT/pages/tinydrive-googledrive-integration.adoc
+++ b/modules/ROOT/pages/tinydrive-googledrive-integration.adoc
@@ -1,6 +1,6 @@
 = Google Drive integration
 
-:title_nav: Google Drive
+:navtitle: Google Drive
 :description: Guide for setting up Tiny Drive with Google Drive.
 :keywords: google drive
 

--- a/modules/ROOT/pages/tinydrive-googledrive-integration.adoc
+++ b/modules/ROOT/pages/tinydrive-googledrive-integration.adoc
@@ -96,4 +96,4 @@ Read more about these options https://gsuite.google.com/learning-center/products
 
 Here is an interactive example of Google Drive enabled on {cloudfilemanager}.
 
-liveDemo::drive-demo-googledrive[ ]
+liveDemo::drive-demo-googledrive[]

--- a/modules/ROOT/pages/tinydrive-introduction.adoc
+++ b/modules/ROOT/pages/tinydrive-introduction.adoc
@@ -5,7 +5,6 @@
 :keywords: tinydrive introduction overview
 :pluginname: Tiny Drive
 :plugincode: tinydrive
-:altplugincode: nil
 :pluginminimumplan: tierone
 
 {cloudfilemanager} is a premium {productname} plugin for cloud-based asset management and storage. {cloudfilemanager} allows your users to upload, manage, and use files in {productname}.

--- a/modules/ROOT/pages/tinydrive-introduction.adoc
+++ b/modules/ROOT/pages/tinydrive-introduction.adoc
@@ -1,6 +1,6 @@
 = Tiny Drive Introduction
 
-:title_nav: Introduction
+:navtitle: Introduction
 :description: Introduction of what Tiny Drive is and its capabilities
 :keywords: tinydrive introduction overview
 :pluginname: Tiny Drive

--- a/modules/ROOT/pages/tinydrive-introduction.adoc
+++ b/modules/ROOT/pages/tinydrive-introduction.adoc
@@ -33,7 +33,7 @@ The storage and bandwidth quota varies based upon your link:{pricingpage}/[{clou
 [[interactive-example]]
 == Interactive example
 
-liveDemo::drive[ ]
+liveDemo::drive[]
 
 include::partial$misc/purchase-premium-plugins.adoc[]
 

--- a/modules/ROOT/pages/tinydrive-java.adoc
+++ b/modules/ROOT/pages/tinydrive-java.adoc
@@ -1,6 +1,6 @@
 = Java Spring
 
-:title_nav: Java Spring
+:navtitle: Java Spring
 :description: Java Spring
 :keywords: tinydrive java spring
 :keyurl: {accountpageurl}/key-manager/

--- a/modules/ROOT/pages/tinydrive-jwt-authentication.adoc
+++ b/modules/ROOT/pages/tinydrive-jwt-authentication.adoc
@@ -1,6 +1,6 @@
 = Set up Tiny Drive JWT Authentication
 
-:title_nav: JWT Authentication setup
+:navtitle: JWT Authentication setup
 :description: Guide on how to setup JWT Authentication for Tiny Drive
 :keywords: jwt authentication
 :pluginname: {cloudfilemanager}

--- a/modules/ROOT/pages/tinydrive-nodejs.adoc
+++ b/modules/ROOT/pages/tinydrive-nodejs.adoc
@@ -1,6 +1,6 @@
 = Node.js
 
-:title_nav: Node.js
+:navtitle: Node.js
 :description: Node.js
 :keywords: tinydrive node.js
 :keyurl: {accountpageurl}/key-manager/

--- a/modules/ROOT/pages/tinydrive-php.adoc
+++ b/modules/ROOT/pages/tinydrive-php.adoc
@@ -1,6 +1,6 @@
 = PHP
 
-:title_nav: PHP
+:navtitle: PHP
 :description: PHP
 :keywords: tinydrive PHP
 

--- a/modules/ROOT/pages/tinydrive-pick.adoc
+++ b/modules/ROOT/pages/tinydrive-pick.adoc
@@ -37,7 +37,7 @@ mdate : The modification date for the file in ISO 8601 format for example: `+201
 [[interactive-example-using-tinydrivepick]]
 === Interactive example: Using `+tinydrive.pick+`
 
-liveDemo::drive-plugin-pick[ ]
+liveDemo::drive-plugin-pick[]
 
 == Configuration options
 

--- a/modules/ROOT/pages/tinydrive-pick.adoc
+++ b/modules/ROOT/pages/tinydrive-pick.adoc
@@ -1,6 +1,6 @@
 = Tiny Drive Pick API
 
-:title_nav: The Pick API
+:navtitle: The Pick API
 :description: Using the Tiny Drive Pick API
 :keywords: tinydrive api pick
 :apiname: pick

--- a/modules/ROOT/pages/tinydrive-setup-options.adoc
+++ b/modules/ROOT/pages/tinydrive-setup-options.adoc
@@ -1,6 +1,6 @@
 = Tiny Drive plugin setup options
 
-:title_nav: Setup options
+:navtitle: Setup options
 :description: List of Tiny Drive plugin configuration options for integrating with TinyMCE.
 :keywords: tinydrive configuration
 :pluginname: Tiny Drive

--- a/modules/ROOT/pages/tinydrive-setup-options.adoc
+++ b/modules/ROOT/pages/tinydrive-setup-options.adoc
@@ -5,7 +5,6 @@
 :keywords: tinydrive configuration
 :pluginname: Tiny Drive
 :plugincode: tinydrive
-:altplugincode: nil
 
 include::partial$configuration/tinydrive_token_provider.adoc[]
 

--- a/modules/ROOT/pages/tinydrive-toolbars-menus.adoc
+++ b/modules/ROOT/pages/tinydrive-toolbars-menus.adoc
@@ -1,6 +1,6 @@
 = Toolbar buttons and menu items for the Tiny Drive plugin
 
-:title_nav: Toolbar buttons and menu items
+:navtitle: Toolbar buttons and menu items
 :description: Details of the toolbar buttons and menu items provided for the Tiny Drive plugin.
 :keywords: drive tinydrive
 :pluginname: Tiny Drive

--- a/modules/ROOT/pages/tinydrive-toolbars-menus.adoc
+++ b/modules/ROOT/pages/tinydrive-toolbars-menus.adoc
@@ -5,7 +5,6 @@
 :keywords: drive tinydrive
 :pluginname: Tiny Drive
 :plugincode: tinydrive
-:altplugincode: nil
 
 
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]

--- a/modules/ROOT/pages/tinydrive-type-interfaces.adoc
+++ b/modules/ROOT/pages/tinydrive-type-interfaces.adoc
@@ -5,7 +5,6 @@
 :keywords: tinydrive configuration typescript
 :pluginname: Tiny Drive
 :plugincode: tinydrive
-:altplugincode: nil
 
 
 Here is a complete API reference as TypeScript types for developers used to TypeScript syntax.

--- a/modules/ROOT/pages/tinydrive-type-interfaces.adoc
+++ b/modules/ROOT/pages/tinydrive-type-interfaces.adoc
@@ -1,6 +1,6 @@
 = Tiny Drive TypeScript interfaces
 
-:title_nav: TypeScript interfaces
+:navtitle: TypeScript interfaces
 :description: List of all available Tiny Drive API interfaces.
 :keywords: tinydrive configuration typescript
 :pluginname: Tiny Drive

--- a/modules/ROOT/pages/tinydrive-ui-options.adoc
+++ b/modules/ROOT/pages/tinydrive-ui-options.adoc
@@ -1,6 +1,6 @@
 = Configuring the Tiny Drive UI
 
-:title_nav: UI options
+:navtitle: UI options
 :description: List of Tiny Drive user interface configuration options.
 :keywords: tinydrive configuration
 :pluginname: Tiny Drive

--- a/modules/ROOT/pages/tinydrive-ui-options.adoc
+++ b/modules/ROOT/pages/tinydrive-ui-options.adoc
@@ -5,7 +5,6 @@
 :keywords: tinydrive configuration
 :pluginname: Tiny Drive
 :plugincode: tinydrive
-:altplugincode: nil
 
 include::partial$configuration/tinydrive_skin.adoc[]
 

--- a/modules/ROOT/pages/tinydrive-upload.adoc
+++ b/modules/ROOT/pages/tinydrive-upload.adoc
@@ -1,6 +1,6 @@
 = Tiny Drive Upload API
 
-:title_nav: The Upload API
+:navtitle: The Upload API
 :description: Using the Tiny Drive Upload API
 :keywords: tinydrive api upload
 :apiname: upload

--- a/modules/ROOT/pages/tinydrive-upload.adoc
+++ b/modules/ROOT/pages/tinydrive-upload.adoc
@@ -10,4 +10,4 @@ The `+tinydrive.upload+` method allows https://developer.mozilla.org/en-US/docs/
 [[interactive-example-using-tinydriveupload]]
 == Interactive example: Using `+tinydrive.upload+`
 
-liveDemo::drive-plugin-upload[ ]
+liveDemo::drive-plugin-upload[]

--- a/modules/ROOT/pages/tinymce-and-cors.adoc
+++ b/modules/ROOT/pages/tinymce-and-cors.adoc
@@ -12,10 +12,8 @@ include::partial$configuration/content_css_cors.adoc[leveloffset=+1]
 
 :pluginname: Edit Image
 :plugincode: editimage
-:altplugincode: nil
 include::partial$configuration/image_cors_hosts.adoc[leveloffset=+1]
 
 :pluginname: Export
 :plugincode: export
-:altplugincode: nil
 include::partial$configuration/image_cors_hosts.adoc[leveloffset=+1]

--- a/modules/ROOT/pages/tinymce-and-cors.adoc
+++ b/modules/ROOT/pages/tinymce-and-cors.adoc
@@ -1,6 +1,6 @@
 = The TinyMCE Cross-Origin Resource Sharing guide
 
-:title_nav: Cross-Origin Resource Sharing (CORS)
+:navtitle: Cross-Origin Resource Sharing (CORS)
 :description: Information and options related to using TinyMCE with Cross-Origin Resource Sharing (CORS)
 :keywords: security cors
 

--- a/modules/ROOT/pages/tinymce-and-csp.adoc
+++ b/modules/ROOT/pages/tinymce-and-csp.adoc
@@ -1,6 +1,6 @@
 = The TinyMCE Content Security Policy guide
 
-:title_nav: Content Security Policies (CSP)
+:navtitle: Content Security Policies (CSP)
 :description: Information and options related to using TinyMCE with a Content Security Policy (CSP)
 :keywords: security csp
 

--- a/modules/ROOT/pages/tinymce-and-screenreaders.adoc
+++ b/modules/ROOT/pages/tinymce-and-screenreaders.adoc
@@ -1,6 +1,6 @@
 = Accessible navigation guide
 
-:title_nav: Accessibility Guide
+:navtitle: Accessibility Guide
 :description_short: Learn how TinyMCE works with screen readers and how screen readers work with TinyMCE.
 :description: Learn how TinyMCE works with screen readers and how screen readers work with TinyMCE.
 :keywords: accessibility wai aria jaws nvda

--- a/modules/ROOT/pages/tinymce-for-mobile.adoc
+++ b/modules/ROOT/pages/tinymce-for-mobile.adoc
@@ -1,6 +1,6 @@
 = TinyMCE for touch-enabled and mobile devices
 
-:title_nav: TinyMCE for mobile
+:navtitle: TinyMCE for mobile
 :description: The TinyMCE rich text editing experience for mobile devices.
 :keywords: mobile tablet
 

--- a/modules/ROOT/pages/toolbar-configuration-options.adoc
+++ b/modules/ROOT/pages/toolbar-configuration-options.adoc
@@ -1,6 +1,6 @@
 = Options for customizing the editor's toolbars
 
-:title_nav: Options
+:navtitle: Options
 :description: Information on options for customizing TinyMCE's toolbars
 
 == Basic toolbar configuration options

--- a/modules/ROOT/pages/upgrading.adoc
+++ b/modules/ROOT/pages/upgrading.adoc
@@ -1,6 +1,6 @@
 = Upgrading TinyMCE
 
-:title_nav: Upgrading TinyMCE
+:navtitle: Upgrading TinyMCE
 :description: How to upgrade TinyMCE via Tiny Cloud, package manager options, and Self-hosted options.
 :keywords: npm bower composer nuget update updating upgrade upgrading
 

--- a/modules/ROOT/pages/upload-images.adoc
+++ b/modules/ROOT/pages/upload-images.adoc
@@ -1,6 +1,6 @@
 = Handling image uploads
 
-:title_nav: Image uploads
+:navtitle: Image uploads
 :description_short: How to manage asynchronous image uploads.
 :description: How to manage asynchronous image uploads.
 :keywords: uploader uploadImages image handler asynchronous async paste_data_images image cors

--- a/modules/ROOT/pages/url-handling.adoc
+++ b/modules/ROOT/pages/url-handling.adoc
@@ -1,6 +1,6 @@
 = URL handling options
 
-:title_nav: URL handling options
+:navtitle: URL handling options
 :description: These settings affect the way URLs are handled by the editor.
 :keywords: url urls relative absolute domain document_base_url
 

--- a/modules/ROOT/pages/urldialog.adoc
+++ b/modules/ROOT/pages/urldialog.adoc
@@ -230,4 +230,4 @@ NOTE: {productname} will ignore all messages received that don't contain a `+mce
 
 This example shows a toolbar button that opens an external URL inside a 640px by 640px dialog without any footer buttons. The dialog can be opened by clicking the `+{;}+` toolbar button.
 
-liveDemo::url-dialog[ height="300" tab="js" ]
+liveDemo::url-dialog[height="300", tab="js"]

--- a/modules/ROOT/pages/urldialog.adoc
+++ b/modules/ROOT/pages/urldialog.adoc
@@ -1,6 +1,6 @@
 = Creating custom URL dialogs
 
-:title_nav: URL dialogs
+:navtitle: URL dialogs
 :description: URL dialogs are a TinyMCE UI component used to display an external page.
 :keywords: dialog urldialog api
 

--- a/modules/ROOT/pages/use-tinymce-classic.adoc
+++ b/modules/ROOT/pages/use-tinymce-classic.adoc
@@ -1,6 +1,6 @@
 = TinyMCE classic editing mode
 
-:title_nav: Classic editing mode
+:navtitle: Classic editing mode
 :description: The Theme that renders iframe or inline modes using the TinyMCE core UI framework.
 :keywords: theme classic
 

--- a/modules/ROOT/pages/use-tinymce-classic.adoc
+++ b/modules/ROOT/pages/use-tinymce-classic.adoc
@@ -19,7 +19,7 @@ There are a few important differences between these modes:
 
 *Classic* mode refers to the standard {productname} integration. Such as:
 
-liveDemo::default[ ]
+liveDemo::default[]
 
 == Example: Replacing a textarea with the default editor
 

--- a/modules/ROOT/pages/use-tinymce-distraction-free.adoc
+++ b/modules/ROOT/pages/use-tinymce-distraction-free.adoc
@@ -1,6 +1,6 @@
 = TinyMCE distraction-free editing mode
 
-:title_nav: Distraction-free editing mode
+:navtitle: Distraction-free editing mode
 :description: Mode that renders a lightweight UI for inline editing.
 :keywords: Mode inlite distraction-free
 

--- a/modules/ROOT/pages/use-tinymce-distraction-free.adoc
+++ b/modules/ROOT/pages/use-tinymce-distraction-free.adoc
@@ -25,7 +25,7 @@ tinymce.init({
 
 The demonstration editor below is a distraction-free editor with some customizations.
 
-liveDemo::editor-dfree[ ]
+liveDemo::editor-dfree[]
 
 == Related configuration options
 

--- a/modules/ROOT/pages/use-tinymce-inline.adoc
+++ b/modules/ROOT/pages/use-tinymce-inline.adoc
@@ -47,6 +47,6 @@ Inline mode only works on content within a block element (such as: `+div+` or `+
 
 The following demonstration is using four {productname} editors in inline mode, two for the headings, and two for the body text.
 
-liveDemo::inline[ ]
+liveDemo::inline[]
 
 For information on inline mode and the `+inline+` setting, see: xref:inline-editor-options.adoc#inline[User interface options - inline].

--- a/modules/ROOT/pages/use-tinymce-inline.adoc
+++ b/modules/ROOT/pages/use-tinymce-inline.adoc
@@ -1,6 +1,6 @@
 = Setup inline editing mode
 
-:title_nav: Inline editing mode
+:navtitle: Inline editing mode
 :description_short: Learn about forms-based editing v. inline editing.
 :description: Understand the difference between traditional forms-based editing and advanced inline editing.
 :keywords: form inline edit stylesheet

--- a/modules/ROOT/pages/user-formatting-options.adoc
+++ b/modules/ROOT/pages/user-formatting-options.adoc
@@ -1,6 +1,6 @@
 = Changing user formatting controls
 
-:title_nav: User formatting
+:navtitle: User formatting
 :description: Options for changing menu and toolbar dropdown formatting options available to users.
 
 include::partial$configuration/block_formats.adoc[]

--- a/modules/ROOT/pages/visualblocks.adoc
+++ b/modules/ROOT/pages/visualblocks.adoc
@@ -1,6 +1,6 @@
 = Visual Blocks plugin
 
-:title_nav: Visual Blocks
+:navtitle: Visual Blocks
 :description: Allows a user to see block level elements such as paragraphs.
 :keywords: visualblocks wysiwyg hidden view visualblocks_default_state
 :controls: toolbar button, menu item

--- a/modules/ROOT/pages/visualblocks.adoc
+++ b/modules/ROOT/pages/visualblocks.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button, menu item
 :pluginname: Visual Blocks
 :plugincode: visualblocks
-:altplugincode: nil
 
 This plugin allows a user to see block level elements in the editable area. It is similar to WYSIWYG hidden character functionality, but at block level. It also adds a toolbar button and a menu item `+Show blocks+` under the `+View+` menu dropdown.
 

--- a/modules/ROOT/pages/visualchars.adoc
+++ b/modules/ROOT/pages/visualchars.adoc
@@ -1,6 +1,6 @@
 = Visual Characters plugin
 
-:title_nav: Visual Characters
+:navtitle: Visual Characters
 :description: See invisible characters like non-breaking spaces.
 :keywords: visualchars
 :controls: toolbar button, menu item

--- a/modules/ROOT/pages/visualchars.adoc
+++ b/modules/ROOT/pages/visualchars.adoc
@@ -6,7 +6,6 @@
 :controls: toolbar button, menu item
 :pluginname: Visual Characters
 :plugincode: visualchars
-:altplugincode: nil
 
 This plugin adds the ability to see invisible characters like `+&nbsp;+` displayed in the editable area. It also adds a toolbar control and a menu item `+Show invisible characters+` under the `+View+` menu.
 

--- a/modules/ROOT/pages/vue-cloud.adoc
+++ b/modules/ROOT/pages/vue-cloud.adoc
@@ -1,6 +1,6 @@
 = Using TinyMCE from the Tiny Cloud CDN with the Vue.js framework
 
-:title_nav: Vue.js
+:navtitle: Vue.js
 :description: A guide on integrating TinyMCE from the Tiny Cloud into the Vue.js framework.
 :keywords: integration integrate vue vuejs tinymce-vue
 :productSource: cloud

--- a/modules/ROOT/pages/vue-pm.adoc
+++ b/modules/ROOT/pages/vue-pm.adoc
@@ -1,6 +1,6 @@
 = Using the TinyMCE package with the Vue.js framework
 
-:title_nav: Using a package manager
+:navtitle: Using a package manager
 :description: A guide on integrating the TinyMCE package into the Vue.js framework.
 :keywords: integration integrate vue vuejs tinymce-vue
 :productSource: package-manager

--- a/modules/ROOT/pages/vue-ref.adoc
+++ b/modules/ROOT/pages/vue-ref.adoc
@@ -1,6 +1,6 @@
 = TinyMCE Vue.js integration technical reference
 
-:title_nav: Technical reference
+:navtitle: Technical reference
 :description: Technical reference for the TinyMCE Vue.js integration
 :keywords: integration integrate vue vueapp
 

--- a/modules/ROOT/pages/vue-zip.adoc
+++ b/modules/ROOT/pages/vue-zip.adoc
@@ -1,6 +1,6 @@
 = Using the TinyMCE .zip package with the Vue.js framework
 
-:title_nav: Using a .zip package
+:navtitle: Using a .zip package
 :description: A guide on integrating a .zip version of TinyMCE into the Vue.js framework.
 :keywords: integration integrate vue vuejs tinymce-vue
 :productSource: zip

--- a/modules/ROOT/pages/webcomponent-cloud.adoc
+++ b/modules/ROOT/pages/webcomponent-cloud.adoc
@@ -1,6 +1,6 @@
 = Using TinyMCE from the Tiny Cloud CDN with the Web Component
 
-:title_nav: Web Component
+:navtitle: Web Component
 :description: A guide on integrating TinyMCE from the Tiny Cloud into the Web Component.
 :keywords: integration integrate web-component
 :productSource: cloud

--- a/modules/ROOT/pages/webcomponent-pm.adoc
+++ b/modules/ROOT/pages/webcomponent-pm.adoc
@@ -1,6 +1,6 @@
 = Using the TinyMCE package with the Web Component
 
-:title_nav: Using a package manager
+:navtitle: Using a package manager
 :description: A guide on integrating the TinyMCE package into the Web Component.
 :keywords: integration integrate web-component
 :productSource: package-manager

--- a/modules/ROOT/pages/webcomponent-ref.adoc
+++ b/modules/ROOT/pages/webcomponent-ref.adoc
@@ -1,6 +1,6 @@
 = TinyMCE Web Component technical reference
 
-:title_nav: Technical reference
+:navtitle: Technical reference
 :description: Technical reference for the TinyMCE Web Component
 :keywords: integration integrate web-component
 

--- a/modules/ROOT/pages/webcomponent-zip.adoc
+++ b/modules/ROOT/pages/webcomponent-zip.adoc
@@ -1,6 +1,6 @@
 = Using the TinyMCE .zip package with the Web Component
 
-:title_nav: Using a .zip package
+:navtitle: Using a .zip package
 :description: A guide on integrating a .zip version of TinyMCE into the Web Component.
 :keywords: integration integrate web-component
 :productSource: zip

--- a/modules/ROOT/pages/webpack-cjs-download.adoc
+++ b/modules/ROOT/pages/webpack-cjs-download.adoc
@@ -1,6 +1,6 @@
 = Bundling a .zip version of TinyMCE with CommonJS and Webpack
 
-:title_nav: CommonJS and a .zip archive
+:navtitle: CommonJS and a .zip archive
 :description_short: Bundling a .zip archive version of TinyMCE in a project using CommonJS and Webpack
 :description: Bundling a .zip archive version of TinyMCE in a project using CommonJS and Webpack
 :keywords: webpack commonjs cjs zip modules tinymce

--- a/modules/ROOT/pages/webpack-cjs-npm.adoc
+++ b/modules/ROOT/pages/webpack-cjs-npm.adoc
@@ -1,6 +1,6 @@
 = Bundling an npm version of TinyMCE with CommonJS and Webpack
 
-:title_nav: CommonJS and npm
+:navtitle: CommonJS and npm
 :description_short: Bundling an npm version of TinyMCE in a project using CommonJS and Webpack
 :description: Bundling an npm version of TinyMCE in a project using CommonJS and Webpack
 :keywords: webpack commonjs cjs npm modules tinymce

--- a/modules/ROOT/pages/webpack-es6-download.adoc
+++ b/modules/ROOT/pages/webpack-es6-download.adoc
@@ -1,6 +1,6 @@
 = Bundling a .zip version of TinyMCE with ES6 and Webpack
 
-:title_nav: ES6 and a .zip archive
+:navtitle: ES6 and a .zip archive
 :description_short: Bundling a .zip archive version of TinyMCE in a project using ES6 and Webpack
 :description: Bundling a .zip archive version of TinyMCE in a project using ES6 and Webpack
 :keywords: webpack es6 es2015 zip modules tinymce

--- a/modules/ROOT/pages/webpack-es6-npm.adoc
+++ b/modules/ROOT/pages/webpack-es6-npm.adoc
@@ -1,6 +1,6 @@
 = Bundling an npm version of TinyMCE with ES6 and Webpack
 
-:title_nav: ES6 and npm
+:navtitle: ES6 and npm
 :description_short: Bundling an npm version of TinyMCE in a project using ES6 and Webpack
 :description: Bundling an npm version of TinyMCE in a project using ES6 and Webpack
 :keywords: webpack es6 es2015 npm modules tinymce

--- a/modules/ROOT/pages/wordcount.adoc
+++ b/modules/ROOT/pages/wordcount.adoc
@@ -1,6 +1,6 @@
 = Word Count plugin
 
-:title_nav: Word Count
+:navtitle: Word Count
 :description: Show a word count in the TinyMCE status bar.
 :keywords: wordcount
 :pluginname: Word Count

--- a/modules/ROOT/pages/wordcount.adoc
+++ b/modules/ROOT/pages/wordcount.adoc
@@ -5,7 +5,6 @@
 :keywords: wordcount
 :pluginname: Word Count
 :plugincode: wordcount
-:altplugincode: nil
 
 The Word Count plugin adds the functionality for counting words to the {productname} editor by placing a counter on the right edge of the status bar. Clicking *Word Count* in the status bar switches between counting words and characters. A dialog box with both word and character counts can be opened using the menu item situated in the *Tools* drop-down, or the toolbar button.
 

--- a/modules/ROOT/pages/wordpress.adoc
+++ b/modules/ROOT/pages/wordpress.adoc
@@ -1,6 +1,6 @@
 = WordPress integration
 
-:title_nav: WordPress
+:navtitle: WordPress
 :description: Add TinyMCE to WordPress
 :keywords: integration integrate wordpress advanced
 

--- a/modules/ROOT/pages/work-with-plugins.adoc
+++ b/modules/ROOT/pages/work-with-plugins.adoc
@@ -1,6 +1,6 @@
 = Work with plugins to extend TinyMCE
 
-:title_nav: Using plugins to extend TinyMCE
+:navtitle: Using plugins to extend TinyMCE
 :description_short: Learn about TinyMCE's plugin functionality.
 :description: TinyMCE is an incredibly powerful, flexible and customizable rich text editor. This section demonstrates the power of plugins with several working examples.
 :keywords: plugin

--- a/modules/ROOT/pages/yeoman-generator.adoc
+++ b/modules/ROOT/pages/yeoman-generator.adoc
@@ -1,6 +1,6 @@
 = TinyMCE plugin Yeoman generator
 
-:title_nav: Yeoman generator
+:navtitle: Yeoman generator
 :description_short: How to use the Yeoman generator to bootstrap a new TinyMCE plugin
 :description: How to use the Yeoman generator to bootstrap a new TinyMCE plugin using ES2015/Babel or TypeScript.
 :keywords: webpack yeoman generator plugin tinymce

--- a/modules/ROOT/pages/zip-install.adoc
+++ b/modules/ROOT/pages/zip-install.adoc
@@ -1,6 +1,6 @@
 = Using TinyMCE from a .zip file
 
-:title_nav: TinyMCE .zip deployments
+:navtitle: TinyMCE .zip deployments
 :description: Learn how to use TinyMCE from a .zip archive.
 :keywords: zip archive unzip install
 :productSource: zip

--- a/modules/ROOT/partials/configuration/builtinformats.adoc
+++ b/modules/ROOT/partials/configuration/builtinformats.adoc
@@ -38,7 +38,7 @@ The following formats will work on most content.
 |===
 
 [NOTE]
---
+====
 The `+mceToggleFormat+` and `+FormatBlock+` xref:editor-command-identifiers.adoc[commands] do not accept the following formats:
 
 * `+forecolor+`
@@ -46,7 +46,7 @@ The `+mceToggleFormat+` and `+FormatBlock+` xref:editor-command-identifiers.adoc
 * `+fontname+`
 * `+fontsize+`
 * `+fontsize_class+`
---
+====
 
 == Definition list related formats
 

--- a/modules/ROOT/partials/configuration/charmap.adoc
+++ b/modules/ROOT/partials/configuration/charmap.adoc
@@ -2,7 +2,6 @@
 == `+charmap+`
 
 :plugincode: charmap
-:altplugincode: nil
 
 With this option it is possible to fully override the default character map. This can be an array or a function that returns an array in the above mentioned format.
 

--- a/modules/ROOT/partials/configuration/content_css.adoc
+++ b/modules/ROOT/partials/configuration/content_css.adoc
@@ -80,7 +80,7 @@ tinymce.init({
 ----
 
 [TIP]
---
+====
 To remove the margins between paragraphs (sometimes requested for using {productname} in email clients), add the following style to the content CSS:
 
 [source,css]
@@ -91,4 +91,4 @@ To remove the margins between paragraphs (sometimes requested for using {product
 */
 p { margin: 0 }
 ----
---
+====

--- a/modules/ROOT/partials/configuration/convert_urls.adoc
+++ b/modules/ROOT/partials/configuration/convert_urls.adoc
@@ -19,4 +19,4 @@ tinymce.init({
 
 === Interactive example: No URL conversion
 
-liveDemo::url-conversion-none[ ]
+liveDemo::url-conversion-none[]

--- a/modules/ROOT/partials/configuration/directionality.adoc
+++ b/modules/ROOT/partials/configuration/directionality.adoc
@@ -2,7 +2,6 @@
 == `+directionality+`
 
 :plugincode: directionality
-:altplugincode: nil
 
 This option allows you to set the base direction of directionally neutral text (i.e., text that doesn't have inherent directionality as defined in Unicode) within the editor. This is similar to the use of the `+'dir'+` attribute when using content editable elements by themselves.
 

--- a/modules/ROOT/partials/configuration/extended_valid_elements.adoc
+++ b/modules/ROOT/partials/configuration/extended_valid_elements.adoc
@@ -35,4 +35,4 @@ extended_valid_elements: 'script[src|async|defer|type|charset]'
 
 This example shows you how to use the xref:content-filtering.adoc#extended_valid_elements[extended_valid_elements] option. This option is used to add additional valid elements and attributes.
 
-liveDemo::valid-elements[ ]
+liveDemo::valid-elements[]

--- a/modules/ROOT/partials/configuration/file_picker_callback.adoc
+++ b/modules/ROOT/partials/configuration/file_picker_callback.adoc
@@ -41,4 +41,4 @@ tinymce.init({
 [[interactiveexample]]
 === Interactive example
 
-liveDemo::file-picker[ ]
+liveDemo::file-picker[]

--- a/modules/ROOT/partials/configuration/filetypes.adoc
+++ b/modules/ROOT/partials/configuration/filetypes.adoc
@@ -12,4 +12,4 @@ Type : `+Array<string>+`
 [[interactive-example-using-filetypes-to-restrict-sitecloudfilemanager-to-image-formats]]
 === Interactive example: Using `+filetypes+` to restrict {cloudfilemanager} to image formats
 
-liveDemo::drive-plugin-pick-images[ ]
+liveDemo::drive-plugin-pick-images[]

--- a/modules/ROOT/partials/configuration/readonly.adoc
+++ b/modules/ROOT/partials/configuration/readonly.adoc
@@ -19,4 +19,4 @@ tinymce.init({
 });
 ----
 
-liveDemo::readonly-demo[ ]
+liveDemo::readonly-demo[]

--- a/modules/ROOT/partials/configuration/rtc_server_disconnected.adoc
+++ b/modules/ROOT/partials/configuration/rtc_server_disconnected.adoc
@@ -26,12 +26,12 @@ Input parameters :
 === Reasons for disconnection
 
 [CAUTION]
---
+====
 It is critical to at least handle the `+client_update_required+` reason. This indicates the RTC plugin in the current editor instance is out-of-date compared to other users on the session. The behavior in this scenario depends on the configuration:
 
 * If the `+rtc_server_disconnected+` is set, no message is displayed to the user for this error. It is up to the integrator to manage cleanly reloading the page.
 * If the `+rtc_server_disconnected+` is not set, the suggested error message will be displayed in a notification asking the user to reload the page.
---
+====
 
 The `+reason+` field will have one of the following values.
 

--- a/modules/ROOT/partials/configuration/style_formats.adoc
+++ b/modules/ROOT/partials/configuration/style_formats.adoc
@@ -76,8 +76,8 @@ This example shows you how to:
 * Override the built-in xref:content-formatting.adoc#formats[formats].
 * Add some custom styles to the `+styles+` dropdown toolbar button and the `+styles+` menu item using the xref:user-formatting-options.adoc#style_formats[style_formats] configuration option.
 
-liveDemo::format-custom[ tab="js" ]
+liveDemo::format-custom[tab="js"]
 
 This example shows you how to edit HTML5 content such as sections and articles.
 
-liveDemo::format-html5[ tab="js" ]
+liveDemo::format-html5[tab="js"]

--- a/modules/ROOT/partials/install/basic-quickstart-base.adoc
+++ b/modules/ROOT/partials/install/basic-quickstart-base.adoc
@@ -167,7 +167,7 @@ For example:
 
 Adding this content to an HTML file and opening it in a web browser will load a TinyMCE editor, such as:
 
-liveDemo::default[ ]
+liveDemo::default[]
 ifeval::["{productSource}" == "cloud"]
 
 == Add your API key

--- a/modules/ROOT/partials/integrations/webcomponent-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/webcomponent-quick-start.adoc
@@ -109,7 +109,7 @@ The following example shows the {productname} Web Component in an HTML page, wit
 * Various {productname} configuration options set using attributes.
 * {productname} sourced from the {cloudname}.
 
-liveDemo::web-component[ tab="html" ]
+liveDemo::web-component[tab="html"]
 
 == Next Steps
 

--- a/modules/ROOT/partials/misc/admon_dont-push-docker-images.adoc
+++ b/modules/ROOT/partials/misc/admon_dont-push-docker-images.adoc
@@ -1,7 +1,7 @@
 [WARNING]
---
+====
 Do not push this docker image to a publicly accessible container registry. Doing so will constitute a breach of the {companyname} Self-Hosted Software License Agreement, _including_:
 
 * link:{legalpages}/tiny-self-hosted-enterprise-agreement/[The {companyname} Self-Hosted Software License Agreement - (Enterprise Users)].
 * link:{legalpages}/tiny-self-hosted-oem-saas-agreement/[The {companyname} Self-Hosted Software License Agreement - (OEM & SaaS Users)].
---
+====

--- a/modules/ROOT/partials/misc/beta-note.adoc
+++ b/modules/ROOT/partials/misc/beta-note.adoc
@@ -1,8 +1,8 @@
 [IMPORTANT]
---
+====
 {beta_feature} is currently in {pre-release_type}. To learn about our pre-release commitment, please read the software licence agreement related to your subscription, _including_:
 
 * link:{legalpages}/cloud-use-subscription-agreement/[The {cloudname} Services Subscription Agreement].
 * link:{legalpages}/tiny-self-hosted-enterprise-agreement/[The {companyname} Self-Hosted Software License Agreement - (Enterprise Users)].
 * link:{legalpages}/tiny-self-hosted-oem-saas-agreement/[The {companyname} Self-Hosted Software License Agreement - (OEM & SaaS Users)].
---
+====

--- a/modules/ROOT/partials/misc/list_ignore_port_service_versions.adoc
+++ b/modules/ROOT/partials/misc/list_ignore_port_service_versions.adoc
@@ -1,8 +1,8 @@
 [NOTE]
---
+====
 This feature is only available in certain versions of the TinyMCE self-hosted server-side components. To check the version of a running service, visit _<domain>_/_<service>_/version. Such as http://localhost:8080/ephox-hyperlinking/version.
 
 * ephox-spelling.war: 2.113.0 or later
 * ephox-hyperlinking.war: 2.104.0 or later
 * ephox-image-proxy.war: 2.104.0 or later
---
+====

--- a/modules/ROOT/partials/misc/onSetup.adoc
+++ b/modules/ROOT/partials/misc/onSetup.adoc
@@ -19,7 +19,7 @@ onSetup: (api) => {
 To bind a callback function to an editor event use `+editor.on(eventName, callback)+`. To unbind an event listener use `+editor.off(eventName, callback)+`. Any event listeners _should_ be unbound in the teardown callback. The only editor event which does not need to be unbound is `+init+` e.g. `+editor.on('init', callback)+`.
 
 [NOTE]
---
+====
 * The callback function for `+editor.off()+` should be the same function passed to `+editor.on()+`. For example, if a `+editorEventCallback+` function is bound to the `+NodeChange+` event when the button is created, `+onSetup+` should return `+(api) => editor.off('NodeChange', editorEventCallback)+`.
 * If `+onSetup+` does not have any event listeners or only listens to the `+init+` event, `+onSetup+` can return an empty function e.g. `+return () => {};+`.
---
+====

--- a/modules/ROOT/partials/misc/plugin-menu-item-id-boilerplate.adoc
+++ b/modules/ROOT/partials/misc/plugin-menu-item-id-boilerplate.adoc
@@ -4,10 +4,10 @@ ifeval::["{docname}" == "available-menu-items"]
 
 The {pluginname} plugin provides the following menu items:
 
-ifeval::["{altplugincode}" != "nil"]
+ifdef::altplugincode[]
 include::partial$menu-item-ids/{altplugincode}-menu-items.adoc[]
 endif::[]
-ifeval::["{altplugincode}" == "nil"]
+ifndef::altplugincode[]
 include::partial$menu-item-ids/{plugincode}-menu-items.adoc[]
 endif::[]
 
@@ -25,10 +25,10 @@ ifeval::["{docname}" != "available-menu-items"]
 
 The {pluginname} plugin provides the following menu items:
 
-ifeval::["{altplugincode}" != "nil"]
+ifdef::altplugincode[]
 include::partial$menu-item-ids/{altplugincode}-menu-items.adoc[]
 endif::[]
-ifeval::["{altplugincode}" == "nil"]
+ifndef::altplugincode[]
 include::partial$menu-item-ids/{plugincode}-menu-items.adoc[]
 endif::[]
 

--- a/modules/ROOT/partials/misc/plugin-toolbar-button-id-boilerplate.adoc
+++ b/modules/ROOT/partials/misc/plugin-toolbar-button-id-boilerplate.adoc
@@ -4,10 +4,10 @@ ifeval::["{docname}" == "available-toolbar-buttons"]
 
 The {pluginname} plugin provides the following toolbar buttons:
 
-ifeval::["{altplugincode}" != "nil"]
+ifdef::altplugincode[]
 include::partial$toolbar-button-ids/{altplugincode}-toolbar-buttons.adoc[]
 endif::[]
-ifeval::["{altplugincode}" == "nil"]
+ifndef::altplugincode[]
 include::partial$toolbar-button-ids/{plugincode}-toolbar-buttons.adoc[]
 endif::[]
 
@@ -25,10 +25,10 @@ ifeval::["{docname}" != "available-toolbar-buttons"]
 
 The {pluginname} plugin provides the following toolbar buttons:
 
-ifeval::["{altplugincode}" != "nil"]
+ifdef::altplugincode[]
 include::partial$toolbar-button-ids/{altplugincode}-toolbar-buttons.adoc[]
 endif::[]
-ifeval::["{altplugincode}" == "nil"]
+ifndef::altplugincode[]
 include::partial$toolbar-button-ids/{plugincode}-toolbar-buttons.adoc[]
 endif::[]
 

--- a/modules/ROOT/partials/misc/purchase-premium-plugins.adoc
+++ b/modules/ROOT/partials/misc/purchase-premium-plugins.adoc
@@ -8,6 +8,19 @@ ifeval::[{pluralExtensionType} != true]
 :isAre: is
 endif::[]
 
+ifeval::["{pluginminimumplan}" == "tierone"]
+:isTierOne:
+endif::[]
+ifeval::["{pluginminimumplan}" == "tiertwo"]
+:isTierTwo:
+endif::[]
+ifeval::["{pluginminimumplan}" == "tierthree"]
+:isTierThree:
+endif::[]
+ifeval::["{pluginminimumplan}" == "enterprise"]
+:isEnterprise:
+endif::[]
+
 ifeval::["{pluginname}" != "Tiny Drive"]
 [[getting-started-with-productname-pluginname]]
 == Getting started with {productname} {pluginname}
@@ -40,31 +53,28 @@ ifeval::["{pluginminimumplan}" == "enterprise"]
 The *{pluginname} {extensionType}* {isAre} included in link:{pricingpage}/[{enterpriseplan}].
 endif::[]
 
-ifeval::["{pluginminimumplan}" == "tierone"]
-* The link:{pricingpage}/[{tieroneplan}].
-* The link:{pricingpage}/[{tiertwoplan}].
-* The link:{pricingpage}/[{tierthreeplan}].
+ifdef::isTierOne[]
+* The link:{pricingpage}[{tieroneplan}].
 endif::[]
-ifeval::["{pluginminimumplan}" == "tiertwo"]
-* The link:{pricingpage}/[{tiertwoplan}].
-* The link:{pricingpage}/[{tierthreeplan}].
+ifdef::isTierOne,isTierTwo[]
+* The link:{pricingpage}[{tiertwoplan}].
 endif::[]
-ifeval::["{pluginminimumplan}" == "tierthree"]
-* The link:{pricingpage}/[{tierthreeplan}].
+ifdef::isTierOne,isTierTwo,isTierThree[]
+* The link:{pricingpage}[{tierthreeplan}].
 endif::[]
-ifeval::["{pluginminimumplan}" != "enterprise"]
+ifndef::isEnterprise[]
 * link:{pricingpage}/[{enterpriseplan}].
 endif::[]
 
-ifeval::["{pluginminimumplan}" == "tiertwo"]
+ifdef::isTierTwo[]
 A 14-day free trial is also available for the {tiertwoplan} and the {tierthreeplan}.
 endif::[]
-ifeval::["{pluginminimumplan}" == "tierthree"]
-A 14-day free trial is also available for the {tiertwoplan} and the {tierthreeplan}.
-endif::[]
-ifeval::["{pluginminimumplan}" == "enterprise"]
+ifdef::isTierThree[]
 A 14-day free trial is available for the {tierthreeplan}.
 endif::[]
 
-
-
+:!isAre:
+:!isTierOne:
+:!istiertwo:
+:!istierthree:
+:!isEnterprise:

--- a/modules/ROOT/partials/misc/tech-preview-note.adoc
+++ b/modules/ROOT/partials/misc/tech-preview-note.adoc
@@ -1,5 +1,5 @@
 [IMPORTANT]
---
+====
 {tech_preview_feature} is a Technology Preview feature only. This feature is provided to allow customers to test experimental functionality and provide feedback during the development process.
 
 Technology Preview features:
@@ -10,4 +10,4 @@ Technology Preview features:
 * Are not guaranteed to be released in a supported manner.
 
 {companynameformal} does not recommend using this feature in production.
---
+====

--- a/modules/ROOT/partials/misc/url-handling.adoc
+++ b/modules/ROOT/partials/misc/url-handling.adoc
@@ -17,11 +17,11 @@ Example: `+http://www.example.com/path1/path2/file.htm+` >> `+path2/file.htm+`
 
 ==== Example: Relative URLs on links and images
 
-liveDemo::url-conversion-relative-1[ ]
+liveDemo::url-conversion-relative-1[]
 
 ==== Example: Relative URLs on links and images to a specific page
 
-liveDemo::url-conversion-relative-2[ ]
+liveDemo::url-conversion-relative-2[]
 
 === Absolute URLs
 
@@ -41,11 +41,11 @@ Example: `+path2/file.htm+` >> `+/path1/path2/file.htm+`
 
 ==== Example: Absolute URLs on links and images
 
-liveDemo::url-conversion-absolute-1[ ]
+liveDemo::url-conversion-absolute-1[]
 
 ==== Example: Absolute URLs and including domain on links and images
 
-liveDemo::url-conversion-absolute-2[ ]
+liveDemo::url-conversion-absolute-2[]
 
 === Domain absolute URLs
 

--- a/modules/ROOT/partials/module-loading/bundling-plugins-that-cant-bundle.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-plugins-that-cant-bundle.adoc
@@ -1,5 +1,5 @@
 [IMPORTANT]
---
+====
 The following premium plugins *can not* be bundled at this time:
 
 * Accessibility Checker (`+a11ychecker+`)
@@ -9,4 +9,4 @@ The following premium plugins *can not* be bundled at this time:
 * Link Checker (`+linkchecker+`)
 * Mentions (`+mentions+`)
 * Page Embed (`+pageembed+`)
---
+====

--- a/modules/ROOT/partials/what-is-tinymce.adoc
+++ b/modules/ROOT/partials/what-is-tinymce.adoc
@@ -1,6 +1,6 @@
 {productname} is a rich-text editor that allows users to create formatted content with in user-friendly interface.
 
-liveDemo::default-editor[ ]
+liveDemo::default-editor[]
 
 The output created is in HTML5 and can include lists, tables, and other useful elements, depending on your configuration. The functionality of the editor can be extended through plugins and customizations, or limited to suit your use-case. {productname} can also be customized to look and feel like part of your application or webpage by customizing the user interface. {productname} can be integrated into a range of frameworks and Content Management Systems (CMSs), and can be either:
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "dotenv": "^16.0.0",
     "ecstatic": "^4.1.4",
     "http-server": "^0.12.3",
-    "liquidjs": "~9.25.0",
+    "liquidjs": "^9.36.0",
     "nodemon": "^2.0.7",
     "npm-run-all": "^4.1.5"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1542,10 +1542,10 @@ leven@2.1.0:
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
   integrity sha1-wuep93IJTe6dNCAq6KzORoeHVYA=
 
-liquidjs@~9.25.0:
-  version "9.25.1"
-  resolved "https://registry.yarnpkg.com/liquidjs/-/liquidjs-9.25.1.tgz#1330e015158e9d7f0a24d4c063d2242049266f79"
-  integrity sha512-V6RYwuFsx13aKZ5ZrSUMHUgTPrEWpcP3GcafEkMdvlWVW9tTlQHOgBoJaK2HtLbOyvjXtaHXT82ZElwmRNY+Kw==
+liquidjs@^9.36.0:
+  version "9.36.0"
+  resolved "https://registry.yarnpkg.com/liquidjs/-/liquidjs-9.36.0.tgz#7d469df0461558b09ea279035d1909864893bd41"
+  integrity sha512-HbU4xBsY1r3ZEORTgPsiluXsOtMx8iI0MqTsPejgIk+sIgta5wQUYsoQgUPuGKWVHKKKMO9PidiMEPKlePl8rg==
 
 load-json-file@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Related Ticket:  DOC-1616

Description of Changes:
* Fixed block admonition markup to use example (`====`) blocks instead of open (`--`) blocks as suggested in the docs: https://docs.asciidoctor.org/asciidoc/latest/blocks/admonitions/#admonition-syntax
* Port improvements for conditionals that were found when converting the 5.x docs. This also includes a fix for the `A 14-day free trial is available for the {tierthreeplan}.` string incorrectly showing when it was "enterprise".
* Improve the live demo extension to work with Antora remote branch builds. As part of this I've also made it cache the liquid templates so it doesn't need to parse the `live-demo.adoc` file multiple times.
* Cleaned up live demo macro syntax to remove excess whitespace and ensure a comma exists between variables passed to the macro.
* Swap from using `title_nav` to `navtitle` to actually be useful since Antora needs the attribute to be called `navtitle`: https://docs.antora.org/antora/latest/page/reftext-and-navtitle/#navtitle

**Note:** Each change is done as a separate commit in an attempt to make it easier to review.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
