### PR TITLE
DOC-1783: Fixed supported versions page missing 6.1

### DIFF
--- a/modules/ROOT/partials/misc/supported-versions.adoc
+++ b/modules/ROOT/partials/misc/supported-versions.adoc
@@ -6,7 +6,8 @@ Supported versions of {productname}:
 [cols="^,^,^",options="header"]
 |===
 |Version |Release Date |End of Support
-|6.0 |2022-04-07 |TBD
+|6.1 |2022-07-13 |TBD
+|6.0 |2022-04-07 |2023-10-07
 |===
 
 To view our Software License Agreements, visit:


### PR DESCRIPTION
Related Ticket: DOC-1783

Description of Changes:
* Added 6.1 to the supported versions list
* Added an End of Support date for 6.0

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
