### PR TITLE
DOC-1674: add note about strict CSP to `general-csp.adoc`

### DIFF
--- a/modules/ROOT/partials/misc/general-csp.adoc
+++ b/modules/ROOT/partials/misc/general-csp.adoc
@@ -27,7 +27,7 @@ There is a hardened approach to CSP, commonly known as _strict CSP_. A strict CS
 
 However, {productname} currently requires the `unsafe-inline` value in the `style-src` directive to present material as other than plain-text, and to position its own user interface elements.
 
-As a consequence, running {productname} from within a strict CSP configuration is not currently supported
+As a consequence, running {productname} from within a strict CSP configuration is not currently supported.
 
 Also, the required directives documented above prevent any content loading from external sources. To allow content from specific sources, add the source domains to the relevant directives. For example, to allow YouTube videos:
 

--- a/modules/ROOT/partials/misc/general-csp.adoc
+++ b/modules/ROOT/partials/misc/general-csp.adoc
@@ -25,7 +25,7 @@ There is a hardened approach to CSP, commonly known as _strict CSP_. A strict CS
 
 4. does not allow the `+unsafe-inline+` value in any directive.
 
-However, {productname} currently requires the `unsafe-inline` value in the `style-src` directive to present material as other than plain-text, and to position its own user interface elements.
+However, {productname} currently requires the `unsafe-inline` value in the `style-src` directive to present content other than plain-text.
 
 As a consequence, running {productname} from within a strict CSP configuration is not currently supported.
 

--- a/modules/ROOT/partials/misc/general-csp.adoc
+++ b/modules/ROOT/partials/misc/general-csp.adoc
@@ -15,7 +15,21 @@
 
 [IMPORTANT]
 ====
-These directives will prevent all content loading from external sources. To allow content from specific sources, add the source domains to the relevant directives. For example, to allow YouTube videos:
+There is a hardened approach to CSP, commonly known as _strict CSP_. A strict CSP
+
+1. uses a `+nonce+` for all `+<script>+` elements;
+
+2. regenerates each `+nonce+` on every page load;
+
+3. refactors inline event handlers such that they are added from a JavaScript block; and
+
+4. does not allow the `+unsafe-inline+` value in any directive.
+
+However, {productname} currently requires the `unsafe-inline` value in the `style-src` directive to present material as other than plain-text, and to position its own user interface elements.
+
+As a consequence, running {productname} from within a strict CSP configuration is not currently supported
+
+Also, the required directives documented above prevent any content loading from external sources. To allow content from specific sources, add the source domains to the relevant directives. For example, to allow YouTube videos:
 
 [source,html]
 ----

--- a/modules/ROOT/partials/misc/general-csp.adoc
+++ b/modules/ROOT/partials/misc/general-csp.adoc
@@ -15,7 +15,7 @@
 
 [IMPORTANT]
 ====
-There is a hardened approach to CSP, commonly known as _strict CSP_. A strict CSP
+There is a hardened approach to CSP, commonly known as _strict CSP_. A strict CSP:
 
 1. uses a `+nonce+` for all `+<script>+` elements;
 


### PR DESCRIPTION
The extant documentation infers that TinyMCE cannot be run from within a strict CSP environment. This edit makes the inference explicit: TinyMCE cannot, currently, run from within a strict CSP environment and this update adds a specific note to this effect.

Related Ticket: 

Description of Changes:
* Placeholder text

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
