### PR TITLE
DOC-1606: Added a demo for the table of contents plugin

### DIFF
--- a/modules/ROOT/examples/live-demos/tableofcontents/index.html
+++ b/modules/ROOT/examples/live-demos/tableofcontents/index.html
@@ -1,0 +1,50 @@
+<textarea id="tableofcontents">
+  <div class="mce-toc">
+    <h2>Table of Contents</h2>
+    <ul>
+      <li><a href="#intro">Table of Contents plugin demo</a>
+        <ul>
+          <li><a href="#how-to-use-the-demo">How to use the demo?</a></li>
+        </ul>
+      </li>
+      <li><a href="#got-questions-or-need-help">Got questions or need help?</a></li>
+      <li><a href="#found-a-bug">Found a bug?</a></li>
+      <li><a href="#conclusion">Finally...</a></li>
+    </ul>
+  </div>
+
+  <h2 id="intro">Table of Contents plugin demo</h2>
+  <p>
+    The Table of Contents plugin provides the ability to automatically create a table of contents based on the headings in your content.
+  </p>
+
+  <h3 id="how-to-use-the-demo">How to use the demo?</h3>
+  <p>
+    To update the table of contents already in this demo, insert some new headings, select the table of contents at the top of the page and then click the
+    update button in the context toolbar that appears.
+  </p>
+  <p>
+    You can also insert a new table of contents anywhere in the content by selecting where you want the table of contents to be inserted and then either click
+    the table of contents toolbar button or by selecting <code>Insert</code> -> <code>Table of contents</code>.
+  </p>
+
+  <h2 id="got-questions-or-need-help">Got questions or need help?</h2>
+  <ul>
+    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
+    <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
+  </ul>
+
+  <h2 id="found-a-bug">Found a bug?</h2>
+  <p>
+    If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.
+  </p>
+
+  <h2 id="conclusion">Finally...</h2>
+  <p>
+    Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.
+  </p>
+  <p>
+    Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.
+  </p>
+</textarea>

--- a/modules/ROOT/examples/live-demos/tableofcontents/index.js
+++ b/modules/ROOT/examples/live-demos/tableofcontents/index.js
@@ -1,0 +1,11 @@
+tinymce.init({
+  selector: 'textarea#tableofcontents',
+  height: 600,
+  plugins: [
+    'advlist', 'autolink', 'lists', 'link', 'image', 'charmap', 'preview',
+    'anchor', 'searchreplace', 'visualblocks', 'code', 'fullscreen',
+    'insertdatetime', 'media', 'table', 'tableofcontents', 'wordcount'
+  ],
+  toolbar: 'tableofcontents | undo redo | styles | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent',
+  content_style: 'body { font-family:Helvetica,Arial,sans-serif; font-size:16px }'
+});

--- a/modules/ROOT/pages/tableofcontents.adoc
+++ b/modules/ROOT/pages/tableofcontents.adoc
@@ -10,6 +10,10 @@
 
 The `+tableofcontents+` plugin will generate basic _Table of Contents_ and insert it into the editor at the current cursor position. Items for the table will be taken from the headers found in the content.
 
+== Interactive Example
+
+liveDemo::tableofcontents[]
+
 include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Basic setup


### PR DESCRIPTION
Related Ticket: DOC-1606

Description of Changes:

Adds a new Table of Contents demo based on our normal template just with some initial content to explain how it works.

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
