### PR TITLE
DOC-1768: Document `format_noneditable_selector` option

### DIFF
--- a/modules/ROOT/pages/content-formatting.adoc
+++ b/modules/ROOT/pages/content-formatting.adoc
@@ -5,3 +5,5 @@
 include::partial$configuration/formats.adoc[]
 
 include::partial$configuration/format_empty_lines.adoc[]
+
+include::partial$configuration/format_noneditable_selector.adoc[]

--- a/modules/ROOT/partials/configuration/format_noneditable_selector.adoc
+++ b/modules/ROOT/partials/configuration/format_noneditable_selector.adoc
@@ -1,0 +1,20 @@
+[[format_noneditable_selector]]
+== `+format_noneditable_selector+`
+
+This option allows a non-editable (`+contenteditable="false"+`) element that matches the selector specified to be wrapped with a valid format.
+
+NOTE: The non-editable element must not have any editable descendants in order for it to be wrappable.
+
+*Type:* `+String+`
+
+*Default value:* `+''+`
+
+=== Example: Using `+format_noneditable_selector+`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  format_noneditable_selector: 'span,p.special'
+});
+----

--- a/modules/ROOT/partials/configuration/format_noneditable_selector.adoc
+++ b/modules/ROOT/partials/configuration/format_noneditable_selector.adoc
@@ -3,11 +3,11 @@
 
 This option allows a non-editable (`+contenteditable="false"+`) element that matches the selector specified to be wrapped with a format.
 
-Formats that can wrap include block formats that have the `+wrapper+` parameter set to `+true+` and inline formats. Selector formats are not supported.
-
 In addition to a non-editable element matching the selector, any non-editable element that has the `+data-mce-cef-wrappable+` attribute can be wrapped with a format.
 
-NOTE: The non-editable element must not have any editable descendants in order for it to be wrappable.
+Formats that can wrap include block formats that have the `+wrapper+` parameter set to `+true+` and inline formats. Selector formats are not supported.
+
+NOTE: The non-editable element must not have any editable (`+contenteditable="true"+`) descendants in order for it to be wrappable.
 
 *Type:* `+String+`
 

--- a/modules/ROOT/partials/configuration/format_noneditable_selector.adoc
+++ b/modules/ROOT/partials/configuration/format_noneditable_selector.adoc
@@ -1,13 +1,15 @@
 [[format_noneditable_selector]]
 == `+format_noneditable_selector+`
 
-This option allows a non-editable (`+contenteditable="false"+`) element that matches the selector specified to be wrapped with a format.
+If an element has a `contenteditable="false"` attribute, the `format_noneditable_selector` allows that element to be wrapped with a format if the element matches the specified selector.
 
-In addition to a non-editable element matching the selector, any non-editable element that has the `+data-mce-cef-wrappable+` attribute can be wrapped with a format.
+As well, an element with a `contenteditable="false"` attribute that also has the `data-mce-cef-wrappable` attribute can be wrapped with a format.
 
-Formats that can wrap include block formats that have the `+wrapper+` parameter set to `+true+` and inline formats. Selector formats are not supported.
+Wrappable formats include block formats that have the `wrapper` parameter set to `true` and inline formats.
 
-NOTE: The non-editable element must not have any editable (`+contenteditable="true"+`) descendants in order for it to be wrappable.
+Selector formats are not supported.
+
+NOTE: elements with `contenteditable="false"` attributes that contain descendant elements with `contenteditable="true"` attributes are not wrappable.
 
 *Type:* `+String+`
 

--- a/modules/ROOT/partials/configuration/format_noneditable_selector.adoc
+++ b/modules/ROOT/partials/configuration/format_noneditable_selector.adoc
@@ -1,13 +1,15 @@
 [[format_noneditable_selector]]
 == `+format_noneditable_selector+`
 
-This option allows a non-editable (`+contenteditable="false"+`) element that matches the selector specified to be wrapped with a valid format.
+This option allows a non-editable (`+contenteditable="false"+`) element that matches the selector specified to be wrapped with a format.
+
+Formats that can wrap include block formats that have the `+wrapper+` parameter set to `+true+` and inline formats. Selector formats are not supported.
+
+In addition to a non-editable element matching the selector, any non-editable element that has the `+data-mce-cef-wrappable+` attribute can be wrapped with a format.
 
 NOTE: The non-editable element must not have any editable descendants in order for it to be wrappable.
 
 *Type:* `+String+`
-
-*Default value:* `+''+`
 
 === Example: Using `+format_noneditable_selector+`
 

--- a/modules/ROOT/partials/configuration/format_noneditable_selector.adoc
+++ b/modules/ROOT/partials/configuration/format_noneditable_selector.adoc
@@ -1,7 +1,7 @@
 [[format_noneditable_selector]]
 == `+format_noneditable_selector+`
 
-If an element has a `contenteditable="false"` attribute, the `format_noneditable_selector` allows that element to be wrapped with a format if the element matches the specified selector.
+If an element has a `contenteditable="false"` attribute, the `format_noneditable_selector` option allows that element to be wrapped with a format if the element matches the specified selector.
 
 As well, an element with a `contenteditable="false"` attribute that also has the `data-mce-cef-wrappable` attribute can be wrapped with a format.
 
@@ -9,7 +9,7 @@ Wrappable formats include block formats that have the `wrapper` parameter set to
 
 Selector formats are not supported.
 
-NOTE: elements with `contenteditable="false"` attributes that contain descendant elements with `contenteditable="true"` attributes are not wrappable.
+NOTE: Elements with `contenteditable="false"` attributes that contain descendant elements with `contenteditable="true"` attributes are not wrappable.
 
 *Type:* `+String+`
 


### PR DESCRIPTION
Related Ticket: DOC-1768, TINY-8905

Description of Changes:
* Document new `format_noneditable_selector` option added as part of TinyMCE 6.2

Pre-checks:
- [X] Branch prefixed with `feature/6/` or `hotfix/6/`
- [X] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [X] Files has been included where required (if applicable)
- [X] Files removed have been deleted, not just excluded from the build (if applicable)
- [X] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
