### PR TITLE
DOC-1755: Document inline formatting’s new effect on list element (bullets and numbers)

### DIFF
--- a/modules/ROOT/pages/advlist.adoc
+++ b/modules/ROOT/pages/advlist.adoc
@@ -31,3 +31,5 @@ include::partial$configuration/advlist_number_styles.adoc[leveloffset=+1]
 The Advanced Lists plugin provides the following {productname} commands.
 
 include::partial$commands/advlist-cmds.adoc[]
+
+include::partial$misc/inline-formatting-of-list-bullets.adoc[]

--- a/modules/ROOT/pages/lists.adoc
+++ b/modules/ROOT/pages/lists.adoc
@@ -33,3 +33,5 @@ include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 The Lists plugin provides the following {productname} commands.
 
 include::partial$commands/lists-cmds.adoc[]
+
+include::partial$misc/inline-formatting-of-list-bullets.adoc[]

--- a/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
+++ b/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
@@ -1,4 +1,4 @@
-== Inline formatting.
+== Inline formatting
 
 include::partial$misc/admon-requires-6.2v.adoc[]
 

--- a/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
+++ b/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
@@ -6,6 +6,8 @@ List bullets and list numbers can now be inline-formatted.
 
 Inline-formatting, also known as spot-formatting, is the direct formatting of an object. It contrasts with formatting applied to an object because that object is a particular type of object.
 
+As of {productname} 6.2, a sub-set of all inline-formatting options can be applied to list bullets and list numbers.
+
 If an end-user selects the entire contents of a list item and applies inline formatting — such as a color change or a font-size change — this spot-formatting is also applied to the list item’s associated bullet or number.
 
 Only the list bullets or list numbers associated with the selection take on the inline-formatting applied to the selection.

--- a/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
+++ b/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
@@ -19,6 +19,8 @@ IMPORTANT: If, after applying inline-formatting, a partial selection of the now 
 
 === PowerPaste Premium plugin support
 
-Users of the xref:introduction-to-powerpaste.adoc[PowerPaste Premium plugin] should note, this plugin does not, currently, support inline-formatted bullets or list numbers.
+Users of the xref:introduction-to-powerpaste.adoc[PowerPaste] Premium plugi] should note, this plugin does not, currently, support inline-formatted bullets or list numbers.
 
 Inline-formatting, as applied to the bullets or list numbers, is lost when such material is copied and pasted using the PowerPaste plugin.
+
+NOTE: Inline-formatting as applied to list elements has always been supported by xref:introduction-to-powerpaste.adoc[PowerPaste] and continues to be so supported.

--- a/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
+++ b/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
@@ -1,0 +1,24 @@
+== Inline formatting.
+
+include::partial$misc/admon-requires-6.2v.adoc[]
+
+List bullets and list numbers can now be inline-formatted.
+
+Inline-formatting, also known as spot-formatting, is the direct formatting of an object. It contrasts with formatting applied to an object because that object is a particular type of object.
+
+If an end-user selects the entire contents of a list item and applies inline formatting — such as a color change or a font-size change — this spot-formatting is also applied to the list item’s associated bullet or number.
+
+Only the list bullets or list numbers associated with the selection take on the inline-formatting applied to the selection.
+
+If the selection having inline formatting applied is one list item (that is, if the selection runs from one `<li>` tag to its associated `</li>` tag), the bullet or number associated with the selected list item takes on the inline-formatting applied to the selection.
+
+If the selection is the entire list, (that is, if the selection runs from the list’s opening `<ol>` or `<ul>` tag to the closing `</ol>` or `</ul>` tag, or if the selection runs from the list’s first `<li>` tag to the last `</li>` tag), every bullet or number takes on the inline-formatting applied to the selection.
+
+IMPORTANT: If, after applying inline-formatting, a partial selection of the now inline-formatted material is made and said inline-formatting is removed from the partial selection, the list bullet or list number formatting will also be removed.
+
+
+=== PowerPaste Premium plugin support
+
+Users of the xref:introduction-to-powerpaste.adoc[PowerPaste Premium plugin] should note, this plugin does not, currently, support inline-formatted bullets or list numbers.
+
+Inline-formatting, as applied to the bullets or list numbers, is lost when such material is copied and pasted using the PowerPaste plugin.


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* Document inline formatting’s new effect on list element (bullets and numbers).

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
