### PR TITLE
DOC-1651: Various minor docs fixes

### DIFF
--- a/modules/ROOT/examples/live-demos/basic-example/index.js
+++ b/modules/ROOT/examples/live-demos/basic-example/index.js
@@ -1,11 +1,10 @@
 tinymce.init({
   selector: 'textarea#basic-example',
   height: 500,
-  menubar: false,
   plugins: [
     'advlist', 'autolink', 'lists', 'link', 'image', 'charmap', 'preview',
     'anchor', 'searchreplace', 'visualblocks', 'code', 'fullscreen',
-    'insertdatetime', 'media', 'table', 'code', 'help', 'wordcount'
+    'insertdatetime', 'media', 'table', 'help', 'wordcount'
   ],
   toolbar: 'undo redo | blocks | ' +
   'bold italic backcolor | alignleft aligncenter ' +

--- a/modules/ROOT/examples/live-demos/context-menu/index.js
+++ b/modules/ROOT/examples/live-demos/context-menu/index.js
@@ -2,6 +2,6 @@ tinymce.init({
   selector: 'textarea#context-menu',
   height: 500,
   plugins: 'link image table lists',
-  contextmenu: 'link image table lists',
+  contextmenu: 'link image table',
   content_style: 'body { font-family:Helvetica,Arial,sans-serif; font-size:16px }'
 });

--- a/modules/ROOT/examples/live-demos/edit-image/index.js
+++ b/modules/ROOT/examples/live-demos/edit-image/index.js
@@ -6,6 +6,6 @@ tinymce.init({
     'anchor', 'searchreplace', 'visualblocks', 'code', 'fullscreen',
     'insertdatetime', 'media', 'table', 'editimage', 'wordcount'
   ],
-  toolbar: 'insertfile undo redo | styles | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image',
+  toolbar: 'undo redo | styles | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image',
   content_style: 'body { font-family:Helvetica,Arial,sans-serif; font-size:16px }'
 });

--- a/modules/ROOT/pages/basic-setup.adoc
+++ b/modules/ROOT/pages/basic-setup.adoc
@@ -262,7 +262,7 @@ Selects the toolbar buttons displayed to the user. Use a comma or space as a sep
 
 [source,js]
 ----
-toolbar: 'insertfile undo redo | styles | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image | print preview media | forecolor backcolor emoticons',
+toolbar: 'undo redo | styles | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image | print preview media | forecolor backcolor emoticons',
 ----
 
 Adds an additional menu named "My Favorites" with `+menu+`, then adds it to the menu bar using `+menubar+`.

--- a/modules/ROOT/partials/commands/editimage-cmds.adoc
+++ b/modules/ROOT/partials/commands/editimage-cmds.adoc
@@ -2,10 +2,10 @@
 |===
 |Command |Description
 |mceEditImage |Opens the Edit Image editing dialog.
-|mceImageRotateRight |Rotates selected image 90 degrees clockwise.
-|mceImageRotateLeft |Rotates selected image 90 degrees counter clockwise.
-|mceImageFlipVertical |Flips selected image vertically.
-|mceImageFlipHorizontal |Flips selected image horizontally.
+|mceImageRotateRight |Rotates the selected image 90 degrees clockwise.
+|mceImageRotateLeft |Rotates the selected image 90 degrees counterclockwise.
+|mceImageFlipVertical |Flips the selected image vertically.
+|mceImageFlipHorizontal |Flips the selected image horizontally.
 |===
 
 .Examples

--- a/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
+++ b/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
@@ -153,11 +153,11 @@ Where an Option name has changed, configurations using that option must be chang
 
 | `a11ychecker_html_version`     | `html4`                     | `html5`   |
 
-| assignment operator character | `:`                         | `~`       | Changed in the `valid_elements` and `extended_valid_elements` schemata
-
-| `config.height`               | `200px`                     | `400px`   | Changed to improve user experience.
+| assignment operator character | `:`                         | `~`       | Changed in the `valid_elements` and `extended_valid_elements` schemata.
 
 | `element_format`              | _no default value assigned_ | `html`    | Changed as part of modernising {productname}’s default behavior.
+
+| `height`                      | `200px`                     | `400px`   | Changed to improve user experience.
 
 | `link_default_protocol`       | `http`                      | `https`   | Changed as part of modernising {productname}’s default behavior.
 


### PR DESCRIPTION
Related Ticket: DOC-1651

Description of Changes:
* Fixed `code` duplicated in the basic example demo and removed the `menubar: false` which prevented some plugins being used.
* Removed the `insertfile` toolbar item from docs/demos where it couldn't be used.
* Fixed an incorrect option name in the migration guide.
* Removed `lists` from the contextmenu demo as it wasn't usable and isn't meant to be overly visible.
* Fixed some typos/grammar issues in the `editimage` commands.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
