### PR TITLE
DOC-1851: release-notes5106.md

### DIFF
--- a/release-notes/release-notes5106.md
+++ b/release-notes/release-notes5106.md
@@ -54,7 +54,7 @@ results in the following, complete, link and no trailing text
 
 > **NOTE**: Exclamation points and colons are still boundary characters for URL detection and delimiting. If the string `https://example.com/colon:` is pasted or typed into a {{site.productname}} document, automatic link detection will produce a link that does not include the trailing colon character.
 
-For information on the PowerPaste plugin, see [PowerPaste plugin]({{site.baseurl}}/plugins/premium/powerpaste/).
+For information on the PowerPaste plugin, see: [PowerPaste plugin]({{site.baseurl}}/plugins/premium/powerpaste/).
 
 
 ## Accompanying Premium self-hosted server-side component changes

--- a/release-notes/release-notes5106.md
+++ b/release-notes/release-notes5106.md
@@ -54,7 +54,7 @@ results in the following, complete, link and no trailing text
 
 > **NOTE**: Exclamation points and colons are still boundary characters for URL detection and delimiting. If the string `https://example.com/colon:` is pasted or typed into a {{site.productname}} document, automatic link detection will produce a link that does not include the trailing colon character.
 
-For information on the PowerPaste plugin, see [PowerPaste Premium plugin]({{site.baseurl}}/plugins/premium/powerpaste/).
+For information on the PowerPaste plugin, see [PowerPaste plugin]({{site.baseurl}}/plugins/premium/powerpaste/).
 
 
 ## Accompanying Premium self-hosted server-side component changes

--- a/release-notes/release-notes5106.md
+++ b/release-notes/release-notes5106.md
@@ -12,7 +12,7 @@ keywords: releasenotes bugfixes
 
 - [Accompanying Premium Plugin changes](#accompanyingpremiumpluginchanges)
 - [Accompanying Premium self-hosted server-side component changes](#accompanyingpremiumself-hostedserver-sidecomponentchanges)
-- [General Bug fixes](#bugfixes)
+- [General Bug fixes](#generalbugfixes)
 - [Upgrading to the latest version of TinyMCE 5](#upgradingtothelatestversionoftinymce5)
 
 {{site.releasenotes_for_stable}}
@@ -54,7 +54,7 @@ results in the following, complete, link and no trailing text
 
 > **NOTE**: Exclamation points and colons are still boundary characters for URL detection and delimiting. If the string `https://example.com/colon:` is pasted or typed into a {{site.productname}} document, automatic link detection will produce a link that does not include the trailing colon character.
 
-For information on the PowerPaste plugin, [PowerPaste plugin]({{site.baseurl}}plugins/premium/powerpaste/).
+For information on the PowerPaste plugin, see [PowerPaste Premium plugin]({{site.baseurl}}plugins/premium/powerpaste/).
 
 
 ## Accompanying Premium self-hosted server-side component changes

--- a/release-notes/release-notes5106.md
+++ b/release-notes/release-notes5106.md
@@ -54,7 +54,7 @@ results in the following, complete, link and no trailing text
 
 > **NOTE**: Exclamation points and colons are still boundary characters for URL detection and delimiting. If the string `https://example.com/colon:` is pasted or typed into a {{site.productname}} document, automatic link detection will produce a link that does not include the trailing colon character.
 
-For information on the PowerPaste plugin, see [PowerPaste Premium plugin]({{site.baseurl}}plugins/premium/powerpaste/).
+For information on the PowerPaste plugin, see [PowerPaste Premium plugin]({{site.baseurl}}/plugins/premium/powerpaste/).
 
 
 ## Accompanying Premium self-hosted server-side component changes


### PR DESCRIPTION
Copy edits for the 5.10.6 release notes.

Related Ticket: [DOC-1851](https://ephocks.atlassian.net/browse/DOC-1851)

Description of Changes:
* Copy edits correcting two link errors in the 5.10.6 Release notes.

Pre-checks:
- [x] Branch prefixed with `feature/5/` or `hotfix/5/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
