### PR TITLE
DOC-1643: Add missing content changes from 5.10 release

### DIFF
--- a/modules/ROOT/pages/configure-spelling-service.adoc
+++ b/modules/ROOT/pages/configure-spelling-service.adoc
@@ -11,6 +11,7 @@ The Spelling service has these configurable settings:
 * `+hunspell-dictionaries-path+`
 * `+custom-dictionaries-path+`
 * `+dynamic-custom-dictionaries+`
+* `+num-incorrect-words-in-suggestions-request-limit+`
 
 [[hunspell-dictionaries-path]]
 === `+hunspell-dictionaries-path+` (optional)
@@ -27,3 +28,8 @@ include::partial$misc/custom-dictionaries-path.adoc[]
 === `+dynamic-custom-dictionaries+` (optional)
 
 include::partial$misc/dynamic-custom-dictionaries.adoc[]
+
+[[num-incorrect-words-in-suggestions-request-limit]]
+=== `+num-incorrect-words-in-suggestions-request-limit+` (optional)
+
+include::partial$misc/num-incorrect-words-in-suggestions-request-limit.adoc[]

--- a/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
+++ b/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
@@ -125,7 +125,7 @@ tinymce.init({
   toolbar: 'spellchecker',
   init_instance_callback: (editor) => {
     editor.on('SpellcheckerIgnoreAll', (e) => {
-      console.log('Ignore word (all)', e.word);
+      console.log('Ignore word (all)', e.word, e.language);
     });
   }
 });

--- a/modules/ROOT/partials/configuration/advtable_value_series.adoc
+++ b/modules/ROOT/partials/configuration/advtable_value_series.adoc
@@ -72,7 +72,7 @@ An object with the following properties is passed to the generator callback func
 |Name |Value |Description
 |sectionType |`+'thead'+`, `+'tbody'+` or `+'tfoot'+` |The section of the table cell.
 |cellType |`+'td'+` or `+'th'+` |The type of the table cell.
-|getRowType |`() => 'header' \| 'body' \| 'footer'` | A function that returns the type of row the table cell is part of. A 'header' row is either a row that is part of a `thead` section or contains all `th` cells.
+|getRowType |`+() => 'header' \| 'body' \| 'footer'+` | A function that returns the type of row the table cell is part of. A 'header' row is either a row that is part of a `thead` section or contains all `th` cells.
 |classes |`+string[]+` |The classes present on the table cell.
 |direction |`+'row'+` or `+'column'+` |The direction of the generator.
 |prev |`+GeneratorResult+` |The generator result from the previous iteration.

--- a/modules/ROOT/partials/configuration/advtable_value_series.adoc
+++ b/modules/ROOT/partials/configuration/advtable_value_series.adoc
@@ -72,6 +72,7 @@ An object with the following properties is passed to the generator callback func
 |Name |Value |Description
 |sectionType |`+'thead'+`, `+'tbody'+` or `+'tfoot'+` |The section of the table cell.
 |cellType |`+'td'+` or `+'th'+` |The type of the table cell.
+|getRowType |`() => 'header' \| 'body' \| 'footer'` | A function that returns the type of row the table cell is part of. A 'header' row is either a row that is part of a `thead` section or contains all `th` cells.
 |classes |`+string[]+` |The classes present on the table cell.
 |direction |`+'row'+` or `+'column'+` |The direction of the generator.
 |prev |`+GeneratorResult+` |The generator result from the previous iteration.

--- a/modules/ROOT/partials/configuration/rtc_token_provider.adoc
+++ b/modules/ROOT/partials/configuration/rtc_token_provider.adoc
@@ -39,6 +39,15 @@ endif::[]
 |`+exp+` |`+integer+` |A timestamp indicating the token expiry date and time.
 |===
 
