### PR TITLE
DOC-1852: Add 'tinycomments' annotator

### DIFF
--- a/modules/ROOT/pages/comments-commands-events-apis.adoc
+++ b/modules/ROOT/pages/comments-commands-events-apis.adoc
@@ -39,7 +39,7 @@ tinymce.init({
 
 == APIs
 
-The {pluginname} plugin provides the following API.
+The {pluginname} plugin provides the xref:comments-commands-events-apis#getEventLog[`+getEventLog()+`] API, as well as an annotator named xref:comments-commands-events-apis#tinycomments-annotator[`+'tinycomments'+`] created using the xref:annotations.adoc[`+editor.annotator+` API].
 
 [[getEventLog]]
 === getEventLog()
@@ -68,7 +68,8 @@ console.log(comments.getEventLog(
 ));
 ----
 
-=== `+editor.annotator+`: `+'tinycomments'+` annotator
+[[tinycomments-annotator]]
+=== The `+'tinycomments'+` annotator
 
 The {pluginname} plugin makes use of the xref:annotations.adoc[`+editor.annotator+` API] to annotate content with attached conversations. The annotator used by the {pluginname} plugin is named `+'tinycomments'+` and is available for use in each of the `+editor.annotator+` API methods. The `+'tinycomments'+` annotator, like all editor APIs, can only be accessed after the editor is initialized.
 
@@ -87,9 +88,9 @@ tinymce.init({
       editor.annotator.annotationChanged('tinycomments', (selected, annotatorName, context) => {
         if (selected) {
           editor.notificationManager.open({
-          text: `The content you have selected contains a conversation. ${annotatorName}: ${context.uid}.`,
-          type: 'info',
-          timeout: 5000
+            text: `The content you have selected contains a conversation. ${annotatorName}: ${context.uid}.`,
+            type: 'info',
+            timeout: 5000
           });
         }
       });

--- a/modules/ROOT/pages/comments-commands-events-apis.adoc
+++ b/modules/ROOT/pages/comments-commands-events-apis.adoc
@@ -67,3 +67,62 @@ console.log(comments.getEventLog(
   { after: '2022-02-22T12:34:56Z' }  // ISO-8601 standard: YYYY-MM-DDThh:mm:ssZ
 ));
 ----
+
+=== `+editor.annotator+`: `+'tinycomments'+` annotator
+
+The {pluginname} plugin makes use of the xref:annotations.adoc[`+editor.annotator+` API] to annotate content with attached conversations. The annotator used by the {pluginname} plugin is named `+'tinycomments'+` and is available for use in each of the `+editor.annotator+` API methods. The `+'tinycomments'+` annotator, like all editor APIs, can only be accessed after the editor is initialized.
+
+==== Example: Using the `+'tinycomments'+` annotator to notify when conversations are selected
+
+This example makes use of the `+annotationChanged+` method in the `+editor.annotator+` API to create a xref:creating-custom-notifications.adoc[custom notification] to display for five seconds each time any content with the `+'tinycomments'+` annotation is selected.
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',
+  plugins: 'tinycomments',
+  toolbar: 'addcomment showcomments',
+  setup: (editor) => {
+    editor.on('init', () => {
+      editor.annotator.annotationChanged('tinycomments', (selected, annotatorName, context) => {
+        if (selected) {
+          editor.notificationManager.open({
+          text: `The content you have selected contains a conversation. ${annotatorName}: ${context.uid}.`,
+          type: 'info',
+          timeout: 5000
+          });
+        }
+      });
+    });
+  }
+});
+----
+
+==== Example: Using the `+'tinycomments'+` annotator to highlight conversations without showing comments
+
+This example makes use of the `+getAll+` method in the `+editor.annotator+` API to apply the `+'background-color: aquamarine;'+` style to any elements annotated by `+'tinycomments'+` once the `+'highlightcomments'+` button on the toolbar is pressed. This gives the elements the appearance that they are highlighted, without requiring to xref:comments-using-comments#show-or-view-a-comment[show comments].
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',
+  plugins: 'tinycomments',
+  toolbar: 'addcomment showcomments highlightcomments',
+  setup: (editor) => {
+    editor.ui.registry.addButton('highlightcomments', {
+      icon: 'highlight-bg-color',
+      onAction: () => {
+        const conversations = editor.annotator.getAll('tinycomments');
+        for (const [conversation, elements] of Object.entries(conversations)) {
+          elements.forEach((element, _) => {
+            const currentStyle = element.getAttribute('style');
+            const highlightColor = 'background-color: aquamarine;';
+            const newStyle = currentStyle ? currentStyle + highlightColor : highlightColor;
+            element.setAttribute('style', newStyle);
+          });
+        }
+      }
+    });
+  }
+});
+----

