### PR TITLE
DOC-1664: Fixed incorrect information in the things we renamed table

### DIFF
--- a/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
+++ b/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
@@ -50,7 +50,7 @@ This section also includes four tables that set out the:
 [[things-we-renamed]]
 == Things we renamed
 
-[cols="1,1,1,1"]
+[cols="2,2,1,2"]
 |===
 | Old name                            | New name                         | Element                             | Notes
 
@@ -72,8 +72,6 @@ This section also includes four tables that set out the:
 
 | `images_upload_timeout`             | `editimage_upload_timeout`       | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-| `editimage_proxy`                   | `export_image_proxy_service_url` | Option                              | Renamed for easier configuration when used with https://tiny.cloud/docs/enterprise/server/[Tiny services].
-
 | `fire()`                            | `dispatch()`                     | API                                 | `fire()` in `tinymce.Editor`, `tinymce.dom.EventUtils`, `tinymce.dom.DOMUtils`, `tinymce.util.Observable` and `tinymce.util.EventDispatcher` has been renamed to `dispatch()`. `fire` has been aliased to `dispatch` but has also been marked as _deprecated_.
 
 | `font_formats`                      | `font_family_formats`            | Option                              | No behavioral changes, but there are related toolbar and menu items changes.
@@ -88,7 +86,7 @@ This section also includes four tables that set out the:
 
 | `fontsizes`                         | `fontsize`                       | Menu item                           | No behavioral changes.
 
-| `formatpainter_blacklisted_formats` | `formatpainter_ignored_formats`  | Option                              | No behavioral changes.
+| `formatpainter_blacklisted_formats` | `formatpainter_ignored_formats`  | Option                              | No behavioral changes.
 
 | `getWhiteSpaceElements()`           | `getWhitespaceElements()`        | Function                            | This function is part of the `Schema` API. It was renamed as part of a general renaming that treats _Whitespace_ as a single word. The behavior of the function has not changed.
 
@@ -96,19 +94,19 @@ This section also includes four tables that set out the:
 
 | `content`                           | `html`                           | Command                             | This `mceInsertClipboardContent` argument was renamed to better reflect what data is passed. NB: The `content` argument can no longer be used with `mceInsertClipboardContent`. If `content` is used, no data is passed.
 
-| `lineheight_formats`                 | `line_height_formats`            | Option                              | No behavioral changes.
+| `lineheight_formats`                | `line_height_formats`            | Option                              | No behavioral changes.
 
-| `default_link_target`               | `link_default_target`            |                                     | Changed for consistency with other `link` and `autolink` options. The functionality, and the values the option can take remain unchanged. This change applies to both `link` and `autolink` plugins.
+| `default_link_target`               | `link_default_target`            | Option                              | Changed for consistency with other `link` and `autolink` options. The functionality, and the values the option can take remain unchanged. This change applies to both `link` and `autolink` plugins.
 
-| `rel_list`                          | `link_rel_list`                  |                                     | Changed for consistency with other options. The functionality, and the values this option can take remain unchanged.
+| `rel_list`                          | `link_rel_list`                  | Option                              | Changed for consistency with other options. The functionality, and the values this option can take remain unchanged.
 
-| `target_list`                       | `link_target_list`               |                                     | Changed for consistency with other options. The functionality, and the values this option can take remain unchanged.
+| `target_list`                       | `link_target_list`               | Option                              | Changed for consistency with other options. The functionality, and the values this option can take remain unchanged.
 
-| `mceInsertTable`                    | `mceInsertTableDialog`           |                                     | Use `mceInsertTableDialog` to open the _Insert Table_ dialog box. NB: `mceInsertTable` (with appropriate arguments) still works to insert a table directly into an existing document. `mceInsertTable` can no longer be used to invoke the _Table_ dialog box, however.
+| `mceInsertTable`                    | `mceInsertTableDialog`           | Command                             | Use `mceInsertTableDialog` to open the _Insert Table_ dialog box. NB: `mceInsertTable` (with appropriate arguments) still works to insert a table directly into an existing document. `mceInsertTable` can no longer be used to invoke the _Table_ dialog box, however.
 
-| `noneditable_noneditable_class`     | `noneditable_class`              |                                     | After upgrading, rename the options in your {productname} init configuration to match the new name. For example, `noneditable_noneditable_class: 'mceNonEditable'` must be renamed `noneditable_class: 'mceNonEditable'`.
+| `noneditable_noneditable_class`     | `noneditable_class`              | Option                              | After upgrading, rename the options in your {productname} init configuration to match the new name. For example, `noneditable_noneditable_class: 'mceNonEditable'` must be renamed `noneditable_class: 'mceNonEditable'`.
 
-| `noneditable_editable_class`        | `editable_class`                 |                                     | After upgrading, rename the options in your {productname} init configuration to match the new name. For example, `noneditable_editable_class: 'mceEditable'` must be renamed `editable_class: 'mceEditable'`.
+| `noneditable_editable_class`        | `editable_class`                 | Option                              | After upgrading, rename the options in your {productname} init configuration to match the new name. For example, `noneditable_editable_class: 'mceEditable'` must be renamed `editable_class: 'mceEditable'`.
 
 | `styleselect`                       | `styles`                         | Toolbar item                        | No behavioral changes.
 
@@ -116,9 +114,9 @@ This section also includes four tables that set out the:
 
 | `textpattern_patterns`              | `text_patterns`                  | Option                              | After upgrading, rename the options in your {productname} init configuration to match the new name. Also, remove `textpattern` from your plugins list. This name-change is consequent to `textpattern` being changed from a Plugin to being part of the {productname} Core.
 
-| `tinymce.Env.browser.isChrome`      | `tinymce.Env.browser.isChromium` | API                                 | Updated so the `Sand` and `Env` APIs better reflect what they are checking for. `isChrome` implies they are checking for _Google Chrome_. They are actually checking for any Chromium-based browser (eg Chromium, Google Chrome, or Chrome Edge) so `isChromium` more accurately reflects what is being done.
+| `tinymce.Env.browser.isChrome`      | `tinymce.Env.browser.isChromium` | API                                 | Updated so the API better reflects what it is checking for. `isChrome` implies it is checking for _Google Chrome_. However, it is actually checking for any Chromium-based browser (eg Chromium, Google Chrome, or Chrome Edge) so `isChromium` more accurately reflects what is being done.
 
-| `tinymce.Env.os.isOSX`              | `tinymce.Env.os.isMacOS`         | API                                 | Updated so the `Sand` and `Env` APIs now use the current name of Apple’s desktop operating system when checking to see if a device’s OS is, in fact, macOS.
+| `tinymce.Env.os.isOSX`              | `tinymce.Env.os.isMacOS`         | API                                 | Updated so the API now uses the current name of Apple’s desktop operating system when checking to see if a device’s OS is, in fact, macOS.
 
 | `toc`                               | `tableofcontents`                | Plugin, Menu item, and Toolbar item | This presents in both the menu item and the toolbar’s tooltip text. NB: _Table of Contents_ is now a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
 


### PR DESCRIPTION
Related Ticket: DOC-1664

Description of Changes:
* Fixed incorrect information around the `editimage_proxy` option.
* Added missing `Element` column values for various items.
* Removed references to `Sand` as that's an internal API and should not be mentioned in public docs.
* Messed with the table rendering a little to give columns with content more space.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
