### PR TITLE
WSRF-1003 - Replace go.tiny.cloud with the actual website url

### DIFF
--- a/_includes/js/notifications.js
+++ b/_includes/js/notifications.js
@@ -7,10 +7,10 @@
     function getPrefixURL(type) {
         switch(type) {
             case "blog":
-                return "https://go.tiny.cloud/blog/";
+                return "https://www.tiny.cloud/blog/";
                 break;
             default:
-                return "https://go.tiny.cloud/blog/";
+                return "https://www.tiny.cloud/blog/";
         }
     }
 

--- a/_includes/template/notification.html
+++ b/_includes/template/notification.html
@@ -1,12 +1,12 @@
 <div class="tiny-news-docs">
     <div>
-        <a href="https://go.tiny.cloud/blog/"
+        <a href="https://www.tiny.cloud/blog/"
            data-marketing="tiny-news-blog-link"
            class="tiny-news-prefix">
         </a>
         <span class="tiny-news-text">Important changes to Tiny Cloud pricing</span>
         &gt;
-        <a href="https://go.tiny.cloud/blog/important-changes-to-tiny-cloud-pricing-metric/"
+        <a href="https://www.tiny.cloud/pricing/"
            data-marketing="tiny-news-pricing-blog-link" class="tiny-news-link">
             Find out more
         </a>


### PR DESCRIPTION
Related Ticket:
WSRF-1003 - SEO: Remove go.tiny.cloud from the source code

Description of Changes:
* go.tiny.cloud urls replaced with the actual website url

Pre-checks:
~~- [ ] Branch prefixed with feature/5/ or hotfix/5/~~
~~- [ ] modules/ROOT/nav.adoc has been updated (if applicable)~~
~~- [ ] Files has been included where required (if applicable)~~
~~- [ ] Files removed have been deleted, not just excluded from the build (if applicable)~~
~~- [ ] (New product features only) Release Note added~~

Review:
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed