### PR TITLE
INT-2850: Fixed the CDN URLs for jquery and webcomponent

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -12,7 +12,7 @@ asciidoc:
     tdcdnurl: https://cdn.tiny.cloud/1/_your_api_key_/tinydrive/6/tinydrive.min.js
     tinymce_live_demo_url: https://cdn.tiny.cloud/1/qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc/tinymce/6/tinymce.min.js
     tinydrive_live_demo_url: https://cdn.tiny.cloud/1/qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc/tinydrive/6/tinydrive.min.js
-    webcomponent_url: https://cdn.jsdelivr.net/npm/@tinymce/tinymce-webcomponent@1/dist/tinymce-webcomponent.min.js
+    webcomponent_url: https://cdn.jsdelivr.net/npm/@tinymce/tinymce-webcomponent@2/dist/tinymce-webcomponent.min.js
     default_meta_keywords: tinymce, documentation, docs, plugins, customizable skins, configuration, examples, html, php, java, javascript, image editor, inline editor, distraction-free editor, classic editor, wysiwyg
     # product variables
     productname: TinyMCE

--- a/antora.yml
+++ b/antora.yml
@@ -13,6 +13,7 @@ asciidoc:
     tinymce_live_demo_url: https://cdn.tiny.cloud/1/qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc/tinymce/6/tinymce.min.js
     tinydrive_live_demo_url: https://cdn.tiny.cloud/1/qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc/tinydrive/6/tinydrive.min.js
     webcomponent_url: https://cdn.jsdelivr.net/npm/@tinymce/tinymce-webcomponent@2/dist/tinymce-webcomponent.min.js
+    jquery_url: https://cdn.jsdelivr.net/npm/@tinymce/tinymce-jquery@2/dist/tinymce-jquery.min.js
     default_meta_keywords: tinymce, documentation, docs, plugins, customizable skins, configuration, examples, html, php, java, javascript, image editor, inline editor, distraction-free editor, classic editor, wysiwyg
     # product variables
     productname: TinyMCE

--- a/modules/ROOT/partials/integrations/jquery-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/jquery-quick-start.adoc
@@ -81,9 +81,9 @@ API key, which is created when signing up to the link:{accountsignup}/[{cloudnam
 
 . Add the following `<script>` element to get the {productname} jQuery integration from the JS Delivr CDN:
 +
-[source,html]
+[source,html,subs="attributes+"]
 ----
-<script src="https://cdn.jsdelivr.net/npm/@tinymce/tinymce-jquery@2/dist/tinymce-jquery.min.js"></script>
+<script src="{jquery_url}"></script>
 ----
 endif::[]
 . Add an initialization point for {productname}, such as:
@@ -160,7 +160,7 @@ ifeval::["{productSource}" == "cloud"]
       src="{cdnurl}"
       referrerpolicy="origin"
     ></script>
-    <script src="https://cdn.jsdelivr.net/npm/@tinymce/tinymce-jquery@2/dist/tinymce-jquery.min.js"></script>
+    <script src="{jquery_url}"></script>
   </head>
   <body>
     <div>

--- a/modules/ROOT/partials/integrations/jquery-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/jquery-quick-start.adoc
@@ -83,7 +83,7 @@ API key, which is created when signing up to the link:{accountsignup}/[{cloudnam
 +
 [source,html]
 ----
-<script src="https://cdn.jsdelivr.net/npm/@tinymce/tinymce-jquery@1/dist/tinymce-jquery.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@tinymce/tinymce-jquery@2/dist/tinymce-jquery.min.js"></script>
 ----
 endif::[]
 . Add an initialization point for {productname}, such as:
@@ -160,7 +160,7 @@ ifeval::["{productSource}" == "cloud"]
       src="{cdnurl}"
       referrerpolicy="origin"
     ></script>
-    <script src="https://cdn.jsdelivr.net/npm/@tinymce/tinymce-jquery@1/dist/tinymce-jquery.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@tinymce/tinymce-jquery@2/dist/tinymce-jquery.min.js"></script>
   </head>
   <body>
     <div>


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Both jquery and webcomponent had an older version of the URLs linked.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] ~~`modules/ROOT/nav.adoc` has been updated~~ (not applicable)
- [x] ~~Files has been included where required~~ (not applicable)
- [x] ~~Files removed have been deleted, not just excluded from the build~~ (not applicable)
- [x] ~~(New product features only) Release Note added~~ (not applicable)

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
