### PR TITLE
DOC-1782: API documentation for searchable menu buttons with new example

### DIFF
--- a/antora-playbook-dev.yml
+++ b/antora-playbook-dev.yml
@@ -13,5 +13,7 @@ ui:
   bundle:
     url: https://tiny-cloud-docs-antora-themes-staging.s3.amazonaws.com/ui-bundle.zip
 asciidoc:
+  attributes:
+    tinymce_live_demo_url: https://cdn.tiny.cloud/1/qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc/tinymce/6-dev/tinymce.min.js
   extensions:
     - '@tinymce/antora-extension-livedemos'

--- a/antora-playbook-staging.yml
+++ b/antora-playbook-staging.yml
@@ -13,5 +13,7 @@ ui:
   bundle:
     url: https://tiny-cloud-docs-antora-themes-staging.s3.amazonaws.com/ui-bundle.zip
 asciidoc:
+  attributes:
+    tinymce_live_demo_url: https://cdn.tiny.cloud/1/qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc/tinymce/6-testing/tinymce.min.js
   extensions:
     - '@tinymce/antora-extension-livedemos'

--- a/modules/ROOT/examples/live-demos/custom-toolbar-menu-button-search/index.html
+++ b/modules/ROOT/examples/live-demos/custom-toolbar-menu-button-search/index.html
@@ -1,0 +1,20 @@
+<textarea id="custom-toolbar-menu-button-search">
+  {{logofordemoshtml}}
+  <h2 style="text-align: center;">Welcome to the TinyMCE editor demo!</h2>
+  <p>Select a menu item from the listbox above and it will insert contents into the editor at the caret position.</p>
+
+  <h2>Got questions or need help?</h2>
+  <ul>
+    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
+    <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
+  </ul>
+
+  <h2>Found a bug?</h2>
+  <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
+
+  <h2>Finally ...</h2>
+  <p>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
+  <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.
+    <br>All the best from the TinyMCE team.</p>
+</textarea>

