### PR TITLE
DOC_1773: full-featured.adoc

### DIFF
--- a/modules/ROOT/pages/demo/full-featured.adoc
+++ b/modules/ROOT/pages/demo/full-featured.adoc
@@ -21,7 +21,7 @@ The following plugins are excluded from this example:
 * xref:plugins/opensource/autoresize.adoc[Autoresize] -- Resizes the editor to fit the content.
 * xref:plugins/opensource/bbcode.adoc[BBCode] -- Changes the markup used for the content. xref:release-notes/6.0-upcoming-changes.adoc#plugins[Deprecated] as of {productname} 5.9.
 * xref:plugins/opensource/code.adoc[Code] -- xref:plugins/premium/advcode.adoc[*Advanced Code Editor*] included instead.
-* xref:plugins/opensource/fullpage.adoc[Full Page] -- Used for modifying HTML `<head>` elements. xref:release-notes/6.0-upcoming-changes/#plugins[Deprecated] as of {productname} 5.9.
+* xref:plugins/opensource/fullpage.adoc[Full Page] -- Used for modifying HTML `<head>` elements. xref:release-notes/6.0-upcoming-changes.adoc/#plugins[Deprecated] as of {productname} 5.9.
 * xref:plugins/opensource/paste.adoc[Paste] -- xref:plugins/premium/powerpaste.adoc[*PowerPaste*] included instead.
 * xref:plugins/opensource/spellchecker.adoc[Spellchecker] -- xref:plugins/premium/tinymcespellchecker.adoc[*Spell Checker Pro*] included instead.
 * xref:plugins/opensource/tabfocus.adoc[Tab Focus] -- Changes the behavior of the TAB-key within the editor.
@@ -37,7 +37,7 @@ The following plugins are excluded from this example:
 
 * link:{plugindirectory}[All premium plugins].
 * xref:plugins/opensource/autoresize.adoc[Autoresize] -- Resizes the editor to fit the content.
-* xref:plugins/opensource/bbcode.adoc[BBCode] -- Changes the markup used for the content. xref:release-notes/6.0-upcoming-changes/#plugins[Deprecated] as of {productname} 5.9.
-* xref:plugins/opensource/fullpage.adoc[Full Page] -- Used for modifying HTML `<head>` elements. xref:release-notes/6.0-upcoming-changes/#plugins[Deprecated] as of {productname} 5.9.
-* xref:plugins/opensource/spellchecker.adoc[Spellchecker] -- Requires Server-Side components, see: xref:general-configuration-guide/spell-checking.adoc[Check spelling in {productname}]. xref:release-notes/release-notes54/#thefreetinymcespellcheckerplugin[Deprecated] as of {productname} 5.4.
+* xref:plugins/opensource/bbcode.adoc[BBCode] -- Changes the markup used for the content. xref:release-notes/6.0-upcoming-changes.adoc/#plugins[Deprecated] as of {productname} 5.9.
+* xref:plugins/opensource/fullpage.adoc[Full Page] -- Used for modifying HTML `<head>` elements. xref:release-notes/6.0-upcoming-changes.adoc/#plugins[Deprecated] as of {productname} 5.9.
+* xref:plugins/opensource/spellchecker.adoc[Spellchecker] -- Requires Server-Side components, see: xref:general-configuration-guide/spell-checking.adoc[Check spelling in {productname}]. xref:release-notes/release-notes54.adoc/#thefreetinymcespellcheckerplugin[Deprecated] as of {productname} 5.4.
 * xref:plugins/opensource/tabfocus.adoc[Tab Focus] -- Changes the behavior of the TAB-key within the editor.

--- a/modules/ROOT/pages/demo/full-featured.adoc
+++ b/modules/ROOT/pages/demo/full-featured.adoc
@@ -37,7 +37,7 @@ The following plugins are excluded from this example:
 
 * link:{plugindirectory}[All premium plugins].
 * xref:plugins/opensource/autoresize.adoc[Autoresize] -- Resizes the editor to fit the content.
