### PR TITLE
DOC-1607: Additional options cleanup fixes identified during review

### DIFF
--- a/modules/ROOT/pages/tinydrive-jwt-authentication.adoc
+++ b/modules/ROOT/pages/tinydrive-jwt-authentication.adoc
@@ -55,17 +55,17 @@ A JSON Web Token (JWT) endpoint for {pluginname} requires:
 JSON Web Tokens produced by the JWT endpoint must include the following claims:
 
 `+sub+` _(required)_::
-*Type:* `+string+` or `+URI+`
+*Type:* `+String+` or `+URI+`
 +
 Unique string or URI to identify the user. This can be a database ID, hashed email address, or similar identifier.
 
 `+name+` _(required)_::
-*Type:* `+string+`
+*Type:* `+String+`
 +
 Full name of the user that will be used for presentation inside {pluginname}. When the user uploads a file, this name is presented as the creator of that file.
 
 `+https://claims.tiny.cloud/drive/root+` _(optional)_::
-*Type:* `+string+`
+*Type:* `+String+`
 +
 Full path to a {pluginname} specific root for example "/johndoe". The user won't be able to see or manage files outside this configured root path.
 

--- a/modules/ROOT/partials/configuration/custom_elements.adoc
+++ b/modules/ROOT/partials/configuration/custom_elements.adoc
@@ -7,8 +7,6 @@ This way you can handle non-HTML elements inside an HTML editor. You can prefix 
 
 *Type:* `+String+`
 
