### PR TITLE
DOC-1724: Update ToC and EditImage minimum plans

### DIFF
--- a/.github/workflows/feature_6_docs.yml
+++ b/.github/workflows/feature_6_docs.yml
@@ -60,3 +60,4 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+        AWS_EC2_METADATA_DISABLED: true

--- a/.github/workflows/release_6_docs.yml
+++ b/.github/workflows/release_6_docs.yml
@@ -51,3 +51,4 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
+        AWS_EC2_METADATA_DISABLED: true

--- a/.github/workflows/staging_6_docs.yml
+++ b/.github/workflows/staging_6_docs.yml
@@ -51,3 +51,4 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+        AWS_EC2_METADATA_DISABLED: true

--- a/modules/ROOT/pages/editimage.adoc
+++ b/modules/ROOT/pages/editimage.adoc
@@ -4,7 +4,7 @@
 :keywords: edit, image, rotate, rotateleft, rotateright, flip, flipv, fliph, editimage, imageoptions
 :pluginname: Enhanced Image Editing
 :plugincode: editimage
-:pluginminimumplan: tierone
+:pluginminimumplan: tiertwo
 
 NOTE: In previous versions of {productname}, the {pluginname} plugin was provided as an open source plugin known as the Image Tools plugin.
 

--- a/modules/ROOT/pages/editimage.adoc
+++ b/modules/ROOT/pages/editimage.adoc
@@ -6,9 +6,11 @@
 :plugincode: editimage
 :pluginminimumplan: tiertwo
 
-NOTE: In previous versions of {productname}, the {pluginname} plugin was provided as an open source plugin known as the Image Tools plugin.
+include::partial$misc/admon-premium-plugin.adoc[]
 
-Enhanced Image Editing (`+editimage+`) plugin adds a contextual editing toolbar to the images in the editor. If toolbar is not appearing on image click, it might be that you need to enable `+editimage_cors_hosts+` or `+editimage_proxy_service_url+` (see below).
+The {pluginname} (`{plugincode}`) plugin adds a contextual editing toolbar to the images in the editor. If toolbar is not appearing on image click, it might be that you need to enable `+editimage_cors_hosts+` or `+editimage_proxy_service_url+` (see below).
+
+NOTE: In previous versions of {productname}, the {pluginname} plugin was provided as an open source plugin known as the Image Tools plugin.
 
 == Interactive example
 

--- a/modules/ROOT/pages/editimage.adoc
+++ b/modules/ROOT/pages/editimage.adoc
@@ -8,7 +8,9 @@
 
 include::partial$misc/admon-premium-plugin.adoc[]
 
-The {pluginname} (`{plugincode}`) plugin adds a contextual editing toolbar to the images in the editor. If toolbar is not appearing on image click, it might be that you need to enable `+editimage_cors_hosts+` or `+editimage_proxy_service_url+` (see below).
+The {pluginname} (`{plugincode}`) plugin adds a contextual editing toolbar to images in the editor.
+
+If the toolbar does not appear after clicking on an image, you may need to enable `+editimage_cors_hosts+` or `+editimage_proxy_service_url+` (see below).
 
 NOTE: In previous versions of {productname}, the {pluginname} plugin was provided as an open source plugin known as the Image Tools plugin.
 

--- a/modules/ROOT/pages/tableofcontents.adoc
+++ b/modules/ROOT/pages/tableofcontents.adoc
@@ -3,13 +3,12 @@
 :description: Insert a simple Table of Contents into the {productname} editor
 :keywords: tableofcontents, tableofcontents_depth, tableofcontents_class, tableofcontents_header, toc
 :pluginname: Table of Contents
-:pluginnamelower: table of contents
 :plugincode: tableofcontents
 :pluginminimumplan: tiertwo
 
 include::partial$misc/admon-premium-plugin.adoc[]
 
-The {pluginname} plugin generates a basic {pluginnamelower} (ToC) and inserts it into the editor at the current cursor position. ToC entries are generated from header elements (`h1 – h7` elements) in the content.
+The {pluginname} plugin generates a basic _table of contents_ (ToC) and inserts it into the editor at the current cursor position. ToC entries are generated from header elements (`h1 – h7` elements) in the content.
 
 NOTE: in previous versions of {productname} the {pluginname} plugin was provided as an open source plugin also called {pluginname}.
 

