### PR TITLE
DOC-1630: Fixed inconsistent use of Configuration options, Options and other variants in headings

### DIFF
--- a/_new_content_templates/pluginpage.adoc
+++ b/_new_content_templates/pluginpage.adoc
@@ -42,7 +42,7 @@ tinymce.init({
 
 // Delete everything not require/relevant from this point on.
 
-== Configuration options
+== Options
 
 The following configuration options affect the behavior of the {pluginname} plugin.
 

--- a/modules/ROOT/pages/a11ychecker.adoc
+++ b/modules/ROOT/pages/a11ychecker.adoc
@@ -314,7 +314,7 @@ xref:a11ychecker_html_version[HTML version]:: HTML4 and HTML5
 
 WCAG 2.1 specification:: https://www.w3.org/WAI/WCAG21/Techniques/html/H63.html[H63 - Using the scope attribute to associate header cells and data cells in data tables].
 
-== Configuration Options
+== Options
 
 The following configuration options affect the behavior of the {pluginname} plugin.
 

--- a/modules/ROOT/pages/advtable.adoc
+++ b/modules/ROOT/pages/advtable.adoc
@@ -63,7 +63,7 @@ A numeric and alpha value series are available by default. The available value s
 
 image:advtable_row_numbering.png[Table with numeric row numbering column and row numbering menu open (Numeric item checked)]
 
-== Configuration options
+== Options
 
 The following configuration options affect the behavior of the {pluginname} plugin.
 

--- a/modules/ROOT/pages/anchor.adoc
+++ b/modules/ROOT/pages/anchor.adoc
@@ -19,7 +19,7 @@ tinymce.init({
 });
 ----
 
-== Related configuration options
+== Options
 
 include::partial$configuration/allow_html_in_named_anchor.adoc[leveloffset=+1]
 

--- a/modules/ROOT/pages/autocompleter.adoc
+++ b/modules/ROOT/pages/autocompleter.adoc
@@ -11,14 +11,14 @@ An autocompleter displays suggestions while the user is typing. Suggestions are 
 
 The method for adding a custom autocompleter is in the *UI Registry* part of the editor API `+editor.ui.registry+`:
 
-* `+editor.ui.registry.addAutocompleter(name, configuration)+`
+* `+editor.ui.registry.addAutocompleter(name, options)+`
 
 The two arguments this method take are:
 
-* `+name+` - A unique name for the autocompleter.
-* `+configuration+` - An object containing the user's configuration.
+* `+name+` -- A unique name for the autocompleter.
+* `+options+` -- An object containing the custom autocompleter configuration.
 
-== Configuration options
+== Options
 
 [cols="1,2,1,4",options="header"]
 |===

--- a/modules/ROOT/pages/casechange.adoc
+++ b/modules/ROOT/pages/casechange.adoc
@@ -46,7 +46,7 @@ The *Title Case* option changes anything other than articles, coordinating conju
 
 *Title Case* can be customized to create user defined rule sets by using the following options:
 
-include::partial$configuration/casechange_title_case_minors.adoc[leveloffset=+1]
+include::partial$configuration/casechange_title_case_minors.adoc[leveloffset=+3]
 
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 

--- a/modules/ROOT/pages/comments-callback-mode.adoc
+++ b/modules/ROOT/pages/comments-callback-mode.adoc
@@ -27,7 +27,7 @@ Current author:: The Comments plugin does not know the name of the current user.
 
 After a user comments (triggering `+tinycomments_create+` for the first comment, or `+tinycomments_reply+` for subsequent comments), the Comments plugin requests the updated conversation using `+tinycomments_lookup+`, which should now contain the additional comment with the proper author.
 
-== Configuration options
+== Options
 
 === Required options
 

--- a/modules/ROOT/pages/comments-embedded-mode.adoc
+++ b/modules/ROOT/pages/comments-embedded-mode.adoc
@@ -26,7 +26,7 @@ This is the minimum recommended setup for the Comments plugin in embedded mode. 
 
 liveDemo::comments-embedded[]
 
-== Configuration options
+== Options
 
 include::partial$configuration/tinycomments_author.adoc[leveloffset=+1]
 

--- a/modules/ROOT/pages/custom-basic-menu-items.adoc
+++ b/modules/ROOT/pages/custom-basic-menu-items.adoc
@@ -5,7 +5,7 @@
 
 A basic menu item triggers its `+onAction+` function when clicked.
 
-== Config options
+== Options
 
 [cols="1,2,1,4",options="header"]
 |===

--- a/modules/ROOT/pages/custom-basic-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-basic-toolbar-button.adoc
@@ -5,7 +5,7 @@
 
 A basic button triggers its `+onAction+` function when clicked.
 
-== Config options
+== Options
 
 [cols="1,2,1,4",options="header"]
 |===

--- a/modules/ROOT/pages/custom-group-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-group-toolbar-button.adoc
@@ -7,7 +7,7 @@ A group toolbar button is a toolbar button that contains a collection of other t
 
 NOTE: The group toolbar button is _only_ supported when using the `+floating+` toolbar mode. If the `+toolbar_groups+` option is used with other toolbar modes, the toolbar group button will not be displayed and a warning message will be printed in the console.
 
-== Config options
+== Options
 
 [cols="1,2,1,4",options="header"]
 |===

--- a/modules/ROOT/pages/custom-menu-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-menu-toolbar-button.adoc
@@ -7,7 +7,7 @@ A toolbar menu button is a toolbar button that opens a menu when clicked. This m
 
 For example: The table plugin's `+table+` toolbar button opens a menu similar to the menubar Table menu.
 
-== Config options
+== Options
 
 [cols="1,2,1,4",options="header"]
 |===

--- a/modules/ROOT/pages/custom-split-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-split-toolbar-button.adoc
@@ -5,7 +5,7 @@
 
 A split button contains a basic button and a menu button, wrapped up into one toolbar item. Clicking the menu button section opens a dropdown list. The basic button section and the menu items can be configured to trigger different actions when clicked.
 
-== Config options
+== Options
 
 [cols="1,2,1,1,3",options="header"]
 |===

--- a/modules/ROOT/pages/custom-toggle-menu-items.adoc
+++ b/modules/ROOT/pages/custom-toggle-menu-items.adoc
@@ -5,7 +5,7 @@
 
 A toggle menu item triggers its `+onAction+` when clicked. It also has a concept of state. This means it can be toggled `+on+` and `+off+`. A toggle menu item gives the user visual feedback for its state through a checkmark that appears to the right of the menu item's text when it is `+on+`.
 
-== Config options
+== Options
 
 [cols="1,2,1,4",options="header"]
 |===

--- a/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
@@ -5,7 +5,7 @@
 
 A toggle button triggers an action when clicked but also has a concept of state. This means it can be toggled `+on+` and `+off+`. A toggle button gives the user visual feedback for its state through CSS styling. An example of this behavior is the *Bold* button that is highlighted when the cursor is in a word with bold formatting.
 
-== Config options
+== Options
 
 [cols="1,2,1,4",options="header"]
 |===

--- a/modules/ROOT/pages/dialog-apis.adoc
+++ b/modules/ROOT/pages/dialog-apis.adoc
@@ -3,7 +3,7 @@
 :description: APIs for custom TinyMCE dialogs
 :keywords: dialog, dialogapi, api
 
-When a dialog is created, a dialog instance API is returned. For example, `+const instanceApi = editor.windowManager.open(config);+`. The dialog API instance is also passed to some of the xref:dialog-configuration.adoc#configuration-options[dialog configuration options].
+When a dialog is created, a dialog instance API is returned. For example, `+const instanceApi = editor.windowManager.open(config);+`. The dialog API instance is also passed to some of the xref:dialog-configuration.adoc#options[dialog configuration options].
 
 The instance API is a JavaScript object containing methods attached to the dialog instance. When the dialog is closed, the instance API is destroyed.
 
@@ -16,7 +16,7 @@ This data store takes the form of a JavaScript object, where the object's keys a
 
 The current value of a dialog's data store can be accessed using the dialog instance API's `+getData()+` function. It can also be set using `+setData()+` which will automatically update the relevant components. For example, if you call `+setData({ myCheckbox: true })+` with the previous example, the checkbox would be toggled to checked.
 
-To set initial values for components when the dialog is opened, use the `+initialData+` xref:dialog-configuration.adoc#configuration-options[dialog configuration option]. For example, you could set the checkbox in the previous example to be checked when the dialog opens by including `+initialData: { myCheckbox: true }+` in the dialog's configuration.
+To set initial values for components when the dialog is opened, use the `+initialData+` xref:dialog-configuration.adoc#options[dialog configuration option]. For example, you could set the checkbox in the previous example to be checked when the dialog opens by including `+initialData: { myCheckbox: true }+` in the dialog's configuration.
 
 [[dialog-api-methods]]
 == Dialog API methods

--- a/modules/ROOT/pages/dialog-components.adoc
+++ b/modules/ROOT/pages/dialog-components.adoc
@@ -57,7 +57,7 @@ The xref:dialog-apis.adoc#dialog-api-methods[dialog instance API] contains the `
 
 === Dialog configuration event callbacks
 
-A dialog can be configured with an xref:dialog-configuration.adoc#configuration-options[`+onTabChange+`] callback. This function is called when the user changes tabs. It is passed the dialog instance API and a `+details+` object which contains `+newTabName+` and `+oldTabName+`.
+A dialog can be configured with an xref:dialog-configuration.adoc#options[`+onTabChange+`] callback. This function is called when the user changes tabs. It is passed the dialog instance API and a `+details+` object which contains `+newTabName+` and `+oldTabName+`.
 
 As an example of when this is useful, the `+charmap+` and `+emoticons+` plugin dialogs use `+newTabName+` to change search results to match the character or emoticon category represented by the current tab.
 

--- a/modules/ROOT/pages/dialog-configuration.adoc
+++ b/modules/ROOT/pages/dialog-configuration.adoc
@@ -36,8 +36,8 @@ tinymce.activeEditor.windowManager.open({
 ----
 
 // Note: The configurationoptions anchor is needed for older external links
-[[configuration-options]]
-== [[configurationoptions]] Configuration options
+[[options]]
+== [[configurationoptions]] Options
 
 [cols="1,2,1,4",options="header"]
 |===

--- a/modules/ROOT/pages/dialog-footer-buttons.adoc
+++ b/modules/ROOT/pages/dialog-footer-buttons.adoc
@@ -35,9 +35,9 @@ The different footer button types will invoke different callbacks when clicked:
 * A *Submit* type button will invoke the `+onSubmit+` callback function provided in the dialog configuration.
 * A *Cancel* type button will invoke the `+onCancel+` and `+onClose+` callback functions. These callback functions are also fired when a user clicks the `+X+` button in the top right of the dialog.
 * A *Custom* type button will invoke the `+onAction+` callback function, and pass it the button's `+name+` in the `+details+` object. This allows developers to create a click handler for each *Custom* type footer button in the dialog. See the xref:dialog-examples.adoc#interactive-example-using-redial[Redial example] for an example of how to use this.
-* A *Menu* type button will fetch a list of options and display them in a drop-down menu. When a menu button item is clicked, the item `+name+` is passed to the xref:dialog-configuration.adoc#configuration-options[_dialog `+onAction+` callback_]. For details, see: xref:dialog-menu-buttons[Dialog menu buttons].
+* A *Menu* type button will fetch a list of options and display them in a drop-down menu. When a menu button item is clicked, the item `+name+` is passed to the xref:dialog-configuration.adoc#options[_dialog `+onAction+` callback_]. For details, see: xref:dialog-menu-buttons[Dialog menu buttons].
 
-See the xref:dialog-configuration.adoc#configuration-options[dialog configuration options] documentation for more information.
+See the xref:dialog-configuration.adoc#options[dialog configuration options] documentation for more information.
 
 === Example: Dialog footer button
 
@@ -59,7 +59,7 @@ See the xref:dialog-configuration.adoc#configuration-options[dialog configuratio
 
 A dialog menu button is a drop-down button that can be used to provide a drop-down list of items in a dialog footer.
 
-When dialog menu items are clicked, a xref:dialog-configuration.adoc#configuration-options[_dialog `+onAction+` callback_] is triggered. The `+name+` of the menu item is passed into the onAction callback. Clicking on the menu footer button won't trigger any callbacks and will only open the menu of specified items.
+When dialog menu items are clicked, a xref:dialog-configuration.adoc#options[_dialog `+onAction+` callback_] is triggered. The `+name+` of the menu item is passed into the onAction callback. Clicking on the menu footer button won't trigger any callbacks and will only open the menu of specified items.
 
 ==== Dialog menu button
 
@@ -84,7 +84,7 @@ The following options can be specified for a dialog menu button _item_:
 [cols="1,1,1,3",options="header"]
 |===
 |Name |Value |Requirement |Description
-|name |string |required |Identifier for the dialog menu item which is passed to the xref:dialog-configuration.adoc#configuration-options[_dialog `+onAction+` callback_]. `+name+` can be used with xref:dialog-configuration.adoc#configuration-options[initialData] to set the initial state.
+|name |string |required |Identifier for the dialog menu item which is passed to the xref:dialog-configuration.adoc#options[_dialog `+onAction+` callback_]. `+name+` can be used with xref:dialog-configuration.adoc#options[initialData] to set the initial state.
 |type |string |required |The type `+togglemenuitem+` should be used.
 |text |string |optional |Text to display if no icon is found.
 |value |string |optional |A value to associate with the menu item.

--- a/modules/ROOT/pages/export.adoc
+++ b/modules/ROOT/pages/export.adoc
@@ -83,7 +83,7 @@ The following plugins are not supported:
 * xref:pageembed.adoc[Page Embed]
 * xref:tableofcontents.adoc[Table of Contents]
 
-== Configuration Options
+== Options
 
 The following configuration options affect the behavior of the {pluginname} plugin.
 

--- a/modules/ROOT/pages/fullscreen.adoc
+++ b/modules/ROOT/pages/fullscreen.adoc
@@ -23,7 +23,7 @@ tinymce.init({
 });
 ----
 
-== Configuration options
+== Options
 
 The following configuration options affect the behavior of the {pluginname} plugin.
 

--- a/modules/ROOT/pages/help.adoc
+++ b/modules/ROOT/pages/help.adoc
@@ -25,7 +25,7 @@ tinymce.init({
 });
 ----
 
-== Config Options
+== Options
 
 include::partial$configuration/help_tabs.adoc[leveloffset=+1]
 

--- a/modules/ROOT/pages/introduction-to-mediaembed.adoc
+++ b/modules/ROOT/pages/introduction-to-mediaembed.adoc
@@ -63,7 +63,7 @@ include::example$css-codeblock/mediaembed-plugin.css[]
 
 The plugin can be used in two ways, either by simply entering a URL on an empty line and pressing the enter key - or by entering the URL into the media plugin's dialog window. Either way the URL will be handled by the service backend and the returned code will be embedded into the editor.
 
-== Configuration Options
+== Options
 
 include::partial$configuration/mediaembed_inline_styles.adoc[leveloffset=+1]
 

--- a/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
+++ b/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
@@ -55,7 +55,7 @@ tinymce.init({
 
 The {productname} Enterprise Spellchecking plugin activates automatically when users type content into the editor. To select a spelling suggestion for a misspelled word, right-click the misspelled word to open the contextual menu.
 
-== Configuration Options
+== Options
 
 include::partial$configuration/spellchecker_active.adoc[leveloffset=+1]
 

--- a/modules/ROOT/pages/menus-configuration-options.adoc
+++ b/modules/ROOT/pages/menus-configuration-options.adoc
@@ -2,7 +2,7 @@
 :navtitle: Options
 :description: Information on options for customizing TinyMCE's menus
 
-== Basic menu configuration options
+== Basic menu options
 
 include::partial$configuration/menubar.adoc[leveloffset=+1]
 

--- a/modules/ROOT/pages/pageembed.adoc
+++ b/modules/ROOT/pages/pageembed.adoc
@@ -66,7 +66,7 @@ NOTE: The *Responsive* option has pre-defined width and height values. The *Widt
 
 NOTE: Not all pages allow embedding, as the X-Frame-Options header can be set to block embedding. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options[this page] for more information.
 
-== Options to configure the Page Embed properties
+== Options
 
 include::partial$configuration/tiny_pageembed_classes.adoc[leveloffset=+1]
 

--- a/modules/ROOT/pages/powerpaste-options.adoc
+++ b/modules/ROOT/pages/powerpaste-options.adoc
@@ -5,7 +5,7 @@
 :pluginname: PowerPaste
 :plugincode: powerpaste
 
-== Configuration Options
+== Options
 
 include::partial$configuration/paste_as_text.adoc[leveloffset=+1]
 
@@ -31,7 +31,7 @@ include::partial$configuration/smart_paste.adoc[leveloffset=+1]
 
 include::partial$configuration/images_file_types.adoc[leveloffset=+1]
 
-== Advanced Config Options
+== Advanced Options
 
 === Pre-filtering and post-filtering callbacks
 

--- a/modules/ROOT/pages/quickbars.adoc
+++ b/modules/ROOT/pages/quickbars.adoc
@@ -125,7 +125,7 @@ tinymce.init({
 });
 ----
 
-== Configuration options
+== Options
 
 include::partial$configuration/selection_toolbar.adoc[leveloffset=+1]
 

--- a/modules/ROOT/pages/rtc-options-optional.adoc
+++ b/modules/ROOT/pages/rtc-options-optional.adoc
@@ -7,7 +7,7 @@
 
 This section covers the recommended and optional configuration options for the RTC plugin. None of these options are required but assist with creating a consistent user experience between your application and {productname} {pluginname}.
 
-== Recommended configuration options
+== Recommended options
 
 For the best user experience, {companyname} recommends including these configuration options:
 
@@ -18,9 +18,9 @@ include::partial$configuration/rtc_server_disconnected.adoc[leveloffset=+1]
 
 include::partial$configuration/rtc_user_details_provider.adoc[leveloffset=+1]
 
-== Optional configuration options
+== Optional options
 
-The following configuration options have been provide to assist with integrating {pluginname} into webpages and applications:
+The following configuration options have been provided to assist with integrating {pluginname} into webpages and applications:
 
 * xref:rtc_snapshot[`+rtc_snapshot+`]
 * xref:rtc_initial_content_provider[`+rtc_initial_content_provider+`]

--- a/modules/ROOT/pages/rtc-options-overview.adoc
+++ b/modules/ROOT/pages/rtc-options-overview.adoc
@@ -11,7 +11,7 @@ The {pluginname} plugin uses promise-based "provider" functions to support a var
 
 == Overview of RTC options
 
-=== Required configuration options
+=== Required options
 
 These options are _required_ when using the {pluginname} plugin.
 
@@ -21,7 +21,7 @@ xref:rtc-options-required.adoc#rtc_encryption_provider[`+rtc_encryption_provider
 
 xref:rtc-options-required.adoc#rtc_token_provider[`+rtc_token_provider+`]:: Provide the editor with a JSON Web Token (JWT) for verifying that the user has access to edit the current document.
 
-=== Recommended configuration options
+=== Recommended options
 
 These options are assist with improving the user experience. They are not required, but are recommended.
 
@@ -37,7 +37,7 @@ xref:rtc-options-optional.adoc#rtc_user_details_provider[`+rtc_user_details_prov
 ** The `+rtc_client_connected+` and `+rtc_client_disconnected+` options.
 ** The `+RtcClientConnected+` and `+RtcClientDisconnected+` events.
 
-=== Optional configuration options
+=== Optional options
 
 The following options assist with integrating Real-Time Collaboration and improving the user experience.
 

--- a/modules/ROOT/pages/table.adoc
+++ b/modules/ROOT/pages/table.adoc
@@ -18,7 +18,7 @@ tinymce.init({
 });
 ----
 
-== Config Options
+== Options
 
 These settings affect the execution of the `+table+` plugin and let you modify the default styles and attributes for tables, preset class lists, and table behavior.
 

--- a/modules/ROOT/pages/template.adoc
+++ b/modules/ROOT/pages/template.adoc
@@ -24,7 +24,7 @@ This example shows how the template plugin can be used to insert custom template
 
 liveDemo::template[tab="js"]
 
-== Configuration Options
+== Options
 
 These settings affect the execution of the `+template+` plugin. Predefined templates for items such as created dates and modified dates can be set here.
 

--- a/modules/ROOT/pages/tinydrive-browse.adoc
+++ b/modules/ROOT/pages/tinydrive-browse.adoc
@@ -10,7 +10,7 @@ The `+tinydrive.browse+` method allows users to browse the files stored in {clou
 
 liveDemo::drive-plugin-browse[]
 
-== Configuration options
+== Options
 
 include::partial$configuration/filetypes.adoc[leveloffset=+1]
 

--- a/modules/ROOT/pages/tinydrive-pick.adoc
+++ b/modules/ROOT/pages/tinydrive-pick.adoc
@@ -38,7 +38,7 @@ mdate:: The modification date for the file in ISO 8601 format for example: `+201
 
 liveDemo::drive-plugin-pick[]
 
-== Configuration options
+== Options
 
 include::partial$configuration/filetypes.adoc[leveloffset=+1]
 

--- a/modules/ROOT/pages/toolbar-configuration-options.adoc
+++ b/modules/ROOT/pages/toolbar-configuration-options.adoc
@@ -2,7 +2,7 @@
 :navtitle: Options
 :description: Information on options for customizing TinyMCE's toolbars
 
-== Basic toolbar configuration options
+== Basic toolbar options
 
 include::partial$configuration/toolbar.adoc[leveloffset=+1]
 

--- a/modules/ROOT/pages/urldialog.adoc
+++ b/modules/ROOT/pages/urldialog.adoc
@@ -27,7 +27,7 @@ A URL Dialog configuration has three main parts to match the three main parts of
 * *URL:* The URL of the external page to load inside the dialog.
 * *Buttons:* (Optional) An array of xref:footer-buttons[footer buttons] that are displayed in the dialog's footer.
 
-== Configuration options
+== Options
 
 [cols="1,1,1,3",options="header"]
 |===

--- a/modules/ROOT/partials/components/choice-menu-items.adoc
+++ b/modules/ROOT/partials/components/choice-menu-items.adoc
@@ -3,7 +3,7 @@
 
 Choice menu items are a special type of menu item used for split toolbar button menu items. For information on split buttons, see: xref:custom-split-toolbar-button.adoc[Split toolbar buttons].
 
-=== Config options
+=== Options
 
 [cols="1,2,1,4",options="header"]
 |===


### PR DESCRIPTION
Related Ticket: DOC-1630

Description of Changes:
* Changed the header titles to `Options` where required
* Fixed an issue with the casechange options using the wrong header level

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
