### PR TITLE
Document the inline formatting of list bullets and list numbers feature

### DIFF
--- a/modules/ROOT/pages/advlist.adoc
+++ b/modules/ROOT/pages/advlist.adoc
@@ -31,3 +31,5 @@ include::partial$configuration/advlist_number_styles.adoc[leveloffset=+1]
 The Advanced Lists plugin provides the following {productname} commands.
 
 include::partial$commands/advlist-cmds.adoc[]
+
+include::partial$misc/inline-formatting-of-list-bullets.adoc[]

--- a/modules/ROOT/pages/lists.adoc
+++ b/modules/ROOT/pages/lists.adoc
@@ -33,3 +33,5 @@ include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 The Lists plugin provides the following {productname} commands.
 
 include::partial$commands/lists-cmds.adoc[]
+
+include::partial$misc/inline-formatting-of-list-bullets.adoc[]

--- a/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
+++ b/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
@@ -6,7 +6,7 @@ Inline-formatting, also known as spot-formatting, is the direct formatting of an
 
 If an end-user selects the entire contents of a list item and applies inline formatting — such as a change of color or change of font-size — this spot-formatting is also applied to the list item’s associated bullet or number.
 
-Only the bullets or list numbers associated with the selection take on the inline-formatting applied to the selection.
+Only the list bullets or list numbers associated with the selection take on the inline-formatting applied to the selection.
 
 If the selection having inline formatting applied is one list item (that is, if the selection runs from one `<li>` tag to its associated `</li>` tag), the bullet or number associated with the selected list item takes on the inline-formatting applied to the selection.
 

