### PR TITLE
DOC-1816 markup correction in `release-notes.adoc` to end asciidoctor warnings

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -54,4 +54,5 @@ Release notes for {productname} 6.0
 // 2. Prepend the inline comment markup to this element
 //    when the number of cells in the table is even.
 //a|
-//|===
+
+|===

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -56,3 +56,4 @@ Release notes for {productname} 6.0
 //a|
 
 |===
+


### PR DESCRIPTION
Removed inline comment pre-pending the closing table markup.

This, incorrectly applied, comment caused AsciiDoctor to produce an `unterminated table block` warning.

Related Ticket: 

Description of Changes:
* markup correction in `release-notes.adoc` to end asciidoctor warnings

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
