### PR TITLE
DOC-1835: added end-of-support date to version 5.10 row of supported versions page

### DIFF
--- a/_includes/misc/supported_versions.md
+++ b/_includes/misc/supported_versions.md
@@ -2,21 +2,21 @@
 
 Supported versions of {{site.productname}}:
 
-| Version |   Release Date    |  End of Support   |
-|:-------:|:-----------------:|:-----------------:|
-|   5.10  | October 20, 2021  |        TBD        |
-|   5.9   | September 15, 2021 |  March 15, 2023  |
-|   5.8   | May 19, 2021      | November 19, 2022 |
-|   5.7   | February 24, 2021 | August 24, 2022   |
-|   5.6   | December 8, 2020  |   June 8, 2022    |
-|   5.5   | October 21, 2020  |   April 21, 2022  |
-|   5.4   | July 23, 2020     | January 23, 2022  |
-|   5.3   | June 11, 2020     | December 11, 2021 |
-|   5.2   | March 9, 2020     | September 9, 2021 |
-|   5.1   | December 11, 2019 |  June 11, 2021    |
-|   5.0   | February 5, 2019  | August 5, 2020    |
-|   4.9   | November 27, 2018 | December 31, 2020 |
-|   4.8   |   July 11, 2018   | January 11, 2020  |
+| Version |   Release Date     |  End of Support   |
+|:-------:|:------------------:|:-----------------:|
+|   5.10  | October 20, 2021   |  April 20, 2023   |
+|   5.9   | September 15, 2021 |  March 15, 2023   |
+|   5.8   | May 19, 2021       | November 19, 2022 |
+|   5.7   | February 24, 2021  | August 24, 2022   |
+|   5.6   | December 8, 2020   |   June 8, 2022    |
+|   5.5   | October 21, 2020   |   April 21, 2022  |
+|   5.4   | July 23, 2020      | January 23, 2022  |
+|   5.3   | June 11, 2020      | December 11, 2021 |
+|   5.2   | March 9, 2020      | September 9, 2021 |
+|   5.1   | December 11, 2019  |  June 11, 2021    |
+|   5.0   | February 5, 2019   | August 5, 2020    |
+|   4.9   | November 27, 2018  | December 31, 2020 |
+|   4.8   |   July 11, 2018    | January 11, 2020  |
 
 To view our Software License Agreements, visit:
 


### PR DESCRIPTION
Related Ticket: [DOC-1835](https://ephocks.atlassian.net/browse/DOC-1835)

Description of Changes:
* Added end-of-support date to version 5.10 row of supported versions page. (Also added spaces to the Markdown table to clean up the table’s presentation when viewed as a plain text file.)

Pre-checks:
- [x] Branch prefixed with `feature/5/` or `hotfix/5/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
