### PR TITLE
DOC-1774: Update autocompleter `trigger` option

### DIFF
--- a/modules/ROOT/pages/autocompleter.adoc
+++ b/modules/ROOT/pages/autocompleter.adoc
@@ -23,12 +23,12 @@ The two arguments this method take are:
 [cols="1,2,1,4",options="header"]
 |===
 |Name |Value |Requirement |Description
-|ch |`+string+` |Required |The character to trigger the autocompleter.
+|ch |`+string+` (of one character) |Required |The character to trigger the autocompleter.
 include::partial$misc/admon-deprecated-6.2v.adoc[]
-It has been replaced with the `+trigger+` option.
+It has been replaced with the `+trigger+` option, which should be used instead.
 |trigger |`+string+` |Required |The string to trigger the autocompleter.
 include::partial$misc/admon-requires-6.2v.adoc[]
-It replaces the deprecated `+ch+` option.
+It replaces the deprecated `+ch+` option, and should be used instead of that option.
 |fetch |`+(pattern: string, maxResults: number, fetchOptions: Record<string, any>) => Promise<AutocompleteItem[] \| CardMenuItem[]+` |Required |A function that is passed the current matched text pattern, the maximum number of expected results and any additional fetch options. The function should return a Promise containing matching results.
 |onAction |`+(api, rng: Range, value: string) => void+` |Required |A function invoked when a fetched item is selected.
 |columns |number or `'auto'` |Optional |default: auto - The number of columns to show. If set to `+1+` column, then icons and text are displayed, otherwise only icons are displayed.

--- a/modules/ROOT/pages/autocompleter.adoc
+++ b/modules/ROOT/pages/autocompleter.adoc
@@ -28,7 +28,6 @@ include::partial$misc/admon-deprecated-6.2v.adoc[]
 It has been replaced with the `+trigger+` option, which should be used instead.
 |trigger |`+string+` |Required |The string to trigger the autocompleter.
 include::partial$misc/admon-requires-6.2v.adoc[]
-It replaces the deprecated `+ch+` option, and should be used instead of that option.
 |fetch |`+(pattern: string, maxResults: number, fetchOptions: Record<string, any>) => Promise<AutocompleteItem[] \| CardMenuItem[]+` |Required |A function that is passed the current matched text pattern, the maximum number of expected results and any additional fetch options. The function should return a Promise containing matching results.
 |onAction |`+(api, rng: Range, value: string) => void+` |Required |A function invoked when a fetched item is selected.
 |columns |number or `'auto'` |Optional |default: auto - The number of columns to show. If set to `+1+` column, then icons and text are displayed, otherwise only icons are displayed.

--- a/modules/ROOT/pages/autocompleter.adoc
+++ b/modules/ROOT/pages/autocompleter.adoc
@@ -23,8 +23,12 @@ The two arguments this method take are:
 [cols="1,2,1,4",options="header"]
 |===
 |Name |Value |Requirement |Description
-|ch |`+string+` |Required |The character to trigger the autocompleter. This option has been deprecated in TinyMCE 6.2 and has been replaced with the `+trigger+` option.
-|trigger |`+string+` |Required |The string to trigger the autocompleter. This option is new in 6.2 and replaces the deprecated `+ch+` option.
+|ch |`+string+` |Required |The character to trigger the autocompleter.
+include::partial$misc/admon-deprecated-6.2v.adoc[]
+It has been replaced with the `+trigger+` option.
+|trigger |`+string+` |Required |The string to trigger the autocompleter.
+include::partial$misc/admon-requires-6.2v.adoc[]
+It replaces the deprecated `+ch+` option.
 |fetch |`+(pattern: string, maxResults: number, fetchOptions: Record<string, any>) => Promise<AutocompleteItem[] \| CardMenuItem[]+` |Required |A function that is passed the current matched text pattern, the maximum number of expected results and any additional fetch options. The function should return a Promise containing matching results.
 |onAction |`+(api, rng: Range, value: string) => void+` |Required |A function invoked when a fetched item is selected.
 |columns |number or `'auto'` |Optional |default: auto - The number of columns to show. If set to `+1+` column, then icons and text are displayed, otherwise only icons are displayed.

