### PR TITLE
DOC-1674: added note about strict CSP to general-csp.adoc

### DIFF
--- a/modules/ROOT/partials/misc/general-csp.adoc
+++ b/modules/ROOT/partials/misc/general-csp.adoc
@@ -15,7 +15,21 @@
 
 [IMPORTANT]
 ====
-These directives will prevent all content loading from external sources. To allow content from specific sources, add the source domains to the relevant directives. For example, to allow YouTube videos:
+There is a hardened approach to CSP, commonly known as _strict CSP_. A strict CSP
+
+1. uses a `+nonce+` for all `+<script>+` elements;
+
+2. regenerates each `+nonce+` on every page load;
+
+3. refactors inline event handlers such that they are added from a JavaScript block; and
+
+4. does not allow the `+unsafe-inline+` value in any directive.
+
+However, {productname} currently requires the `unsafe-inline` value in the `style-src` directive to present material as other than plain-text, and to position its own user interface elements.
+
+As a consequence, running {productname} from within a strict CSP configuration is not currently supported
+
+Also, the required directives documented above prevent any content loading from external sources. To allow content from specific sources, add the source domains to the relevant directives. For example, to allow YouTube videos:
 
 [source,html]
 ----


### PR DESCRIPTION
TinyMCE does not, currently, support being run from within a strict CSP environment. The extant documentation infers this but does not outright state this. With this edit the documentation now explicitly notes that TinyMCE cannot, currently, run from within a strict CSP environment.

Related Ticket: 

Description of Changes:
* Placeholder text

Pre-checks:
- [ ] Branch prefixed with `feature/6/` or `hotfix/6/`
- [ ] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [ ] Files has been included where required (if applicable)
- [ ] Files removed have been deleted, not just excluded from the build (if applicable)
- [ ] (New product features only) Release Note added

Review:
- [ ] Documentation Team Lead has reviewed
- [ ] Product Manager has reviewed
