### PR TITLE
DOC-1818: typo correction in `mergtags.adoc`

### DIFF
--- a/modules/ROOT/pages/mergetags.adoc
+++ b/modules/ROOT/pages/mergetags.adoc
@@ -76,7 +76,7 @@ The `+mergetags_list+` option allows for the specification of a nested menu item
 
 == Styling Merge Tags
 
-It's possible to change the visual appearance of the Merge tags within the editor using a custom CSS file provided through the xref:add-css-options.adoc#content_css[content_css] option. Here is an example on how to style the various elements of the merge tag.
+It's possible to change the visual appearance of the Merge Tags within the editor using a custom CSS file provided through the xref:add-css-options.adoc#content_css[content_css] option. Here is an example of how to style the various elements of the merge tag.
 
 [source,css]
 ----

--- a/modules/ROOT/pages/mergetags.adoc
+++ b/modules/ROOT/pages/mergetags.adoc
@@ -74,7 +74,7 @@ Content containing the specified prefix and suffix, and matching a specified mer
 +
 The `+mergetags_list+` option allows for the specification of a nested menu item within the merge tags toolbar menu button. This option allows any number of nested menus and items for merge tag categorisation.
 
-== Styling Merge tags
+== Styling Merge Tags
 
 It's possible to change the visual appearance of the Merge tags within the editor using a custom CSS file provided through the xref:add-css-options.adoc#content_css[content_css] option. Here is an example on how to style the various elements of the merge tag.
 


### PR DESCRIPTION
Typo correction: s/tags/Tags/.

Related Ticket: 

Description of Changes:
* typo correction in `mergtags.adoc`

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