--- a/modules/ROOT/pages/autocompleter.adoc
+++ b/modules/ROOT/pages/autocompleter.adoc
@@ -23,7 +23,7 @@ The two arguments this method take are:
 [cols="1,2,1,4",options="header"]
 |===
 |Name |Value |Requirement |Description
-|ch |string (of one character) |Required |The character to trigger the autocompleter.
+|trigger |`+string+` |Required |The string to trigger the autocompleter.
 |fetch |`+(pattern: string, maxResults: number, fetchOptions: Record<string, any>) => Promise<AutocompleteItem[] \| CardMenuItem[]+` |Required |A function that is passed the current matched text pattern, the maximum number of expected results and any additional fetch options. The function should return a Promise containing matching results.
 |onAction |`+(api, rng: Range, value: string) => void+` |Required |A function invoked when a fetched item is selected.
 |columns |number or `'auto'` |Optional |default: auto - The number of columns to show. If set to `+1+` column, then icons and text are displayed, otherwise only icons are displayed.

--- a/modules/ROOT/pages/autocompleter.adoc
+++ b/modules/ROOT/pages/autocompleter.adoc
@@ -23,7 +23,7 @@ The two arguments this method take are:
 [cols="1,2,1,4",options="header"]
 |===
 |Name |Value |Requirement |Description
-|ch |`+string+` |Required |The character to trigger the autocompleter. This option has been deprecated in TinyMCE 6.2, and has been replaced in 6.2 with the `+trigger+` option.
+|ch |`+string+` |Required |The character to trigger the autocompleter. This option has been deprecated in TinyMCE 6.2 and has been replaced with the `+trigger+` option.
 |trigger |`+string+` |Required |The string to trigger the autocompleter. This option is new in 6.2 and replaces the deprecated `+ch+` option.
 |fetch |`+(pattern: string, maxResults: number, fetchOptions: Record<string, any>) => Promise<AutocompleteItem[] \| CardMenuItem[]+` |Required |A function that is passed the current matched text pattern, the maximum number of expected results and any additional fetch options. The function should return a Promise containing matching results.
 |onAction |`+(api, rng: Range, value: string) => void+` |Required |A function invoked when a fetched item is selected.

--- a/modules/ROOT/pages/autocompleter.adoc
+++ b/modules/ROOT/pages/autocompleter.adoc
@@ -23,7 +23,8 @@ The two arguments this method take are:
 [cols="1,2,1,4",options="header"]
 |===
 |Name |Value |Requirement |Description
-|trigger |`+string+` |Required |The string to trigger the autocompleter.
+|ch |`+string+` |Required |The character to trigger the autocompleter. This option has been deprecated in TinyMCE 6.2, and has been replaced in 6.2 with the `+trigger+` option.
+|trigger |`+string+` |Required |The string to trigger the autocompleter. This option is new in 6.2 and replaces the deprecated `+ch+` option.
 |fetch |`+(pattern: string, maxResults: number, fetchOptions: Record<string, any>) => Promise<AutocompleteItem[] \| CardMenuItem[]+` |Required |A function that is passed the current matched text pattern, the maximum number of expected results and any additional fetch options. The function should return a Promise containing matching results.
 |onAction |`+(api, rng: Range, value: string) => void+` |Required |A function invoked when a fetched item is selected.
 |columns |number or `'auto'` |Optional |default: auto - The number of columns to show. If set to `+1+` column, then icons and text are displayed, otherwise only icons are displayed.

--- a/modules/ROOT/partials/misc/admon-deprecated-6.2v.adoc
+++ b/modules/ROOT/partials/misc/admon-deprecated-6.2v.adoc
@@ -1,0 +1,1 @@
+NOTE: This feature is deprecated in {productname} 6.2 and later.

--- a/modules/ROOT/partials/misc/admon-requires-6.2v.adoc
+++ b/modules/ROOT/partials/misc/admon-requires-6.2v.adoc
@@ -1,0 +1,1 @@
+NOTE: This feature is only available for {productname} 6.2 and later.


### PR DESCRIPTION
Related Ticket: DOC-1774

Description of Changes:
* Update name of `ch` single character trigger option to `trigger` option with multiple character (string) support

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
