### PR TITLE
DOC-1640: Use the legacy AWS secrets instead

### DIFF
--- a/.github/workflows/feature_5_legacy_docs.yml
+++ b/.github/workflows/feature_5_legacy_docs.yml
@@ -63,5 +63,5 @@ jobs:
     - name: (deploy) Upload website to S3
       run: aws s3 sync --acl=public-read --delete ./_site $(cat S3_BUCKET)/docs
       env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_LEGACY_AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_LEGACY_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release_5_legacy_docs.yml
+++ b/.github/workflows/release_5_legacy_docs.yml
@@ -45,11 +45,11 @@ jobs:
     - name: (deploy) Upload to S3
       run: aws s3 sync --acl=public-read --delete ./_site s3://tiny-cloud-docs-production/docs
       env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_LEGACY_AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_LEGACY_AWS_SECRET_ACCESS_KEY }}
 
     - name: (deploy) Invalidate Cache
       run: aws cloudfront create-invalidation --distribution-id E3LFU502SQ5UR --paths "/docs/*"
       env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_LEGACY_AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_LEGACY_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/staging_5_legacy_docs.yml
+++ b/.github/workflows/staging_5_legacy_docs.yml
@@ -45,11 +45,11 @@ jobs:
     - name: (deploy) Upload to S3
       run: aws s3 sync --acl=public-read --delete ./_site s3://tiny-cloud-docs-staging/docs
       env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_LEGACY_AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_LEGACY_AWS_SECRET_ACCESS_KEY }}
 
     - name: (deploy) Invalidate Cache
       run: aws cloudfront create-invalidation --distribution-id E7DUUPEI08HNW --paths "/docs/*"
       env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_LEGACY_AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_LEGACY_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Related Ticket: DOC-1640

Description of Changes:
* Swap to using different AWS keys as the current ones only work for Antora buckets

Pre-checks:
- [x] Branch prefixed with `feature/` or `hotfix/`
- [x] `_data/nav.yml` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] ~Documentation Team Lead has reviewed~
- [x] ~Product Manager has reviewed~
