### PR TITLE
DOC-1562: Add latest TinyMCE changelog and release notes

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -275,6 +275,7 @@
 * xref:migration-from-froala.adoc[Migrating from Froala]
 * Release notes for TinyMCE 5
 ** xref:release-notes/6.0-upcoming-changes.adoc[Upcoming changes for TinyMCE 6]
+** xref:release-notes/release-notes5103.adoc[TinyMCE 5.10.3]
 ** xref:release-notes/release-notes5102.adoc[TinyMCE 5.10.2]
 ** xref:release-notes/release-notes5101.adoc[TinyMCE 5.10.1]
 ** xref:release-notes/release-notes510.adoc[TinyMCE 5.10]

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -5,6 +5,18 @@
 
 NOTE: This is the {productname} Community version changelog. For information about the latest {cloudname} or {enterpriseversion} Release, see: xref:release-notes/index.adoc[{productname} Release Notes].
 
+== 5.10.4 - 2022-04-27
+
+=== Fixed
+* Inline toolbars flickered when switching between editors.
+* Multiple inline toolbars were shown if focused too quickly.
+
+== 5.10.3 - 2022-02-09
+
+=== Fixed
+* Alignment would sometimes be removed on parent elements when changing alignment on certain inline nodes, such as images.
+* The `fullscreen` plugin would reset the scroll position when exiting fullscreen mode.
+
 == 5.10.2 - 2021-11-17
 
 === Fixed

--- a/modules/ROOT/pages/release-notes/release-notes5103.adoc
+++ b/modules/ROOT/pages/release-notes/release-notes5103.adoc
@@ -1,0 +1,82 @@
+= TinyMCE 5.10.3
+:description: Release notes for TinyMCE 5.10.3
+:keywords: releasenotes bugfixes
+:title_nav: TinyMCE 5.10.3
+
+== Overview
+
+{productname} 5.10.3 was released for {enterpriseversion} and {cloudname} on Tuesday, February 15^th^, 2022. It includes {productname} 5.10.3 and additional changes to premium plugins. These release notes provide an overview of the changes for {productname} 5.10.3, including:
+
+* xref:accompanyingpremiumself-hostedserver-sidecomponentchanges[Accompanying Premium self-hosted server-side component changes]
+* xref:generalbugfixes[General bug fixes]
+* xref:securityfixes[Security fixes]
+* xref:upgradingtothelatestversionoftinymce5[Upgrading to the latest version of TinyMCE 5]
+
+include::partial$misc/releasenotes_for_stable.adoc[]
+
+[[accompanyingpremiumself-hostedserver-sidecomponentchanges]]
+== Accompanying Premium self-hosted server-side component changes
+
+The {productname} 5.10.3 release includes changes affecting the {productname} *self-hosted* services for the following plugins:
+
+* The Enhanced Media Embed plugin (`mediaembed`)
+* The Image Tools plugin (`imagetools`)
+* The Link Checker plugin (`linkchecker`)
+* The Spell Checker Pro plugin (`tinymcespellchecker`)
+
+The Java server-side components have been updated to the following versions:
+
+* `ephox-spelling.war`: 2.118.4
+* `ephox-hyperlinking.war`: 2.105.9
+* `ephox-image-proxy.war`: 2.106.1
+
+This version requires Java 8 or higher. For information on the removal of Java 7 support, see: xref:release-notes/release-notes53.adoc#removalofjava7support[Removal of Java 7 support for TinyMCE 5.3 and later].
+
+For information on:
+
+* The Spell Checker Pro plugin, see: xref:plugins/premium/tinymcespellchecker.adoc[Spell Checker Pro plugin].
+* The Link Checker plugin, see: xref:plugins/premium/linkchecker.adoc[Link Checker plugin].
+* The Image Tools plugin, see: xref:plugins/opensource/imagetools.adoc[Image Tools plugin].
+* The Enhanced Media Embed plugin, see: xref:plugins/premium/mediaembed.adoc[Enhanced Media Embed plugin].
+* Deploying the server-side components, see: xref:enterprise/server/index.adoc[Server-side component installation].
+
+=== Updating the self-hosted server-side components
+
+The new versions of the server-side services provide updates for the Java-based server-side components. To deploy the updated version of the server-side components:
+
+. Update your Java Application Server to the minimum required version:
+ ** Eclipse Jetty 9.4 or later
+ ** Apache Tomcat:
+  *** 9 or later
+  *** 8.5.12+
+  *** 8.0.42+
+  *** 7.0.76+
+. Replace the existing server-side `.war` files with the `.war` files bundled with {productname} 5.10.3 or later.
+
+For information on:
+
+* Deploying the server-side components, see: xref:enterprise/server/index.adoc[Server-side component installation].
+* Deploying the server-side components using Docker, see: xref:enterprise/server/dockerservices.adoc[Containerized service deployments].
+
+[[generalbugfixes]]
+== General bug fixes
+
+{productname} 5.10.3 provides fixes for the following bugs:
+
+* Alignment would sometimes be removed on parent elements when changing alignment on certain inline nodes, such as images.
+* The `fullscreen` plugin would incorrectly reset the scroll position when exiting fullscreen mode.
+
+[[securityfixes]]
+== Security fixes
+
+{productname} 5.10.3 fixes the following security issues:
+
+All 3 server-side components updates include dependency updates that address security issues. This includes _Low_ severity vulnerability fixes.
+
+For information on the server-side components updates, see: xref:accompanyingpremiumself-hostedserver-sidecomponentchanges[Accompanying Premium self-hosted server-side component changes].
+
+:enterprise: true
+
+include::partial$install/upgrading-info.adoc[]
+
+:enterprise: false


### PR DESCRIPTION
Related Ticket: DOC-1562

Description of Changes:
* Add missing changelog sections for 5.10.3 and 5.10.4
* Add and convert missing release notes files for 5.10.3 (I am not sure if this should be done separately so can remove it if necessary)

Pre-checks:
- [X] ~~Branch prefixed with `feature/6/` or `hotfix/6/`~~
- [X] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [X] Files has been included where required (if applicable)
- [X] Files removed have been deleted, not just excluded from the build (if applicable)
- [X] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
