### PR TITLE
DOC-1760: Document `transparent` prop for iframe UI component

### DIFF
--- a/modules/ROOT/pages/dialog-components.adoc
+++ b/modules/ROOT/pages/dialog-components.adoc
@@ -330,6 +330,7 @@ NOTE: To replace the entire dialog body with an iframe that loads its content fr
 |name |string |required |A identifier for the button.
 |label |string |optional |String to use for the iframe's `+title+` attribute.
 |sandboxed |boolean |optional |default: `+true+` - When true, sets the iframe's `+sandbox+` attribute to `+"allow-scripts allow-same-origin"+`.
+|transparent |boolean |optional |default: `+true+` - When true, sets the iframe's background to transparent instead of opaque.
 |===
 
 [source,js]
@@ -338,7 +339,8 @@ NOTE: To replace the entire dialog body with an iframe that loads its content fr
   type: 'iframe', // component type
   name: 'iframe', // identifier
   label: 'Description of iframe', // text for the iframe's title attribute
-  sandboxed: true
+  sandboxed: true,
+  transparent: true
 }
 ----
 

--- a/modules/ROOT/pages/dialog-components.adoc
+++ b/modules/ROOT/pages/dialog-components.adoc
@@ -330,7 +330,7 @@ NOTE: To replace the entire dialog body with an iframe that loads its content fr
 |name |string |required |A identifier for the button.
 |label |string |optional |String to use for the iframe's `+title+` attribute.
 |sandboxed |boolean |optional |default: `+true+` - When true, sets the iframe's `+sandbox+` attribute to `+"allow-scripts allow-same-origin"+`.
-|transparent |boolean |optional |default: `+true+` - When true, sets the iframe's background to transparent instead of opaque.
+|transparent |boolean |optional |default: `+true+` - When true, sets the iframe's background to transparent instead of opaque. NOTE: This feature is only available for {productname} 6.1 and later.
 |===
 
 [source,js]

--- a/modules/ROOT/pages/dialog-components.adoc
+++ b/modules/ROOT/pages/dialog-components.adoc
@@ -330,7 +330,8 @@ NOTE: To replace the entire dialog body with an iframe that loads its content fr
 |name |string |required |A identifier for the button.
 |label |string |optional |String to use for the iframe's `+title+` attribute.
 |sandboxed |boolean |optional |default: `+true+` - When true, sets the iframe's `+sandbox+` attribute to `+"allow-scripts allow-same-origin"+`.
-|transparent |boolean |optional |default: `+true+` - When true, sets the iframe's background to transparent instead of opaque. NOTE: This feature is only available for {productname} 6.1 and later.
+|transparent |boolean |optional |default: `+true+` - When true, sets the iframe's background to transparent instead of opaque.
+include::partial$misc/admon-requires-6.1v.adoc[]
 |===
 
 [source,js]


### PR DESCRIPTION
Related Ticket: DOC-1760

Description of Changes:
* Document new `transparent` property for iframe UI component

Pre-checks:
- [X] Branch prefixed with `feature/6/` or `hotfix/6/`
- [X] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [X] Files has been included where required (if applicable)
- [X] Files removed have been deleted, not just excluded from the build (if applicable)
- [X] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
