### PR TITLE
DOC-1821: mergetags.adoc, 6.2-release-notes.adoc, mergetags-menu-item…

### DIFF
--- a/modules/ROOT/pages/6.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.2-release-notes.adoc
@@ -551,7 +551,7 @@ There are several known issues in {productname} 6.2.
 
 There are several circumstances where typing the Merge Tags prefix (by default, `+{{+`) does not activate the `autocompleter`. Consequently, choosing a Merge tag from the expected pop-up menu is not possible because the pop-up menu does not present.
 
-Moreover, in the circumstances where the `autocompleter` does not activate, even typing the entire Merge tag does not result in the string being turned in to a Merge tag.
+Moreover, in the circumstances where the `autocompleter` does not activate, even typing the entire merge tag does not result in the string being turned in to a merge tag.
 
 There is a workaround, however.
 

--- a/modules/ROOT/pages/6.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.2-release-notes.adoc
@@ -549,19 +549,19 @@ There are several known issues in {productname} 6.2.
 
 === Merge Tags cannot be manually added to a {productname} document in some circumstances
 
-There are several circumstances where typing the Merge tags prefix (by default, `+{{+`) does not activate the `autocompleter`. Consequently, choosing a Merge tag from the expected pop-up menu is not possible because the pop-up menu does not present.
+There are several circumstances where typing the Merge Tags prefix (by default, `+{{+`) does not activate the `autocompleter`. Consequently, choosing a Merge tag from the expected pop-up menu is not possible because the pop-up menu does not present.
 
 Moreover, in the circumstances where the `autocompleter` does not activate, even typing the entire Merge tag does not result in the string being turned in to a Merge tag.
 
 There is a workaround, however.
 
-If typing the Merge tags prefix does not work as expected, clicking the Merge tags toolbar button and selecting the desired Merge tag from the resultant menu inserts a functioning Merge tag.
+If typing the Merge Tags prefix does not work as expected, clicking the Merge Tags toolbar button and selecting the desired merge tag from the resultant menu inserts a functioning merge tag.
 
-=== Merge tags does not validate inserted strings that match merge tag syntax
+=== Merge Tags does not validate inserted strings that match merge tag syntax
 
 If a string is pasted or otherwise inserted into a {productname} document and that string presents as a complete merge tag, the Merge tag plugin will turn the string into an apparently working merge tag, regardless of the string’s content.
 
-For example, if a {productname} instance is running the Merge tags plugin and the plugin is using the default prefix and suffix characters — `+{{+` and `+}}+` — pasting
+For example, if a {productname} instance is running the Merge Tags plugin and the plugin is using the default prefix and suffix characters — `+{{+` and `+}}+` — pasting
 
 `{{not.a.merge.tag.value.for.this.document}}`
 
@@ -569,7 +569,7 @@ into the document results in the pasted string being turned in to an apparently 
 
 There is no current workaround.
 
-=== A Merge tags UI element has not been translated
+=== A Merge Tags UI element has not been translated
 
 {productname} 6.2 adds a new UI option to menu toolbar buttons. These buttons can now present a search field at the top of the menu.
 

--- a/modules/ROOT/pages/6.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.2-release-notes.adoc
@@ -559,7 +559,7 @@ If typing the Merge Tags prefix does not work as expected, clicking the Merge Ta
 
 === Merge Tags does not validate inserted strings that match merge tag syntax
 
-If a string is pasted or otherwise inserted into a {productname} document and that string presents as a complete merge tag, the Merge tag plugin will turn the string into an apparently working merge tag, regardless of the string’s content.
+If a string is pasted or otherwise inserted into a {productname} document and that string presents as a complete merge tag, the Merge Tags plugin will turn the string into an apparently working merge tag, regardless of the string’s content.
 
 For example, if a {productname} instance is running the Merge Tags plugin and the plugin is using the default prefix and suffix characters — `+{{+` and `+}}+` — pasting
 

--- a/modules/ROOT/pages/mergetags.adoc
+++ b/modules/ROOT/pages/mergetags.adoc
@@ -12,7 +12,7 @@ include::partial$misc/admon-requires-6.2v.adoc[]
 
 The {pluginname} plugin allows the user to insert a merge tag (also known as a personalization token, or a mail merge field).
 
-Merge tags can be inserted by selecting from a drop-down list when a specified prefix is typed, or selected and inserted from the searchable Merge tags toolbar menu button.
+{pluginname} can be inserted by selecting from a drop-down list when a specified prefix is typed, or selected and inserted from the searchable {pluginname} toolbar menu button.
 
 Once a merge tag is inserted, the plugin leaves a non-editable variable wrapped with a prefix and suffix, making it easily identifiable.
 
@@ -54,29 +54,29 @@ The autocompleter is triggered by typing a specified prefix, controlled by the x
 
 By default, this prefix is `{{`.
 
-Entering characters after the prefix begins filtering the merge tags list.
+Entering characters after the prefix begins filtering the {pluginname} list.
 
-== Using Merge Tags
+== Using {pluginname}
 
-. Merge tag contents are non-editable but can have any inline-formats applied to them.
+. {pluginname} contents are non-editable but can have any inline-formats applied to them.
 +
 For example, a merge tag can be set to any available typeface, type-size, foreground or background color, or can be set to *bold*, or _italic_.
 
-. Merge tags can be changed.
+. {pluginname} can be changed.
 +
