### PR TITLE
DOC-1795: add ‘lightning bolt’ to keywords field of `editor-premium-upgrade-promotion.adoc`

### DIFF
--- a/modules/ROOT/pages/editor-premium-upgrade-promotion.adoc
+++ b/modules/ROOT/pages/editor-premium-upgrade-promotion.adoc
@@ -1,7 +1,7 @@
 = Premium upgrade promotion
 :navtitle: {productname} Premium upgrade promotion
 :description: Editor options related to turning the Premium promotion display off
-:keywords: upgrade, promotion, premium, button
+:keywords: upgrade, promotion, premium, button, lightning bolt
 
 include::partial$misc/premium-upgrade-promotion-option.adoc[]
 


### PR DESCRIPTION
Added ‘lightning bolt’ to document keywords field.

Related Ticket: 

Description of Changes:
* Added ‘lightning bolt’ to keywords field.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)


Review:
- [x] Documentation Team Lead has reviewed
