### PR TITLE
DOC-1759: Updated end_container_on_empty_block

### DIFF
--- a/modules/ROOT/partials/configuration/end_container_on_empty_block.adoc
+++ b/modules/ROOT/partials/configuration/end_container_on_empty_block.adoc
@@ -1,13 +1,13 @@
 [[end_container_on_empty_block]]
 == `+end_container_on_empty_block+`
 
-This option allows you to to split the current container block element if the enter key is pressed inside an empty inner block element.
+This option allows you to split the current container block element if the enter key is pressed inside an empty inner block element, and specify the type of element created.
 
-*Type:* `+Boolean+`
+*Type:* `+Boolean+` or `+String+`
 
-*Default value:* `+false+`
+*Default value:* `+'blockquote'+`
 
-*Possible values:* `+true+`, `+false+`
+*Possible values:* `+true+`, `+false+`, `+String+`
 
 === Example: Using `+end_container_on_empty_block+`
 
@@ -15,6 +15,6 @@ This option allows you to to split the current container block element if the en
 ----
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  end_container_on_empty_block: true
+  end_container_on_empty_block: 'blockquote'
 });
 ----

--- a/modules/ROOT/partials/configuration/end_container_on_empty_block.adoc
+++ b/modules/ROOT/partials/configuration/end_container_on_empty_block.adoc
@@ -11,7 +11,7 @@ This option specifies how the current container block element is split when the 
 
 *Default value:* `+'blockquote'+`
 
-*Possible values:* `+true+`, `+false+` or comma separated `+String+` of element tag names
+*Possible values:* `+true+`, `+false+` or a comma separated `+String+` of element tag names
 
 NOTE: Prior to {productname} 6.1, this option only accepted `+Boolean+` values.
 
@@ -21,6 +21,6 @@ NOTE: Prior to {productname} 6.1, this option only accepted `+Boolean+` values.
 ----
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  end_container_on_empty_block: 'blockquote'
+  end_container_on_empty_block: true
 });
 ----

--- a/modules/ROOT/partials/configuration/end_container_on_empty_block.adoc
+++ b/modules/ROOT/partials/configuration/end_container_on_empty_block.adoc
@@ -1,7 +1,7 @@
 [[end_container_on_empty_block]]
 == `+end_container_on_empty_block+`
 
-This option allows you to split the current container block element if the enter key is pressed inside an empty inner block element, and specify the type of element created.
+This option allows you to split the current container block element and specify the type of element created if the enter key is pressed inside an empty inner block element.
 
 *Type:* `+Boolean+` or `+String+`
 

--- a/modules/ROOT/partials/configuration/end_container_on_empty_block.adoc
+++ b/modules/ROOT/partials/configuration/end_container_on_empty_block.adoc
@@ -1,13 +1,15 @@
 [[end_container_on_empty_block]]
 == `+end_container_on_empty_block+`
 
-This option allows you to split the current container block element and specify the type of element created if the enter key is pressed inside an empty inner block element.
+This option allows you to split the current container block element when the enter key is pressed, and specify which blocks should be split.
 
 *Type:* `+Boolean+` or `+String+`
 
 *Default value:* `+'blockquote'+`
 
-*Possible values:* `+true+`, `+false+`, `+String+`
+*Possible values:* `+true+`, `+false+` or comma separated `+String+` of element tag names
+
+NOTE: Prior to {productname} 6.1, this option only accepted `+Boolean+` values.
 
 === Example: Using `+end_container_on_empty_block+`
 

--- a/modules/ROOT/partials/configuration/end_container_on_empty_block.adoc
+++ b/modules/ROOT/partials/configuration/end_container_on_empty_block.adoc
@@ -1,7 +1,11 @@
 [[end_container_on_empty_block]]
 == `+end_container_on_empty_block+`
 
-This option allows you to split the current container block element when the enter key is pressed, and specify which blocks should be split.
+This option specifies how the current container block element is split when the Enter key is pressed inside an empty inner block element. The available options are:
+
+* always split the block;
+* split for specific block elements; or
+* do not split the block at all.
 
 *Type:* `+Boolean+` or `+String+`
 


### PR DESCRIPTION
Related Ticket: DOC-1759

Description of Changes:
* Updated type and default value of `end_container_on_empty_block` option

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