-* xref:plugins/opensource/bbcode.adoc[BBCode] -- Changes the markup used for the content. xref:release-notes/6.0-upcoming-changes.adoc/#plugins[Deprecated] as of {productname} 5.9.
+* xref:plugins/opensource/bbcode.adoc[BBCode] -- Changes the markup used for the content. xref:release-notes/6.0-upcoming-changes.adoc#plugins[Deprecated] as of {productname} 5.9.
 * xref:plugins/opensource/fullpage.adoc[Full Page] -- Used for modifying HTML `<head>` elements. xref:release-notes/6.0-upcoming-changes.adoc#plugins[Deprecated] as of {productname} 5.9.
 * xref:plugins/opensource/spellchecker.adoc[Spellchecker] -- Requires Server-Side components, see: xref:general-configuration-guide/spell-checking.adoc[Check spelling in {productname}]. xref:release-notes/release-notes54.adoc#thefreetinymcespellcheckerplugin[Deprecated] as of {productname} 5.4.
 * xref:plugins/opensource/tabfocus.adoc[Tab Focus] -- Changes the behavior of the TAB-key within the editor.

--- a/modules/ROOT/pages/demo/full-featured.adoc
+++ b/modules/ROOT/pages/demo/full-featured.adoc
@@ -39,5 +39,5 @@ The following plugins are excluded from this example:
 * xref:plugins/opensource/autoresize.adoc[Autoresize] -- Resizes the editor to fit the content.
 * xref:plugins/opensource/bbcode.adoc[BBCode] -- Changes the markup used for the content. xref:release-notes/6.0-upcoming-changes.adoc/#plugins[Deprecated] as of {productname} 5.9.
 * xref:plugins/opensource/fullpage.adoc[Full Page] -- Used for modifying HTML `<head>` elements. xref:release-notes/6.0-upcoming-changes.adoc/#plugins[Deprecated] as of {productname} 5.9.
-* xref:plugins/opensource/spellchecker.adoc[Spellchecker] -- Requires Server-Side components, see: xref:general-configuration-guide/spell-checking.adoc[Check spelling in {productname}]. xref:release-notes/release-notes54.adoc/#thefreetinymcespellcheckerplugin[Deprecated] as of {productname} 5.4.
+* xref:plugins/opensource/spellchecker.adoc[Spellchecker] -- Requires Server-Side components, see: xref:general-configuration-guide/spell-checking.adoc[Check spelling in {productname}]. xref:release-notes/release-notes54.adoc#thefreetinymcespellcheckerplugin[Deprecated] as of {productname} 5.4.
 * xref:plugins/opensource/tabfocus.adoc[Tab Focus] -- Changes the behavior of the TAB-key within the editor.

--- a/modules/ROOT/pages/demo/full-featured.adoc
+++ b/modules/ROOT/pages/demo/full-featured.adoc
@@ -38,6 +38,6 @@ The following plugins are excluded from this example:
 * link:{plugindirectory}[All premium plugins].
 * xref:plugins/opensource/autoresize.adoc[Autoresize] -- Resizes the editor to fit the content.
 * xref:plugins/opensource/bbcode.adoc[BBCode] -- Changes the markup used for the content. xref:release-notes/6.0-upcoming-changes.adoc/#plugins[Deprecated] as of {productname} 5.9.
-* xref:plugins/opensource/fullpage.adoc[Full Page] -- Used for modifying HTML `<head>` elements. xref:release-notes/6.0-upcoming-changes.adoc/#plugins[Deprecated] as of {productname} 5.9.
+* xref:plugins/opensource/fullpage.adoc[Full Page] -- Used for modifying HTML `<head>` elements. xref:release-notes/6.0-upcoming-changes.adoc#plugins[Deprecated] as of {productname} 5.9.
 * xref:plugins/opensource/spellchecker.adoc[Spellchecker] -- Requires Server-Side components, see: xref:general-configuration-guide/spell-checking.adoc[Check spelling in {productname}]. xref:release-notes/release-notes54.adoc#thefreetinymcespellcheckerplugin[Deprecated] as of {productname} 5.4.
 * xref:plugins/opensource/tabfocus.adoc[Tab Focus] -- Changes the behavior of the TAB-key within the editor.

--- a/modules/ROOT/pages/demo/full-featured.adoc
+++ b/modules/ROOT/pages/demo/full-featured.adoc
@@ -21,7 +21,7 @@ The following plugins are excluded from this example:
 * xref:plugins/opensource/autoresize.adoc[Autoresize] -- Resizes the editor to fit the content.
 * xref:plugins/opensource/bbcode.adoc[BBCode] -- Changes the markup used for the content. xref:release-notes/6.0-upcoming-changes.adoc#plugins[Deprecated] as of {productname} 5.9.
 * xref:plugins/opensource/code.adoc[Code] -- xref:plugins/premium/advcode.adoc[*Advanced Code Editor*] included instead.
