### PR TITLE
DOC-1662: Fix incorrect advlist command examples

### DIFF
--- a/modules/ROOT/partials/commands/advlist-cmds.adoc
+++ b/modules/ROOT/partials/commands/advlist-cmds.adoc
@@ -11,9 +11,9 @@ For information on available list types, see: https://developer.mozilla.org/en-U
 [source,js]
 ----
 tinymce.activeEditor.execCommand('ApplyOrderedListStyle', false, {
-  'list-style-type': 'disc'
+  'list-style-type': 'decimal'
 });
 tinymce.activeEditor.execCommand('ApplyUnorderedListStyle', false, {
-  'list-style-type': 'decimal'
+  'list-style-type': 'disc'
 });
 ----


### PR DESCRIPTION
Corrects error in example JavaScript in `advlist-cmds.adoc`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed