### PR TITLE
DOC-1824: Added missing services releases information

### DIFF
--- a/_new_content_templates/releasenotes_blank/x_y_z-release-notes-premium-changes.adoc
+++ b/_new_content_templates/releasenotes_blank/x_y_z-release-notes-premium-changes.adoc
@@ -69,6 +69,7 @@ The {productname} vnumtxt release includes accompanying changes affecting the {p
 * Enhanced Image Editing plugin (`editimage`)
 * Link Checker plugin (`linkchecker`)
 * Spell Checker Pro plugin (`tinymcespellchecker`)
+* Spelling Autocorrect plugin (`autocorrect`)
 
 The Java server-side components have been updated to the following versions:
 
@@ -83,6 +84,7 @@ For information on:
 * The Enhanced Image Editing plugin, see: xref:editimage.adoc[Enhanced Image Editing plugin].
 * The Link Checker plugin, see: xref:linkchecker.adoc[Link Checker plugin].
 * The Spell Checker Pro plugin, see: xref:introduction-to-tiny-spellchecker.adoc[Spell Checker Pro plugin].
+* The Spelling Autocorrect plugin, see: xref:autocorrect.adoc[Spelling Autocorrect plugin].
 * Deploying the server-side components, see: xref:introduction-to-premium-selfhosted-services.adoc[Server-side component installation].
 
 === Updating the self-hosted server-side components

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -391,7 +391,7 @@
 ** xref:release-notes.adoc[Release notes for TinyMCE 6]
 *** TinyMCE 6.2
 **** xref:6.2-release-notes.adoc#overview[Overview]
-**** xref:6.2-release-notes.adoc#ref:accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]
+**** xref:6.2-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]
 **** xref:6.2-release-notes.adoc#accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]
 **** xref:6.2-release-notes.adoc#improvements[Improvements]
 **** xref:6.2-release-notes.adoc#additions[Additions]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -393,10 +393,12 @@
 **** xref:6.2-release-notes.adoc#overview[Overview]
 **** xref:6.2-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]
 **** xref:6.2-release-notes.adoc#accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]
+**** xref:6.2-release-notes.adoc#accompanying-premium-self-hosted-server-side-component-changes[Accompanying Premium self-hosted server-side component changes]
 **** xref:6.2-release-notes.adoc#improvements[Improvements]
 **** xref:6.2-release-notes.adoc#additions[Additions]
 **** xref:6.2-release-notes.adoc#changes[Changes]
 **** xref:6.2-release-notes.adoc#bug-fixes[Bug fixes]
+**** xref:6.2-release-notes.adoc#security-fixes[Security fixes]
 **** xref:6.2-release-notes.adoc#deprecated[Deprecated]
 **** xref:6.2-release-notes.adoc#known-issues[Known issues]
 *** TinyMCE 6.1.2

--- a/modules/ROOT/pages/6.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.2-release-notes.adoc
@@ -14,10 +14,12 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 * xref:new-premium-plugins[New Premium plugins]
 * xref:accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]
 * xref:accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]
+* xref:accompanying-premium-self-hosted-server-side-component-changes[Accompanying Premium self-hosted server-side component changes]
 * xref:improvements[Improvements]
 * xref:additions[Additions]
 * xref:changes[Changes]
 * xref:bug-fixes[Bug fixes]
+* xref:security-fixes[Security fixes]
 * xref:deprecated[Deprecated]
 * xref:known-issues[Known issues]
 
@@ -148,6 +150,49 @@ Two new icons were added to all icon packs: `addtag` and `footnote`.
 The **Premium Skins and Icon Packs** were rebuilt to pull in the changes also incorporated into the default {productname} 6.2 skin, Oxide.
 
 For information on using premium skins and icon packs, see: xref:premium-skins-and-icons.adoc[Premium Skins and Icon Packs].
+
+[[accompanying-premium-self-hosted-server-side-component-changes]]
+== Accompanying Premium self-hosted server-side component changes
+
+The {productname} 6.2 release includes accompanying changes affecting the {productname} **self-hosted** services for the following plugins:
+
+* Enhanced Media Embed plugin (`mediaembed`)
+* Export plugin (`export`)
+* Enhanced Image Editing plugin (`editimage`)
+* Link Checker plugin (`linkchecker`)
+* Spell Checker Pro plugin (`tinymcespellchecker`)
+* Spelling Autocorrect plugin (`autocorrect`)
+
+The Java server-side components have been updated to the following versions:
+
+* `ephox-hyperlinking.war`: 2.105.13
+* `ephox-image-proxy.war`: 2.106.4
+* `ephox-spelling.war`: 2.118.6
+
+For information on:
+
+* The Enhanced Media Embed plugin, see: xref:introduction-to-mediaembed.adoc[Enhanced Media Embed plugin].
+* The Export plugin, see: xref:export.adoc[Export plugin].
+* The Enhanced Image Editing plugin, see: xref:editimage.adoc[Enhanced Image Editing plugin].
+* The Link Checker plugin, see: xref:linkchecker.adoc[Link Checker plugin].
+* The Spell Checker Pro plugin, see: xref:introduction-to-tiny-spellchecker.adoc[Spell Checker Pro plugin].
+* The Spelling Autocorrect plugin, see: xref:autocorrect.adoc[Spelling Autocorrect plugin].
+* Deploying the server-side components, see: xref:introduction-to-premium-selfhosted-services.adoc[Server-side component installation].
+
+=== Updating the self-hosted server-side components
+
+The new versions of the server-side services provide updates for the Java-based server-side components. To deploy the updated version of the server-side components:
+
+. Update your Java Application Server to the minimum required version:
+
+include::partial$misc/supported-application-servers.adoc[]
+
+. Replace the existing server-side `.war` files with the `.war` files bundled with {productname} vnumtxt or later.
+
+For information on:
+
+* Deploying the server-side components, see: xref:introduction-to-premium-selfhosted-services.adoc[Server-side component installation].
+* Deploying the server-side components using Docker, see: xref:bundle-intro-setup.adoc[Containerized service deployments].
 
 
 [[improvements]]
@@ -471,6 +516,14 @@ The presented list was not entirely alphabetical, however.
 
 With this update Premium plugin names are, now, correctly sorted in alphabetical order by name.
 
+[[security-fixes]]
+== Security fixes
+
+{productname} 6.2 provides fixes for the following security issues:
+
+All 3 server-side components have been updated to include dependency updates addressing security issues. This includes Medium severity vulnerability fixes.
+
+For information on the server-side components updates, see: xref:#accompanying-premium-self-hosted-server-side-component-changes[Accompanying Premium self-hosted server-side component changes].
 
 [[deprecated]]
 == Deprecated

--- a/modules/ROOT/pages/6.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.2-release-notes.adoc
@@ -292,7 +292,7 @@ In {productname} 6.2, the Autolink plugin is now able to handle this text node f
 
 As part of switching to TypeScript’s strict mode, multiple public {productname} APIs were found to be typed incorrectly.
 
-These types have been corrected types in {productname} 6.2. 
+These types have been corrected types in {productname} 6.2.
 
 === The number of blank lines returned from `editor.getContent({format: 'text'})` differed between browsers
 
@@ -364,7 +364,7 @@ In particular, this includes ensuring that formatting is not directly removed fr
 
 === Spaces could be incorrectly added to `urlinput` dialog components in certain cases
 
-The handling of spaces inserted into the xref:dialog-components.adoc#urlinput[UrlInput] dialog component, specifically its implementation in the xref:link[Link Dialog], was inconsistent.
+The handling of spaces inserted into the xref:dialog-components.adoc#urlinput[UrlInput] dialog component, specifically its implementation in the xref:link.adoc[Link Dialog], was inconsistent.
 
 It allowed spaces to be entered when it was empty and the text input contained text, but did not allow spaces to be entered when both fields were empty.
 
@@ -395,7 +395,7 @@ In {productname} 6.2, dragging elements with `contenteditable=false` attributes 
 
 === Parsing large documents no longer throws a Maximum call stack size exceeded exception
 
-Previously, parsing very large documents would throw an error to the console that they had exceeded the Maximum call stack size. 
+Previously, parsing very large documents would throw an error to the console that they had exceeded the Maximum call stack size.
 
 For example:
 

--- a/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
+++ b/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
@@ -1,3 +1,4 @@
+[[inline-formatting]]
 == Inline formatting
 
 include::partial$misc/admon-requires-6.2v.adoc[]

--- a/modules/ROOT/partials/misc/premium-upgrade-promotion-option.adoc
+++ b/modules/ROOT/partials/misc/premium-upgrade-promotion-option.adoc
@@ -1,3 +1,4 @@
+[[premium-upgrade-promotion-option]]
 == Premium upgrade promotion option
 
 include::partial$configuration/promotion.adoc[leveloffset=+1]


### PR DESCRIPTION
Related Ticket: DOC-1824

Description of Changes:

This copies the template and fills it out for the missing server side security fixes that were included in 6.2. @brian-forte please feel free to reword this however you see fit.

Note: I've also fixed other various issues I found while writing these.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [ ] Documentation Team Lead has reviewed
