### PR TITLE
Fix typos in `editor-premium-upgrade-promotion.adoc` and `premium-upgrade-promotion-option.adoc`.

### DIFF
--- a/modules/ROOT/pages/content-appearance.adoc
+++ b/modules/ROOT/pages/content-appearance.adoc
@@ -18,5 +18,5 @@ To enable visual aids for "hidden" characters, see: xref:visualchars.adoc[The Vi
 
 To enable outlines for block elements, see: xref:visualblocks.adoc[The Visual Blocks plugin].
 
-include::partial$configuration/premium-upgrade-promotion-option.adoc[]
+include::partial$misc/premium-upgrade-promotion-option.adoc[]
 

--- a/modules/ROOT/pages/customize-ui.adoc
+++ b/modules/ROOT/pages/customize-ui.adoc
@@ -158,6 +158,6 @@ tinymce.init({
 });
 ----
 
-include::partial$configuration/premium-upgrade-promotion-option.adoc[]
+include::partial$misc/premium-upgrade-promotion-option.adoc[]
 
 The ability to customize the user interface is an integral part of ensuring an integrated and complete user experience.

--- a/modules/ROOT/pages/editor-premium-upgrade-promotion.adoc
+++ b/modules/ROOT/pages/editor-premium-upgrade-promotion.adoc
@@ -14,7 +14,7 @@ This promotion button redirects to a link:{companyurl}/tinymce-self-hosted-premi
 
 When {productname} 6.2 or later is running as part of a Premium plan, the *Upgrade* promotion button is disabled. And it is disabled when running with a Premium plan whether {productname} is running in the {cloudname} or as a self-hosted instance.
 
-The {productname} Community distribution displays the promotion button when running as a self-hosted instance because the `promotion` option is set to `true` by default. To turn this button off in the Community disribution, set the `promotion` option to `false`.
+The {productname} Community distribution displays the promotion button when running as a self-hosted instance because the `promotion` option is set to `true` by default. To turn this button off in the Community distribution, set the `promotion` option to `false`.
 
 [source,js]
 ----

--- a/modules/ROOT/pages/editor-premium-upgrade-promotion.adoc
+++ b/modules/ROOT/pages/editor-premium-upgrade-promotion.adoc
@@ -3,7 +3,7 @@
 :description: Editor options related to turning the Premium promotion display off
 :keywords: upgrade, promotion, premium, button
 
-include::partial$configuration/premium-upgrade-promotion-option.adoc[]
+include::partial$configuration/premium-upgrade-promotion-option.adoc[leveloffset=+1]
 
 [premium-upgrade-promotion-defaults]
 === Premium upgrade promotion defaults

--- a/modules/ROOT/pages/editor-premium-upgrade-promotion.adoc
+++ b/modules/ROOT/pages/editor-premium-upgrade-promotion.adoc
@@ -6,7 +6,7 @@
 include::partial$configuration/premium-upgrade-promotion-option.adoc[]
 
 [premium-upgrade-promotion-defaults]
-== Premium upgrade promotion defaults
+=== Premium upgrade promotion defaults
 
 When the Community distribution of {productname} 6.2 is running as a self-hosted instance, an *Upgrade* promotion button appears in the unused corner of the editor menu bar by default. The button does not appear when Community distributions of {productname} are running on the {cloudname}.
 

--- a/modules/ROOT/pages/editor-premium-upgrade-promotion.adoc
+++ b/modules/ROOT/pages/editor-premium-upgrade-promotion.adoc
@@ -3,14 +3,14 @@
 :description: Editor options related to turning the Premium promotion display off
 :keywords: upgrade, promotion, premium, button
 
-include::partial$configuration/premium-upgrade-promotion-option.adoc[leveloffset=+1]
+include::partial$misc/premium-upgrade-promotion-option.adoc[]
 
-[premium-upgrade-promotion-defaults]
+[[premium-upgrade-promotion-defaults]]
 === Premium upgrade promotion defaults
 
 When the Community distribution of {productname} 6.2 is running as a self-hosted instance, an *Upgrade* promotion button appears in the unused corner of the editor menu bar by default. The button does not appear when Community distributions of {productname} are running on the {cloudname}.
 
-This promotion button redirects to a link:{companyurl}/tinymce-self-hosted-premium-features/[promotion page], showcasing the benefits of the variety of xref:plugins#premium-plugins[Premium Plugins] available for {productname}.
+This promotion button redirects to a link:{companyurl}/tinymce-self-hosted-premium-features/[promotion page], showcasing the benefits of the variety of xref:plugins.adoc#premium-plugins[Premium Plugins] available for {productname}.
 
 When {productname} 6.2 or later is running as part of a Premium plan, the *Upgrade* promotion button is disabled. And it is disabled when running with a Premium plan whether {productname} is running in the {cloudname} or as a self-hosted instance.
 

--- a/modules/ROOT/partials/configuration/premium-upgrade-promotion-option.adoc
+++ b/modules/ROOT/partials/configuration/premium-upgrade-promotion-option.adoc
@@ -3,7 +3,7 @@
 {productname} 6.2 and later includes the `promotion` option. It controls the presentation or otherwise of a Tiny-specific promotion button.
 
 [[promotion]]
-=== `+promotion+`
+== `+promotion+`
 
 *Type:* `+Boolean+`
 

--- a/modules/ROOT/partials/configuration/premium-upgrade-promotion-option.adoc
+++ b/modules/ROOT/partials/configuration/premium-upgrade-promotion-option.adoc
@@ -3,7 +3,7 @@
 {productname} 6.2 and later includes the `promotion` option. It controls the presentation or otherwise of a Tiny-specific promotion button.
 
 [[promotion]]
-== `+promotion+`
+=== `+promotion+`
 
 *Type:* `+Boolean+`
 

--- a/modules/ROOT/partials/configuration/premium-upgrade-promotion-option.adoc
+++ b/modules/ROOT/partials/configuration/premium-upgrade-promotion-option.adoc
@@ -13,7 +13,7 @@
 
 See xref:editor-premium-upgrade-promotion.adoc#premium-upgrade-promotion-defaults[Premium upgrade promotion defaults] for details.
 
-== Example: Using `+promotion+`
+=== Example: Using `+promotion+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/promotion.adoc
+++ b/modules/ROOT/partials/configuration/promotion.adoc
@@ -1,9 +1,7 @@
-== Premium upgrade promotion option
-
-{productname} 6.2 and later includes the `promotion` option. It controls the presentation or otherwise of a Tiny-specific promotion button.
-
 [[promotion]]
 == `+promotion+`
+
+{productname} 6.2 and later includes the `promotion` option. It controls the presentation or otherwise of a Tiny-specific promotion button.
 
 *Type:* `+Boolean+`
 

--- a/modules/ROOT/partials/misc/premium-upgrade-promotion-option.adoc
+++ b/modules/ROOT/partials/misc/premium-upgrade-promotion-option.adoc
@@ -1,0 +1,3 @@
+== Premium upgrade promotion option
+
+include::partial$configuration/promotion.adoc[leveloffset=+1]


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Typo fixed: s/disribution/distribution in `editor-premium-upgrade-promotion.adoc`.
* header level fixed in `premium-upgrade-promotion-option.adoc`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
