### PR TITLE
DOC-1784: Correct grammar errors on Media plugin page

### DIFF
--- a/modules/ROOT/pages/media.adoc
+++ b/modules/ROOT/pages/media.adoc
@@ -20,7 +20,7 @@ tinymce.init({
 
 == Options
 
-These settings affect the execution of the `+media+` plugin. Namely the ability to disable parts of the media dialog box when inserting/editing media items. In addition, the user may disable the cross-site scripting sanitation filter for video/object elements here.
+These settings affect the execution of the `+media+` plugin, namely the ability to disable parts of the media dialog box when inserting/editing media items. In addition, the user may disable the cross-site scripting sanitation filter for video/object elements here.
 
 include::partial$configuration/audio_template_callback.adoc[leveloffset=+1]
 

--- a/modules/ROOT/partials/configuration/media_url_resolver.adoc
+++ b/modules/ROOT/partials/configuration/media_url_resolver.adoc
@@ -5,7 +5,7 @@ This option allows you to specify a function that will be used to replace {produ
 
 The media url resolver function takes three arguments: `+data+`, a `+resolve+` callback and a `+reject+` callback. The `+data+` argument will be an object with a `+url+` property on it. In your custom handler function you can then handle the `+url+` in whatever way you want and return the HTML you want to embed by calling the `+resolve+` callback and passing it an object with the HTML set on the `+html+` property, like this: `+resolve({ html: 'YOUR_HTML' })+`.
 
-If you in your handler would like fall back to the default media embed logic you can simple call the `+resolve+` callback with an object where the `+html+` property is set to an empty string, like this: `+resolve({ html: '' })+`.
+If you in your handler would like to fall back to the default media embed logic you can simply call the `+resolve+` callback with an object where the `+html+` property is set to an empty string, like this: `+resolve({ html: '' })+`.
 
 If something goes wrong in your function and you want to show an error to the user you can do so by calling the `+reject+` callback with an object where the message you want to show the user is set under the `+msg+` property, like this: `+reject({ msg: 'YOUR_ERROR_MESSAGE' })+`. The message entered will be shown in an error notification to the user.
 


### PR DESCRIPTION
Related Ticket: 
[DOC-1784](https://ephocks.atlassian.net/browse/DOC-1784)

Description of Changes:

Address grammatical errors found when reviewing the Media plugin page:

* “These settings affect the execution of the media plugin. Namely the ability to disable parts of the media dialog box when inserting/…” - plugin, namely

* “If you in your handler would like fall back to the default media embed logic you can simple call the resolve callback with an object where the html property is set to…” - simple → simply; fall back → to fall back

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [ ] Documentation Team Lead has reviewed