--- a/modules/ROOT/pages/comments-commands-events-apis.adoc
+++ b/modules/ROOT/pages/comments-commands-events-apis.adoc
@@ -71,11 +71,17 @@ console.log(comments.getEventLog(
 [[tinycomments-annotator]]
 === The `+'tinycomments'+` annotator
 
-The {pluginname} plugin makes use of the xref:annotations.adoc[`+editor.annotator+` API] to annotate content with attached conversations. The annotator used by the {pluginname} plugin is named `+'tinycomments'+` and is available for use in each of the `+editor.annotator+` API methods. The `+'tinycomments'+` annotator, like all editor APIs, can only be accessed after the editor is initialized.
+The {pluginname} plugin provides an annotator named `+'tinycomments'+`, constructed using the xref:annotations.adoc[`+editor.annotator+` API].
+
+The `+'tinycomments'+` annotator is used to annotate content with conversations attached, and is available for use in each of the `+editor.annotator+` API methods.
+
+The `+'tinycomments'+` annotator, like all editor APIs, can only be accessed after the editor is initialized.
 
 ==== Example: Using the `+'tinycomments'+` annotator to notify when conversations are selected
 
-This example makes use of the `+annotationChanged+` method in the `+editor.annotator+` API to create a xref:creating-custom-notifications.adoc[custom notification] to display for five seconds each time any content with the `+'tinycomments'+` annotation is selected.
+This example makes use of the `+annotationChanged+` method in the `+editor.annotator+` API to create a xref:creating-custom-notifications.adoc[custom notification].
+
+This notification displays for five seconds every time any content with a `+'tinycomments'+` annotation is selected.
 
 [source,js]
 ----
@@ -101,7 +107,9 @@ tinymce.init({
 
 ==== Example: Using the `+'tinycomments'+` annotator to highlight conversations without showing comments
 
-This example makes use of the `+getAll+` method in the `+editor.annotator+` API to apply the `+'background-color: aquamarine;'+` style to any elements annotated by `+'tinycomments'+` once the `+'highlightcomments'+` button on the toolbar is pressed. This gives the elements the appearance that they are highlighted, without requiring to xref:comments-using-comments#show-or-view-a-comment[show comments].
+This example makes use of the `+getAll+` method in the `+editor.annotator+` API to highlight every element annotated by `+'tinycomments'+`.
+
+When the `+'highlightcomments'+` button on the toolbar is toggled on, every annotated element is highlighted `+aquamarine+`, without requiring the user to xref:comments-using-comments#show-or-view-a-comment[show comments].
 
 [source,js]
 ----
@@ -110,16 +118,18 @@ tinymce.init({
   plugins: 'tinycomments',
   toolbar: 'addcomment showcomments highlightcomments',
   setup: (editor) => {
-    editor.ui.registry.addButton('highlightcomments', {
+    editor.ui.registry.addToggleButton('highlightcomments', {
       icon: 'highlight-bg-color',
-      onAction: () => {
+      onAction: (api) => {
+        api.setActive(!api.isActive());
         const conversations = editor.annotator.getAll('tinycomments');
         for (const [conversation, elements] of Object.entries(conversations)) {
           elements.forEach((element, _) => {
-            const currentStyle = element.getAttribute('style');
-            const highlightColor = 'background-color: aquamarine;';
-            const newStyle = currentStyle ? currentStyle + highlightColor : highlightColor;
-            element.setAttribute('style', newStyle);
+            if (api.isActive()) {
+              element.style.setProperty('background-color', 'aquamarine');
+            } else {
+              element.style.removeProperty('background-color');
+            }
           });
         }
       }


### PR DESCRIPTION
Related Ticket: DOC-1852

Description of Changes:
* Add description for the `'tinycomments'` annotator API
* Add example for displaying notification with `annotationChanged` method
* Add example for highlighting annotations with `getAll` method

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
