### PR TITLE
DOC-1642: Merge release/docs-6 into staging/docs-6

### DIFF
--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -4,6 +4,15 @@
 
 NOTE: This is the {productname} Community version changelog. For information about the latest {cloudname} or {enterpriseversion} Release, see: xref:release-notes.adoc[{productname} Release Notes].
 
+== 6.0.2 - 2022-04-27
+
+=== Fixed
+* Some media elements wouldn't update when changing the source URL.
+* Inline toolbars flickered when switching between editors.
+* Multiple inline toolbars were shown if focused too quickly.
+* Added background and additional spacing for the text labeled buttons in the toolbar to improve visual clarity.
+* Toolbar split buttons with text used an incorrect width on touch devices.
+
 == 6.0.1 - 2022-03-23
 
 === Fixed


### PR DESCRIPTION
Related Ticket: DOC-1642

Description of Changes:
* Merge release/docs-6 into staging/docs-6 which includes the changelog entries for TinyMCE 6.0.2

Pre-checks:
- [X] Branch prefixed with `feature/6/` or `hotfix/6/`
- [X] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [X] Files has been included where required (if applicable)
- [X] Files removed have been deleted, not just excluded from the build (if applicable)
- [X] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed

When merging:
- [x] Ensure a merge commit is used