### PR TITLE
DOC-1663: Add `sidebar_show` doc

### DIFF
--- a/modules/ROOT/pages/comments-using-comments.adoc
+++ b/modules/ROOT/pages/comments-using-comments.adoc
@@ -13,6 +13,7 @@ I'm trying to:
 * xref:delete-a-comment-thread-conversation[Delete a comment thread (conversation)].
 * xref:resolve-a-comment-thread-conversation[Resolve a comment thread (conversation)].
 * xref:show-or-view-a-comment[Show or view a comment].
+* xref:show-comments-on-init[Show comments on initialisation].
 * xref:delete-all-comment-threads[Delete all comment threads].
 
 [[add-a-comment]]
@@ -104,3 +105,17 @@ image:comments-delete-conversations.png[Delete all conversations]
 . Click *Ok* to remove the all the comments or *Cancel* to dismiss the action.
 
 *Result*: All the comments for the selected document will be deleted.
+
+[[show-comments-on-init]]
+== Show comments on initialisation
+Set `sidebar_show` option to `'showcomments'` in the TinyMCE configuration as below:
+
+```javascript
+  tinymce.init({
+    selector: 'textarea',   // change this value according to your html
+    plugins: 'tinycomments',
+    toolbar: 'addcomment showcomments',
+    sidebar_show: 'showcomments',
+    // other configurations for TinyMCE Comments plugin
+  });
+```

--- a/modules/ROOT/pages/comments-using-comments.adoc
+++ b/modules/ROOT/pages/comments-using-comments.adoc
@@ -13,7 +13,6 @@ I'm trying to:
 * xref:delete-a-comment-thread-conversation[Delete a comment thread (conversation)].
 * xref:resolve-a-comment-thread-conversation[Resolve a comment thread (conversation)].
 * xref:show-or-view-a-comment[Show or view a comment].
-* xref:show-comments-on-init[Show comments on initialisation].
 * xref:delete-all-comment-threads[Delete all comment threads].
 
 [[add-a-comment]]
@@ -105,17 +104,3 @@ image:comments-delete-conversations.png[Delete all conversations]
 . Click *Ok* to remove the all the comments or *Cancel* to dismiss the action.
 
 *Result*: All the comments for the selected document will be deleted.
-
-[[show-comments-on-init]]
-== Show comments on initialisation
-Set `sidebar_show` option to `'showcomments'` in the TinyMCE configuration as below:
-
-```javascript
-  tinymce.init({
-    selector: 'textarea',   // change this value according to your html
-    plugins: 'tinycomments',
-    toolbar: 'addcomment showcomments',
-    sidebar_show: 'showcomments',
-    // other configurations for TinyMCE Comments plugin
-  });
-```

--- a/modules/ROOT/pages/customsidebar.adoc
+++ b/modules/ROOT/pages/customsidebar.adoc
@@ -60,6 +60,10 @@ The `+onHide+` specifies a function to be called when the panel is hidden. It pa
 
 The `+element():HTMLElement+` function returns the root element of the sidebar panel.
 
+=== Options
+
+include::partial$configuration/sidebar_show.adoc[leveloffset=+2]
+
 [[example-inside-the-tinymceinit]]
 == Example inside the tinymce.init
 

--- a/modules/ROOT/pages/customsidebar.adoc
+++ b/modules/ROOT/pages/customsidebar.adoc
@@ -60,9 +60,9 @@ The `+onHide+` specifies a function to be called when the panel is hidden. It pa
 
 The `+element():HTMLElement+` function returns the root element of the sidebar panel.
 
-=== Options
+== Options
 
-include::partial$configuration/sidebar_show.adoc[leveloffset=+2]
+include::partial$configuration/sidebar_show.adoc[leveloffset=+1]
 
 [[example-inside-the-tinymceinit]]
 == Example inside the tinymce.init

--- a/modules/ROOT/partials/configuration/sidebar_show.adoc
+++ b/modules/ROOT/partials/configuration/sidebar_show.adoc
@@ -1,5 +1,8 @@
 [[sidebar_show]]
 == `+sidebar_show+`
+
+NOTE: This option is only available for TinyMCE 6.1 and later.
+
 This option allows you to show the specified sidebar on initialization.
 
 *Type:* `+String+`

--- a/modules/ROOT/partials/configuration/sidebar_show.adoc
+++ b/modules/ROOT/partials/configuration/sidebar_show.adoc
@@ -1,0 +1,24 @@
+[[sidebar_show]]
+== `+sidebar_show+`
+This option allows you to show the specified sidebar on initialization.
+
+*Type:* `+String+`
+
+=== Example: Using `+sidebar_show+`
+
+[source,js]
+
+```javascript
+  tinymce.init({
+    setup: (editor) => {
+      editor.ui.registry.addSidebar('mysidebar', {
+        tooltip: 'My sidebar',
+        icon: 'comment',
+        onShow: (api) => {
+          api.element().innerHTML = 'Hello world!';
+        },
+      });
+    },
+    sidebar_show: 'mysidebar'
+  });
+```

--- a/modules/ROOT/partials/configuration/sidebar_show.adoc
+++ b/modules/ROOT/partials/configuration/sidebar_show.adoc
@@ -3,7 +3,7 @@
 
 include::partial$misc/admon-requires-6.1v.adoc[]
 
-This option allows you to show the specified sidebar on initialization.
+This option allows the specified sidebar to be shown on editor initialization.
 
 *Type:* `+String+`
 

