### PR TITLE
DOC-1831: added outbound links to browser-native APIs documentation that replaced two deprecated and removed TinyMCE APIs.

### DIFF
--- a/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
+++ b/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
@@ -230,7 +230,7 @@ The following elements were previously deprecated and have, with this release, b
 
 | `images_dataimg_filter`               | Option        |
 
-| JSON                                  | API           | Use the native JSON https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON[API] instead.
+| `JSON`                                  | API           | Use the native JSON https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON[API] instead.
 
 | `JSONP`                               | API           |
 
@@ -276,7 +276,7 @@ The following elements were previously deprecated and have, with this release, b
 
 | `validate`                            | Schema option |
 
-| XHR                                   | API           | Any remaining XHR users have been replaced with https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API[`fetch`].
+| `XHR`                                   | API           | Any remaining XHR users have been replaced with https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API[`fetch`].
 |===
 
 // end::previously-deprecated-items-now-removed[]

--- a/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
+++ b/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
@@ -230,7 +230,7 @@ The following elements were previously deprecated and have, with this release, b
 
 | `images_dataimg_filter`               | Option        |
 
-| `JSON`                                | API           |
+| JSON                                  | API           | Use the native JSON https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON[API] instead.
 
 | `JSONP`                               | API           |
 
@@ -276,7 +276,7 @@ The following elements were previously deprecated and have, with this release, b
 
 | `validate`                            | Schema option |
 
-| `XHR`                                 | API           | Any remaining `XHR` users have been replaced with `fetch`.
+| XHR                                   | API           | Any remaining XHR users have been replaced with https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API[`fetch`].
 |===
 
 // end::previously-deprecated-items-now-removed[]

--- a/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
+++ b/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
@@ -230,7 +230,7 @@ The following elements were previously deprecated and have, with this release, b
 
 | `images_dataimg_filter`               | Option        |
 
-| `JSON`                                | API           | Use the native JSON https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON[API] instead.
+| `JSON`                                | API           | Use the native `JSON` https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON[API] instead.
 
 | `JSONP`                               | API           |
 
@@ -276,7 +276,7 @@ The following elements were previously deprecated and have, with this release, b
 
 | `validate`                            | Schema option |
 
-| `XHR`                                 | API           | Any remaining XHR uses have been replaced with https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API[`fetch`].
+| `XHR`                                 | API           | Any remaining `XHR` uses have been replaced with https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API[`fetch`].
 |===
 
 // end::previously-deprecated-items-now-removed[]

--- a/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
+++ b/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
@@ -230,7 +230,7 @@ The following elements were previously deprecated and have, with this release, b
 
 | `images_dataimg_filter`               | Option        |
 
-| `JSON`                                  | API           | Use the native JSON https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON[API] instead.
+| `JSON`                                | API           | Use the native JSON https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON[API] instead.
 
 | `JSONP`                               | API           |
 
@@ -276,7 +276,7 @@ The following elements were previously deprecated and have, with this release, b
 
 | `validate`                            | Schema option |
 
-| `XHR`                                   | API           | Any remaining XHR users have been replaced with https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API[`fetch`].
+| `XHR`                                 | API           | Any remaining XHR users have been replaced with https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API[`fetch`].
 |===
 
 // end::previously-deprecated-items-now-removed[]

--- a/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
+++ b/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
@@ -276,7 +276,7 @@ The following elements were previously deprecated and have, with this release, b
 
 | `validate`                            | Schema option |
 
-| `XHR`                                 | API           | Any remaining XHR users have been replaced with https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API[`fetch`].
+| `XHR`                                 | API           | Any remaining XHR uses have been replaced with https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API[`fetch`].
 |===
 
 // end::previously-deprecated-items-now-removed[]


### PR DESCRIPTION
In deprecated and removed table: added outbound links to browser-native APIs documentation that replaced two deprecated and removed TinyMCE APIs.

Related Ticket: 

Description of Changes:
* Added outbound links to browser-native APIs documentation that replaced two deprecated and removed TinyMCE APIs.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
