### PR TITLE
DOC-1834: 6.2-release-notes.adoc & 6.2-release-notes-autocompleter-trigger-configuration-property.adoc

### DIFF
--- a/modules/ROOT/pages/6.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.2-release-notes.adoc
@@ -210,13 +210,13 @@ This new capability is configurable using the new `format_noneditable_selector` 
 
 For details see xref:content-formatting.adoc#format_noneditable_selector[Content Formatting].
 
-=== The autocompleter now supports a multiple character trigger using the new trigger configuration
+=== The autocompleter now supports a multiple character trigger using the new `trigger` configuration
 
-Previously, the autocompleter only supported a single character trigger.
+include::partial$release-notes/6.2-release-notes-autocompleter-trigger-configuration-property.adoc[]
 
-With this update, the autocompleter now supports multi-character triggers.
+The new xref:mergetags.adoc[Merge Tags] Premium plugin, for example, uses the `trigger` property to set the `+{{+` string as its default trigger.
 
-The new xref:mergetags.adoc[Merge Tags] Premium plugin, for example, uses the string `+{{+` as its default trigger.
+For details see the xref:autocompleter.adoc[Autocompleter] UI component.
 
 === Some inline formatting, such as color and font size, can now be applied to list item elements
 
@@ -530,14 +530,7 @@ For information on the server-side components updates, see: xref:#accompanying-p
 
 === The `autocompleter` configuration property, `ch`, has been deprecated
 
-The `ch` autocompleter configuration property will be removed in the next major release.
-
-The `trigger` property should be used instead, as it allows one or more characters to be specified.
-
-[source,js]
-----
-trigger: '<string>',
-----
+include::partial$release-notes/6.2-release-notes-autocompleter-trigger-configuration-property.adoc[]
 
 
 [[known-issues]]

--- a/modules/ROOT/partials/release-notes/6.2-release-notes-autocompleter-trigger-configuration-property.adoc
+++ b/modules/ROOT/partials/release-notes/6.2-release-notes-autocompleter-trigger-configuration-property.adoc
@@ -1,4 +1,4 @@
-Previously, autocompleter used the `ch` configuration property to set a single character trigger.
+Previously, the autocompleter used the `ch` configuration property to set a single character trigger.
 
 This property has been deprecated and will be removed in the next major release.
 

--- a/modules/ROOT/partials/release-notes/6.2-release-notes-autocompleter-trigger-configuration-property.adoc
+++ b/modules/ROOT/partials/release-notes/6.2-release-notes-autocompleter-trigger-configuration-property.adoc
@@ -1,0 +1,10 @@
+Previously, autocompleter used the `ch` configuration property to set a single character trigger.
+
+This property has been deprecated and will be removed in the next major release.
+
+The `trigger` configuration property should be used instead. It allows one or more characters to be specified as a trigger.
+
+[source,js]
+----
+trigger: '<string>',
+----


### PR DESCRIPTION
Added new partial — `6.2-release-notes-autocompleter-trigger-configuration-property.adoc` — and includes to said partial to two sections in `6.2-release-notes.adoc`.

Related Ticket: 

Description of Changes:
* Edits to and restructuring of the autocompleter and `ch` deprecation sections of the 6.2 release notes to more explicitly note the new `trigger` property’s utility.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
