### PR TITLE
DOC-1844: Move onSetup links to correct rows in buttons pages

### DIFF
--- a/modules/ROOT/pages/custom-basic-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-basic-toolbar-button.adoc
@@ -15,8 +15,8 @@ A basic button triggers its `+onAction+` function when clicked.
 include::partial$misc/admon-predefined-icons-only.adoc[]
 |tooltip |string |optional |Text for button tooltip.
 |enabled |boolean |optional |default: `true` - Represents the button's state. When `false`, the button is unclickable. Toggled by the button's API.
-|onSetup |`+(api) => (api) => void+` |optional |default: `+() => () => {}+` - Function invoked when the button is rendered.
-|onAction |`+(api) => void+` |required |Function invoked when the button is clicked. For details, see: xref:using-onsetup[Using `+onSetup+`].
+|onSetup |`+(api) => (api) => void+` |optional |default: `+() => () => {}+` - Function invoked when the button is rendered. For details, see: xref:using-onsetup[Using `+onSetup+`].
+|onAction |`+(api) => void+` |required |Function invoked when the button is clicked.
 |===
 
 == API

--- a/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
@@ -16,8 +16,8 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |tooltip |string |optional |Text for button tooltip.
 |enabled |boolean |optional |default: `true` - Represents the button's state. When `false`, the button is unclickable. Toggled by the button's API.
 |active |boolean |optional |default: `false` - Represents the button's state. When `true`, the button is highlighted. Toggled by the button's API.
-|onSetup |`+(api) => (api) => void+` |optional |default: `+() => () => {}+` - Function invoked when the button is rendered.
-|onAction |`+(api) => void+` |required |Function invoked when the button is clicked. For details, see: xref:using-onsetup[Using `+onSetup+`].
+|onSetup |`+(api) => (api) => void+` |optional |default: `+() => () => {}+` - Function invoked when the button is rendered. For details, see: xref:using-onsetup[Using `+onSetup+`].
+|onAction |`+(api) => void+` |required |Function invoked when the button is clicked.
 |===
 
 == API


### PR DESCRIPTION
Related Ticket: DOC-1844

Description of Changes:
* Very minor change, just moved links to correct rows

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
