### PR TITLE
DOC-1836: fullscreen.adoc & fullscreen_native.adoc

### DIFF
--- a/modules/ROOT/pages/events.adoc
+++ b/modules/ROOT/pages/events.adoc
@@ -140,7 +140,7 @@ The following events are provided by the {productname} editor.
 |PreProcess |`+{ node: Element, format: string }+` |Fired before serializing a DOM node to HTML content.
 |PostProcess |`+{ node: Element, format: string }+` |Fired after serializing a DOM node to HTML content.
 |SetAttrib |`+{ attrElm: Element, attrName: string, attrValue: string }+` |Fired when an attribute is updated using the editor xref:apis/tinymce.dom.domutils.adoc[DOMUtils API].
-|ResizeEditor |N/A |Fired when the editor is resized, either by the resize handles or the auto-resize plugin.
+|ResizeEditor |N/A |Fired when the editor is resized, either by the resize handles or the auto-resize plugin. In {productname} 6.1 and later, this event is also fired when the xref:fullscreen.adoc[`fullscreen`] plugin toogles fullscreen mode.
 |SkinLoaded |N/A |Fired when the editor skin has been loaded.
 |SkinLoadError |`+{ message: string }+` |Fired when the editor skin fails to load.
 |ThemeLoadError |`+{ message: string }+` |Fired when the editor theme fails to load.

--- a/modules/ROOT/pages/events.adoc
+++ b/modules/ROOT/pages/events.adoc
@@ -140,7 +140,7 @@ The following events are provided by the {productname} editor.
 |PreProcess |`+{ node: Element, format: string }+` |Fired before serializing a DOM node to HTML content.
 |PostProcess |`+{ node: Element, format: string }+` |Fired after serializing a DOM node to HTML content.
 |SetAttrib |`+{ attrElm: Element, attrName: string, attrValue: string }+` |Fired when an attribute is updated using the editor xref:apis/tinymce.dom.domutils.adoc[DOMUtils API].
-|ResizeEditor |N/A |Fired when the editor is resized, either by the resize handles or the auto-resize plugin. In {productname} 6.1 and later, this event is also fired when the xref:fullscreen.adoc[`fullscreen`] plugin toogles fullscreen mode.
+|ResizeEditor |N/A |Fired when the editor is resized, either by the resize handles or the auto-resize plugin. In {productname} 6.1 and later, this event is also fired when the xref:fullscreen.adoc[`fullscreen`] plugin toggles fullscreen mode.
 |SkinLoaded |N/A |Fired when the editor skin has been loaded.
 |SkinLoadError |`+{ message: string }+` |Fired when the editor skin fails to load.
 |ThemeLoadError |`+{ message: string }+` |Fired when the editor theme fails to load.

--- a/modules/ROOT/pages/events.adoc
+++ b/modules/ROOT/pages/events.adoc
@@ -140,7 +140,7 @@ The following events are provided by the {productname} editor.
 |PreProcess |`+{ node: Element, format: string }+` |Fired before serializing a DOM node to HTML content.
 |PostProcess |`+{ node: Element, format: string }+` |Fired after serializing a DOM node to HTML content.
 |SetAttrib |`+{ attrElm: Element, attrName: string, attrValue: string }+` |Fired when an attribute is updated using the editor xref:apis/tinymce.dom.domutils.adoc[DOMUtils API].
-|ResizeEditor |N/A |Fired when the editor is resized, either by the resize handles or the auto-resize plugin. In {productname} 6.1 and later, this event is also fired when the xref:fullscreen.adoc[`fullscreen`] plugin toggles fullscreen mode.
+|ResizeEditor |N/A |Fired when the editor is resized, either by the resize handles or the auto-resize plugin. In {productname} 6.1 and later, this event is also fired when fullscreen mode is toggled. Toggling fullscreen mode requires the xref:fullscreen.adoc[`fullscreen`] plugin to be enabled.
 |SkinLoaded |N/A |Fired when the editor skin has been loaded.
 |SkinLoadError |`+{ message: string }+` |Fired when the editor skin fails to load.
 |ThemeLoadError |`+{ message: string }+` |Fired when the editor theme fails to load.

--- a/modules/ROOT/pages/fullscreen.adoc
+++ b/modules/ROOT/pages/fullscreen.adoc
@@ -23,8 +23,6 @@ tinymce.init({
 });
 ----
 
-NOTE: As of {productname} 6.1, toggling fullscreen mode with the `fullscreen` plugin also fires the `ResizeEditor` event.
-
 == Options
 
 The following configuration options affect the behavior of the {pluginname} plugin.

--- a/modules/ROOT/pages/fullscreen.adoc
+++ b/modules/ROOT/pages/fullscreen.adoc
@@ -23,6 +23,8 @@ tinymce.init({
 });
 ----
 
+NOTE: As of {productname} 6.1, toggling fullscreen mode with the `fullscreen` plugin also fires the `ResizeEditor` event.
+
 == Options
 
 The following configuration options affect the behavior of the {pluginname} plugin.

--- a/modules/ROOT/partials/configuration/fullscreen_native.adoc
+++ b/modules/ROOT/partials/configuration/fullscreen_native.adoc
@@ -32,5 +32,5 @@ tinymce.init({
 The `+fullscreen_native+` option has the following limitations. When `+fullscreen_native+` is enabled:
 
 * The Escape keyboard key (Esc) will exit full screen mode. Default editor behavior of the Esc key will be overridden by browser and the Esc key will exit full screen mode instead of closing dialogs, menus, or moving focus from the editor UI to the editor content. This may lead to accessibility issues.
-* Firefox users - The full screen keyboard shortcut (Ctrl+Shift+F) cannot be used to repeatedly toggle the browser-native full screen mode on and off without interacting with the editor between on toggles. If the user does not interact with the editor between off and on toggles, the plugin will fall-back to filling the browser window.
+* For Firefox users, the full screen keyboard shortcut (Command+Shift+F or Ctrl+Shift+F) cannot be used to repeatedly toggle the browser-native full screen mode on and off without interacting with the editor between on toggles. If the user does not interact with the editor between off and on toggles, the plugin will fall-back to filling the browser window.
 * If the editor is initialized inside an iframe element, full screen mode will only fill the iframe on Firefox.


### PR DESCRIPTION
Added a NOTE admonition to `fullscreen.adoc` to keep this in sync with the equivalent admonition added to the 5.x docs consequent to the release of 5.10.6.

Plus a small copy-edit tweak to one of the bullet list items in the ‘Limitations of the fullscreen_native option’ section of `fullscreen_native.adoc`.

Said copy-edit was noted when trawling through looking for the right spot to add the NOTE above.

Related Ticket: 

Description of Changes:
* NOTE admonition added to `fullscreen.adoc` and copy-edit applied to `fullscreen_native.adoc`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
