### PR TITLE
DOC-1850: Fixed incorrect charmap xref

### DIFF
--- a/modules/ROOT/partials/index-pages/opensource-plugins.adoc
+++ b/modules/ROOT/partials/index-pages/opensource-plugins.adoc
@@ -35,7 +35,7 @@ Automatically save content in your local browser.
 
 a|
 [.lead]
-xref:autoresize.adoc[Character Map]
+xref:charmap.adoc[Character Map]
 
 Insert special characters into {productname}.
 


### PR DESCRIPTION
Related Ticket: [DOC-1850](https://ephocks.atlassian.net/jira/software/c/projects/DOC/boards/171/backlog?view=detail&selectedIssue=DOC-1850&issueLimit=100&assignee=63368ea08b75455be4572778)

Description of Changes:

Update incorrect xref link in adoc file.
* Affected file
/modules/ROOT/partials/index-pages/opensource-plugins.adoc

Fix
-xref:autoresize.adoc[Character Map]
+xref:charmap.adoc[Character Map]

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