--- a/modules/ROOT/partials/configuration/sidebar_show.adoc
+++ b/modules/ROOT/partials/configuration/sidebar_show.adoc
@@ -10,8 +10,7 @@ This option allows you to show the specified sidebar on initialization.
 === Example: Using `+sidebar_show+`
 
 [source,js]
-
-```javascript
+----
   tinymce.init({
     setup: (editor) => {
       editor.ui.registry.addSidebar('mysidebar', {
@@ -24,4 +23,4 @@ This option allows you to show the specified sidebar on initialization.
     },
     sidebar_show: 'mysidebar'
   });
-```
+----

--- a/modules/ROOT/partials/configuration/sidebar_show.adoc
+++ b/modules/ROOT/partials/configuration/sidebar_show.adoc
@@ -12,6 +12,8 @@ This option allows you to show the specified sidebar on initialization.
 [source,js]
 ----
   tinymce.init({
+    selector: 'textarea', // change this value according to your HTML
+    sidebar_show: 'mysidebar',
     setup: (editor) => {
       editor.ui.registry.addSidebar('mysidebar', {
         tooltip: 'My sidebar',
@@ -20,7 +22,6 @@ This option allows you to show the specified sidebar on initialization.
           api.element().innerHTML = 'Hello world!';
         },
       });
-    },
-    sidebar_show: 'mysidebar'
+    }
   });
 ----

--- a/modules/ROOT/partials/configuration/sidebar_show.adoc
+++ b/modules/ROOT/partials/configuration/sidebar_show.adoc
@@ -1,7 +1,7 @@
 [[sidebar_show]]
 == `+sidebar_show+`
 
-NOTE: This option is only available for TinyMCE 6.1 and later.
+include::partial$misc/admon-requires-6.1v.adoc[]
 
 This option allows you to show the specified sidebar on initialization.
 
@@ -11,17 +11,17 @@ This option allows you to show the specified sidebar on initialization.
 
 [source,js]
 ----
-  tinymce.init({
-    selector: 'textarea', // change this value according to your HTML
-    sidebar_show: 'mysidebar',
-    setup: (editor) => {
-      editor.ui.registry.addSidebar('mysidebar', {
-        tooltip: 'My sidebar',
-        icon: 'comment',
-        onShow: (api) => {
-          api.element().innerHTML = 'Hello world!';
-        },
-      });
-    }
-  });
+tinymce.init({
+  selector: 'textarea', // change this value according to your HTML
+  sidebar_show: 'mysidebar',
+  setup: (editor) => {
+    editor.ui.registry.addSidebar('mysidebar', {
+      tooltip: 'My sidebar',
+      icon: 'comment',
+      onShow: (api) => {
+        api.element().innerHTML = 'Hello world!';
+      },
+    });
+  }
+});
 ----

--- a/modules/ROOT/partials/plugins/comments-open-sidebar.adoc
+++ b/modules/ROOT/partials/plugins/comments-open-sidebar.adoc
@@ -1,6 +1,6 @@
 == Show the comments sidebar when TinyMCE loads
 
-To show the comments sidebar when the editor is loaded or to display the sidebar by default.
+The xref:customsidebar.adoc#sidebar_show[`sidebar_show`] option can be used to show the comments sidebar when the editor is loaded.
 
 For example:
 

--- a/modules/ROOT/partials/plugins/comments-open-sidebar.adoc
+++ b/modules/ROOT/partials/plugins/comments-open-sidebar.adoc
@@ -38,12 +38,7 @@ tinymce.init({
   tinycomments_mode: 'embedded',
   tinycomments_author: currentAuthor,
   tinycomments_can_resolve: canResolveCommentsCallback,
-  /* The following setup callback opens the comments sidebar when the editor loads */
-  setup: (editor) => {
-    editor.on('SkinLoaded', () => {
-      editor.execCommand("ToggleSidebar", false, "showcomments");
-    })
-  }
+  sidebar_show: 'showcomments',
 });
 ----
 endif::[]

--- a/modules/ROOT/partials/plugins/comments-open-sidebar.adoc
+++ b/modules/ROOT/partials/plugins/comments-open-sidebar.adoc
@@ -1,6 +1,6 @@
 == Show the comments sidebar when TinyMCE loads
 
-To show the comments sidebar when the editor is loaded or to display the sidebar by default, add a callback to open the sidebar once the editor 'skin' is loaded.
+To show the comments sidebar when the editor is loaded or to display the sidebar by default.
 
 For example:
 
@@ -18,13 +18,7 @@ tinymce.init({
   tinycomments_delete_all,
   tinycomments_delete_comment,
   tinycomments_lookup,
-
-  /* The following setup callback opens the comments sidebar when the editor loads */
-  setup: (editor) => {
-    editor.on('SkinLoaded', () => {
-      editor.execCommand("ToggleSidebar", false, "showcomments");
-    })
-  }
+  sidebar_show: 'showcomments'
 });
 ----
 endif::[]
@@ -38,7 +32,7 @@ tinymce.init({
   tinycomments_mode: 'embedded',
   tinycomments_author: currentAuthor,
   tinycomments_can_resolve: canResolveCommentsCallback,
-  sidebar_show: 'showcomments',
+  sidebar_show: 'showcomments'
 });
 ----
 endif::[]


### PR DESCRIPTION
Related Ticket: DOC-1663

Description of Changes:
- Added option section to the custom sidebar page
- Updated the example of comments embedded mode to use `sidebar_show` option to show comments sidebar on load

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
