### PR TITLE
DOC-1638: Fixed working with plugins using advlist without the lists plugin

### DIFF
--- a/modules/ROOT/pages/work-with-plugins.adoc
+++ b/modules/ROOT/pages/work-with-plugins.adoc
@@ -86,15 +86,15 @@ Even if you found the above example quite easy, hang with us we'll show you how 
 
 === Advanced List
 
-The xref:advlist.adoc[Advanced List] plugin extends the default unordered and ordered list toolbar controls by adding CSS `+list-style-type+` styled number formats and bullet types to the controls.
+The xref:advlist.adoc[Advanced List] plugin extends the default unordered and ordered list toolbar controls provided in the Lists plugin by adding CSS `+list-style-type+` styled number formats and bullet types to the controls.
 
-As before, let's start by adding the `+plugins+` key and giving it the Advanced List value of `+'advlist'+`.
+As before, let's start by adding the `+plugins+` key and assign the value `+'advlist lists'+`. This will enable the Advanced List and Lists plugins.
 
 [source,js]
 ----
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  plugins: 'advlist'
+  plugins: 'advlist lists'
 });
 ----
 
@@ -116,7 +116,7 @@ Let's add the Advanced List options and give them some of the available options.
 ----
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  plugins: 'advlist',
+  plugins: 'advlist lists',
   menubar: false,
   toolbar: 'bullist numlist',
   advlist_bullet_styles: 'square',


### PR DESCRIPTION
Related Ticket: DOC-1638

Description of Changes:
* Fixed the "Work with plugins to extend TinyMCE" page using advlist without the lists plugin

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