+=== Optional JWT claims
+
+[cols="2,1,3",options="header"]
+|===
+|Field |Type |Description
+|`https://claims.tiny.cloud/rtc/document` |`+string+` |The document ID that this JWT can access. If omitted, the JWT will be able to access any document on the same account.
+|`https://claims.tiny.cloud/rtc/role` |`+string+` |The possible role values are: `editor` or `viewer`. `viewer` will put the editor into readonly mode and `editor` (default) will let the user edit the document.
+|===
+
 === Example: Using `+rtc_token_provider+`
 
 This example shows the minimum required configuration for the Real-Time Collaboration plugin, including the `+rtc_token_provider+` option.

--- a/modules/ROOT/partials/events/tinymcespellchecker-events.adoc
+++ b/modules/ROOT/partials/events/tinymcespellchecker-events.adoc
@@ -4,7 +4,7 @@ The following events are provided by the xref:introduction-to-tiny-spellchecker.
 |===
 |Name |Data |Description
 |SpellcheckerIgnore |`+{ word: string }+` |Fired when a single instance of a word has been marked as ignored.
-|SpellcheckerIgnoreAll |`+{ word: string }+` |Fired when all instances of a word have been marked as ignored.
+|SpellcheckerIgnoreAll |`{ word: string, language: string }` |Fired when all instances of a word (in a certain language) have been marked as ignored.
 |SpellcheckError |`+{ message: string }+` |Fired when a spellchecker error occurs, such as when the Spell Checker Pro service can't be reached.
 |SpellcheckStart |N/A |Fired when spellchecking is enabled.
 |SpellcheckEnd |N/A |Fired when spellchecking is disabled.

--- a/modules/ROOT/partials/events/tinymcespellchecker-events.adoc
+++ b/modules/ROOT/partials/events/tinymcespellchecker-events.adoc
@@ -4,7 +4,7 @@ The following events are provided by the xref:introduction-to-tiny-spellchecker.
 |===
 |Name |Data |Description
 |SpellcheckerIgnore |`+{ word: string }+` |Fired when a single instance of a word has been marked as ignored.
-|SpellcheckerIgnoreAll |`{ word: string, language: string }` |Fired when all instances of a word (in a certain language) have been marked as ignored.
+|SpellcheckerIgnoreAll |`+{ word: string, language: string }+` |Fired when all instances of a word (in a certain language) have been marked as ignored.
 |SpellcheckError |`+{ message: string }+` |Fired when a spellchecker error occurs, such as when the Spell Checker Pro service can't be reached.
 |SpellcheckStart |N/A |Fired when spellchecking is enabled.
 |SpellcheckEnd |N/A |Fired when spellchecking is disabled.

--- a/modules/ROOT/partials/misc/num-incorrect-words-in-suggestions-request-limit.adoc
+++ b/modules/ROOT/partials/misc/num-incorrect-words-in-suggestions-request-limit.adoc
@@ -1,0 +1,12 @@
+Adding the `num-incorrect-words-in-suggestions-request-limit` element and setting it to a number instructs the spelling service to reject any requests for `/2/` suggestions where the number of **incorrect** words exceeds the specified limit. The default is to have no limit.
+
+Example:
+
+[source,properties]
+----
+ephox {
+  spelling {
+    num-incorrect-words-in-suggestions-request-limit = 100
+  }
+}
+----


### PR DESCRIPTION
Related Ticket: DOC-1643

Description of Changes:
* There looks to have been an issue where some commits from the v5 docs branches were missed being included in the v6 docs branches. The main one missed was the file changes for the 5.10 docs release (#2145). Potentially other commits were missed- this has to be looked into separately. This PR adds back some of the files changes made in the 5.10 docs release.

Pre-checks:
- [X] Branch prefixed with `feature/` or `hotfix/`
- [X] `_data/nav.yml` has been updated (if applicable)
- [X] Files has been included where required (if applicable)
- [X] Files removed have been deleted, not just excluded from the build (if applicable)
- [X] ~~(New product features only) Release Note added~~

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