-* xref:plugins/opensource/fullpage.adoc[Full Page] -- Used for modifying HTML `<head>` elements. xref:release-notes/6.0-upcoming-changes.adoc/#plugins[Deprecated] as of {productname} 5.9.
+* xref:plugins/opensource/fullpage.adoc[Full Page] -- Used for modifying HTML `<head>` elements. xref:release-notes/6.0-upcoming-changes.adoc#plugins[Deprecated] as of {productname} 5.9.
 * xref:plugins/opensource/paste.adoc[Paste] -- xref:plugins/premium/powerpaste.adoc[*PowerPaste*] included instead.
 * xref:plugins/opensource/spellchecker.adoc[Spellchecker] -- xref:plugins/premium/tinymcespellchecker.adoc[*Spell Checker Pro*] included instead.
 * xref:plugins/opensource/tabfocus.adoc[Tab Focus] -- Changes the behavior of the TAB-key within the editor.

--- a/modules/ROOT/pages/demo/full-featured.adoc
+++ b/modules/ROOT/pages/demo/full-featured.adoc
@@ -7,7 +7,7 @@
 [[fullfeaturedincludingpremiumplugins]]
 == Full Featured: Including Premium Plugins
 
-IMPORTANT: This demonstration page is for {productname} 5.10. {productname} 5.10 is still a supported version but it is not the current release. The full-featured demonstration page for {productname} 6 is xref:tinymce/6/full-featured-premium-demo.adoc[available] in the {productname} 6 xref:tinymce/6/[documentation].
+IMPORTANT: This demonstration page is for {productname} {productmajorversion}. {productname} {productmajorversion} is still a supported version but it is not the current release. The full-featured demonstration page for {productname} 6 is link:{{site-url}}/tinymce/6/full-featured-premium-demo/[available] in the {productname} 6 link:{{site-url}}/tinymce/6/[documentation].
 
 This example includes most of the available {productname} plugins, including plugins available on {cloudname} premium subscriptions. Please note, it includes link:{plugindirectory}[premium plugins].
 

--- a/modules/ROOT/pages/demo/full-featured.adoc
+++ b/modules/ROOT/pages/demo/full-featured.adoc
@@ -7,6 +7,8 @@
 [[fullfeaturedincludingpremiumplugins]]
 == Full Featured: Including Premium Plugins
 
+IMPORTANT: This demonstration page is for {productname} 5.10. {productname} 5.10 is still a supported version but it is not the current release. The full-featured demonstration page for {productname} 6 is xref:tinymce/6/full-featured-premium-demo.adoc[available] in the {productname} 6 xref:tinymce/6/[documentation].
+
 This example includes most of the available {productname} plugins, including plugins available on {cloudname} premium subscriptions. Please note, it includes link:{plugindirectory}[premium plugins].
 
 Want to try it for yourself ? link:{accountsignup}[Get started with TinyMCE now on Cloud].
@@ -17,12 +19,13 @@ The following plugins are excluded from this example:
 
 * xref:plugins/premium/moxiemanager.adoc[MoxieManager (Premium Plugin)] -- xref:plugins/premium/tinydrive.adoc[*{cloudfilemanager}*] included instead.
 * xref:plugins/opensource/autoresize.adoc[Autoresize] -- Resizes the editor to fit the content.
-* xref:plugins/opensource/bbcode.adoc[BBCode] -- Changes the markup used for the content.
+* xref:plugins/opensource/bbcode.adoc[BBCode] -- Changes the markup used for the content. xref:release-notes/6.0-upcoming-changes/#plugins[Deprecated] as of {productname} 5.9.
 * xref:plugins/opensource/code.adoc[Code] -- xref:plugins/premium/advcode.adoc[*Advanced Code Editor*] included instead.
