### PR TITLE
DOC-1658: Added documentation for the comments avatar changes

### DIFF
--- a/modules/ROOT/pages/comments-embedded-mode.adoc
+++ b/modules/ROOT/pages/comments-embedded-mode.adoc
@@ -30,6 +30,8 @@ liveDemo::comments-embedded[]
 
 include::partial$configuration/tinycomments_author.adoc[leveloffset=+1]
 
+include::partial$configuration/tinycomments_author_avatar.adoc[leveloffset=+1]
+
 include::partial$configuration/tinycomments_author_name.adoc[leveloffset=+1]
 
 include::partial$configuration/tinycomments_can_delete.adoc[leveloffset=+1]

--- a/modules/ROOT/partials/configuration/tinycomments_author_avatar.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_author_avatar.adoc
@@ -1,0 +1,27 @@
+[[tinycomments_author_avatar]]
+== `+tinycomments_author_avatar+`
+
+include::partial$misc/admon-requires-6.1v.adoc[]
+
+_Optional_ - This option sets the URL for the author's avatar to be used when creating or replying to comments. If this option is omitted, a generated avatar will be used instead. The avatar, if provided:
+
+* will be scaled to a 36px diameter circle; and
+* can be any filetype able to be wrapped in an `<img>` element.
+
+IMPORTANT: The avatar will be stored alongside the embedded comment data when a new comment is created and cannot be changed later by changing this options value. To change the avatar image, the image on the server that the URL points to should be updated instead.
+
+*Type:* `+String+`
+
+=== Example: Using `+tinycomments_author_avatar+`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your html
+  plugins: 'tinycomments',
+  tinycomments_mode: 'embedded',
+  tinycomments_author: 'embedded_journalist',
+  tinycomments_author_name: 'Embedded Journalist',
+  tinycomments_author_avatar: 'https://example.com/image.ext'
+});
+----

--- a/modules/ROOT/partials/configuration/tinycomments_author_name.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_author_name.adoc
@@ -1,8 +1,6 @@
 [[tinycomments_author_name]]
 == `+tinycomments_author_name+`
 
-NOTE: Available in Tiny Comments version 2.1 onwards.
-
 _Optional_ - This option sets the author's display name to be used when creating or replying to comments. If this option is omitted, then the author id is used instead.
 
 *Type:* `+String+`

--- a/modules/ROOT/partials/configuration/tinycomments_lookup.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_lookup.adoc
@@ -24,6 +24,7 @@ The `+done+` callback should accept the following object:
     {
       author: string, // author of first comment
       authorName: string, // optional - Display name to use instead of author. Defaults to using `author` if not specified
+      authorAvatar: string, // optional - URL to the author's avatar. If not provided an automated avatar will be generated
       createdAt: date, // when the first comment was created
       content: string, // content of first comment
       modifiedAt: date, // when the first comment was created/last updated
@@ -32,6 +33,7 @@ The `+done+` callback should accept the following object:
     {
       author: string, // author of second comment
       authorName: string, // optional - Display name to use instead of author. Defaults to using `author` if not specified
+      authorAvatar: string, // optional - URL to the author's avatar. If not provided an automated avatar will be generated
       createdAt: date, // when the second comment was created
       content: string, // content of second comment
       modifiedAt: date, // when the second comment was created/last updated
@@ -42,7 +44,15 @@ The `+done+` callback should accept the following object:
 }
 ----
 
-NOTE: The dates should use https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString[ISO 8601 format]. This can be generated in JavaScript with: `+new Date().toISOString()+`.
+[NOTE]
+====
+The dates should use https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString[ISO 8601 format]. This can be generated in JavaScript with: `+new Date().toISOString()+`.
+
+The author avatar feature is only available in {productname} 6.1 or higher and if provided:
+
+* will be scaled to a 36px diameter circle; and
+* can be any filetype able to be wrapped in an `<img>` element.
+====
 
 For example:
 
@@ -66,12 +76,16 @@ const lookup_comment = ({ conversationUid }, done, fail) => {
     return {
       conversation: {
         uid: conversationUid,
-        comments: comments.map((comment) => ({
-          ...comment,
-          content: comment.content,
-          authorName: getUser(comment.author)?.displayName,
-        })),
-      },
+        comments: comments.map((comment) => {
+          const user = getUser(comment.author);
+          return {
+            ...comment,
+            content: comment.content,
+            authorName: user?.displayName,
+            authorAvatar: user?.avatarUrl
+          };
+        })
+      }
     };
   };
 

--- a/modules/ROOT/partials/misc/admon-requires-6.1v.adoc
+++ b/modules/ROOT/partials/misc/admon-requires-6.1v.adoc
@@ -1,0 +1,1 @@
+NOTE: This feature is only available for {productname} 6.1 and later.


### PR DESCRIPTION
Related Ticket: DOC-1658

Description of Changes:
* Added the `tinycomments_author_avatar` option to the comments embedded page and added a note about the URL not being able to be changed once a comment is added.
* Added the `authorAvatar` property details to the `tinycomments_lookup` callback mode option. I didn't add the warning here as the avatar can safely be changed at anytime for callback mode.
* Removed a note about Comments 2.1 in `tinycomments_author_name` as that was only useful for the 5.x docs.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