-*Default value:* `+'div'+` elements
-
 [source,js]
 ----
 tinymce.init({

--- a/modules/ROOT/partials/configuration/editimage_credentials_hosts.adoc
+++ b/modules/ROOT/partials/configuration/editimage_credentials_hosts.adoc
@@ -3,7 +3,7 @@
 
 This option can be used together with the `+editimage_cors_hosts+` option to allow credentials to be sent to the CORS host. This is not enabled by default since the server needs to have proper CORS headers to support this.
 
-*Type:* `+String[]+`
+*Type:* `+Array+`
 
 === Example: Using `+editimage_credentials_hosts+`
 

--- a/modules/ROOT/partials/configuration/filetypes.adoc
+++ b/modules/ROOT/partials/configuration/filetypes.adoc
@@ -7,7 +7,7 @@ include::partial$plugins/tinydrive-filetypeslist.adoc[]
 
 For example: If the application is using {cloudfilemanager} to insert images, then set `+['image']+` in the file types array.
 
-*Type:* `+Array<string>+`
+*Type:* `+Array+`
 
 [[interactive-example-using-filetypes-to-restrict-sitecloudfilemanager-to-image-formats]]
 === Interactive example: Using `+filetypes+` to restrict {cloudfilemanager} to image formats

--- a/modules/ROOT/partials/configuration/image_cors_hosts.adoc
+++ b/modules/ROOT/partials/configuration/image_cors_hosts.adoc
@@ -15,7 +15,7 @@ NOTE: Each string in the array _must_ be in the format of `+mydomain.com+`. Do n
 
 NOTE: `{plugincode}_cors_hosts` is *not* required when enabling this plugin via xref:editor-and-features.adoc[{cloudname}].
 
-*Type:* `+String[]+`
+*Type:* `+Array+`
 
 *Default value:* `+[]+`
 

--- a/modules/ROOT/partials/configuration/importcss_file_filter.adoc
+++ b/modules/ROOT/partials/configuration/importcss_file_filter.adoc
@@ -1,7 +1,7 @@
 [[importcss_file_filter]]
 == `+importcss_file_filter+`
 
-This option enables you to add the CSS files that should be used for populating the styles drop down. This will go through any `+@import+` rules and only target the specified file. This option can be either a `+string+`, `+regexp+` or a `+function+`. This also allows you to import styles form existing files on the currently editable page in inline mode.
+This option enables you to add the CSS files that should be used for populating the styles drop down. This will go through any `+@import+` rules and only target the specified file. This option can be either a `+String+`, `+RegExp+` or a `+Function+`. This also allows you to import styles form existing files on the currently editable page in inline mode.
 
 *Type:* `+String+`, `+RegExp+` or `+Function+`
 

--- a/modules/ROOT/partials/configuration/importcss_groups.adoc
+++ b/modules/ROOT/partials/configuration/importcss_groups.adoc
@@ -1,7 +1,7 @@
 [[importcss_groups]]
 == `+importcss_groups+`
 
-This option enables group matching selectors into submenus in the `+Formats+` menu dropdown. You can use a `+string+`, `+regexp+` or a `+function+` to filter selectors. You can also omit the filter to get all non-matching ones into a specific group. You can also specify a group specific `+selector_converter+` so that formats for a specific group are produced by that converter.
+This option enables group matching selectors into submenus in the `+Formats+` menu dropdown. You can use a `+String+`, `+RegExp+` or a `+Function+` to filter selectors. You can also omit the filter to get all non-matching ones into a specific group. You can also specify a group specific `+selector_converter+` so that formats for a specific group are produced by that converter.
 
 *Type:* `+Array+`
 

--- a/modules/ROOT/partials/configuration/importcss_selector_filter.adoc
+++ b/modules/ROOT/partials/configuration/importcss_selector_filter.adoc
@@ -1,7 +1,7 @@
 [[importcss_selector_filter]]
 == `+importcss_selector_filter+`
 
-This option enables you to only import classes from selectors matching the filter. The filter can be a `+string+`, `+regexp+` or a `+function+`. See the examples below.
+This option enables you to only import classes from selectors matching the filter. The filter can be a `+String+`, `+RegExp+` or a `+Function+`. See the examples below.
 
 *Type:* `+String+`, `+RegExp+` or `+Function+`
 

--- a/modules/ROOT/partials/configuration/link_assume_external_targets.adoc
+++ b/modules/ROOT/partials/configuration/link_assume_external_targets.adoc
@@ -8,6 +8,8 @@ Set whether {productname} should prepend a `+http://+` prefix if the supplied UR
 * `+'http'+`: URLs are assumed to be external. URLs without a protocol prefix are prepended a `+http://+` prefix.
 * `+'https'+`: URLs are assumed to be external. URLs without a protocol prefix are prepended a `+https://+` prefix.
 
+*Type:* `+Boolean+` or `+String+`
+
 *Default value:* `+false+`
 
 *Possible values:* `+true+`, `+false+`, `+'http'+`, `+'https'+`

--- a/modules/ROOT/partials/configuration/menubar.adoc
+++ b/modules/ROOT/partials/configuration/menubar.adoc
@@ -5,7 +5,7 @@ This option allows you to specify which menus should appear and the order that t
 
 To specify the menus that should appear on {productname}'s menu bar, the menubar option should be provided with a space separated list of menus.
 
-*Type:* `+String+` _or_ `+Boolean+`
+*Type:* `+String+` or `+Boolean+`
 
 *Default value:* `+true+`
 

--- a/modules/ROOT/partials/configuration/paste_block_drop.adoc
+++ b/modules/ROOT/partials/configuration/paste_block_drop.adoc
@@ -10,6 +10,8 @@ endif::[]
 
 Due to browser limitations, it is not possible to filter content that is dragged and dropped into the editor. When `{pasteblockdropname}` is set to true dragging and dropping content into the editor will be disabled. This prevents the unfiltered content from being introduced. Copy and paste is still enabled.
 
+*Type:* `+Boolean+`
+
 *Default value:* `+false+`
 
 *Possible values:* `+true+`, `+false+`

--- a/modules/ROOT/partials/configuration/powerpaste_allow_local_images.adoc
+++ b/modules/ROOT/partials/configuration/powerpaste_allow_local_images.adoc
@@ -3,6 +3,8 @@
 
 When set to `+true+`, Base64 encoded images using a data URI in the copied content will not be removed after pasting.
 
+*Type:* `+Boolean+`
+
 *Default value:* `+true+`
 
 *Possible values:* `+true+`, `+false+`

--- a/modules/ROOT/partials/configuration/powerpaste_clean_filtered_inline_elements.adoc
+++ b/modules/ROOT/partials/configuration/powerpaste_clean_filtered_inline_elements.adoc
@@ -5,7 +5,9 @@ This option allows for configuration of PowerPaste's *"clean"* paste filters for
 
 The list of inline elements that should be removed on paste can be specified by setting `+powerpaste_clean_filtered_inline_elements+` to a comma-separated string of inline element tag names.
 
-*Possible values:* A comma-separated string.
+*Type:* A comma-separated string or `+Array+`
+
+*Default value:* `+[]+`
 
 === Example: `+powerpaste_clean_filtered_inline_elements+`
 

--- a/modules/ROOT/partials/configuration/powerpaste_keep_unsupported_src.adoc
+++ b/modules/ROOT/partials/configuration/powerpaste_keep_unsupported_src.adoc
@@ -5,6 +5,8 @@ Due to browser limitations, PowerPaste is not able to support all image types su
 
 For example, browsers do not allow PowerPaste to access the file system. If your application has access to the file system, setting `+powerpaste_keep_unsupported_src+` to `+true+` may allow you to replace unsupported images during post-processing using the original file paths.
 
+*Type:* `+Boolean+`
+
 *Default value:* `+false+`
 
 *Possible values:* `+true+`, `+false+`

--- a/modules/ROOT/partials/configuration/spellchecker_ignore_list.adoc
+++ b/modules/ROOT/partials/configuration/spellchecker_ignore_list.adoc
@@ -5,7 +5,7 @@ This option specifies which words should be ignored by the spell checker. If an 
 
 NOTE: Languages specified as keys in the `+spellchecker_ignore_list+` object must match the configured xref:introduction-to-tiny-spellchecker.adoc#spellchecker_languages[Spellchecker Languages].
 
-*Type:* `+String[]+` or `+Object+`
+*Type:* `+Array+` or `+Object+`
 
 === Example: Using `+spellchecker_ignore_list+` to ignore words in all languages
 

--- a/modules/ROOT/partials/configuration/spellchecker_languages.adoc
+++ b/modules/ROOT/partials/configuration/spellchecker_languages.adoc
@@ -3,7 +3,7 @@
 
 This option specifies the spellchecker languages that are available to the user, provided as a comma delimited string. For a list of available languages, see: xref:introduction-to-tiny-spellchecker.adoc#supportedlanguages[Supported languages].
 
-*Type:* comma-separated `+String+`
+*Type:* A comma-separated string.
 
 *Default value:*
 [source,js]

--- a/modules/ROOT/partials/configuration/table_clone_elements.adoc
+++ b/modules/ROOT/partials/configuration/table_clone_elements.adoc
@@ -1,7 +1,7 @@
 [[table_clone_elements]]
 == `+table_clone_elements+`
 
-This option enables you to specify which elements should be cloned as empty children when inserting rows/columns to a table. By default it will clone these '`+strong+` `+em+` `+b+` `+i+` `+span+` `+font+` `+h1+` `+h2+` `+h3+` `+h4+` `+h5+` `+h6+` `+p+` `+div+`' into new cells.
+This option enables you to specify which elements should be cloned as empty children when inserting rows/columns to a table. By default it will clone `+strong+`, `+em+`, `+b+`, `+i+`, `+span+`, `+font+`, `+h1+`, `+h2+`, `+h3+`, `+h4+`, `+h5+`, `+h6+`, `+p+` and `+div+` elements into new cells.
 
 *Type:* `+String+`
 

--- a/modules/ROOT/partials/configuration/tinydrive_dropbox_app_key.adoc
+++ b/modules/ROOT/partials/configuration/tinydrive_dropbox_app_key.adoc
@@ -3,7 +3,7 @@
 
 This option is used to specify the Dropbox API key for integrating Dropbox into {cloudfilemanager}. For information on how to generate a Dropbox API key, refer to the xref:tinydrive-dropbox-integration.adoc[Dropbox integration guide].
 
-*Type:* `+string+`
+*Type:* `+String+`
 
 === Example: Using `+tinydrive_dropbox_app_key+`
 

--- a/modules/ROOT/partials/configuration/tinydrive_google_drive_client_id.adoc
+++ b/modules/ROOT/partials/configuration/tinydrive_google_drive_client_id.adoc
@@ -3,7 +3,7 @@
 
 This option sets the Google Drive client ID for integrating Google Drive into {cloudfilemanager}. For information on how to generate this ID, refer to the xref:tinydrive-googledrive-integration.adoc[Google Drive integration guide].
 
-*Type:* `+string+`
+*Type:* `+String+`
 
 === Example: Using `+tinydrive_google_drive_client_id+`
 

--- a/modules/ROOT/partials/configuration/tinydrive_google_drive_key.adoc
+++ b/modules/ROOT/partials/configuration/tinydrive_google_drive_key.adoc
@@ -3,7 +3,7 @@
 
 This option sets the Google Drive API key for integrating Google Drive into {cloudfilemanager}. For information on how to generate this key, refer to the xref:tinydrive-googledrive-integration.adoc[Google Drive integration guide].
 
-*Type:* `+string+`
+*Type:* `+String+`
 
 === Example: Using `+tinydrive_google_drive_key+`
 

--- a/modules/ROOT/partials/integrations/angular-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/angular-tech-ref.adoc
@@ -176,11 +176,11 @@ The `+disabled+` property can dynamically switch the editor between a "disabled"
 [[id]]
 === `+id+`
 
-An id for the editor. Used for retrieving the editor instance using the `+tinymce.get('ID')+` method. Defaults to an automatically generated https://tools.ietf.org/html/rfc4122[UUID].
+An id for the editor. Used for retrieving the editor instance using the `+tinymce.get('ID')+` method.
 
 *Type:* `+String+`
 
-*Default value:* Automatically generated https://tools.ietf.org/html/rfc4122[UUID].
+*Default value:* Automatically generated https://tools.ietf.org/html/rfc4122[UUID]
 
 ==== Example: Using `+id+`
 

--- a/modules/ROOT/partials/integrations/angular-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/angular-tech-ref.adoc
@@ -112,9 +112,9 @@ None of the configuration properties are *required* for `+tinymce-angular+` to w
 
 include::partial$misc/get-an-api-key.adoc[]
 
-*Default value:* `+'no-api-key'+`
-
 *Type:* `+String+`
+
+*Default value:* `+'no-api-key'+`
 
 ==== Example: Using `+apiKey+`
 
@@ -128,15 +128,18 @@ include::partial$misc/get-an-api-key.adoc[]
 [[cloudchannel]]
 === `+cloudChannel+`
 
-*Default value:* `{productmajorversion}`
+*Type:* `+String+`
 
-*Possible values:* `{productmajorversion}-stable`, `{productmajorversion}-testing`, `{productmajorversion}-dev`
+*Default value:* `'{productmajorversion}'`
+
+*Possible values:* `'{productmajorversion}-stable'`, `'{productmajorversion}-testing'`, `'{productmajorversion}-dev'`, `'{productminorversion}'`
 
 Changes the {productname} build used for the editor to one of the following {cloudname} channels:
 
 * `{productmajorversion}-stable` (*Default*): The current enterprise release of {productname}.
 * `{productmajorversion}-testing`: The current release candidate for the next enterprise release of {productname}.
 * `{productmajorversion}-dev`: The nightly-build version of {productname}.
+* A version number such as `{productminorversion}`: The specific enterprise release version of {productname}.
 
 Such as:
 
@@ -154,6 +157,8 @@ For information {productname} development channels, see: xref:editor-plugin-vers
 === `+disabled+`
 
 The `+disabled+` property can dynamically switch the editor between a "disabled" (read-only) mode (`+true+`) and the standard editable mode (`+false+`).
+
+*Type:* `+Boolean+`
 
 *Default value:* `+false+`
 
@@ -173,9 +178,9 @@ The `+disabled+` property can dynamically switch the editor between a "disabled"
 
 An id for the editor. Used for retrieving the editor instance using the `+tinymce.get('ID')+` method. Defaults to an automatically generated https://tools.ietf.org/html/rfc4122[UUID].
 
-*Default value:* Automatically generated https://tools.ietf.org/html/rfc4122[UUID].
-
 *Type:* `+String+`
+
+*Default value:* Automatically generated https://tools.ietf.org/html/rfc4122[UUID].
 
 ==== Example: Using `+id+`
 
@@ -193,9 +198,9 @@ Object sent to the `+tinymce.init+` method used to initialize the editor.
 
 For information on the {productname} selector (`+tinymce.init+`), see: xref:basic-setup.adoc[Basic setup].
 
-*Default value:* `+{ }+`
-
 *Type:* `+Object+`
+
+*Default value:* `+{ }+`
 
 ==== Example: Using `+init+`
 
@@ -214,9 +219,9 @@ For information on the {productname} selector (`+tinymce.init+`), see: xref:basi
 
 Initial content of the editor when the editor is initialized.
 
-*Default value:* `+' '+`
-
 *Type:* `+String+`
+
+*Default value:* `+' '+`
 
 ==== Example: Using `+initialValue+`
 
@@ -233,6 +238,8 @@ Initial content of the editor when the editor is initialized.
 Used to set the editor to inline mode. Using `+<editor [inline]="true"></editor>+` is the same as setting `+{inline: true}+` in the {productname} selector (`+tinymce.init+`).
 
 For information on inline mode, see: xref:inline-editor-options.adoc#inline[User interface options - `+inline+`] and xref:use-tinymce-inline.adoc[Setup inline editing mode].
+
+*Type:* `+Boolean+`
 
 *Default value:* `+false+`
 
@@ -290,9 +297,9 @@ Used to specify the format of the content emitted by the `+tinymce-angular+` com
 
 Only valid when xref:inline[`+<editor [inline]="true"></editor>+`]. Used to define the HTML element for the editor in inline mode.
 
-*Default value:* `+'div'+`
-
 *Type:* `+String+`
+
+*Default value:* `+'div'+`
 
 ==== Example: Using `+tagName+`
 
@@ -311,9 +318,9 @@ Used to set the toolbar for the editor. Using `+<editor toolbar="bold italic"></
 
 For information setting the toolbar for {productname}, see: xref:toolbar-configuration-options.adoc#toolbar[User interface options - toolbar].
 
-*Possible values:* See xref:available-toolbar-buttons.adoc[Toolbar Buttons Available for {productname}].
-
 *Type:* `+String+`
+
+*Possible values:* See xref:available-toolbar-buttons.adoc[Toolbar Buttons Available for {productname}].
 
 ==== Example: Using `+toolbar+`
 
@@ -344,11 +351,11 @@ NOTE: This property requires `+tinymce-angular+` 4.0.0 or newer
 
 Used to specify the events that trigger the `+NgModelChange+` to emit.
 
+*Type:* `+String+`
+
 *Default value:* `+'change input undo redo'+`.
 
 *Possible values:* A space separated list of TinyMCE editor events.
-
-*Type:* `+String+`
 
 ==== Example: Using `+modelEvents+`
 
@@ -472,9 +479,9 @@ NOTE: This property requires `+tinymce-angular+` 4.2.0 or newer
 
 Used to provide an allow-list of valid events to trigger from the editor to the `+tinymce-angular+` component. By default, the component will emit all the events listed in the xref:eventbinding[Event binding section].
 
-*Possible values:* A comma separated list of events to allow.
-
 *Type:* `+String+`
+
+*Possible values:* A comma separated list of events to allow.
 
 ==== Example: Using `+allowedEvents+`
 
@@ -492,9 +499,9 @@ NOTE: This property requires `+tinymce-angular+` 4.2.0 or newer
 
 Used to block a list of events from the `+tinymce-angular+` component.
 
-*Possible values:* A comma separated list of events to ignore.
-
 *Type:* `+String+`
+
+*Possible values:* A comma separated list of events to ignore.
 
 ==== Example: Using `+ignoreEvents+`
 

--- a/modules/ROOT/partials/integrations/blazor-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/blazor-tech-ref.adoc
@@ -68,7 +68,7 @@ Specified an Id for the editor. Used for retrieving the editor instance using th
 
 *Type:* `+String+`
 
-*Default value:* Automatically generated UUID
+*Default value:* Automatically generated https://tools.ietf.org/html/rfc4122[UUID]
 
 ==== Example using Id
 

--- a/modules/ROOT/partials/integrations/blazor-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/blazor-tech-ref.adoc
@@ -26,13 +26,13 @@ The `+TinyMCE.Blazor+` `+Editor+` component accepts the following properties:
 
 None of the configuration properties are required for the TinyMCE Blazor integration to work.
 
-=== ApiKey
+=== `ApiKey`
 
 {cloudname} API key. Required for deployments using the {cloudname} to provide the {productname} editor.
 
-*Default value:* `+'no-api-key'+`
+*Type:* `+String+`
 
-*Type:* String
+*Default value:* `+'no-api-key'+`
 
 ==== Example using ApiKey
 
@@ -43,30 +43,32 @@ None of the configuration properties are required for the TinyMCE Blazor integra
 />
 ----
 
-=== CloudChannel
+=== `CloudChannel`
 
 Specifies the {cloudname} channel to use. For information on {productname} development channels, see: xref:editor-plugin-version.adoc[Specifying the {productname} editor version deployed from Cloud].
 
-*Default value:* `+'5'+`
+*Type:* `+String+`
 
-*Type:* String
+*Default value:* `'{productmajorversion}'`
+
+*Possible values:* `'{productmajorversion}-stable'`, `'{productmajorversion}-testing'`, `'{productmajorversion}-dev'`, `'{productminorversion}'`
 
 ==== Example using CloudChannel
 
-[source,cs]
+[source,cs,subs="attributes+"]
 ----
 <Editor
-  CloudChannel="5-dev"
+  CloudChannel="{productmajorversion}-dev"
 />
 ----
 
-=== Id
+=== `Id`
 
 Specified an Id for the editor. Used for retrieving the editor instance using the `+tinymce.get('ID')+` method.
 
-*Default value:* Automatically generated UUID
+*Type:* `+String+`
 
-*Type:* String
+*Default value:* Automatically generated UUID
 
 ==== Example using Id
 
@@ -77,13 +79,13 @@ Specified an Id for the editor. Used for retrieving the editor instance using th
 />
 ----
 
-=== ClassName
+=== `ClassName`
 
 Specifies the class of the Editor's container `+div+` in the component. This `+div+` is the parent of the Editor and adding styles to it will not add styles to the editor.
 
-*Default value:* `+'tinymce-wrapper'+`
+*Type:* `+String+`
 
-*Type:* String
+*Default value:* `+'tinymce-wrapper'+`
 
 ==== Examples using ClassName
 
@@ -101,13 +103,13 @@ Setting a dynamic class name:
 <Editor ClassName="@((isEditorActive) ? "active-editor-div" : "default-editor-div")" />
 ----
 
-=== Inline
+=== `Inline`
 
 Set the editor to inline mode.
 
-*Default value:* `+false+`
+*Type:* `+Boolean+`
 
-*Type:* Boolean
+*Default value:* `+false+`
 
 ==== Example using Inline
 
@@ -118,13 +120,13 @@ Set the editor to inline mode.
 />
 ----
 
-=== Disable
+=== `Disable`
 
 Set the editor to readonly mode.
 
-*Default value:* `+false+`
+*Type:* `+Boolean+`
 
-*Type:* Boolean
+*Default value:* `+false+`
 
 ==== Example using Disable
 
@@ -136,13 +138,13 @@ Set the editor to readonly mode.
 <button @onclick="@(() => disable = !disable)">Toggle</button>
 ----
 
-=== JsConfSrc
+=== `JsConfSrc`
 
 Use a JS object as base configuration for the editor by specifying the path to the object relative to the window object.
 
-*Default value:* `+null+`
+*Type:* `+String+`
 
-*Type:* String
+*Default value:* `+null+`
 
 ==== Example using JsConfSrc
 
@@ -165,7 +167,7 @@ In your component:
 />
 ----
 
-=== ScriptSrc
+=== `ScriptSrc`
 
 Use the `+ScriptSrc+` property to specify the location of {productname} to lazy load when the application is not using {cloudname}. This setting is required if the application uses a self-hosted version of {productname}, such as the https://www.nuget.org/packages/TinyMCE/[{productname} NuGet package] or a .zip package of {productname}.
 
@@ -180,13 +182,13 @@ Use the `+ScriptSrc+` property to specify the location of {productname} to lazy 
 />
 ----
 
-=== Conf
+=== `Conf`
 
 Specify a set of properties for the `+Tinymce.init+` method to initialize the editor.
 
-*Default value:* `+null+`
+*Type:* `+Dictionary<string, object>+`
 
-*Type:* Dictionary<string, object>
+*Default value:* `+null+`
 
 ==== Example using Conf
 

--- a/modules/ROOT/partials/integrations/react-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/react-tech-ref.adoc
@@ -235,7 +235,7 @@ An id for the editor. Used for retrieving the editor instance using the `+tinymc
 
 *Type:* `+String+`
 
-*Default value:* Automatically generated https://tools.ietf.org/html/rfc4122[UUID].
+*Default value:* Automatically generated https://tools.ietf.org/html/rfc4122[UUID]
 
 ==== Example: Using `+id+`
 

--- a/modules/ROOT/partials/integrations/react-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/react-tech-ref.adoc
@@ -166,7 +166,7 @@ include::partial$misc/get-an-api-key.adoc[]
 
 *Type:* `+String+`
 
-*Default value:* `+"no-api-key"+`
+*Default value:* `+'no-api-key'+`
 
 ==== Example: Using `+apiKey+`
 
@@ -182,7 +182,9 @@ include::partial$misc/get-an-api-key.adoc[]
 
 Changes the {productname} build used for the editor to either a specific version or a channel indicating a stability level.
 
-*Default value:* `'{productmajorversion}-stable'`
+*Type:* `+String+`
+
+*Default value:* `'{productmajorversion}'`
 
 *Possible values:* `'{productmajorversion}-stable'`, `'{productmajorversion}-testing'`, `'{productmajorversion}-dev'`, `'{productminorversion}'`
 
@@ -211,6 +213,8 @@ For information {productname} development channels, see: xref:editor-plugin-vers
 
 The `+disabled+` prop can dynamically switch the editor between a "disabled" (read-only) mode (`+true+`) and the standard editable mode (`+false+`).
 
+*Type:* `Boolean`
+
 *Default value:* `+false+`
 
 *Possible values:* `+true+`, `+false+`
@@ -229,9 +233,9 @@ The `+disabled+` prop can dynamically switch the editor between a "disabled" (re
 
 An id for the editor. Used for retrieving the editor instance using the `+tinymce.get('ID')+` method.
 
-*Default value:* Automatically generated https://tools.ietf.org/html/rfc4122[UUID].
-
 *Type:* `+String+`
+
+*Default value:* Automatically generated https://tools.ietf.org/html/rfc4122[UUID].
 
 ==== Example: Using `+id+`
 
@@ -254,9 +258,9 @@ When using `+tinymce-react+`:
 * The `+init+` prop does not require the `+selector+` or `+target+` options
 * If the `+selector+`, `+target+`, or `+readonly+` options are set using the `+init+` prop, they will be _overridden_ by the integration.
 
-*Default value:* `+{ }+`
-
 *Type:* `+Object+`
+
+*Default value:* `+{ }+`
 
 ==== Example: Using `+init+`
 
@@ -279,9 +283,9 @@ This may be set either before the editor loads, or soon afterwards by an asynchr
 
 IMPORTANT: Ensure that this is *not* updated by `+onEditorChange+` or the editor will be unusable.
 
-*Default value:* `+''+`
-
 *Type:* `+String+`
+
+*Default value:* `+''+`
 
 ==== Example: Using static `+initialValue+`
 
@@ -315,6 +319,8 @@ return (
 Used to set the editor to inline mode. Using `+<Editor inline={true} />+` is the same as setting `+{inline: true}+` in the {productname} `+tinymce.init({...})+` method.
 
 For information on inline mode, see: xref:inline-editor-options.adoc#inline[User interface options - `+inline+`] and xref:use-tinymce-inline.adoc[Setup inline editing mode].
+
+*Type:* `+Boolean+`
 
 *Default value:* `+false+`
 
@@ -440,6 +446,8 @@ Contains 3 settings:
 [quote, https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-async]
 For classic scripts, if the async attribute is present, then the classic script will be fetched in parallel to parsing and evaluated as soon as it is available.
 
+*Type:* `+Boolean+`
+
 *Default value:* `false`
 
 `+defer+`:: Sets the https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-defer[`+defer+`] attribute on the script tag created to load {productname}.
@@ -447,13 +455,15 @@ For classic scripts, if the async attribute is present, then the classic script 
 [quote, https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-defer]
 This Boolean attribute is set to indicate to a browser that the script is meant to be executed after the document has been parsed, but before firing DOMContentLoaded.
 
+*Type:* `+Boolean+`
+
 *Default value:* `false`
 
 `+delay+`:: The script tag to load {productname} will be added after the specified delay in milliseconds.
 
-*Default value:* `0`
+*Type:* `+Object+`
 
-**Type:** `Object`
+*Default value:* `0`
 
 [source,ts]
 ----
@@ -485,9 +495,9 @@ This Boolean attribute is set to indicate to a browser that the script is meant 
 
 Only valid when xref:inline[`+<Editor inline={true} />+`]. Used to define the HTML element for the editor in inline mode.
 
-*Default value:* `+'div'+`
-
 *Type:* `+String+`
+
+*Default value:* `+'div'+`
 
 ==== Example: Using `+tagName+`
 
@@ -503,8 +513,6 @@ Only valid when xref:inline[`+<Editor inline={true} />+`]. Used to define the HT
 === `+textareaName+`
 
 Only valid when the editor is in classic (iframe) mode. Sets the `+name+` attribute for the `+textarea+` element used for the editor in forms.
-
-*Default value:* `+'undefined'+`
 
 *Type:* `+String+`
 
@@ -527,9 +535,9 @@ Used to set the toolbar for the editor. Using `+<Editor toolbar='bold' />+` is t
 
 For information setting the toolbar for {productname}, see: xref:toolbar-configuration-options.adoc#toolbar[User interface options - toolbar].
 
-*Possible values:* See xref:available-toolbar-buttons.adoc[Toolbar Buttons Available for {productname}].
-
 *Type:* `+String+`
+
+*Possible values:* See xref:available-toolbar-buttons.adoc[Toolbar Buttons Available for {productname}].
 
 ==== Example: Using `+toolbar+`
 

--- a/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
@@ -30,9 +30,9 @@ The `+tinymce-svelte+` `+Editor+` component accepts the following properties:
 
 {cloudname} API key. Required for deployments using the {cloudname} to provide the {productname} editor.
 
-*Default value:* `+'no-api-key'+`
+*Type:* `+String+`
 
-*Type:* String
+*Default value:* `+'no-api-key'+`
 
 ==== Example using apiKey
 
@@ -48,16 +48,18 @@ The `+tinymce-svelte+` `+Editor+` component accepts the following properties:
 
 Specifies the {cloudname} channel to use. For information on {cloudname} deployment channels, see: xref:editor-plugin-version.adoc[Specifying the {productname} editor version deployed from Cloud].
 
-*Default value:* `+'5'+`
+*Type:* `+String+`
 
-*Type:* String
+*Default value:* `'{productmajorversion}'`
+
+*Possible values:* `'{productmajorversion}-stable'`, `'{productmajorversion}-testing'`, `'{productmajorversion}-dev'`, `'{productminorversion}'`
 
 ==== Example using channel
 
-[source,jsx]
+[source,jsx,subs="attributes+"]
 ----
 <Editor
-  channel="5-dev"
+  channel="{productmajorversion}-dev"
 />
 ----
 
@@ -66,9 +68,9 @@ Specifies the {cloudname} channel to use. For information on {cloudname} deploym
 
 Specified an Id for the editor. Used for retrieving the editor instance using the `+tinymce.get('ID')+` method.
 
-*Default value:* Automatically generated UUID
+*Type:* `+String+`
 
-*Type:* String
+*Default value:* Automatically generated UUID
 
 ==== Example using id
 
@@ -84,9 +86,9 @@ Specified an Id for the editor. Used for retrieving the editor instance using th
 
 Set the editor to inline mode.
 
-*Default value:* `+false+`
+*Type:* `+Boolean+`
 
-*Type:* Boolean
+*Default value:* `+false+`
 
 ==== Example using inline
 
@@ -102,9 +104,9 @@ Set the editor to inline mode.
 
 Set the editor to readonly mode.
 
-*Default value:* `+false+`
+*Type:* `+Boolean+`
 
-*Type:* Boolean
+*Default value:* `+false+`
 
 ==== Example using disabled
 
@@ -120,7 +122,7 @@ Set the editor to readonly mode.
 
 Use the `+scriptSrc+` property to specify the location of {productname} to lazy load when the application is not using {cloudname}. This setting is required if the application uses a self-hosted version of {productname}, such as the {productname} npm package or a .zip package of {productname}.
 
-*Type:* String
+*Type:* `+String+`
 
 ==== Example using scriptSrc
 
@@ -136,9 +138,9 @@ Use the `+scriptSrc+` property to specify the location of {productname} to lazy 
 
 Specify a set of properties for the `+Tinymce.init+` method to initialize the editor.
 
-*Default value:* `+{}+`
+*Type:* `+Object+`
 
-*Type:* Object
+*Default value:* `+{}+`
 
 ==== Example using conf
 

--- a/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
@@ -70,7 +70,7 @@ Specified an Id for the editor. Used for retrieving the editor instance using th
 
 *Type:* `+String+`
 
-*Default value:* Automatically generated UUID
+*Default value:* Automatically generated https://tools.ietf.org/html/rfc4122[UUID]
 
 ==== Example using id
 

--- a/modules/ROOT/partials/integrations/vue-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/vue-tech-ref.adoc
@@ -176,11 +176,11 @@ The `+disabled+` property can dynamically switch the editor between a "disabled"
 [[id]]
 === `+id+`
 
-An id for the editor. Used for retrieving the editor instance using the `+tinymce.get('ID')+` method. Defaults to an automatically generated https://tools.ietf.org/html/rfc4122[UUID].
+An id for the editor. Used for retrieving the editor instance using the `+tinymce.get('ID')+` method.
 
 *Type:* `+String+`
 
-*Default value:* Automatically generated https://tools.ietf.org/html/rfc4122[UUID].
+*Default value:* Automatically generated https://tools.ietf.org/html/rfc4122[UUID]
 
 ==== Example: Using `+id+`
 

--- a/modules/ROOT/partials/integrations/vue-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/vue-tech-ref.adoc
@@ -111,9 +111,9 @@ None of the configuration properties are *required* for `+tinymce-vue+` to work.
 
 include::partial$misc/get-an-api-key.adoc[]
 
-*Default value:* `+'no-api-key'+`
-
 *Type:* `+String+`
+
+*Default value:* `+'no-api-key'+`
 
 ==== Example: Using `+api-key+`
 
@@ -127,15 +127,18 @@ include::partial$misc/get-an-api-key.adoc[]
 [[cloud-channel]]
 === `+cloud-channel+`
 
+*Type:* `+String+`
+
 *Default value:* `'{productmajorversion}'`
 
-*Possible values:* `'{productmajorversion}-stable'`, `'{productmajorversion}-testing'`, `'{productmajorversion}-dev'`
+*Possible values:* `'{productmajorversion}-stable'`, `'{productmajorversion}-testing'`, `'{productmajorversion}-dev'`, `'{productminorversion}'`
 
 Changes the {productname} build used for the editor to one of the following {cloudname} channels:
 
 * `{productmajorversion}`, `{productmajorversion}-stable` (*Default*): The current enterprise release of {productname}.
 * `{productmajorversion}-testing`: The current release candidate for the next enterprise release of {productname}.
 * `{productmajorversion}-dev`: The nightly-build version of {productname}.
+* A version number such as `{productminorversion}`: The specific enterprise release version of {productname}.
 
 Such as:
 
@@ -155,6 +158,8 @@ For information {productname} development channels, see: xref:editor-plugin-vers
 
 The `+disabled+` property can dynamically switch the editor between a "disabled" (read-only) mode (`+true+`) and the standard editable mode (`+false+`).
 
+*Type:* `+Boolean+`
+
 *Default value:* `+false+`
 
 *Possible values:* `+true+`, `+false+`
@@ -171,11 +176,11 @@ The `+disabled+` property can dynamically switch the editor between a "disabled"
 [[id]]
 === `+id+`
 
-An id for the editor. Used for retrieving the editor instance using the `+tinymce.get('ID')+` method. Defaults to an automatically generated https://tools.ietf.org/html/rfc4122[UUID].*
-
-*Default value:* Automatically generated https://tools.ietf.org/html/rfc4122[UUID].
+An id for the editor. Used for retrieving the editor instance using the `+tinymce.get('ID')+` method. Defaults to an automatically generated https://tools.ietf.org/html/rfc4122[UUID].
 
 *Type:* `+String+`
+
+*Default value:* Automatically generated https://tools.ietf.org/html/rfc4122[UUID].
 
 ==== Example: Using `+id+`
 
@@ -193,9 +198,9 @@ Object sent to the `+tinymce.init+` method used to initialize the editor.
 
 For information on the {productname} selector (`+tinymce.init+`), see: xref:basic-setup.adoc[Basic setup].
 
-*Default value:* `+'{ }'+`
-
 *Type:* `+Object+`
+
+*Default value:* `+'{ }'+`
 
 ==== Example: Using `+init+`
 
@@ -214,9 +219,9 @@ For information on the {productname} selector (`+tinymce.init+`), see: xref:basi
 
 Initial content of the editor when the editor is initialized.
 
-*Default value:* `+' '+`
-
 *Type:* `+String+`
+
+*Default value:* `+' '+`
 
 ==== Example: Using `+initial-value+`
 
@@ -233,6 +238,8 @@ Initial content of the editor when the editor is initialized.
 Used to set the editor to inline mode. Using `+<editor :inline=true />+` is the same as setting `+{inline: true}+` in the {productname} selector (`+tinymce.init+`).
 
 For information on inline mode, see: xref:inline-editor-options.adoc#inline[User interface options - `+inline+`] and xref:use-tinymce-inline.adoc[Setup inline editing mode].
+
+*Type:* `+Boolean+`
 
 *Default value:* `+false+`
 
@@ -254,9 +261,9 @@ Sets the trigger events for xref:forminputbindingsv-model[v-model events].
 
 For a list of available {productname} events, see: xref:events.adoc#editorcoreevents[Available Events - Editor events].
 
-*Default value:* `+'change keyup undo redo'+`.
-
 *Type:* `+String+`
+
+*Default value:* `+'change keyup undo redo'+`.
 
 ==== Example: Using `+model-events+`
 
@@ -310,9 +317,9 @@ For information on adding plugins to {productname}, see: xref:work-with-plugins.
 
 Only valid when xref:inline[`+<editor :inline=true />+`]. Used to define the HTML element for the editor in inline mode.
 
-*Default value:* `+'div'+`
-
 *Type:* `+String+`
+
+*Default value:* `+'div'+`
 
 ==== Example: Using `+tag-name+`
 
@@ -331,9 +338,9 @@ Used to set the toolbar for the editor. Using `+<editor toolbar="bold italic" />
 
 For information setting the toolbar for {productname}, see: xref:toolbar-configuration-options.adoc#toolbar[User interface options - toolbar].
 
-*Possible values:* See xref:available-toolbar-buttons.adoc[Toolbar Buttons Available for {productname}].
-
 *Type:* `+String+`
+
+*Possible values:* See xref:available-toolbar-buttons.adoc[Toolbar Buttons Available for {productname}].
 
 ==== Example: Using `+toolbar+`
 


### PR DESCRIPTION
Related Ticket: DOC-1607

Description of Changes:

This just includes the various fixes for things regarding option inconsistencies that @ltrouton pointed out or that I found when looking further that weren't in the original scope:

- Cleanup the inconsistent ordering and markup in the integrations tech references
- Ensure consistent casing of `String`, etc...
- Ensure consistent use of `Array` since we had three variants in use: `Array`, `Array<string>` and `String[]`
- Fixed missing `Type` fields
- Removed the incorrect default for `custom_elements`

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