-* xref:plugins/opensource/fullpage.adoc[Full Page] -- Used for modifying HTML `<head>` elements.
+* xref:plugins/opensource/fullpage.adoc[Full Page] -- Used for modifying HTML `<head>` elements. xref:release-notes/6.0-upcoming-changes/#plugins[Deprecated] as of {productname} 5.9.
 * xref:plugins/opensource/paste.adoc[Paste] -- xref:plugins/premium/powerpaste.adoc[*PowerPaste*] included instead.
 * xref:plugins/opensource/spellchecker.adoc[Spellchecker] -- xref:plugins/premium/tinymcespellchecker.adoc[*Spell Checker Pro*] included instead.
 * xref:plugins/opensource/tabfocus.adoc[Tab Focus] -- Changes the behavior of the TAB-key within the editor.
+
 
 == Full Featured: Non-Premium Plugins
 
@@ -34,7 +37,7 @@ The following plugins are excluded from this example:
 
 * link:{plugindirectory}[All premium plugins].
 * xref:plugins/opensource/autoresize.adoc[Autoresize] -- Resizes the editor to fit the content.
-* xref:plugins/opensource/bbcode.adoc[BBCode] -- Changes the markup used for the content.
-* xref:plugins/opensource/fullpage.adoc[Full Page] -- Used for modifying HTML `<head>` elements.
-* xref:plugins/opensource/spellchecker.adoc[Spellchecker] -- Requires Server-Side components, see: xref:general-configuration-guide/spell-checking.adoc[Check spelling in {productname}].
+* xref:plugins/opensource/bbcode.adoc[BBCode] -- Changes the markup used for the content. xref:release-notes/6.0-upcoming-changes/#plugins[Deprecated] as of {productname} 5.9.
+* xref:plugins/opensource/fullpage.adoc[Full Page] -- Used for modifying HTML `<head>` elements. xref:release-notes/6.0-upcoming-changes/#plugins[Deprecated] as of {productname} 5.9.
+* xref:plugins/opensource/spellchecker.adoc[Spellchecker] -- Requires Server-Side components, see: xref:general-configuration-guide/spell-checking.adoc[Check spelling in {productname}]. xref:release-notes/release-notes54/#thefreetinymcespellcheckerplugin[Deprecated] as of {productname} 5.4.
 * xref:plugins/opensource/tabfocus.adoc[Tab Focus] -- Changes the behavior of the TAB-key within the editor.

--- a/modules/ROOT/pages/demo/full-featured.adoc
+++ b/modules/ROOT/pages/demo/full-featured.adoc
@@ -19,7 +19,7 @@ The following plugins are excluded from this example:
 
 * xref:plugins/premium/moxiemanager.adoc[MoxieManager (Premium Plugin)] -- xref:plugins/premium/tinydrive.adoc[*{cloudfilemanager}*] included instead.
 * xref:plugins/opensource/autoresize.adoc[Autoresize] -- Resizes the editor to fit the content.
-* xref:plugins/opensource/bbcode.adoc[BBCode] -- Changes the markup used for the content. xref:release-notes/6.0-upcoming-changes/#plugins[Deprecated] as of {productname} 5.9.
+* xref:plugins/opensource/bbcode.adoc[BBCode] -- Changes the markup used for the content. xref:release-notes/6.0-upcoming-changes.adoc#plugins[Deprecated] as of {productname} 5.9.
 * xref:plugins/opensource/code.adoc[Code] -- xref:plugins/premium/advcode.adoc[*Advanced Code Editor*] included instead.
 * xref:plugins/opensource/fullpage.adoc[Full Page] -- Used for modifying HTML `<head>` elements. xref:release-notes/6.0-upcoming-changes/#plugins[Deprecated] as of {productname} 5.9.
 * xref:plugins/opensource/paste.adoc[Paste] -- xref:plugins/premium/powerpaste.adoc[*PowerPaste*] included instead.


### PR DESCRIPTION
Added an IMPORTANT note pointing out this demonstration page is for the old (albeit still supported) version.

Said note also points to the equivalent demonstration page in the 6.x docs.

Also added specific ‘deprecated’ info regarding some of the listed (albeit unused) plugins.

Related Ticket: 

Description of Changes:
* Placeholder text

Pre-checks:
- [ ] Branch prefixed with `feature/6/` or `hotfix/6/`
- [ ] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [ ] Files has been included where required (if applicable)
- [ ] Files removed have been deleted, not just excluded from the build (if applicable)
- [ ] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
