### PR TITLE
DOC-1608: Update admonitions for shared link and autolink options

### DIFF
--- a/modules/ROOT/partials/configuration/link_default_protocol.adoc
+++ b/modules/ROOT/partials/configuration/link_default_protocol.adoc
@@ -11,7 +11,6 @@ This option allows you to set a default protocol for links when inserting/editin
 ifeval::["{plugincode}" == "link"]
 NOTE: This option also applies to the xref:autolink.adoc[autolink] plugin.
 endif::[]
-
 ifeval::["{plugincode}" == "autolink"]
 NOTE: This option also applies to the xref:link.adoc[link] plugin.
 endif::[]

--- a/modules/ROOT/partials/configuration/link_default_protocol.adoc
+++ b/modules/ROOT/partials/configuration/link_default_protocol.adoc
@@ -8,7 +8,13 @@ endif::[]
 
 This option allows you to set a default protocol for links when inserting/editing a link via the link dialog. The protocol will apply to any links where the protocol has not been specified and the prefix prompt has been accepted.
 
+ifeval::["{plugincode}" == "link"]
 NOTE: This option also applies to the xref:autolink.adoc[autolink] plugin.
+endif::[]
+
+ifeval::["{plugincode}" == "autolink"]
+NOTE: This option also applies to the xref:link.adoc[link] plugin.
+endif::[]
 
 *Type:* `+String+`
 

--- a/modules/ROOT/partials/configuration/link_default_target.adoc
+++ b/modules/ROOT/partials/configuration/link_default_target.adoc
@@ -11,7 +11,6 @@ This option allows you to set a default `+target+` value for links when insertin
 ifeval::["{plugincode}" == "link"]
 NOTE: This option also applies to the xref:autolink.adoc[autolink] plugin.
 endif::[]
-
 ifeval::["{plugincode}" == "autolink"]
 NOTE: This option also applies to the xref:link.adoc[link] plugin.
 endif::[]

--- a/modules/ROOT/partials/configuration/link_default_target.adoc
+++ b/modules/ROOT/partials/configuration/link_default_target.adoc
@@ -8,7 +8,13 @@ endif::[]
 
 This option allows you to set a default `+target+` value for links when inserting/editing a link via the link dialog. If the value of `+link_default_target+` matches a value specified by the xref:link.adoc#link_target_list[`+link_target_list+`] option, that item will be set as the default item for the targets dropdown in the link dialog.
 
+ifeval::["{plugincode}" == "link"]
 NOTE: This option also applies to the xref:autolink.adoc[autolink] plugin.
+endif::[]
+
+ifeval::["{plugincode}" == "autolink"]
+NOTE: This option also applies to the xref:link.adoc[link] plugin.
+endif::[]
 
 *Type:* `+String+`
 


### PR DESCRIPTION
Related Ticket: DOC-1608

Description of Changes:
* Update `link_default_protocol` and `link_default_target` documentation to show correct plugin in admonition.

Pre-checks:
- [X] Branch prefixed with `feature/` or `hotfix/`
- [X] `_data/nav.yml` has been updated (if applicable)
- [X] Files has been included where required (if applicable)
- [X] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
