### PR TITLE
DOC-1623: Fixed more missed conversion issues

### DIFF
--- a/modules/ROOT/examples/live-demos/open-source-plugins/index.html
+++ b/modules/ROOT/examples/live-demos/open-source-plugins/index.html
@@ -1,11 +1,11 @@
 <textarea id="open-source-plugins">
   {{logofordemoshtml}}
   <h2 style="text-align: center;">Welcome to the TinyMCE Cloud demo!</h2>
-  <p>Please try out the features provided in this full featured example (excluding <a href="https://www.tiny.cloud/apps/">Premium Plugins</a> ).</p>
+  <p>Please try out the features provided in this full featured example (excluding <a href="{{plugindirectory}}">Premium Plugins</a> ).</p>
 
   <h2>Got questions or need help?</h2>
   <ul>
-    <li>Our <a class="mceNonEditable" href="https://www.tiny.cloud/docs/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a class="mceNonEditable" href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>

--- a/modules/ROOT/pages/pagebreak.adoc
+++ b/modules/ROOT/pages/pagebreak.adoc
@@ -22,7 +22,7 @@ tinymce.init({
 
 == Options
 
-These settings affect the execution of the `+pagebreak+` plugin. They enable you to specify how the page break should be generated in the HTML source code and determine whether the page break element(s) should be wrapped in `+<p>+`tags`+</p>+`.
+These settings affect the execution of the `+pagebreak+` plugin. They enable you to specify how the page break should be generated in the HTML source code and determine whether the page break element(s) should be wrapped in `+<p>+` tags.
 
 include::partial$configuration/pagebreak_separator.adoc[leveloffset=+1]
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -2,7 +2,7 @@
 :description: Release notes for {productname} {productmajorversion}
 :keywords: releasenotes, newfeatures, deleted, bugfixes, knownissues
 
-include::partial$misc/admon_releasenotes_for_stable.adoc[]
+include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 This section lists the releases for {productname} 6 and the changes made in each release.
 

--- a/modules/ROOT/partials/configuration/images_reuse_filename.adoc
+++ b/modules/ROOT/partials/configuration/images_reuse_filename.adoc
@@ -1,7 +1,7 @@
 [[images_reuse_filename]]
 == `+images_reuse_filename+`
 
-By default {productname} will generate unique filename for each uploaded file (for details refer to xref:upload-images.adoc#image-uploader-requirements[Upload Images]). Sometimes this might have undesirable side-effects. For example, ,when `+automatic_uploads+` is enabled, every manipulation on the image done with the xref:editimage.adoc[Enhanced Image Editing] plugin, results in file upload and each time under a different filename, despite the fact that the image stays the same.
+By default {productname} will generate unique filename for each uploaded file (for details refer to xref:upload-images.adoc#image-uploader-requirements[Upload Images]). Sometimes this might have undesirable side-effects. For example, when `+automatic_uploads+` is enabled, every manipulation on the image done with the xref:editimage.adoc[Enhanced Image Editing] plugin, results in file upload and each time under a different filename, despite the fact that the image stays the same.
 
 Setting `+images_reuse_filename+` to _true_ tells {productname} to use the actual filename of the image, instead of generating a new one each time. Take into account that `+src+` attribute of the corresponding `+<img>+` tag gets replaced with whatever filename you send back from the server (see xref:file-image-upload.adoc#images_upload_url[images_upload_url]). It can be the same filename or something else, but the next time that filename is used for the upload.
 

--- a/modules/ROOT/partials/configuration/images_upload_credentials.adoc
+++ b/modules/ROOT/partials/configuration/images_upload_credentials.adoc
@@ -1,7 +1,7 @@
 [[images_upload_credentials]]
 == `+images_upload_credentials+`
 
-The *images_upload_credentials* option specifies whether calls to the configured xref:file-image-upload.adoc#images_upload_url[`+images_upload_url+`] should pass along credentials (such as cookies, authorization headers, or TLS client certificates) for cross-domain uploads. When set to `+true+`, credentials will be sent to the upload handler, similar to the https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials[`+withCredentials+` property of `+XMLHttpRequest+`s].
+The *images_upload_credentials* option specifies whether calls to the configured xref:file-image-upload.adoc#images_upload_url[`+images_upload_url+`] should pass along credentials (such as cookies, authorization headers, or TLS client certificates) for cross-domain uploads. When set to `+true+`, credentials will be sent to the upload handler, similar to the https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials[`+withCredentials+` property of `+XMLHttpRequest+`].
 
 *Type:* `+Boolean+`
 


### PR DESCRIPTION
Related Ticket: DOC-1623

Description of Changes:
* Fixed a markup and minor content issue in the pagebreak docs
* Fixed other minor markup issues found on the Image and file options page

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
