### PR TITLE
DOC-1641: Remove incorrect line from JWT docs

### DIFF
--- a/modules/ROOT/pages/rtc-jwt-authentication.adoc
+++ b/modules/ROOT/pages/rtc-jwt-authentication.adoc
@@ -128,7 +128,6 @@ tinymce.init({
       body: JSON.stringify({ documentId }),
     })
     .then((response) => response.json())
-    .then(({ jwt }) => ({ token: jwt }))
     .catch((error) => console.log('Failed to return a JWT\n' + error))
 });
 ----
@@ -197,7 +196,6 @@ tinymce.init({
       body: JSON.stringify({ documentId }),
     })
     .then((response) => response.json())
-    .then(({ jwt }) => ({ token: jwt }))
     .catch((error) => console.log('Failed to return a JWT\n' + error))
 });
 ----


### PR DESCRIPTION
Related Ticket: DOC-1641

Description of Changes:
* This line was designed to show customers the object structure required by the RTC plugin, but then we duplicated the server-side endpoint examples from Tiny Drive which already return the correct structure. So all this did was create `{ token: undefined }` objects.
* I don't like deleting it, but I can't reasonably change the server-side example. We want it to be easy to use both Tiny Drive and RTC.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
