### PR TITLE
DOC-1673: Added Release Notes for TinyMCE 5.10.5

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -967,6 +967,11 @@
 - url: "release-notes"
   pages:
   - url: "6.0-upcoming-changes"
+  - url: "release-notes5105"
+    pages:
+    - url: "#Overview"
+    - url: "#General bug fixes"
+    - url: "#Upgrading to the latest version of TinyMCE 5"
   - url: "release-notes5104"
     pages:
     - url: "#Overview"

--- a/release-notes/release-notes5105.md
+++ b/release-notes/release-notes5105.md
@@ -1,0 +1,86 @@
+---
+layout: default
+title: TinyMCE 5.10.5
+title_nav: TinyMCE 5.10.5
+description: Release notes for TinyMCE 5.10.5
+keywords: releasenotes bugfixes
+---
+
+## Overview
+
+{{site.productname}} 5.10.5 was released for {{site.enterpriseversion}} and {{site.cloudname}} on Wednesday, June 1<sup>st</sup>, 2022. It includes {{site.productname}} 5.10.4. These release notes provide an overview of the changes for {{site.productname}} 5.10.4, including:
+
+- [General bug fixes](#generalbugfixes)
+- [Upgrading to the latest version of TinyMCE 5](#upgradingtothelatestversionoftinymce5)
+
+{{site.releasenotes_for_stable}}
+
+## General bug fixes
+
+{{site.productname}} 5.10.4 provides fixes for the following bugs:
+
+### base64 encoded images were corrupted and not displayed when added immediately following the string `data:`
+
+When the string `data:` immediately preceded the insertion point, or was only separated from the insertion point by a Return character (ie, was on the line above the insertion point), adding an image in to a {{site.productname}} 5.x document caused the added image data to be parsed incorrectly.
+
+Rather than displaying the encoded image, the mis-parsing caused the image to corrupt and present as a raw string of base64 text within html tags, which also displayed as text.
+
+With this update, the `extractBase64DataUris` function, which was responsible for the mis-parsing, now engages in more comprehensive sanity checking. These further sanity checks prevent the function from mis-parsing a user-entered `data:` string.
+
+Consequently, adding images to a {{site.productname}} 5.x document now works in this circumstance: the image is not corrupted and displays at the insertion point as expected.
+
+
+### `format_empty_lines` did not work as documented
+
+Previously, when `format_empty_lines` was set to `true`, lines that included no text (ie, a line consisting of just a Return) did not preserve inline formatting when saved.
+
+So, for example, a line
+
+```html
+<p> 
+<em> 
+<strong> 
+<span style="font-family: arial, helvetica, sans-serif;" ><br /></span> 
+</strong> 
+</em> 
+</p> 
+```
+
+when saved, became
+
+```html]
+<p> 
+&nbsp; 
+</p> 
+```
+
+That is, the line was preserved, but the formatting was not.
+
+With this update, `format_empty_lines: true` behaves as it should (and as advertised), and formatting added to an otherwise empty line is preserved when saved.
+
+NOTE: By default `format_empty_lines` is set to `false`.
+
+
+### Some inline elements specified by the {{site.productname}} schema were not removed by default when empty
+
+By default, the {{site.productname}} schema removes empty inline `html` elements.
+
+Previously, however, some inline `html` elements — including `s`, `u`, `var`, `cite`, `dfn`, `code`, `mark`, `q`, `sup`, `sub`, and `samp` — were not removed when they were present but empty.
+
+With this update, inline `html` elements such as those noted above will have the `removeEmpty` schema flag set, as expected.
+
+
+### The default {{site.productname}} schema did not include the <s> element
+
+Previously, the default {{site.productname}} schema did not include the `<s>` element in the text inline elements section of the schema. The element was included in the full element list, however.
+
+Consequently, although `strike-through` elements rendered as expected, anything that relied on the `schema.getTextInlineElements()` API may not have handled the `<s>` element correctly.
+
+This update corrects the omission in the {{site.productname}} schema and `<s>` element is now correctly returned by the `schema.getTextInlineElements()` API.```
+
+
+{% assign enterprise = true %}
+
+{% include install/upgrading-info.md %}
+
+{% assign enterprise = false %}

--- a/release-notes/release-notes5105.md
+++ b/release-notes/release-notes5105.md
@@ -76,7 +76,7 @@ Previously, the default {{site.productname}} schema did not include the `<s>` el
 
 Consequently, although `strike-through` elements rendered as expected, anything that relied on the `schema.getTextInlineElements()` API may not have handled the `<s>` element correctly.
 
-This update corrects the omission in the {{site.productname}} schema and `<s>` element is now correctly returned by the `schema.getTextInlineElements()` API.```
+This update corrects the omission in the {{site.productname}} schema and `<s>` element is now correctly returned by the `schema.getTextInlineElements()` API.
 
 
 {% assign enterprise = true %}

--- a/release-notes/release-notes5105.md
+++ b/release-notes/release-notes5105.md
@@ -48,7 +48,7 @@ So, for example, a line
 
 when saved, became
 
-```html]
+```html
 <p> 
 &nbsp; 
 </p> 

--- a/release-notes/release-notes5105.md
+++ b/release-notes/release-notes5105.md
@@ -8,7 +8,7 @@ keywords: releasenotes bugfixes
 
 ## Overview
 
-{{site.productname}} 5.10.5 was released for {{site.enterpriseversion}} and {{site.cloudname}} on Wednesday, June 1<sup>st</sup>, 2022. It includes {{site.productname}} 5.10.4. These release notes provide an overview of the changes for {{site.productname}} 5.10.4, including:
+{{site.productname}} 5.10.5 was released for {{site.enterpriseversion}} and {{site.cloudname}} on Wednesday, June 1<sup>st</sup>, 2022. It includes {{site.productname}} 5.10.5. These release notes provide an overview of the changes for {{site.productname}} 5.10.5, including:
 
 - [General bug fixes](#generalbugfixes)
 - [Upgrading to the latest version of TinyMCE 5](#upgradingtothelatestversionoftinymce5)

--- a/release-notes/release-notes5105.md
+++ b/release-notes/release-notes5105.md
@@ -25,7 +25,7 @@ When the string `data:` immediately preceded the insertion point, or was only se
 
 Rather than displaying the encoded image, the mis-parsing caused the image to corrupt and present as a raw string of base64 text within html tags, which also displayed as text.
 
-With this update, the `extractBase64DataUris` function, which was responsible for the mis-parsing, now engages in more comprehensive sanity checking. These further sanity checks prevent the function from mis-parsing a user-entered `data:` string.
+With this update, the code responsible for the mis-parsing now engages in more comprehensive sanity checking. These further sanity checks prevent the function from mis-parsing a user-entered `data:` string.
 
 Consequently, adding images to a {{site.productname}} 5.x document now works in this circumstance: the image is not corrupted and displays at the insertion point as expected.
 

--- a/release-notes/release-notes5105.md
+++ b/release-notes/release-notes5105.md
@@ -17,7 +17,7 @@ keywords: releasenotes bugfixes
 
 ## General bug fixes
 
-{{site.productname}} 5.10.4 provides fixes for the following bugs:
+{{site.productname}} 5.10.5 provides fixes for the following bugs:
 
 ### base64 encoded images were corrupted and not displayed when added immediately following the string `data:`
 


### PR DESCRIPTION
Added Release Notes file for TinyMCE 5.10.5.

Related Ticket: 

Description of Changes:
* Placeholder text

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