--- a/modules/ROOT/pages/tableofcontents.adoc
+++ b/modules/ROOT/pages/tableofcontents.adoc
@@ -10,7 +10,7 @@ include::partial$misc/admon-premium-plugin.adoc[]
 
 The {pluginname} plugin generates a basic _table of contents_ (ToC) and inserts it into the editor at the current cursor position. ToC entries are generated from header elements (`h1 – h7` elements) in the content.
 
-NOTE: in previous versions of {productname} the {pluginname} plugin was provided as an open source plugin also called {pluginname}.
+NOTE: In previous versions of {productname} the {pluginname} plugin was provided as an open source plugin also called {pluginname}.
 
 == Interactive Example
 

--- a/modules/ROOT/pages/tableofcontents.adoc
+++ b/modules/ROOT/pages/tableofcontents.adoc
@@ -4,7 +4,7 @@
 :keywords: tableofcontents, tableofcontents_depth, tableofcontents_class, tableofcontents_header, toc
 :pluginname: Table of Contents
 :plugincode: tableofcontents
-:pluginminimumplan: tierone
+:pluginminimumplan: tiertwo
 
 The `+tableofcontents+` plugin will generate basic _Table of Contents_ and insert it into the editor at the current cursor position. Items for the table will be taken from the headers found in the content.
 

--- a/modules/ROOT/pages/tableofcontents.adoc
+++ b/modules/ROOT/pages/tableofcontents.adoc
@@ -3,10 +3,15 @@
 :description: Insert a simple Table of Contents into the {productname} editor
 :keywords: tableofcontents, tableofcontents_depth, tableofcontents_class, tableofcontents_header, toc
 :pluginname: Table of Contents
+:pluginnamelower: table of contents
 :plugincode: tableofcontents
 :pluginminimumplan: tiertwo
 
-The `+tableofcontents+` plugin will generate basic _Table of Contents_ and insert it into the editor at the current cursor position. Items for the table will be taken from the headers found in the content.
+include::partial$misc/admon-premium-plugin.adoc[]
+
+The {pluginname} plugin will generate basic {pluginnamelower} and insert it into the editor at the current cursor position. Items for the table will be taken from the headers found in the content.
+
+NOTE: In previous versions of {productname}, the {pluginname} plugin was provided as an open source plugin.
 
 == Interactive Example
 

--- a/modules/ROOT/pages/tableofcontents.adoc
+++ b/modules/ROOT/pages/tableofcontents.adoc
@@ -8,7 +8,7 @@
 
 include::partial$misc/admon-premium-plugin.adoc[]
 
-The {pluginname} plugin generates a basic _table of contents_ (ToC) and inserts it into the editor at the current cursor position. ToC entries are generated from header elements (`h1 – h7` elements) in the content.
+The {pluginname} plugin generates a basic _table of contents_ (ToC) and inserts it into the editor at the current cursor position. ToC entries are generated from header elements (`h1 – h6` elements) in the content.
 
 NOTE: In previous versions of {productname} the {pluginname} plugin was provided as an open source plugin also called {pluginname}.
 

--- a/modules/ROOT/pages/tableofcontents.adoc
+++ b/modules/ROOT/pages/tableofcontents.adoc
@@ -9,9 +9,9 @@
 
 include::partial$misc/admon-premium-plugin.adoc[]
 
-The {pluginname} plugin will generate basic {pluginnamelower} and insert it into the editor at the current cursor position. Items for the table will be taken from the headers found in the content.
+The {pluginname} plugin generates a basic {pluginnamelower} (ToC) and inserts it into the editor at the current cursor position. ToC entries are generated from header elements (`h1 – h7` elements) in the content.
 
-NOTE: In previous versions of {productname}, the {pluginname} plugin was provided as an open source plugin.
+NOTE: in previous versions of {productname} the {pluginname} plugin was provided as an open source plugin also called {pluginname}.
 
 == Interactive Example
 


### PR DESCRIPTION
Related Ticket: DOC-1724

Description of Changes:
* Update minimum plan tier for Table of Contents and Enhanced Image Editing premium plugins

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- ~[x] `modules/ROOT/nav.adoc` has been updated (if applicable)~
- ~[x] Files has been included where required (if applicable)~
- ~[x] Files removed have been deleted, not just excluded from the build (if applicable)~
- ~[x] (New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