--- a/modules/ROOT/examples/live-demos/custom-toolbar-menu-button-search/index.js
+++ b/modules/ROOT/examples/live-demos/custom-toolbar-menu-button-search/index.js
@@ -12,7 +12,7 @@ tinymce.init({
     editor.ui.registry.addMenuButton('mybutton', {
       text: 'My searchable button',
       search: {
-        placeholder: 'What do you want to search for?'
+        placeholder: 'Type...'
       },
       fetch: (callback, fetchContext) => {
         if (fetchContext.pattern.length > 0) {

--- a/modules/ROOT/examples/live-demos/custom-toolbar-menu-button-search/index.js
+++ b/modules/ROOT/examples/live-demos/custom-toolbar-menu-button-search/index.js
@@ -1,0 +1,53 @@
+tinymce.init({
+  selector: 'textarea#custom-toolbar-menu-button-search',
+  height: 500,
+  toolbar: 'mybutton',
+
+  setup: (editor) => {
+    /* Menu items are recreated when the menu is closed and opened, so we need
+       a variable to store the toggle menu item state. */
+    let toggleState = false;
+
+    /* example, adding a toolbar menu button */
+    editor.ui.registry.addMenuButton('mybutton', {
+      text: 'My searchable button',
+      search: {
+        placeholder: 'What do you want to search for?'
+      },
+      fetch: (callback, fetchContext) => {
+        if (fetchContext.pattern.length > 0) {
+          callback([
+            {
+              type: 'menuitem',
+              text: `You searched for: "${fetchContext.pattern}"`,
+              onAction: () => editor.insertContent(`<strong>Inserted selected search result</strong>`)
+            }
+          ])
+        } else {
+          const items = [
+            {
+              type: 'menuitem',
+              text: 'Menu item 1',
+              onAction: () => editor.insertContent('&nbsp;<em>You clicked menu item 1!</em>')
+            },
+            {
+              type: 'togglemenuitem',
+              text: 'Toggle menu item',
+              onAction: () => {
+                toggleState = !toggleState;
+                editor.insertContent('&nbsp;<em>You toggled a menuitem ' + (toggleState ? 'on' : 'off') + '</em>');
+              },
+              onSetup: (api) => {
+                api.setActive(toggleState);
+                return () => {};
+              }
+            }
+          ];
+          callback(items);
+        }
+      }
+    });
+
+  },
+  content_style: 'body { font-family:Helvetica,Arial,sans-serif; font-size:16px }'
+});

--- a/modules/ROOT/examples/live-demos/custom-toolbar-menu-button-search/index.js
+++ b/modules/ROOT/examples/live-demos/custom-toolbar-menu-button-search/index.js
@@ -22,7 +22,7 @@ tinymce.init({
               text: `You searched for: "${fetchContext.pattern}"`,
               onAction: () => editor.insertContent(`<strong>Inserted selected search result</strong>`)
             }
-          ])
+          ]);
         } else {
           const items = [
             {

--- a/modules/ROOT/pages/custom-menu-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-menu-toolbar-button.adoc
@@ -57,7 +57,7 @@ The following is a simple toolbar menu button example, where searching has been 
 
 liveDemo::custom-toolbar-menu-button-search[tab="js"]
 
-This example configures a toolbar menu button with the label `+My searchable button+` that opens the specified menu when clicked. The menu will contain a search input field because `+search+` is not `+false+`. The input field's https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#placeholder[placeholder attribute] will be `+What do you want to search for?+`.
+This example configures a toolbar menu button with the label `+My searchable button+` that opens the specified menu when clicked. The menu will contain a search input field because `+search+` is not `+false+`. The input field's https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#placeholder[placeholder attribute] will be `+Type...+`.
 
 Initially, when the menu opens, the search input field will be empty, and the `+fetch+` function is called with an empty `+pattern+` for its `+fetchContext+`. In that situation, `+fetch+` passes back an array of two items to be rendered in the drop-down menu. When the user types in the input field, `+fetch+` will be called again, except this time, the `+pattern+` property in `+fetchContext+` will reflect the value typed in the input field. For illustration purposes, this example then passes back an item that contains this pattern inside the item's text. In a more real-life example, the `+pattern+` could be used to filter which of the items are passed to the callback.
 

--- a/modules/ROOT/pages/custom-menu-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-menu-toolbar-button.adoc
@@ -12,10 +12,11 @@ For example: The table plugin's `+table+` toolbar button opens a menu similar to
 [cols="1,2,1,4",options="header"]
 |===
 |Name |Value |Requirement |Description
-|fetch |`+(success: (menu) => void) => void+` |required |Function that takes a callback which must be passed the list of options for the button's dropdown.
+|fetch |`+(success: (menu) => void, fetchContext) => void+` |required |Function that takes a callback and a `+fetchContext+` object. The callback function must be passed the list of options for the button's dropdown. The `+fetchContext+` object provides information which is useful for choosing which items should be passed to the callback. For more details on `fetchContext`, see xref:searchable-menu-buttons[Searchable Menu Buttons]
 |text |string |optional |Text to display if no icon is found.
 |icon |string |optional |
 include::partial$misc/admon-predefined-icons-only.adoc[]
+|search|boolean or object|optional |If not false, adds a search field to the menu. For more details, see xref:searchable-menu-buttons[Searchable Menu Buttons]
 |tooltip |string |optional |Text for button tooltip.
 |onSetup |`+(api) => (api) => void+` |optional |default: `+() => () => {}+` - Function that's invoked when the button is rendered. For details, see: xref:using-onsetup[Using `+onSetup+`].
 |===
@@ -38,5 +39,26 @@ liveDemo::custom-toolbar-menu-button[tab="js"]
 This example configures a toolbar menu button with the label `+My Button+` that opens the specified menu when clicked. The top-level menu contains two items. The first menu item inserts content when clicked and the second menu item opens a submenu containing two menu items which insert content when clicked.
 
 The `+fetch+` function is called when the toolbar menu button's menu is opened. It is a function that takes a callback and passes it an array of menu items to be rendered in the drop-down menu. This allows for asynchronous fetching of the menu items.
+
+[[searchable-menu-buttons]]
+== Searchable Menu Buttons
+
+include::partial$misc/admon-requires-6.2v.adoc[]
+
+The button's menu can be configured to have an input field for searching, as well as its usual items. The presence of the input field is controlled by the `+search+` field in the xref:options[options]. The `+search+` field can be a `+boolean+` or an `+object+` containing a single optional string `placeholder`. By default, `+search+` is false. If `+search+` is not false, the button's menu will contain an input field with any specified placeholder text. As the user types into this field, the `+fetch+` function will be called with the text in the input field passed back as part of `+fetchContext+`. The `+fetch+` function is responsible for using this `+fetchContext+` to determine which items to pass to its `+success+` callback.
+
+The `+fetchContext+` is an object containing a single string property: `+pattern+`. If the toolbar menu button has not configured `search` to be active, then the `+pattern+` string will be empty.
+
+== Searchable menu button example and explanation
+
+include::partial$misc/admon-requires-6.2v.adoc[]
+
+The following is a simple toolbar menu button example, where searching has been configured:
+
+liveDemo::custom-toolbar-menu-button-search[tab="js"]
+
+This example configures a toolbar menu button with the label `+My searchable button+` that opens the specified menu when clicked. The menu will contain a search input field because `+search+` is not `+false+`. The input field's https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#placeholder[placeholder attribute] will be `+What do you want to search for?+`.
+
+Initially, when the menu opens, the search input field will be empty, and the `+fetch+` function is called with an empty `+pattern+` for its `+fetchContext+`. In that situation, `+fetch+` passes back an array of two items to be rendered in the drop-down menu. When the user types in the input field, `+fetch+` will be called again, except this time, the `+pattern+` property in `+fetchContext+` will reflect the value typed in the input field. For illustration purposes, this example then passes back an item that contains this pattern inside the item's text. In a more real-life example, the `+pattern+` could be used to filter which of the items are passed to the callback.
 
 include::partial$misc/onSetup.adoc[]

--- a/modules/ROOT/pages/custom-menu-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-menu-toolbar-button.adoc
@@ -41,7 +41,7 @@ This example configures a toolbar menu button with the label `+My Button+` that 
 The `+fetch+` function is called when the toolbar menu button's menu is opened. It is a function that takes a callback and passes it an array of menu items to be rendered in the drop-down menu. This allows for asynchronous fetching of the menu items.
 
 [[searchable-menu-buttons]]
-== Searchable Menu Buttons
+== Searchable menu buttons
 
 include::partial$misc/admon-requires-6.2v.adoc[]
 


### PR DESCRIPTION
Related Ticket: DOC-1782

Description of Changes:
* Added documentation and an example for the new searchable toolbar menu buttons

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] Files has been included where required (if applicable)
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