-A selected merge tag can be changed to any other merge tag by using the merge tags toolbar menu button.
+A selected merge tag can be changed to any other merge tag by using the {pluginname} toolbar menu button.
 
 . Text that matches an existing merge tag will be recognised as a merge tag when it is pasted or otherwise inserted into a {productname} document.
 +
 Content containing the specified prefix and suffix, and matching a specified merge tag, will be inserted as a merge tag when pasted into the editor. For example, if `Sender.Firstname` is a Merge tag value, and the Merge tag prefix and suffix have their default values, adding the string, `{{Sender.FirstName}}`, to a {productname} document will result in the string automatically being recognised as a Merge tag.
 
-. Merge tags can be nested within the `+mergetags_list+` option.
+. {pluginname} can be nested within the `+mergetags_list+` option.
 +
-The `+mergetags_list+` option allows for the specification of a nested menu item within the merge tags toolbar menu button. This option allows any number of nested menus and items for merge tag categorisation.
+The `+mergetags_list+` option allows for the specification of a nested menu item within the {pluginname} toolbar menu button. This option allows any number of nested menus and items for merge tag categorisation.
 
 == Styling Merge Tags
 
-It's possible to change the visual appearance of the Merge Tags within the editor using a custom CSS file provided through the xref:add-css-options.adoc#content_css[content_css] option. Here is an example of how to style the various elements of the merge tag.
+It's possible to change the visual appearance of the {pluginname} within the editor using a custom CSS file provided through the xref:add-css-options.adoc#content_css[content_css] option. Here is an example of how to style the {pluginname} elements.
 
 [source,css]
 ----
@@ -90,7 +90,7 @@ It's possible to change the visual appearance of the Merge Tags within the edito
 }
 ----
 
-Here is an example of the Merge tag HTML structure.
+Here is an example of the {pluginname} HTML structure.
 
 [source,html]
 ----

--- a/modules/ROOT/pages/mergetags.adoc
+++ b/modules/ROOT/pages/mergetags.adoc
@@ -68,7 +68,7 @@ A selected merge tag can be changed to any other merge tag by using the {pluginn
 
 . Text that matches an existing merge tag will be recognised as a merge tag when it is pasted or otherwise inserted into a {productname} document.
 +
-Content containing the specified prefix and suffix, and matching a specified merge tag, will be inserted as a merge tag when pasted into the editor. For example, if `Sender.Firstname` is a Merge tag value, and the Merge tag prefix and suffix have their default values, adding the string, `{{Sender.FirstName}}`, to a {productname} document will result in the string automatically being recognised as a Merge tag.
+Content containing the specified prefix and suffix, and matching a specified merge tag, will be inserted as a merge tag when pasted into the editor. For example, if `Sender.Firstname` is a merge tag value, and the merge tag prefix and suffix have their default values, adding the string, `{{Sender.FirstName}}`, to a {productname} document will result in the string automatically being recognised as a merge tag.
 
 . {pluginname} can be nested within the `+mergetags_list+` option.
 +

--- a/modules/ROOT/partials/configuration/mergetags_list.adoc
+++ b/modules/ROOT/partials/configuration/mergetags_list.adoc
@@ -3,7 +3,7 @@
 
 `+mergetags_list+` is an object array that specifies the menu content used for merge tags insertion. Every object specifies the configuration of a submenu or a menu item.
 
-IMPORTANT: If the `+mergetags_list+` option is not set, or contains no entries, both the merge tags toolbar button and the merge tags menu item are hidden. Merge tag autosuggestions are also disabled if the `+mergetags_list+` option is not set, or contains no entries.
+IMPORTANT: If the `+mergetags_list+` option is not set, or contains no entries, both the Merge Tags toolbar button and the Merge Tags menu item are hidden. Merge tag autosuggestions are also disabled if the `+mergetags_list+` option is not set, or contains no entries.
 
 *Type:* `+Array+`
 

--- a/modules/ROOT/partials/menu-item-ids/mergetags-menu-items.adoc
+++ b/modules/ROOT/partials/menu-item-ids/mergetags-menu-items.adoc
@@ -1,5 +1,5 @@
 [cols="1,1,2",options="header"]
 |===
 |Menu item identifier |xref:menus-configuration-options.adoc#example-the-tinymce-default-menu-items[Default Menu Location] |Description
-|`+mergetags+` |Insert |Inserts a merge tag from a nested menu. The nested menu contains the merge tags list, as specified in xref:mergetags.adoc#mergetags_list[`+mergetags_list+`]
+|`+mergetags+` |Insert |Inserts a merge tag from a nested menu. The nested menu contains the Merge Tags list, as specified in xref:mergetags.adoc#mergetags_list[`+mergetags_list+`]
 |===


### PR DESCRIPTION
DOC-1821: mergetags.adoc, 6.2-release-notes.adoc, mergetags-menu-items.adoc, & mergetags_list.adoc

1. mergetags.adoc: replaced instances of ‘Merge Tags’ (however capitalised) with ‘{pluginname}’.

Attributes are defined and declared; I should use them.

Some instances were copy-edited to ‘merge tags’. The plugin is a Proper Noun and gets both words capitalised. But the particular strings that are placeholders for other data are specific merge tags, which are plain old noun phrases.

2. Corrected capitalisation instances through other files, most particularly, `6.2-release-notes.adoc`.

The same ‘if it is a placeholder string, it is a plain old noun phrase otherwise it is set as a Proper Noun’ treatment applied through these files as well.

Related Ticket: 

Description of Changes:
* Get the presentation of the string ‘Merge Tags’ consistent.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
