### PR TITLE
DOC-1619: Rename community plan to core plan

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -29,7 +29,7 @@ asciidoc:
     #### some plugin names
     prem_skins_icons: Tiny Skins and Icon Packs
     #### Plan names
-    tieroneplan: Tiny Cloud Community Plan
+    tieroneplan: Tiny Cloud Core Plan
     tiertwoplan: Tiny Cloud Essential Plan
     tierthreeplan: Tiny Cloud Professional Plan
     enterpriseplan: Tiny Custom Plans


### PR DESCRIPTION
Related Ticket: DOC-1619

Description of Changes:
* Renamed the `Tiny Cloud Community Plan` to `Tiny Cloud Core Plan

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