--- a/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
+++ b/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
@@ -12,7 +12,7 @@ If the selection having inline formatting applied is one list item (that is, if 
 
 If the selection is the entire list, (that is, if the selection runs from the list’s opening `<ol>` or `<ul>` tag to the closing `</ol>` or `</ul>` tag, or if the selection runs from the list’s first `<li>` tag to the last `</li>` tag), every bullet or number takes on the inline-formatting applied to the selection.
 
-IMPORTANT: If, after applying inline-formatting, a partial selection of the now inline-formatted material is made and said inline-formatting is removed from the partial selection, the bullet or list-number formatting will also be removed.
+IMPORTANT: If, after applying inline-formatting, a partial selection of the now inline-formatted material is made and said inline-formatting is removed from the partial selection, the list bullet or list number formatting will also be removed.
 
 
 === PowerPaste Premium plugin support

--- a/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
+++ b/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
@@ -19,8 +19,8 @@ If the selection is the entire list, (that is, if the selection runs from the li
 IMPORTANT: If, after applying inline-formatting, a partial selection of the now inline-formatted material is made and said inline-formatting is removed from the partial selection, the bullet or list-number formatting will also be removed.
 
 
+=== PowerPaste Premium plugin support
 
-////
-NOTE: PowerPaste does not, currently, support inline-formatted bullets or list numbers. Inline-formatting, as applied to the bullets or list numbers, is lost when such material is copied and pasted.
+Users of the PowerPaste Premium plugin should note, this plugin does not, currently, support inline-formatted bullets or list numbers.
 
-////
+Inline-formatting, as applied to the bullets or list numbers, is lost when such material is copied and pasted using the PowerPaste plugin.

--- a/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
+++ b/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
@@ -1,12 +1,12 @@
 == Inline formatting.
 
-Bullets and numbers are spot- or inline-formatted by default.
+List bullets and list numbers can be spot- or inline-formatted.
 
-If an end-user selects the contents of a list item and applies inline formatting, such as a change of color or change of font-size, this spot formatting is also applied to the bullet or number.
-
-NOTE: PowerPaste does not, currently, support inline-formatted bullets or list numbers. Inline-formatting, as applied to the bullets or list numbers, is lost when such material is copied and pasted.
+If an end-user selects the contents of a list item and applies inline formatting, such as a change of color or change of font-size, this spot formatting is also applied to the list item’s associated bullet or number.
 
 Only the bullets or list numbers associated with the selection are inline-formatted.
+
+NOTE: PowerPaste does not, currently, support inline-formatted bullets or list numbers. Inline-formatting, as applied to the bullets or list numbers, is lost when such material is copied and pasted.
 
 If the selection is one list item (ie, if the selection runs from an particular `<li>` tag to its associated `</li>` tag), only the bullet or number associated with the single selected list item takes on the inline-formatting.
 

--- a/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
+++ b/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
@@ -8,7 +8,7 @@ Only the bullets or list numbers associated with the selection are inline-format
 
 NOTE: PowerPaste does not, currently, support inline-formatted bullets or list numbers. Inline-formatting, as applied to the bullets or list numbers, is lost when such material is copied and pasted.
 
-If the selection is one list item (ie, if the selection runs from an particular `<li>` tag to its associated `</li>` tag), only the bullet or number associated with the single selected list item takes on the inline-formatting.
+If the selection is one list item (that is, if the selection runs from an particular `<li>` tag to its associated `</li>` tag), only the bullet or number associated with the single selected list item takes on the inline-formatting.
 
 If the selection is the entire list, (ie, if the selection runs from the list’s opening `<ol>` or `<ul>` tag to the closing `</ol>` or `</ul>` tag, or if the selection runs from the list’s first `<li>` tag to the last `</li>` tag), every bullet or number takes on the inline-formatting.
 

--- a/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
+++ b/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
@@ -2,17 +2,13 @@
 
 List bullets and list numbers can now be inline-formatted.
 
-Inline-formatting is the direct formatting of an object. It contrasts with formatting applied to an object because that object is a particular type of object.
+Inline-formatting, also known as spot-formatting, is the direct formatting of an object. It contrasts with formatting applied to an object because that object is a particular type of object.
 
-If all Table Headers are formatted a particular way, that is not inline formatting. When a particular Table Header is selected and has formatting specifically applied to it, that is inline formatting.
-
-Inline-formatting is also known as spot-formatting.
-
-If an end-user selects the entire content of a list item and applies inline formatting, such as a change of color or change of font-size, this spot-formatting is also applied to the list item’s associated bullet or number.
+If an end-user selects the entire contents of a list item and applies inline formatting — such as a change of color or change of font-size — this spot-formatting is also applied to the list item’s associated bullet or number.
 
 Only the bullets or list numbers associated with the selection take on the inline-formatting applied to the selection.
 
-If the selection having inline formatting applied is one list item (that is, if the selection runs from an particular `<li>` tag to its associated `</li>` tag), the bullet or number associated with that single selected list item takes on the inline-formatting applied to the selection.
+If the selection having inline formatting applied is one list item (that is, if the selection runs from one `<li>` tag to its associated `</li>` tag), the bullet or number associated with the selected list item takes on the inline-formatting applied to the selection.
 
 If the selection is the entire list, (that is, if the selection runs from the list’s opening `<ol>` or `<ul>` tag to the closing `</ol>` or `</ul>` tag, or if the selection runs from the list’s first `<li>` tag to the last `</li>` tag), every bullet or number takes on the inline-formatting applied to the selection.
 

--- a/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
+++ b/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
@@ -1,21 +1,26 @@
 == Inline formatting.
 
-List bullets and list numbers can be inline-formatted.
+List bullets and list numbers can new be inline-formatted.
 
 Inline-formatting is the direct formatting of an object. It contrasts with formatting applied to an object because that object is a particular type of object.
 
-If all Table Headers are formatted a particular way, that is not inline formatting. When a particular Table Header is selected and has formatting specifically applied to it, this is inline formatting.
+If all Table Headers are formatted a particular way, that is not inline formatting. When a particular Table Header is selected and has formatting specifically applied to it, that is inline formatting.
 
 Inline-formatting is also known as spot-formatting.
 
-If an end-user selects all the contents of a list item and applies inline formatting, such as a change of color or change of font-size, this spot formatting is also applied to the list item’s associated bullet or number.
+If an end-user selects the entire content of a list item and applies inline formatting, such as a change of color or change of font-size, this spot-formatting is also applied to the list item’s associated bullet or number.
 
-Only the bullets or list numbers associated with the selection are inline-formatted.
+Only the bullets or list numbers associated with the selection take on the inline-formatting applied to the selection.
 
-NOTE: PowerPaste does not, currently, support inline-formatted bullets or list numbers. Inline-formatting, as applied to the bullets or list numbers, is lost when such material is copied and pasted.
+If the selection having inline formatting applied is one list item (that is, if the selection runs from an particular `<li>` tag to its associated `</li>` tag), the bullet or number associated with that single selected list item takes on the inline-formatting applied to the selection.
 
-If the selection is one list item (that is, if the selection runs from an particular `<li>` tag to its associated `</li>` tag), only the bullet or number associated with the single selected list item takes on the inline-formatting.
-
-If the selection is the entire list, (ie, if the selection runs from the list’s opening `<ol>` or `<ul>` tag to the closing `</ol>` or `</ul>` tag, or if the selection runs from the list’s first `<li>` tag to the last `</li>` tag), every bullet or number takes on the inline-formatting.
+If the selection is the entire list, (that is, if the selection runs from the list’s opening `<ol>` or `<ul>` tag to the closing `</ol>` or `</ul>` tag, or if the selection runs from the list’s first `<li>` tag to the last `</li>` tag), every bullet or number takes on the inline-formatting applied to the selection.
 
 IMPORTANT: If, after applying inline-formatting, a partial selection of the now inline-formatted material is made and said inline-formatting is removed from the partial selection, the bullet or list-number formatting will also be removed.
+
+
+
+////
+NOTE: PowerPaste does not, currently, support inline-formatted bullets or list numbers. Inline-formatting, as applied to the bullets or list numbers, is lost when such material is copied and pasted.
+
+////

--- a/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
+++ b/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
@@ -1,6 +1,6 @@
 == Inline formatting.
 
-List bullets and list numbers can new be inline-formatted.
+List bullets and list numbers can now be inline-formatted.
 
 Inline-formatting is the direct formatting of an object. It contrasts with formatting applied to an object because that object is a particular type of object.
 

--- a/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
+++ b/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
@@ -1,0 +1,15 @@
+== Inline formatting.
+
+Bullets and numbers are spot- or inline-formatted by default.
+
+If an end-user selects the contents of a list item and applies inline formatting, such as a change of color or change of font-size, this spot formatting is also applied to the bullet or number.
+
+NOTE: PowerPaste does not, currently, support inline-formatted bullets or list numbers. Inline-formatting, as applied to the bullets or list numbers, is lost when such material is copied and pasted.
+
+Only the bullets or list numbers associated with the selection are inline-formatted.
+
+If the selection is one list item (ie, if the selection runs from an particular `<li>` tag to its associated `</li>` tag), only the bullet or number associated with the single selected list item takes on the inline-formatting.
+
+If the selection is the entire list, (ie, if the selection runs from the list’s opening `<ol>` or `<ul>` tag to the closing `</ol>` or `</ul>` tag, or if the selection runs from the list’s first `<li>` tag to the last `</li>` tag), every bullet or number takes on the inline-formatting.
+
+IMPORTANT: If, after applying inline-formatting, a partial selection of the now inline-formatted material is made and said inline-formatting is removed from the partial selection, the bullet or list-number formatting will also be removed.

--- a/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
+++ b/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
@@ -1,5 +1,7 @@
 == Inline formatting.
 
+include::partial$misc/admon-requires-6.2v.adoc[]
+
 List bullets and list numbers can now be inline-formatted.
 
 Inline-formatting, also known as spot-formatting, is the direct formatting of an object. It contrasts with formatting applied to an object because that object is a particular type of object.

--- a/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
+++ b/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
@@ -21,6 +21,6 @@ IMPORTANT: If, after applying inline-formatting, a partial selection of the now 
 
 === PowerPaste Premium plugin support
 
-Users of the PowerPaste Premium plugin should note, this plugin does not, currently, support inline-formatted bullets or list numbers.
+Users of the xref:introduction-to-powerpaste.adoc[PowerPaste Premium plugin] should note, this plugin does not, currently, support inline-formatted bullets or list numbers.
 
 Inline-formatting, as applied to the bullets or list numbers, is lost when such material is copied and pasted using the PowerPaste plugin.

--- a/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
+++ b/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
@@ -1,8 +1,14 @@
 == Inline formatting.
 
-List bullets and list numbers can be spot- or inline-formatted.
+List bullets and list numbers can be inline-formatted.
 
-If an end-user selects the contents of a list item and applies inline formatting, such as a change of color or change of font-size, this spot formatting is also applied to the list item’s associated bullet or number.
+Inline-formatting is the direct formatting of an object. It contrasts with formatting applied to an object because that object is a particular type of object.
+
+If all Table Headers are formatted a particular way, that is not inline formatting. When a particular Table Header is selected and has formatting specifically applied to it, this is inline formatting.
+
+Inline-formatting is also known as spot-formatting.
+
+If an end-user selects all the contents of a list item and applies inline formatting, such as a change of color or change of font-size, this spot formatting is also applied to the list item’s associated bullet or number.
 
 Only the bullets or list numbers associated with the selection are inline-formatted.
 


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* New file, `/partial/misc/inline-formatting-of-list-bullets.adoc`, documents inline formatting capability.
* `include` statements added to above put the documentation in both `lists.adoc` and `advlist.adoc`.

Pre-checks:
- [ ] Branch prefixed with `feature/6/` or `hotfix/6/`
- [ ] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [ ] Files has been included where required (if applicable)
- [ ] Files removed have been deleted, not just excluded from the build (if applicable)
- [ ] (New product features only) Release Note added

Review:
- [ ] Documentation Team Lead has reviewed
