### PR TITLE
DOC-1540: Replacing premium keyword >> enterprise

### DIFF
--- a/_includes/configuration/language.md
+++ b/_includes/configuration/language.md
@@ -4,12 +4,12 @@ This option specifies the language used for the {{site.productname}} user interf
 
 Before changing the language option, ensure that the language pack is available to the {{site.productname}} instance. {{site.companyname}} provides two collections of language packs:
 
-- _Premium_ language packs - Professionally localized language packs provided on {{site.cloudname}} and bundled with premium self-hosted bundles.
+- _Enterprise_ language packs - Professionally localized language packs provided on {{site.cloudname}} and bundled with enterprise self-hosted bundles.
 - _Community_ language packs - Localizations provided by {{site.productname}} users through Transifex, which need to be downloaded prior to use, from [the {{site. companyname}} Downloads Page - Language Packages]({{site.gettiny}}/language-packages/).
 
 For information on:
 
-- Using the premium language packs, see: [Using the premium language packs](#usingthepremiumlanguagepacks).
+- Using the enterprise language packs, see: [Using the enterprise language packs](#usingtheenterpriselanguagepacks).
 - Using the community language packs, see: [Using the community language packs](#usingthecommunitylanguagepacks).
 
 **Option:** `language`
@@ -29,9 +29,9 @@ tinymce.init({
 });
 ```
 
-### Using the premium language packs
+### Using the enterprise language packs
 
-The following professionally localized language packs are provided to paid {{site.cloudname}} and premium self-hosted deployments. To use these language packs, set the `language` option to the corresponding language code. No additional configuration is required.
+The following professionally localized language packs are provided to paid {{site.cloudname}} and enterprise self-hosted deployments. To use these language packs, set the `language` option to the corresponding language code. No additional configuration is required.
 
 {% include misc/ui-languages.md %}
 


### PR DESCRIPTION
Related Ticket: [DOC-1540](https://ephocks.atlassian.net/jira/software/c/projects/DOC/boards/171?modal=detail&selectedIssue=DOC-1540&assignee=63368ea08b75455be4572778)

Description of Changes:
* [Using the premium language packs](https://www.tiny.cloud/docs/configure/localization/#usingthepremiumlanguagepacks) → replace the ‘premium’ keyword with ‘enterprise’ [Language Packages | Trusted Rich Text Editor | TinyMCE](https://www.tiny.cloud/get-tiny/language-packages/) )

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
