### PR TITLE
DOC-1858: Words following ‘Example:’ in sub-heads now start with a lower case letter.

### DIFF
--- a/_new_content_templates/configuration-option-setting.adoc
+++ b/_new_content_templates/configuration-option-setting.adoc
@@ -16,7 +16,7 @@ Is there any risks? (But explain them without saying the word `risk` or similar.
 
 *Default value:* `false`, `1`, `'string1'`
 
-=== Example: Using `<configuration_option>`
+=== Example: using `<configuration_option>`
 
 // This should be a working configuration. Please test.
 [source,js]
@@ -28,7 +28,7 @@ tinymce.init({
 ----
 
 // Remove if not required. add additional examples as required.
-=== Example: Disabling the <feature>
+=== Example: disabling the <feature>
 
 To disable the <feature>, set the `<configuration_option>` to `false`.
 // This should be a working configuration. Please test.

--- a/modules/ROOT/pages/a11ychecker.adoc
+++ b/modules/ROOT/pages/a11ychecker.adoc
@@ -345,7 +345,7 @@ The {pluginname} plugin provides the following APIs.
 
 Opens and closes the accessibility checker dialog with the results of the audit and options to correct the problems, if any.
 
-==== Example: Using `+toggleaudit()+`
+==== Example: using `+toggleaudit()+`
 
 [source,js]
 ----
@@ -357,7 +357,7 @@ editor.plugins.a11ychecker.toggleaudit();
 
 Conducts an accessibility audit and reports the results without opening the dialog. The report produced is an array of objects, where each object represents an xref:a11ychecker.adoc#issue[issue].
 
-==== Example: Using `+getReport()+`
+==== Example: using `+getReport()+`
 
 [source,js]
 ----

--- a/modules/ROOT/pages/advcode.adoc
+++ b/modules/ROOT/pages/advcode.adoc
@@ -23,7 +23,7 @@ liveDemo::advcode[]
 
 include::partial$misc/purchase-premium-plugins.adoc[]
 
-== Example: Basic setup
+== Example: basic setup
 
 [source,js]
 ----

--- a/modules/ROOT/pages/autocompleter.adoc
+++ b/modules/ROOT/pages/autocompleter.adoc
@@ -192,13 +192,13 @@ A `+CardContainer+` is a layout component used to apply a layout to an array of 
 
 The following examples show how to create a special characters autocompleters.
 
-=== Example: Standard Autocompleter
+=== Example: standard Autocompleter
 
 This example uses the standard autocompleter item and will show when user types the colon (`+:+`) character and at least one additional character.
 
 liveDemo::autocompleter-autocompleteitem[height="300", tab="js"]
 
-=== Example: Using `+CardMenuItems+` in the Autocompleter
+=== Example: using `+CardMenuItems+` in the Autocompleter
 
 This example uses xref:cardmenuitem[CardMenuItems] and will show when a user types a hyphen (`+-+`) character and at least one additional character.
 

--- a/modules/ROOT/pages/comments-commands-events-apis.adoc
+++ b/modules/ROOT/pages/comments-commands-events-apis.adoc
@@ -21,7 +21,7 @@ include::partial$misc/admon-requires-6.1v.adoc[]
 
 Fired when a comment is added, resolved, deleted, edited, or replied to. Contains the `getEventLog` API for retrieving log of comment changes.
 
-==== Example: The CommentChange event
+==== Example: the CommentChange event
 
 [source,js]
 ----
@@ -56,7 +56,7 @@ Returns a log with information and timestamps of all changes to comments, includ
 
 The event log can be retrieved either in full or with the `after` option, which restricts the returned list to Comment events after a time-stamp date in the link:https://en.wikipedia.org/wiki/ISO_8601[ISO-8601] format, both shown in the following:
 
-==== Example: Using `+getEventLog()+`
+==== Example: using `+getEventLog()+`
 
 [source,js]
 ----
@@ -77,7 +77,7 @@ The `+'tinycomments'+` annotator is used to annotate content with conversations 
 
 The `+'tinycomments'+` annotator, like all editor APIs, can only be accessed after the editor is initialized.
 
-==== Example: Using the `+'tinycomments'+` annotator to notify when conversations are selected
+==== Example: using the `+'tinycomments'+` annotator to notify when conversations are selected
 
 This example makes use of the `+annotationChanged+` method in the `+editor.annotator+` API to create a xref:creating-custom-notifications.adoc[custom notification].
 
@@ -105,7 +105,7 @@ tinymce.init({
 });
 ----
 
-==== Example: Using the `+'tinycomments'+` annotator to highlight conversations without showing comments
+==== Example: using the `+'tinycomments'+` annotator to highlight conversations without showing comments
 
 This example makes use of the `+getAll+` method in the `+editor.annotator+` API to highlight every element annotated by `+'tinycomments'+`.
 

--- a/modules/ROOT/pages/creating-a-plugin.adoc
+++ b/modules/ROOT/pages/creating-a-plugin.adoc
@@ -33,7 +33,7 @@ Optionally, the function passed to `+PluginManager.add()+` can return an object 
 * `+name+`: A string that contains the plugin's name, usually in a human-readable format.
 * `+url+`: A string that contains a URL, usually used to link to help documentation.
 
-=== Example: Plugin registration boilerplate
+=== Example: plugin registration boilerplate
 
 [source,js]
 ----
@@ -58,7 +58,7 @@ Custom plugins can be added to a {productname} instance by either:
 
 NOTE: {companyname} recommends using the `+external_plugins+` option for custom plugins.
 
-=== Example: Using `+external_plugins+`
+=== Example: using `+external_plugins+`
 
 [source,js]
 ----
@@ -71,7 +71,7 @@ tinymce.init({
 });
 ----
 
-=== Example: Copying plugin code into the `+plugins+` folder
+=== Example: copying plugin code into the `+plugins+` folder
 
 [source,js]
 ----
@@ -98,7 +98,7 @@ The files should be JavaScript files and use the relevant language code as the f
 . In each translation file, add translation strings by passing an object containing key-value pairs of source strings and translation strings to the xref:apis/tinymce.root.adoc#addI18n[`+tinymce.addI18n()+` API].
 . In the plugin's entry point file, call `+tinymce.PluginManager.requireLangPack()+` and pass it the plugin identifier and a comma-delimitated string of the language codes to load.
 
-=== Example: The content of a translation file for additional Spanish translations
+=== Example: the content of a translation file for additional Spanish translations
 
 [source,js]
 ----
@@ -107,7 +107,7 @@ tinymce.addI18n('es_ES', {
 });
 ----
 
-=== Example: Loading additional translation files for a custom plugin
+=== Example: loading additional translation files for a custom plugin
 
 [source,js]
 ----

--- a/modules/ROOT/pages/custom-basic-menu-items.adoc
+++ b/modules/ROOT/pages/custom-basic-menu-items.adoc
@@ -29,7 +29,7 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |setEnabled |`+(state: boolean) => void+` |Sets the menu item's enabled state.
 |===
 
-== Example: Creating a basic menu item
+== Example: creating a basic menu item
 
 [source,js]
 ----

--- a/modules/ROOT/pages/custom-nested-menu-items.adoc
+++ b/modules/ROOT/pages/custom-nested-menu-items.adoc
@@ -26,7 +26,7 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |setEnabled |`+(state: boolean) => void+` |Sets the menu item's enabled state.
 |===
 
-== Example: Creating a nested menu item
+== Example: creating a nested menu item
 
 [source,js]
 ----

--- a/modules/ROOT/pages/custom-toggle-menu-items.adoc
+++ b/modules/ROOT/pages/custom-toggle-menu-items.adoc
@@ -31,7 +31,7 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |setEnabled |`+(state: boolean) => void+` |Sets the menu item's enabled state.
 |===
 
-== Example: Creating a toggle menu item
+== Example: creating a toggle menu item
 
 [source,js]
 ----

--- a/modules/ROOT/pages/customize-ui.adoc
+++ b/modules/ROOT/pages/customize-ui.adoc
@@ -114,7 +114,7 @@ See the xref:add-css-options.adoc#content_css[content_css] customization page fo
 
 The status bar is the gray bar aligned to the bottom of the editor's editable area. The status bar contains the path information and the resize handle. Removing the status bar disables the ability for users to change the size of the editable area.
 
-=== Example: Hiding the status bar
+=== Example: hiding the status bar
 
 The following example disables the status bar.
 
@@ -145,7 +145,7 @@ tinymce.init({
 
 All of the buttons disappear after the `+code+` button is added to the toolbar and a new menu called `+Tools+` with the menu item `+Source code+` is created. (See xref:cloud-quick-start.adoc[this page] for a basic HTML code block.)
 
-=== Example: Adding the code toolbar button
+=== Example: adding the code toolbar button
 
 The following example displays the default toolbar in addition to the `+code+` functionality:
 

--- a/modules/ROOT/pages/dialog-components.adoc
+++ b/modules/ROOT/pages/dialog-components.adoc
@@ -61,7 +61,7 @@ A dialog can be configured with an xref:dialog-configuration.adoc#options[`+onTa
 
 As an example of when this is useful, the `+charmap+` and `+emoticons+` plugin dialogs use `+newTabName+` to change search results to match the character or emoticon category represented by the current tab.
 
-=== Example: Using the dialog API
+=== Example: using the dialog API
 
 Below is a trivial example of how to use `+onTabChange+` and `+showTab()+`.
 

--- a/modules/ROOT/pages/dialog-footer-buttons.adoc
+++ b/modules/ROOT/pages/dialog-footer-buttons.adoc
@@ -39,7 +39,7 @@ The different footer button types will invoke different callbacks when clicked:
 
 See the xref:dialog-configuration.adoc#options[dialog configuration options] documentation for more information.
 
-=== Example: Dialog footer button
+=== Example: dialog footer button
 
 [source,js]
 ----
@@ -90,7 +90,7 @@ The following options can be specified for a dialog menu button _item_:
 |value |string |optional |A value to associate with the menu item.
 |===
 
-==== Example: Dialog footer menu button
+==== Example: dialog footer menu button
 
 [source,js]
 ----

--- a/modules/ROOT/pages/editor-plugin-version.adoc
+++ b/modules/ROOT/pages/editor-plugin-version.adoc
@@ -34,7 +34,7 @@ These channels are updated automatically and provide the latest {productname} ve
 This channel deploys the latest release of {productname} that has passed our quality assurance process. The current version of {productname} available through the `/{productmajorversion}` channel can be found on the https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}/version.txt[{cloudname} {productname} {productmajorversion} version page]. The {productname} {productmajorversion} channel can be loaded from `{cdnurl}`.
 
 [#example-using-the-{productmajorversion}-release-channel]
-===== Example: Using the `{productmajorversion}` release channel
+===== Example: using the `{productmajorversion}` release channel
 
 [source,html,subs="attributes+"]
 ----
@@ -47,7 +47,7 @@ This channel deploys the latest release of {productname} that has passed our qua
 This channel deploys the current *release candidate* for the `{productmajorversion}` channel. The {productname} release candidate is undergoing quality assurance. The current version of {productname} available through the `{productmajorversion}-testing` channel can be found on the https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}-testing/version.txt[{cloudname} {productname} {productmajorversion}-testing version page].
 
 [#example-using-the-{productmajorversion}-testing-release-channel]
-===== Example: Using the `{productmajorversion}-testing` release channel
+===== Example: using the `{productmajorversion}-testing` release channel
 
 [source,html,subs="attributes+"]
 ----
@@ -60,7 +60,7 @@ This channel deploys the current *release candidate* for the `{productmajorversi
 This channel deploys nightly builds of {productname}. This channel includes the unreleased changes documented in the https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/CHANGELOG.md[{productname} changelog]. The current version of {productname} available through the `{productmajorversion}-dev` channel can be found on the https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}-dev/version.txt[{cloudname} {productname} {productmajorversion}-dev version page].
 
 [#example-using-the-{productmajorversion}-dev-release-channel]
-===== Example: Using the `{productmajorversion}-dev` release channel
+===== Example: using the `{productmajorversion}-dev` release channel
 
 [source,html,subs="attributes+"]
 ----

--- a/modules/ROOT/pages/help.adoc
+++ b/modules/ROOT/pages/help.adoc
@@ -38,7 +38,7 @@ include::partial$configuration/help_tabs.adoc[leveloffset=+1]
 |addTab |tabSpec: xref:dialog-components.adoc#tabpanel[TabPanel] |Register a tab for the Help dialog
 |===
 
-=== Example: Using the `+addTab+` API
+=== Example: using the `+addTab+` API
 
 [source,js]
 ----

--- a/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
+++ b/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
@@ -95,7 +95,7 @@ include::partial$events/tinymcespellchecker-events.adoc[]
 
 This event triggers when the user selects *Ignore* on a misspelled word.
 
-==== Example: The SpellcheckerIgnore event
+==== Example: the SpellcheckerIgnore event
 
 [source,js]
 ----
@@ -115,7 +115,7 @@ tinymce.init({
 
 This event triggers when the user selects *Ignore All* on a misspelled word.
 
-==== Example: The SpellcheckerIgnoreAll event
+==== Example: the SpellcheckerIgnoreAll event
 
 [source,js]
 ----
@@ -135,7 +135,7 @@ tinymce.init({
 
 This event triggers when the user *enables* the `+spellchecker+`.
 
-==== Example: The SpellcheckStart event
+==== Example: the SpellcheckStart event
 
 [source,js]
 ----
@@ -155,7 +155,7 @@ tinymce.init({
 
 This event triggers when the user *disables* the `+spellchecker+`.
 
-==== Example: The SpellcheckEnd event
+==== Example: the SpellcheckEnd event
 
 [source,js]
 ----
@@ -175,7 +175,7 @@ tinymce.init({
 
 This event triggers when a spellchecker error occurs, such as the Spell Checker Pro service can’t be reached.
 
-==== Example: The SpellcheckError event
+==== Example: the SpellcheckError event
 
 [source,js]
 ----
@@ -195,7 +195,7 @@ tinymce.init({
 
 This event fires when the spellchecking language is changed.
 
-==== Example: The SpellcheckerLanguageChanged event
+==== Example: the SpellcheckerLanguageChanged event
 
 [source,js]
 ----

--- a/modules/ROOT/pages/premium-skins-and-icons.adoc
+++ b/modules/ROOT/pages/premium-skins-and-icons.adoc
@@ -30,7 +30,7 @@ Available values for xref:add-css-options.adoc#content_css[content_css]:
 * fabric
 * fluent
 
-=== Example: Using a premium skin
+=== Example: using a premium skin
 
 [source,js]
 ----
@@ -53,7 +53,7 @@ Available values for xref:editor-icons.adoc#icons[icon] packs:
 * jam
 * thin
 
-=== Example: Using a premium icon pack
+=== Example: using a premium icon pack
 
 [source,js]
 ----

--- a/modules/ROOT/pages/quickbars.adoc
+++ b/modules/ROOT/pages/quickbars.adoc
@@ -35,7 +35,7 @@ tinymce.init({
 
 The following examples show how to disable specific quick toolbars for editors where they are not required.
 
-==== Example: Disabling the Quick Insert context toolbar
+==== Example: disabling the Quick Insert context toolbar
 
 [source,js]
 ----
@@ -46,7 +46,7 @@ tinymce.init({
 });
 ----
 
-==== Example: Disabling the Quick Selection context toolbar
+==== Example: disabling the Quick Selection context toolbar
 
 [source,js]
 ----
@@ -57,7 +57,7 @@ tinymce.init({
 });
 ----
 
-==== Example: Disabling the Quick Image context toolbar
+==== Example: disabling the Quick Image context toolbar
 
 [source,js]
 ----
@@ -74,7 +74,7 @@ tinymce.init({
 
 The Quick Link (`+quicklink+`) toolbar button lets the user quickly insert/edit links inline. It is included in the Quick Selection context toolbar by default and can be used in other context toolbars.
 
-==== Example: Using quicklink in a custom context toolbar
+==== Example: using quicklink in a custom context toolbar
 
 [source,js]
 ----
@@ -99,7 +99,7 @@ The Quick Image (`+quickimage+`) toolbar button allows users to quickly insert i
 
 NOTE: To enable automatic upload of images on insertion, xref:upload-images.adoc[image upload] must be configured.
 
-==== Example: Using quickimage in the editor toolbar
+==== Example: using quickimage in the editor toolbar
 
 [source,js]
 ----
@@ -114,7 +114,7 @@ tinymce.init({
 
 The Quick Table (`+quicktable+`) toolbar button inserts a 2x2 table with 100% width. It is included in the Quick Insert context toolbar by default and can be used in other toolbars.
 
-==== Example: Using quicktable in the editor toolbar
+==== Example: using quicktable in the editor toolbar
 
 [source,js]
 ----

--- a/modules/ROOT/pages/shortcuts.adoc
+++ b/modules/ROOT/pages/shortcuts.adoc
@@ -12,11 +12,11 @@ To add a custom keyboard shortcut to {productname}, use either:
 
 include::partial$misc/shortcut-os-mappings.adoc[]
 
-== Example: Custom keyboard shortcut
+== Example: custom keyboard shortcut
 
 liveDemo::custom-shortcut[tab="js"]
 
-== Example: Adding a custom shortcut for a menu item
+== Example: adding a custom shortcut for a menu item
 
 When adding a shortcut for a custom menu item, add both a custom shortcut and a custom menu item. To display the shortcut on a custom menu item, add the `+shortcut+` configuration option when creating the menu item.
 

--- a/modules/ROOT/pages/template.adoc
+++ b/modules/ROOT/pages/template.adoc
@@ -46,7 +46,7 @@ include::partial$configuration/template_selected_content_classes.adoc[leveloffse
 
 == Template Plugin Examples
 
-=== Example: Using the `+template+` plugin
+=== Example: using the `+template+` plugin
 
 [source,js]
 ----

--- a/modules/ROOT/pages/tinydrive-ui-options.adoc
+++ b/modules/ROOT/pages/tinydrive-ui-options.adoc
@@ -13,7 +13,7 @@ include::partial$configuration/tinydrive_skin.adoc[]
 
 The Insert File toolbar button will insert images as `+img+` elements or other files as links to that file.
 
-=== Example: Adding the `+insertfile+` toolbar button
+=== Example: adding the `+insertfile+` toolbar button
 
 This is an example of configuring the 'insertfile' toolbar button.
 

--- a/modules/ROOT/pages/use-tinymce-classic.adoc
+++ b/modules/ROOT/pages/use-tinymce-classic.adoc
@@ -20,7 +20,7 @@ There are a few important differences between these modes:
 
 liveDemo::default[]
 
-== Example: Replacing a textarea with the default editor
+== Example: replacing a textarea with the default editor
 
 A basic TinyMCE editor can be added to a `+textarea+` element with the id `+mytextarea+` using:
 

--- a/modules/ROOT/pages/wordcount.adoc
+++ b/modules/ROOT/pages/wordcount.adoc
@@ -32,7 +32,7 @@ include::partial$commands/wordcount-cmds.adoc[]
 
 The Word Count plugin exposes an API for retrieving the word and character count of either the whole document or the current editor selection. Following is an example of how to retrieve each property.
 
-=== Example: Using the `+wordcount+` plugin APIs
+=== Example: using the `+wordcount+` plugin APIs
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/a11y_advanced_options.adoc
+++ b/modules/ROOT/partials/configuration/a11y_advanced_options.adoc
@@ -19,7 +19,7 @@ IMPORTANT: When `+a11y_advanced_options+` is set to `+true+`, xref:a11ychecker.a
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+a11y_advanced_options+`
+=== Example: using `+a11y_advanced_options+`
 
 ifeval::["{includedSection}" == "imagePlugin"]
 

--- a/modules/ROOT/partials/configuration/a11ychecker_allow_decorative_images.adoc
+++ b/modules/ROOT/partials/configuration/a11ychecker_allow_decorative_images.adoc
@@ -33,7 +33,7 @@ NOTE: If xref:a11ychecker.adoc#a11y_advanced_options[`+a11y_advanced_options+`] 
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+a11ychecker_allow_decorative_images+`
+=== Example: using `+a11ychecker_allow_decorative_images+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/a11ychecker_filter_issue.adoc
+++ b/modules/ROOT/partials/configuration/a11ychecker_filter_issue.adoc
@@ -13,7 +13,7 @@ The callback function will be passed xref:a11ychecker.adoc#issue[`issue` objects
 (issue) => true;
 ----
 
-=== Example: Using `+a11ychecker_filter_issue+` to filter out the Accessibility Checker T1 rule
+=== Example: using `+a11ychecker_filter_issue+` to filter out the Accessibility Checker T1 rule
 
 The callback function in the following example will return `false` if the issue `id` value is `'T1'`, filtering `'T1'` issues from the Accessibility Checker report.
 
@@ -29,7 +29,7 @@ tinymce.init({
 });
 ----
 
-=== Example: Using `+a11ychecker_filter_issue+` to filter out all Accessibility Checker table rules and rules less than `+'error'+` level
+=== Example: using `+a11ychecker_filter_issue+` to filter out all Accessibility Checker table rules and rules less than `+'error'+` level
 
 The callback function in the following example will only return `+false+` if the issue `+element+` is a `+'table'+` and the `+'severity'+` level is not `+'error'+`, filtering all low-severity and `+table+` element-related issues from the Accessibility Checker report.
 
@@ -45,7 +45,7 @@ tinymce.init({
 });
 ----
 
-=== Example: Using `+a11ychecker_filter_issue+` to filter images with empty alternative text from the Accessibility Checker I1 rule
+=== Example: using `+a11ychecker_filter_issue+` to filter images with empty alternative text from the Accessibility Checker I1 rule
 
 The callback function in the following example will only return `false` for any issues with `'I1'` as the `+'id'+` image elements with an empty `+'alt+'` attribute, otherwise the issue won’t be filtered out. This implementation can be useful as allowing images to have empty alternative text can be another method of applying the `+role="presentation"+` attribute to mark an image as `+decorative+`.
 

--- a/modules/ROOT/partials/configuration/a11ychecker_html_version.adoc
+++ b/modules/ROOT/partials/configuration/a11ychecker_html_version.adoc
@@ -11,7 +11,7 @@ For example: Setting the version to HTML 4 will enable the rule "Complex tables 
 
 *Possible values:* `+html4+`, `+html5+`
 
-=== Example: Using `+a11ychecker_html_version+`
+=== Example: using `+a11ychecker_html_version+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/a11ychecker_ignored_rules.adoc
+++ b/modules/ROOT/partials/configuration/a11ychecker_ignored_rules.adoc
@@ -9,7 +9,7 @@ The `+a11ychecker_ignored_rules+` option prevents specific Accessibility Checker
 
 *Possible values:* `+'D1'+`, `+'D2'+`, `+'D3'+`, `+'D4O'+`, `+'D4U'+`, `+'D5A'+`, `+'D5B'+`, `+'D5C'+`, `+'H93'+`, `+'I1'+`, `+'I2'+`, `+'T1'+`, `+'T2'+`, `+'T3'+`, `+'T4A'+`, `+'T4B'+`, `+'T4C'+`
 
-=== Example: Using `+a11ychecker_ignored_rules+`
+=== Example: using `+a11ychecker_ignored_rules+`
 
 This examples shows how to ignore the following checks (rules):
 

--- a/modules/ROOT/partials/configuration/a11ychecker_issue_url_callback.adoc
+++ b/modules/ROOT/partials/configuration/a11ychecker_issue_url_callback.adoc
@@ -11,7 +11,7 @@ The `+a11ychecker_issue_url_callback+` option is used to change the target URL f
 (ruleId) => `https://www.tiny.cloud/docs/tinymce/6/a11ychecker/#${ruleId}`
 ----
 
-=== Example: Using `+a11ychecker_issue_url_callback+`
+=== Example: using `+a11ychecker_issue_url_callback+`
 
 This example shows how to change the link for the "Click for more info" button (image:icons/help.svg[help icon - a question mark inside a circle]) on the Accessibility Checker dialog to point to anchors at `+www.example.com/tinymce/a11ychecker/more_info+`.
 

--- a/modules/ROOT/partials/configuration/a11ychecker_level.adoc
+++ b/modules/ROOT/partials/configuration/a11ychecker_level.adoc
@@ -14,7 +14,7 @@ For example, the "Text must have a contrast ratio of at least ..." rule:
 
 *Possible values:* `+a+`, `+aa+`, `+aaa+`
 
-=== Example: Using `+a11ychecker_level+`
+=== Example: using `+a11ychecker_level+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/advlist_bullet_styles.adoc
+++ b/modules/ROOT/partials/configuration/advlist_bullet_styles.adoc
@@ -14,7 +14,7 @@ This option allows you to include specific unordered list item markers in the de
 * `+disc+`: a filled circle
 * `+square+`: a filled square
 
-=== Example: Using `+advlist_bullet_styles+`
+=== Example: using `+advlist_bullet_styles+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/advlist_number_styles.adoc
+++ b/modules/ROOT/partials/configuration/advlist_number_styles.adoc
@@ -16,7 +16,7 @@ This option allows you to include specific ordered list item markers in the defa
 * `+upper-alpha+`: uppercase ASCII letters, e.g. A, B, C, ... Z
 * `+upper-roman+`: uppercase roman numerals, e.g. I, II, III, IV, V ...
 
-=== Example: Using `+advlist_number_styles+`
+=== Example: using `+advlist_number_styles+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/advtable_value_series.adoc
+++ b/modules/ROOT/partials/configuration/advtable_value_series.adoc
@@ -91,7 +91,7 @@ The generator callback function should return an object with the following prope
 |value |`+string+`, `+number+` or `+undefined+` |Optional |The value of the table cell. If the value is `+undefined+`, the editor will use the previous value of the table cell.
 |===
 
-=== Example: Using `+advtable_value_series+`
+=== Example: using `+advtable_value_series+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/allow_conditional_comments.adoc
+++ b/modules/ROOT/partials/configuration/allow_conditional_comments.adoc
@@ -9,7 +9,7 @@ This option allows you to specify whether the editor should parse and keep condi
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+allow_conditional_comments+`
+=== Example: using `+allow_conditional_comments+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/allow_html_in_named_anchor.adoc
+++ b/modules/ROOT/partials/configuration/allow_html_in_named_anchor.adoc
@@ -9,7 +9,7 @@ This option allows you to specify whether the editor should parse and keep `+htm
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+allow_html_in_named_anchor+`
+=== Example: using `+allow_html_in_named_anchor+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/allow_script_urls.adoc
+++ b/modules/ROOT/partials/configuration/allow_script_urls.adoc
@@ -9,7 +9,7 @@ Enabling this option will allow `+javascript: urls+` in links and images. This i
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+allow_script_urls+`
+=== Example: using `+allow_script_urls+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/allow_unsafe_link_target.adoc
+++ b/modules/ROOT/partials/configuration/allow_unsafe_link_target.adoc
@@ -11,7 +11,7 @@ By default all links with a `+target+` of _{blanktarget}_ will get a `+rel+` att
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+allow_unsafe_link_target+`
+=== Example: using `+allow_unsafe_link_target+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/audio_template_callback.adoc
+++ b/modules/ROOT/partials/configuration/audio_template_callback.adoc
@@ -5,7 +5,7 @@ This option allows you to specify the function that will return the HTML embed c
 
 *Type:* `+Function+`
 
-=== Example: Using `+audio_template_callback+`
+=== Example: using `+audio_template_callback+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/auto_focus.adoc
+++ b/modules/ROOT/partials/configuration/auto_focus.adoc
@@ -5,7 +5,7 @@ Automatically set the focus to an editor instance. The value of this option shou
 
 *Type:* `+String+`
 
-=== Example: Using `+auto_focus+`
+=== Example: using `+auto_focus+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/autocorrect_autocorrect.adoc
+++ b/modules/ROOT/partials/configuration/autocorrect_autocorrect.adoc
@@ -13,7 +13,7 @@ include::partial$misc/autocorrect-options-notes.adoc[]
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+autocorrect_autocorrect+`
+=== Example: using `+autocorrect_autocorrect+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/autocorrect_capitalize.adoc
+++ b/modules/ROOT/partials/configuration/autocorrect_capitalize.adoc
@@ -13,7 +13,7 @@ include::partial$misc/autocorrect-options-notes.adoc[]
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+autocorrect_capitalize+`
+=== Example: using `+autocorrect_capitalize+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/autocorrect_service_url.adoc
+++ b/modules/ROOT/partials/configuration/autocorrect_service_url.adoc
@@ -9,7 +9,7 @@ NOTE: `autocorrect_service_url` is *not* required when enabling this plugin via 
 
 *Type:* `+String+`
 
-=== Example: Using `+autocorrect_service_url+`
+=== Example: using `+autocorrect_service_url+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/automatic_uploads.adoc
+++ b/modules/ROOT/partials/configuration/automatic_uploads.adoc
@@ -11,7 +11,7 @@ NOTE: This option will do nothing if `+images_upload_url+` is not specified.
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+automatic_uploads+`
+=== Example: using `+automatic_uploads+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/autoresize_bottom_margin.adoc
+++ b/modules/ROOT/partials/configuration/autoresize_bottom_margin.adoc
@@ -5,7 +5,7 @@ This option allows you to specify the size of the `+padding+` at the bottom of t
 
 *Type:* `+Number+`
 
-=== Example: Using `+autoresize_bottom_margin+`
+=== Example: using `+autoresize_bottom_margin+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/autosave_ask_before_unload.adoc
+++ b/modules/ROOT/partials/configuration/autosave_ask_before_unload.adoc
@@ -9,7 +9,7 @@ This option allows you to set whether the editor should prompt the user to advis
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+autosave_ask_before_unload+`
+=== Example: using `+autosave_ask_before_unload+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/autosave_interval.adoc
+++ b/modules/ROOT/partials/configuration/autosave_interval.adoc
@@ -7,7 +7,7 @@ This option enables you to specify the time the editor should wait between takin
 
 *Default value:* `+'30s'+`
 
-=== Example: Using `+autosave_interval+`
+=== Example: using `+autosave_interval+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/autosave_prefix.adoc
+++ b/modules/ROOT/partials/configuration/autosave_prefix.adoc
@@ -7,7 +7,7 @@ This option allows you to set the prefix that is used for local storage keys.
 
 *Default value:* `+'tinymce-autosave-{path}{query}-{id}-'+`
 
-=== Example: Using `+autosave_prefix+`
+=== Example: using `+autosave_prefix+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/autosave_restore_when_empty.adoc
+++ b/modules/ROOT/partials/configuration/autosave_restore_when_empty.adoc
@@ -9,7 +9,7 @@ This option enables you to specify if {productname} should automatically restore
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+autosave_restore_when_empty+`
+=== Example: using `+autosave_restore_when_empty+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/autosave_retention.adoc
+++ b/modules/ROOT/partials/configuration/autosave_retention.adoc
@@ -7,7 +7,7 @@ This option lets you to specify the duration editor content should remain in loc
 
 *Default value:* `+'20m'+`
 
-=== Example: Using `+autosave_retention+`
+=== Example: using `+autosave_retention+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/base_url.adoc
+++ b/modules/ROOT/partials/configuration/base_url.adoc
@@ -7,7 +7,7 @@ By default, the `+base_url+` is the directory containing {productname} javascrip
 
 *Type:* `+String+`
 
-=== Example: Using `+base_url+`
+=== Example: using `+base_url+`
 
 [source,js,subs="attributes+"]
 ----

--- a/modules/ROOT/partials/configuration/block_formats.adoc
+++ b/modules/ROOT/partials/configuration/block_formats.adoc
@@ -7,7 +7,7 @@ This option defines the formats to be displayed in the `+blocks+` dropdown toolb
 
 *Default value:* `+'Paragraph=p; Heading 1=h1; Heading 2=h2; Heading 3=h3; Heading 4=h4; Heading 5=h5; Heading 6=h6;+`
 
-=== Example: Using `+block_formats+`
+=== Example: using `+block_formats+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/block_unsupported_drop.adoc
+++ b/modules/ROOT/partials/configuration/block_unsupported_drop.adoc
@@ -9,7 +9,7 @@ When the `+block_unsupported_drop+` option is set to `+true+`, the editor blocks
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+block_unsupported_drop+`
+=== Example: using `+block_unsupported_drop+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/body_class.adoc
+++ b/modules/ROOT/partials/configuration/body_class.adoc
@@ -5,7 +5,7 @@ Use the `+body_class+` option to add a class to the body of each editor instance
 
 *Type:* `+String+`
 
-=== Example: Using `+body_class+`
+=== Example: using `+body_class+`
 
 This will add the same class to all editors that gets created by the `+init+` call.
 

--- a/modules/ROOT/partials/configuration/body_id.adoc
+++ b/modules/ROOT/partials/configuration/body_id.adoc
@@ -5,7 +5,7 @@ This option enables you to specify an id for the body of each editor instance. T
 
 *Type:* `+String+`
 
-=== Example: Using `+body_id+`
+=== Example: using `+body_id+`
 
 This will add the same id to all editors that gets created by the `+init+` call.
 

--- a/modules/ROOT/partials/configuration/br_in_pre.adoc
+++ b/modules/ROOT/partials/configuration/br_in_pre.adoc
@@ -17,7 +17,7 @@ NOTE: When this option is set to `+false+`, `+shift+enter+` will insert a `+br+`
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+br_in_pre+`
+=== Example: using `+br_in_pre+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/branding.adoc
+++ b/modules/ROOT/partials/configuration/branding.adoc
@@ -13,7 +13,7 @@ For information on {productname} attribution requirements, see: link:{legalpages
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+branding+`
+=== Example: using `+branding+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/cache_suffix.adoc
+++ b/modules/ROOT/partials/configuration/cache_suffix.adoc
@@ -5,7 +5,7 @@ This option allows a custom cache buster URL part to be added at the end of each
 
 *Type:* `+String+`
 
-=== Example: Using `+cache_suffix+`
+=== Example: using `+cache_suffix+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/casechange_title_case_minors.adoc
+++ b/modules/ROOT/partials/configuration/casechange_title_case_minors.adoc
@@ -7,7 +7,7 @@ The `+casechange_title_case_minors+` option is used to customize the rules while
 
 *Default value:* _A rule set based on https://titlecaseconverter.com/rules/#WP[Wikipedia Title Case]_
 
-=== Example: Using `+casechange_title_case_minors+`
+=== Example: using `+casechange_title_case_minors+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/charmap.adoc
+++ b/modules/ROOT/partials/configuration/charmap.adoc
@@ -7,7 +7,7 @@ With this option it is possible to fully override the default character map. Thi
 
 *Type:* `+Array+`, `+Function+`
 
-=== Example: Using `+charmap+`
+=== Example: using `+charmap+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/charmap_append.adoc
+++ b/modules/ROOT/partials/configuration/charmap_append.adoc
@@ -5,7 +5,7 @@ This option provides a way to append some additional characters to the default c
 
 *Type:* `+Array+`, `+Function+`
 
-=== Example: Using `+charmap_append+`
+=== Example: using `+charmap_append+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/codesample_global_prismjs.adoc
+++ b/modules/ROOT/partials/configuration/codesample_global_prismjs.adoc
@@ -17,7 +17,7 @@ When using this option, ensure that Prism.js and any language add-ons are loaded
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+codesample_global_prismjs+`
+=== Example: using `+codesample_global_prismjs+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/codesample_languages.adoc
+++ b/modules/ROOT/partials/configuration/codesample_languages.adoc
@@ -3,7 +3,7 @@
 
 This configuration option enables you to set a list of languages to be displayed in the languages drop down.
 
-=== Example: Using `+codesample_languages+`
+=== Example: using `+codesample_languages+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/content_css_cors.adoc
+++ b/modules/ROOT/partials/configuration/content_css_cors.adoc
@@ -9,7 +9,7 @@ When `+content_css_cors+` is set to `+true+`, the editor will add a `+crossorigi
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+content_css_cors+`
+=== Example: using `+content_css_cors+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/content_langs.adoc
+++ b/modules/ROOT/partials/configuration/content_langs.adoc
@@ -7,7 +7,7 @@ There is no default value for the `+content_langs+` option. If no value is speci
 
 *Type:* `+Array+`
 
-=== Example: Using `+content_langs+`
+=== Example: using `+content_langs+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/content_security_policy.adoc
+++ b/modules/ROOT/partials/configuration/content_security_policy.adoc
@@ -5,7 +5,7 @@ This option allows a custom content security policy to be set for the editor's i
 
 *Type:* `+String+`
 
-=== Example: Using `+content_security_policy+`
+=== Example: using `+content_security_policy+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/content_style.adoc
+++ b/modules/ROOT/partials/configuration/content_style.adoc
@@ -7,7 +7,7 @@ This option allows custom CSS styles to be set as a string. The styles are injec
 
 NOTE: `+content_style+` styles are not saved within {productname}'s content. If they are needed for display purposes, ensure the styles are also included in the page the content will be displayed on.
 
-=== Example: Applying one CSS style using `+content_style+`
+=== Example: applying one CSS style using `+content_style+`
 
 [source,js]
 ----
@@ -19,7 +19,7 @@ tinymce.init({
 
 To add two or more styles with this option, provide the styles as a single string.
 
-=== Example: Applying two or more CSS styles using `+content_style+`
+=== Example: applying two or more CSS styles using `+content_style+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/contextmenu.adoc
+++ b/modules/ROOT/partials/configuration/contextmenu.adoc
@@ -21,7 +21,7 @@ To disable the editor's context menu, set this option to `+false+`.
 
 include::partial$misc/admon-ctrl-right-click.adoc[]
 
-=== Example: Using `+contextmenu+`
+=== Example: using `+contextmenu+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/contextmenu_never_use_native.adoc
+++ b/modules/ROOT/partials/configuration/contextmenu_never_use_native.adoc
@@ -9,7 +9,7 @@ CAUTION: Using this option may result in unexpected behavior when right-clicking
 
 *Default value:* `+false+`
 
-=== Example: Using `+contextmenu_never_use_native+`
+=== Example: using `+contextmenu_never_use_native+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/custom_ui_selector.adoc
+++ b/modules/ROOT/partials/configuration/custom_ui_selector.adoc
@@ -5,7 +5,7 @@ Use the *custom_ui_selector* option to specify the elements that you want {produ
 
 *Type:* `+String+`
 
-=== Example: Using `+custom_ui_selector+`
+=== Example: using `+custom_ui_selector+`
 
 [source,html]
 ----

--- a/modules/ROOT/partials/configuration/custom_undo_redo_levels.adoc
+++ b/modules/ROOT/partials/configuration/custom_undo_redo_levels.adoc
@@ -7,7 +7,7 @@ This option should contain the number of undo levels to keep in memory. By defau
 
 *Default value:* `+unlimited+`
 
-=== Example: Using `+custom_undo_redo_levels+`
+=== Example: using `+custom_undo_redo_levels+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/directionality.adoc
+++ b/modules/ROOT/partials/configuration/directionality.adoc
@@ -11,7 +11,7 @@ This option allows you to set the base direction of directionally neutral text (
 
 *Possible values:* `+'ltr'+`, `+'rtl'+`
 
-=== Example: Using `+directionality+`
+=== Example: using `+directionality+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/document_base_url.adoc
+++ b/modules/ROOT/partials/configuration/document_base_url.adoc
@@ -7,7 +7,7 @@ This option also interacts with the xref:url-handling.adoc#relative_urls[relativ
 
 *Type:* `+String+`
 
-=== Example: Using `+document_base_url+`
+=== Example: using `+document_base_url+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/draggable_modal.adoc
+++ b/modules/ROOT/partials/configuration/draggable_modal.adoc
@@ -9,7 +9,7 @@ Use the `+draggable_modal+` option to enable dragging for xref:dialog.adoc[modal
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+draggable_modal+`
+=== Example: using `+draggable_modal+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/editable_class.adoc
+++ b/modules/ROOT/partials/configuration/editable_class.adoc
@@ -9,7 +9,7 @@ Note that classes with the `+mceItem+` prefix are invisible within {productname}
 
 *Default value:* `+'mceEditable'+`
 
-=== Example: Using `+editable_class+`
+=== Example: using `+editable_class+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/editimage_credentials_hosts.adoc
+++ b/modules/ROOT/partials/configuration/editimage_credentials_hosts.adoc
@@ -5,7 +5,7 @@ This option can be used together with the `+editimage_cors_hosts+` option to all
 
 *Type:* `+Array+`
 
-=== Example: Using `+editimage_credentials_hosts+`
+=== Example: using `+editimage_credentials_hosts+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/editimage_fetch_image.adoc
+++ b/modules/ROOT/partials/configuration/editimage_fetch_image.adoc
@@ -5,7 +5,7 @@ This option can be used to define a custom fetch function, which provides anothe
 
 *Type:* `+Function+`
 
-=== Example: Using `+editimage_fetch_image+`
+=== Example: using `+editimage_fetch_image+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/editimage_toolbar.adoc
+++ b/modules/ROOT/partials/configuration/editimage_toolbar.adoc
@@ -16,7 +16,7 @@ The exact selection of buttons that will appear on the contextual toolbar can be
 
 *Default value:* `+'rotateleft rotateright | flipv fliph | editimage imageoptions'+`
 
-=== Example: Using `+editimage_toolbar+`
+=== Example: using `+editimage_toolbar+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/editimage_upload_timeout.adoc
+++ b/modules/ROOT/partials/configuration/editimage_upload_timeout.adoc
@@ -7,7 +7,7 @@ This option can be used to configure how long an image upload should be allowed 
 
 *Default value:* `+30000+`
 
-=== Example: Using `+editimage_upload_timeout+`
+=== Example: using `+editimage_upload_timeout+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/element_format.adoc
+++ b/modules/ROOT/partials/configuration/element_format.adoc
@@ -9,7 +9,7 @@ This option controls whether elements are output in the HTML or XHTML mode. `+ht
 
 *Possible values:* `+'xhtml'+`, `+'html'+`
 
-=== Example: Using `+element_format+`
+=== Example: using `+element_format+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/elementpath.adoc
+++ b/modules/ROOT/partials/configuration/elementpath.adoc
@@ -15,7 +15,7 @@ Selecting elements from the element path allows users to perform operations on b
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+elementpath+`
+=== Example: using `+elementpath+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/emoticons_append.adoc
+++ b/modules/ROOT/partials/configuration/emoticons_append.adoc
@@ -5,7 +5,7 @@ This option provides a way to append some additional emoji to the default emoji 
 
 *Type:* `+Object+`
 
-=== Example: Using `+emoticons_append+`
+=== Example: using `+emoticons_append+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/emoticons_database.adoc
+++ b/modules/ROOT/partials/configuration/emoticons_database.adoc
@@ -17,7 +17,7 @@ include::partial$misc/under-license.adoc[]
 
 *Default value:* `+'emojis'+`
 
-=== Example: Using `+emoticons_database+`
+=== Example: using `+emoticons_database+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/emoticons_database_url.adoc
+++ b/modules/ROOT/partials/configuration/emoticons_database_url.adoc
@@ -18,7 +18,7 @@ tinymce.Resource.add('tinymce.plugins.emoticons', {
 });
 ----
 
-=== Example: Using `+emoticons_database_url+`
+=== Example: using `+emoticons_database_url+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/emoticons_images_url.adoc
+++ b/modules/ROOT/partials/configuration/emoticons_images_url.adoc
@@ -9,7 +9,7 @@ By default, this option loads the required image _assets_ from the Twemoji CDN. 
 
 *Default value:* `+'https://twemoji.maxcdn.com/v/13.0.1/72x72/'+`
 
-=== Example: Using `+emoticons_images_url+`
+=== Example: using `+emoticons_images_url+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/encoding.adoc
+++ b/modules/ROOT/partials/configuration/encoding.adoc
@@ -7,7 +7,7 @@ This option is disabled by default.
 
 *Type:* `+String+`
 
-=== Example: Using `+encoding+`
+=== Example: using `+encoding+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/end_container_on_empty_block.adoc
+++ b/modules/ROOT/partials/configuration/end_container_on_empty_block.adoc
@@ -15,7 +15,7 @@ This option specifies how the current container block element is split when the 
 
 NOTE: Prior to {productname} 6.1, this option only accepted `+Boolean+` values.
 
-=== Example: Using `+end_container_on_empty_block+`
+=== Example: using `+end_container_on_empty_block+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/entities.adoc
+++ b/modules/ROOT/partials/configuration/entities.adoc
@@ -52,7 +52,7 @@ _This setting will only encode characters higher than \u007E (126 in unicode)._
 'permil,8249,lsaquo,8250,rsaquo,8364,euro'
 ----
 
-=== Example: Using `entities`
+=== Example: using `entities`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/entity_encoding.adoc
+++ b/modules/ROOT/partials/configuration/entity_encoding.adoc
@@ -17,7 +17,7 @@ The base entities `+<+`, `+>+`, `+&+`, `+'+`, and `+"+` will always be entity en
 
 *Type:* `+String+`
 
-==== Example: Using `+entity_encoding+`
+==== Example: using `+entity_encoding+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/event_root.adoc
+++ b/modules/ROOT/partials/configuration/event_root.adoc
@@ -7,7 +7,7 @@ By default all events gets bound to the editable area. But in some implementatio
 
 *Type:* `+String+`
 
-=== Example: Using `+event_root+`
+=== Example: using `+event_root+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/extended_valid_elements.adoc
+++ b/modules/ROOT/partials/configuration/extended_valid_elements.adoc
@@ -9,7 +9,7 @@ The below example replaces the current `+img+` rule (including the global elemen
 
 *Type:* `+String+`
 
-=== Example: Using `+extended_valid_elements+`
+=== Example: using `+extended_valid_elements+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/external_plugins.adoc
+++ b/modules/ROOT/partials/configuration/external_plugins.adoc
@@ -15,7 +15,7 @@ The URLs provided can be:
 
 *Type:* `+Object+`
 
-=== Example: Using `+external_plugins+`
+=== Example: using `+external_plugins+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/file_picker_callback.adoc
+++ b/modules/ROOT/partials/configuration/file_picker_callback.adoc
@@ -13,7 +13,7 @@ It should be noted, that we only provide a hook. It is up to you to implement sp
 
 NOTE: The following example demonstrates how you can use `+file_picker_callback+` API, but doesn't pick any real files. Check the xref:interactive-example[Interactive example] for a more functional example.
 
-=== Example: Using `+file_picker_callback+`
+=== Example: using `+file_picker_callback+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/file_picker_types.adoc
+++ b/modules/ROOT/partials/configuration/file_picker_types.adoc
@@ -7,7 +7,7 @@ This option enables you to specify what types of file pickers you need by a spac
 
 *Possible values:* `+'file'+`, `+'image'+`, `+'media'+`
 
-=== Example: Using `+file_picker_types+`
+=== Example: using `+file_picker_types+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/fix_list_elements.adoc
+++ b/modules/ROOT/partials/configuration/fix_list_elements.adoc
@@ -38,7 +38,7 @@ Gets converted into this valid list:
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+fix_list_elements+`
+=== Example: using `+fix_list_elements+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/fixed_toolbar_container.adoc
+++ b/modules/ROOT/partials/configuration/fixed_toolbar_container.adoc
@@ -7,7 +7,7 @@ Use this option to render the inline toolbar into a fixed positioned HTML elemen
 
 *Type:* `+String+`
 
-=== Example: Using `+fixed_toolbar_container+`
+=== Example: using `+fixed_toolbar_container+`
 
 This example takes a CSS 3 selector named `+'#mytoolbar'+` and renders any inline toolbars into this element.
 

--- a/modules/ROOT/partials/configuration/fixed_toolbar_container_target.adoc
+++ b/modules/ROOT/partials/configuration/fixed_toolbar_container_target.adoc
@@ -9,7 +9,7 @@ IMPORTANT: `+fixed_toolbar_container+` has precedence over `+fixed_toolbar_conta
 
 *Type:* `+HTMLElement+`
 
-=== Example: Using `+fixed_toolbar_container_target+`
+=== Example: using `+fixed_toolbar_container_target+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/font_family_formats.adoc
+++ b/modules/ROOT/partials/configuration/font_family_formats.adoc
@@ -11,7 +11,7 @@ This option defines the fonts to be displayed in the `+fontfamily+` dropdown too
 'Andale Mono=andale mono,times; Arial=arial,helvetica,sans-serif; Arial Black=arial black,avant garde; Book Antiqua=book antiqua,palatino; Comic Sans MS=comic sans ms,sans-serif; Courier New=courier new,courier; Georgia=georgia,palatino; Helvetica=helvetica; Impact=impact,chicago; Symbol=symbol; Tahoma=tahoma,arial,helvetica,sans-serif; Terminal=terminal,monaco; Times New Roman=times new roman,times; Trebuchet MS=trebuchet ms,geneva; Verdana=verdana,geneva; Webdings=webdings; Wingdings=wingdings,zapf dingbats'
 ----
 
-=== Example: Using `font_family_formats`
+=== Example: using `font_family_formats`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/font_size_formats.adoc
+++ b/modules/ROOT/partials/configuration/font_size_formats.adoc
@@ -7,7 +7,7 @@ This option allows you to override the font sizes displayed in the `+fontsize+` 
 
 *Default value:* `+'8pt 10pt 12pt 14pt 18pt 24pt 36pt'+`
 
-=== Example: Using `+font_size_formats+`
+=== Example: using `+font_size_formats+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/forced_root_block.adoc
+++ b/modules/ROOT/partials/configuration/forced_root_block.adoc
@@ -11,7 +11,7 @@ WARNING: Not using `+p+` elements as the root block will impair the functionalit
 
 *Default value:* `+'p'+`
 
-=== Example: Using `+forced_root_block+`
+=== Example: using `+forced_root_block+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/forced_root_block_attrs.adoc
+++ b/modules/ROOT/partials/configuration/forced_root_block_attrs.adoc
@@ -5,7 +5,7 @@ This option enables you specify attributes for the xref:content-filtering.adoc#f
 
 *Type:* `+Object+`
 
-=== Example: Using `+forced_root_block_attrs+`
+=== Example: using `+forced_root_block_attrs+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/format_empty_lines.adoc
+++ b/modules/ROOT/partials/configuration/format_empty_lines.adoc
@@ -7,7 +7,7 @@ This option allows "inline" formats to be applied to empty lines for multi-line 
 
 *Default value:* `+false+`
 
-=== Example: Using `+format_empty_lines+`
+=== Example: using `+format_empty_lines+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/format_noneditable_selector.adoc
+++ b/modules/ROOT/partials/configuration/format_noneditable_selector.adoc
@@ -13,7 +13,7 @@ NOTE: Elements with `contenteditable="false"` attributes that contain descendant
 
 *Type:* `+String+`
 
-=== Example: Using `+format_noneditable_selector+`
+=== Example: using `+format_noneditable_selector+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/formatpainter_formats.adoc
+++ b/modules/ROOT/partials/configuration/formatpainter_formats.adoc
@@ -7,7 +7,7 @@ The example below showcases the formats registered automatically by the plugin u
 
 *Type:* `+Object+`
 
-=== Example: Using `+formats+`
+=== Example: using `+formats+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/formatpainter_ignored_formats.adoc
+++ b/modules/ROOT/partials/configuration/formatpainter_ignored_formats.adoc
@@ -7,7 +7,7 @@ This option makes it possible to block the unwanted formats in the format painte
 
 *Default value:* `+'link,address,removeformat,formatpainter_removeformat'+`
 
-=== Example: Using `+formatpainter_ignored_formats+`
+=== Example: using `+formatpainter_ignored_formats+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/formats.adoc
+++ b/modules/ROOT/partials/configuration/formats.adoc
@@ -82,7 +82,7 @@ Tag name of the block element to use as a wrapper, for example, `+h1+`. Existing
 
 *Type:* `+String+`
 
-===== Example: Using `+block+` format
+===== Example: using `+block+` format
 
 [source,js]
 ----
@@ -102,7 +102,7 @@ Tag name of the inline element to use as a wrapper, for example, `+span+` is use
 
 *Type:* `+String+`
 
-===== Example: Using `+inline+` format
+===== Example: using `+inline+` format
 
 [source,js]
 ----
@@ -122,7 +122,7 @@ CSS3 selector pattern that is used to find elements within the selection. It can
 
 *Type:* `+String+`
 
-===== Example: Using `+selector+` format
+===== Example: using `+selector+` format
 
 [source,js]
 ----
@@ -155,7 +155,7 @@ To replace existing classes, use the `+class+` attribute.
 
 *Type:* `+String+`
 
-===== Example: Using `+classes+` parameter
+===== Example: using `+classes+` parameter
 
 [source,js]
 ----
@@ -175,7 +175,7 @@ Key/value object with CSS styles to apply to the selected or newly created inlin
 
 *Type:* `+Object+`
 
-===== Example: Using `+styles+` parameter
+===== Example: using `+styles+` parameter
 
 [source,js]
 ----
@@ -195,7 +195,7 @@ Key/value object with attributes to apply to the selected or newly created inlin
 
 *Type:* `+Object+`
 
-===== Example: Using `+attributes+` parameter
+===== Example: using `+attributes+` parameter
 
 [source,js]
 ----
@@ -208,7 +208,7 @@ tinymce.init({
 });
 ----
 
-===== Example: Using `+class+` in the attributes parameter
+===== Example: using `+class+` in the attributes parameter
 
 To apply a class to new or selected existing elements, add the `+'class'+` attribute to the `+attributes+` parameter. The provided class will replace any existing classes on the element when the format is applied.
 
@@ -235,7 +235,7 @@ Makes sure that the format is not merged with other wrappers having the same for
 
 *Default value:* `+false+`
 
-===== Example: Using `+exact+` parameter
+===== Example: using `+exact+` parameter
 
 [source,js]
 ----
@@ -258,7 +258,7 @@ States that the format is a container format for block elements. For example, a 
 
 *Default value:* `+false+`
 
-===== Example: Using `+wrapper+`
+===== Example: using `+wrapper+`
 
 [source,js]
 ----
@@ -286,7 +286,7 @@ This can be set to three different modes:
 * *empty*: If the element has no styles, classes, or attributes then the element is removed.
 * *all*: Removes the element regardless of its styles, classes, and or attributes.
 
-===== Example: Using `+remove+`
+===== Example: using `+remove+`
 
 [source,js]
 ----
@@ -317,7 +317,7 @@ So if the selection is from _a_ to _b_ in this html contents `+<h1><b>[a</b></h1
 
 *Type:* `+Boolean+`
 
-===== Example: Using `+block_expand+`
+===== Example: using `+block_expand+`
 
 [source,js]
 ----
@@ -356,7 +356,7 @@ Enables control for removing the child elements of the matching format. This is 
 
 *Default value:* `+false+` for `+selector+` formats
 
-===== Example: Using `+deep+`
+===== Example: using `+deep+`
 
 [source,js]
 ----
@@ -394,7 +394,7 @@ After merge:
 
 *Default value:* `+true+`
 
-===== Example: Using `+merge_siblings+`
+===== Example: using `+merge_siblings+`
 
 [source,js]
 ----
@@ -414,7 +414,7 @@ This example overrides some of the built-in formats and tells {productname} to a
 
 *Type:* `+Object+`
 
-==== Example: Using the `+formats+` option
+==== Example: using the `+formats+` option
 
 [source,js]
 ----
@@ -472,7 +472,7 @@ Use the `+removeformat+` option to specify how the `+clear formatting+` feature 
 
 *Type:* `+Array+`
 
-==== Example: Removing a format
+==== Example: removing a format
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/fullscreen_native.adoc
+++ b/modules/ROOT/partials/configuration/fullscreen_native.adoc
@@ -13,7 +13,7 @@ The `+fullscreen_native+` option allows the editor to use the browser full scree
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+fullscreen_native+`
+=== Example: using `+fullscreen_native+`
 
 To use the browser-native full screen mode for the {productname} editor, set `+fullscreen_native+` to `+true+`. For example:
 

--- a/modules/ROOT/partials/configuration/height.adoc
+++ b/modules/ROOT/partials/configuration/height.adoc
@@ -9,7 +9,7 @@ NOTE: If a number is provided, {productname} sets the height in pixels. If a str
 
 *Default value:* `+400+` or the size of the target element if larger than 400 pixels
 
-=== Example: Using `+height+`
+=== Example: using `+height+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/help_tabs.adoc
+++ b/modules/ROOT/partials/configuration/help_tabs.adoc
@@ -11,7 +11,7 @@ If `+help_tabs+` is not configured, any tabs defined using `+addTab+` will be di
 
 *Default value:* `+[ 'shortcuts', 'keyboardnav', 'plugins', 'versions' ]+`
 
-=== Example: Using `+help_tabs+`
+=== Example: using `+help_tabs+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/hidden_input.adoc
+++ b/modules/ROOT/partials/configuration/hidden_input.adoc
@@ -11,7 +11,7 @@ The *hidden_input* option can be disabled if you don't need these controls.
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+hidden_input+`
+=== Example: using `+hidden_input+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/icons.adoc
+++ b/modules/ROOT/partials/configuration/icons.adoc
@@ -43,7 +43,7 @@ tinymce.init({
 endif::[]
 ifeval::[{customIconPack} != true]
 
-=== Example: Using `+icons+`
+=== Example: using `+icons+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/icons_url.adoc
+++ b/modules/ROOT/partials/configuration/icons_url.adoc
@@ -25,7 +25,7 @@ endif::[]
 ifeval::[{customIconPack} != true]
 *Type:* `+String+`
 
-=== Example: Using `+icons_url+`
+=== Example: using `+icons_url+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/iframe_aria_text.adoc
+++ b/modules/ROOT/partials/configuration/iframe_aria_text.adoc
@@ -14,7 +14,7 @@ The `+title+` attribute is read by screen-readers to help users identify the edi
 
 *Default value:* `+'Rich Text Area. Press ALT-0 for help.'+`
 
-=== Example: Using `+iframe_aria_text+`
+=== Example: using `+iframe_aria_text+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/iframe_template_callback.adoc
+++ b/modules/ROOT/partials/configuration/iframe_template_callback.adoc
@@ -7,7 +7,7 @@ This option allows you to specify the function that will return the HTML embed c
 
 *Type:* `+Function+`
 
-=== Example: Using `+iframe_template_callback+`
+=== Example: using `+iframe_template_callback+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/image_advtab.adoc
+++ b/modules/ROOT/partials/configuration/image_advtab.adoc
@@ -9,7 +9,7 @@ This option adds an "Advanced" tab to the image dialog allowing you to add custo
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+image_advtab+`
+=== Example: using `+image_advtab+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/image_caption.adoc
+++ b/modules/ROOT/partials/configuration/image_caption.adoc
@@ -9,7 +9,7 @@ This option lets users enable captions for images. When this option is enabled t
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+image_caption+`
+=== Example: using `+image_caption+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/image_class_list.adoc
+++ b/modules/ROOT/partials/configuration/image_class_list.adoc
@@ -5,7 +5,7 @@ This option lets you specify a predefined list of classes to add to an image. It
 
 *Type:* `+Array+`
 
-=== Example: Using `+image_class_list+`
+=== Example: using `+image_class_list+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/image_description.adoc
+++ b/modules/ROOT/partials/configuration/image_description.adoc
@@ -9,7 +9,7 @@ This options allows you disable the image description input field in the image d
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+image_description+`
+=== Example: using `+image_description+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/image_dimensions.adoc
+++ b/modules/ROOT/partials/configuration/image_dimensions.adoc
@@ -9,7 +9,7 @@ This options allows you disable the image dimensions input field in the image di
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+image_dimensions+`
+=== Example: using `+image_dimensions+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/image_list.adoc
+++ b/modules/ROOT/partials/configuration/image_list.adoc
@@ -7,7 +7,7 @@ This option lets you specify a predefined list of sources for images. `+image_li
 
 *Default value:* `+false+`
 
-=== Example: Using `+image_list+`
+=== Example: using `+image_list+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/image_prepend_url.adoc
+++ b/modules/ROOT/partials/configuration/image_prepend_url.adoc
@@ -5,7 +5,7 @@ This option allows you to specify a URL prefix that will be applied to images wh
 
 *Type:* `+String+`
 
-=== Example: Using `+image_prepend_url+`
+=== Example: using `+image_prepend_url+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/image_proxy.adoc
+++ b/modules/ROOT/partials/configuration/image_proxy.adoc
@@ -17,7 +17,7 @@ NOTE: `{proxy_setting_name}` is *not* required when enabling this plugin via xre
 
 *Type:* `+String+`
 
-=== Example: Using `{proxy_setting_name}`
+=== Example: using `{proxy_setting_name}`
 
 [source,js,subs="attributes+"]
 ----

--- a/modules/ROOT/partials/configuration/image_proxy_service_url.adoc
+++ b/modules/ROOT/partials/configuration/image_proxy_service_url.adoc
@@ -17,7 +17,7 @@ NOTE: `{proxy_setting_name}` is *not* required when enabling this plugin via xre
 
 *Type:* `+String+`
 
-=== Example: Using `{proxy_setting_name}`
+=== Example: using `{proxy_setting_name}`
 
 [source,js,subs="attributes+"]
 ----

--- a/modules/ROOT/partials/configuration/image_title.adoc
+++ b/modules/ROOT/partials/configuration/image_title.adoc
@@ -9,7 +9,7 @@ This options allows you enable the image title input field in the image dialog.
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+image_title+`
+=== Example: using `+image_title+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/image_toolbar.adoc
+++ b/modules/ROOT/partials/configuration/image_toolbar.adoc
@@ -9,7 +9,7 @@ To disable the Quick Image toolbar, set `+quickbars_image_toolbar+` to `+false+`
 
 *Default value:* `+'alignleft aligncenter alignright'+`
 
-=== Example: Customizing the Quick Image toolbar
+=== Example: customizing the Quick Image toolbar
 
 [source,js]
 ----
@@ -20,7 +20,7 @@ tinymce.init({
 });
 ----
 
-=== Example: Disabling the Quick Image toolbar
+=== Example: disabling the Quick Image toolbar
 
 To disable the Quick Image toolbar, set `+quickbars_image_toolbar+` to `+false+`.
 

--- a/modules/ROOT/partials/configuration/image_uploadtab.adoc
+++ b/modules/ROOT/partials/configuration/image_uploadtab.adoc
@@ -9,7 +9,7 @@ This option adds an "Upload" tab to the image dialog allowing you to upload loca
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+image_uploadtab+`
+=== Example: using `+image_uploadtab+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/images_file_types.adoc
+++ b/modules/ROOT/partials/configuration/images_file_types.adoc
@@ -12,7 +12,7 @@ This option configures which image file formats are accepted by the editor. Chan
 
 *Possible values:* A list of valid web image file extensions. For a list of possible values see: https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types[MDN Web Docs - Image file type and format guide].
 
-=== Example: Using `+images_file_types+`
+=== Example: using `+images_file_types+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/images_reuse_filename.adoc
+++ b/modules/ROOT/partials/configuration/images_reuse_filename.adoc
@@ -11,7 +11,7 @@ Setting `+images_reuse_filename+` to _true_ tells {productname} to use the actua
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+images_reuse_filename+`
+=== Example: using `+images_reuse_filename+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/images_upload_base_path.adoc
+++ b/modules/ROOT/partials/configuration/images_upload_base_path.adoc
@@ -5,7 +5,7 @@ This option lets you specify a `+basepath+` to prepend to URLs returned from the
 
 *Type:* `+String+`
 
-=== Example: Using `+images_upload_base_path+`
+=== Example: using `+images_upload_base_path+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/images_upload_credentials.adoc
+++ b/modules/ROOT/partials/configuration/images_upload_credentials.adoc
@@ -9,7 +9,7 @@ The *images_upload_credentials* option specifies whether calls to the configured
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+images_upload_credentials+`
+=== Example: using `+images_upload_credentials+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/images_upload_handler.adoc
+++ b/modules/ROOT/partials/configuration/images_upload_handler.adoc
@@ -17,7 +17,7 @@ When this option is not set, {productname} utilizes an `+XMLHttpRequest+` to upl
 
 *Type:* `+Function+`
 
-=== Example: Using `+images_upload_handler+`
+=== Example: using `+images_upload_handler+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/images_upload_url.adoc
+++ b/modules/ROOT/partials/configuration/images_upload_url.adoc
@@ -12,7 +12,7 @@ Be sure to checkout a demo implementation of the server-side upload handler xref
 
 *Type:* `+String+`
 
-=== Example: Using `+images_upload_url+`
+=== Example: using `+images_upload_url+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/importcss_append.adoc
+++ b/modules/ROOT/partials/configuration/importcss_append.adoc
@@ -7,7 +7,7 @@ If set to `+true+` this option will append the imported styles to the end of the
 
 *Default value:* `+false+`
 
-=== Example: Using `+importcss_append+`
+=== Example: using `+importcss_append+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/importcss_exclusive.adoc
+++ b/modules/ROOT/partials/configuration/importcss_exclusive.adoc
@@ -7,7 +7,7 @@ If set to `+false+` then selectors will not be globally exclusive meaning they c
 
 *Default value:* `+true+`
 
-=== Example: Using `+importcss_exclusive+`
+=== Example: using `+importcss_exclusive+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/importcss_file_filter.adoc
+++ b/modules/ROOT/partials/configuration/importcss_file_filter.adoc
@@ -5,7 +5,7 @@ This option enables you to add the CSS files that should be used for populating 
 
 *Type:* `+String+`, `+RegExp+` or `+Function+`
 
-=== Example: Using `+importcss_file_filter+`
+=== Example: using `+importcss_file_filter+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/importcss_merge_classes.adoc
+++ b/modules/ROOT/partials/configuration/importcss_merge_classes.adoc
@@ -7,7 +7,7 @@ This option is used in cases where the class attribute should be replaced or mer
 
 *Default value:* `+true+`
 
-=== Example: Using `+importcss_merge_classes+`
+=== Example: using `+importcss_merge_classes+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/importcss_selector_converter.adoc
+++ b/modules/ROOT/partials/configuration/importcss_selector_converter.adoc
@@ -5,7 +5,7 @@ This option allows you to override the default selector to format converter func
 
 *Type:* `+Function+`
 
-=== Example: Using `+importcss_selector_converter+`
+=== Example: using `+importcss_selector_converter+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/indent_use_margin.adoc
+++ b/modules/ROOT/partials/configuration/indent_use_margin.adoc
@@ -7,7 +7,7 @@ This option is set if the editor should use margin instead of padding when inden
 
 *Default value:* `+false+`
 
-=== Example: Using `+indent_use_margin+`
+=== Example: using `+indent_use_margin+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/indentation.adoc
+++ b/modules/ROOT/partials/configuration/indentation.adoc
@@ -9,7 +9,7 @@ The *indentation* option defaults to 30px but can be any value.
 
 *Default value:* `+'30px'+`
 
-=== Example: Using `+indentation+`
+=== Example: using `+indentation+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/init_instance_callback.adoc
+++ b/modules/ROOT/partials/configuration/init_instance_callback.adoc
@@ -5,7 +5,7 @@ This option allows a function to be provided that will be executed each time an 
 
 *Type:* `+Function+`
 
-=== Example: Using `+init_instance_callback+`
+=== Example: using `+init_instance_callback+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/inline.adoc
+++ b/modules/ROOT/partials/configuration/inline.adoc
@@ -13,7 +13,7 @@ The inline editing mode is useful when creating user experiences where you want 
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+inline+`
+=== Example: using `+inline+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/inline_boundaries.adoc
+++ b/modules/ROOT/partials/configuration/inline_boundaries.adoc
@@ -9,7 +9,7 @@ This option allows you to disable the inline boundaries. For information on how 
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+inline_boundaries+`
+=== Example: using `+inline_boundaries+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/inline_boundaries_selector.adoc
+++ b/modules/ROOT/partials/configuration/inline_boundaries_selector.adoc
@@ -9,7 +9,7 @@ If you add new elements, you need to add CSS selectors for them in the content C
 
 *Default value:* `+'a[href],code,.mce-annotation'+`
 
-=== Example: Using `+inline_boundaries_selector+`
+=== Example: using `+inline_boundaries_selector+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/insert_toolbar.adoc
+++ b/modules/ROOT/partials/configuration/insert_toolbar.adoc
@@ -9,7 +9,7 @@ To disable the Quick Insert toolbar, set `+quickbars_insert_toolbar+` to `+false
 
 *Default value:* `+'quickimage quicktable'+`
 
-=== Example: Customizing the Quick Insert toolbar
+=== Example: customizing the Quick Insert toolbar
 
 [source,js]
 ----
@@ -20,7 +20,7 @@ tinymce.init({
 });
 ----
 
-=== Example: Disabling the Quick Insert toolbar
+=== Example: disabling the Quick Insert toolbar
 
 To disable the Quick Insert toolbar, set `+quickbars_insert_toolbar+` to `+false+`.
 

--- a/modules/ROOT/partials/configuration/insertdatetime_dateformat.adoc
+++ b/modules/ROOT/partials/configuration/insertdatetime_dateformat.adoc
@@ -7,7 +7,7 @@ This option allows you to override the default formatting rule for date formats 
 
 *Default value:* `+'%Y-%m-%d'+`
 
-=== Example: Using `+insertdatetime_dateformat+`
+=== Example: using `+insertdatetime_dateformat+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/insertdatetime_element.adoc
+++ b/modules/ROOT/partials/configuration/insertdatetime_element.adoc
@@ -9,7 +9,7 @@ When this option is enabled HTML5 time elements gets generated when you insert d
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+insertdatetime_element+`
+=== Example: using `+insertdatetime_element+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/insertdatetime_formats.adoc
+++ b/modules/ROOT/partials/configuration/insertdatetime_formats.adoc
@@ -7,7 +7,7 @@ Allows you to specify a list of date/time formats to be used in the date menu or
 
 *Default value:* `+[ '%H:%M:%S', '%Y-%m-%d', '%I:%M:%S %p', '%D' ]+`
 
-=== Example: Using `+insertdatetime_formats+`
+=== Example: using `+insertdatetime_formats+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/insertdatetime_timeformat.adoc
+++ b/modules/ROOT/partials/configuration/insertdatetime_timeformat.adoc
@@ -7,7 +7,7 @@ This option allows you to override the default formatting rule for times inserte
 
 *Default value:* `+'%H:%M:%S'+`
 
-=== Example: Using `+insertdatetime_timeformat+`
+=== Example: using `+insertdatetime_timeformat+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/invalid_elements.adoc
+++ b/modules/ROOT/partials/configuration/invalid_elements.adoc
@@ -5,7 +5,7 @@ This option instructs the editor to remove specific elements when {productname} 
 
 *Type:* `+String+`
 
-=== Example: Using `+invalid_elements+`
+=== Example: using `+invalid_elements+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/invalid_styles.adoc
+++ b/modules/ROOT/partials/configuration/invalid_styles.adoc
@@ -10,7 +10,7 @@ This option enables you to restrict the styles that are valid for specific eleme
 
 *Type:* `+String+`, `+Object+`
 
-==== Example: Using `+invalid_styles+` string
+==== Example: using `+invalid_styles+` string
 
 [source,js]
 ----
@@ -24,7 +24,7 @@ tinymce.init({
 
 *Type:* `+String+`, `+Object+`
 
-==== Example: Using `+invalid_styles+` object
+==== Example: using `+invalid_styles+` object
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/keep_styles.adoc
+++ b/modules/ROOT/partials/configuration/keep_styles.adoc
@@ -9,7 +9,7 @@ The *keep_styles* option will keep the editor's current text style when a user p
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+keep_styles+`
+=== Example: using `+keep_styles+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/language.adoc
+++ b/modules/ROOT/partials/configuration/language.adoc
@@ -17,7 +17,7 @@ For information on:
 
 *Default value:* `+'en_US'+`
 
-=== Example: Using `+language+`
+=== Example: using `+language+`
 
 In this example we will set the editor language to Swedish.
 

--- a/modules/ROOT/partials/configuration/language_url.adoc
+++ b/modules/ROOT/partials/configuration/language_url.adoc
@@ -5,7 +5,7 @@ When using the xref:ui-localization.adoc#language[`+language+`] option to set th
 
 *Type:* `+String+`
 
-=== Example: Using `+language_url+`
+=== Example: using `+language_url+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/line_height_formats.adoc
+++ b/modules/ROOT/partials/configuration/line_height_formats.adoc
@@ -7,7 +7,7 @@ This option allows you to override the line heights displayed in the `+lineheigh
 
 *Default value:* `+'1 1.1 1.2 1.3 1.4 1.5 2'+`
 
-=== Example: Using `+line_height_formats+`
+=== Example: using `+line_height_formats+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/link_assume_external_targets.adoc
+++ b/modules/ROOT/partials/configuration/link_assume_external_targets.adoc
@@ -14,7 +14,7 @@ Set whether {productname} should prepend a `+http://+` prefix if the supplied UR
 
 *Possible values:* `+true+`, `+false+`, `+'http'+`, `+'https'+`
 
-=== Example: Using `+link_assume_external_targets+`
+=== Example: using `+link_assume_external_targets+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/link_class_list.adoc
+++ b/modules/ROOT/partials/configuration/link_class_list.adoc
@@ -7,7 +7,7 @@ The `+link_class_list+` option allows you to specify a list of classes for the l
 
 *Default value:* `+[]+`
 
-=== Example: Using `+link_class_list+`
+=== Example: using `+link_class_list+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/link_context_toolbar.adoc
+++ b/modules/ROOT/partials/configuration/link_context_toolbar.adoc
@@ -11,7 +11,7 @@ NOTE: This context toolbar is the same as the context toolbar mentioned in the x
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+link_context_toolbar+`
+=== Example: using `+link_context_toolbar+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/link_default_protocol.adoc
+++ b/modules/ROOT/partials/configuration/link_default_protocol.adoc
@@ -19,7 +19,7 @@ endif::[]
 
 *Default value:* `+'https'+`
 
-=== Example: Using `+link_default_protocol+`
+=== Example: using `+link_default_protocol+`
 
 [source,js,subs="attributes+"]
 ----

--- a/modules/ROOT/partials/configuration/link_default_target.adoc
+++ b/modules/ROOT/partials/configuration/link_default_target.adoc
@@ -17,7 +17,7 @@ endif::[]
 
 *Type:* `+String+`
 
-=== Example: Using `+link_default_target+`
+=== Example: using `+link_default_target+`
 
 [source,js,subs="attributes+"]
 ----

--- a/modules/ROOT/partials/configuration/link_quicklink.adoc
+++ b/modules/ROOT/partials/configuration/link_quicklink.adoc
@@ -11,7 +11,7 @@ NOTE: This context toolbar is the same as the context toolbar mentioned in the x
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+link_quicklink+`
+=== Example: using `+link_quicklink+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/link_rel_list.adoc
+++ b/modules/ROOT/partials/configuration/link_rel_list.adoc
@@ -7,7 +7,7 @@ This option lets you specify a list of `+rel+` values for the `+link+` dialog. T
 
 *Default value:* `+[]+`
 
-=== Example: Using `+link_rel_list+`
+=== Example: using `+link_rel_list+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/link_target_list.adoc
+++ b/modules/ROOT/partials/configuration/link_target_list.adoc
@@ -16,7 +16,7 @@ If xref:link.adoc#link_default_target[`+link_default_target+`] is also configure
 ]
 ----
 
-=== Example: Adding a `_parent` target to the dropdown list
+=== Example: adding a `_parent` target to the dropdown list
 
 [source,js]
 ----
@@ -35,7 +35,7 @@ tinymce.init({
 
 To disable the option dialog, set `+link_target_list+` to `+false+`.
 
-=== Example: Turning off the target list dialog
+=== Example: turning off the target list dialog
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/link_title.adoc
+++ b/modules/ROOT/partials/configuration/link_title.adoc
@@ -9,7 +9,7 @@ This options allows you disable the link `+title+` input field in the `+link+` d
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+link_title+`
+=== Example: using `+link_title+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/linkchecker_content_css.adoc
+++ b/modules/ROOT/partials/configuration/linkchecker_content_css.adoc
@@ -21,7 +21,7 @@ It is possible to replace or extend those styles, by providing a URL to custom s
 
 *Type:* `+String+`
 
-=== Example: Using `+linkchecker_content_css+`
+=== Example: using `+linkchecker_content_css+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/linkchecker_preprocess.adoc
+++ b/modules/ROOT/partials/configuration/linkchecker_preprocess.adoc
@@ -5,7 +5,7 @@ The `+linkchecker_preprocess+` function is used for adjusting links before perfo
 
 *Type:* `+Function+`
 
-=== Example: Using `+linkchecker_preprocess+`
+=== Example: using `+linkchecker_preprocess+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/linkchecker_service_url.adoc
+++ b/modules/ROOT/partials/configuration/linkchecker_service_url.adoc
@@ -5,7 +5,7 @@ A URL of the server-side link validation service. This is a required option, wit
 
 *Type:* `+String+`
 
-=== Example: Using `+linkchecker_service_url+`
+=== Example: using `+linkchecker_service_url+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/lists_indent_on_tab.adoc
+++ b/modules/ROOT/partials/configuration/lists_indent_on_tab.adoc
@@ -9,7 +9,7 @@ This boolean option allows to disable the indent on tab key functionality. Its d
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+lists_indent_on_tab+`
+=== Example: using `+lists_indent_on_tab+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/max_height.adoc
+++ b/modules/ROOT/partials/configuration/max_height.adoc
@@ -8,7 +8,7 @@ The `+max_height+` option has two kinds of behaviors depending on the state of t
 
 *Type:* `+Number+`
 
-=== Example: Using `+max_height+`
+=== Example: using `+max_height+`
 
 ifeval::["{plugincode}" != "autoresize"]
 [source,js]

--- a/modules/ROOT/partials/configuration/max_image_dimension.adoc
+++ b/modules/ROOT/partials/configuration/max_image_dimension.adoc
@@ -6,7 +6,7 @@ This option constrains the width and height of uploaded images. When specified, 
 *Type:* `+Number+`
 
 [[example-using-max_image_dimension-with-the-tinydrivebrowse-api]]
-=== Example: Using `+max_image_dimension+` with the tinydrive.browse API
+=== Example: using `+max_image_dimension+` with the tinydrive.browse API
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/max_width.adoc
+++ b/modules/ROOT/partials/configuration/max_width.adoc
@@ -7,7 +7,7 @@ NOTE: This behavior is different than the xref:autoresize.adoc[`+autoresize+`] p
 
 *Type:* `+Number+`
 
-=== Example: Using `+max_width+`
+=== Example: using `+max_width+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/media_alt_source.adoc
+++ b/modules/ROOT/partials/configuration/media_alt_source.adoc
@@ -9,7 +9,7 @@ This options allows you disable the `+Alternative source+` input field in the me
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+media_alt_source+`
+=== Example: using `+media_alt_source+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/media_dimensions.adoc
+++ b/modules/ROOT/partials/configuration/media_dimensions.adoc
@@ -9,7 +9,7 @@ This options allows you disable the `+Dimensions+` input fields in the media dia
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+media_dimensions+`
+=== Example: using `+media_dimensions+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/media_filter_html.adoc
+++ b/modules/ROOT/partials/configuration/media_filter_html.adoc
@@ -9,7 +9,7 @@ This option allows you disable the XSS sanitation filter for video/object elemen
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+media_filter_html+`
+=== Example: using `+media_filter_html+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/media_live_embeds.adoc
+++ b/modules/ROOT/partials/configuration/media_live_embeds.adoc
@@ -11,7 +11,7 @@ This option is enabled by default and accepts URLs input into the source field o
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+media_live_embeds+`
+=== Example: using `+media_live_embeds+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/media_poster.adoc
+++ b/modules/ROOT/partials/configuration/media_poster.adoc
@@ -9,7 +9,7 @@ To remove the `+Poster+` input field in the media dialog, set this option to `+f
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+media_poster+`
+=== Example: using `+media_poster+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/media_url_resolver.adoc
+++ b/modules/ROOT/partials/configuration/media_url_resolver.adoc
@@ -11,7 +11,7 @@ If something goes wrong in your function and you want to show an error to the us
 
 *Type:* `+Function+`
 
-=== Example: Using `+media_url_resolver+`
+=== Example: using `+media_url_resolver+`
 
 The following example simply checks if the url contains some special url and returns an iframe if it does. Otherwise it calls the `+resolve+` callback with an empty string, falling back to the default media embed logic.
 

--- a/modules/ROOT/partials/configuration/mediaembed_inline_styles.adoc
+++ b/modules/ROOT/partials/configuration/mediaembed_inline_styles.adoc
@@ -9,7 +9,7 @@ This option will inline all styles, instead of using CSS classes, when rendering
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+mediaembed_inline_styles+`
+=== Example: using `+mediaembed_inline_styles+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/mediaembed_max_width.adoc
+++ b/modules/ROOT/partials/configuration/mediaembed_max_width.adoc
@@ -7,7 +7,7 @@ This option specifies a maximum width in pixels of the embedded content. Default
 
 *Default value:* `+650+`
 
-=== Example: Using `+mediaembed_max_width+`
+=== Example: using `+mediaembed_max_width+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/mediaembed_service_url.adoc
+++ b/modules/ROOT/partials/configuration/mediaembed_service_url.adoc
@@ -5,7 +5,7 @@ This option specifies the URL to the service that will handle your requests and 
 
 *Type:* `+String+`
 
-=== Example: Using `+mediaembed_service_url+`
+=== Example: using `+mediaembed_service_url+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/mentions_fetch.adoc
+++ b/modules/ROOT/partials/configuration/mentions_fetch.adoc
@@ -5,7 +5,7 @@ This option lets you request a list of users from your server that match a searc
 
 *Type:* `+Function+`
 
-=== Example: Using `+mentions_fetch+`
+=== Example: using `+mentions_fetch+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/mentions_item_type.adoc
+++ b/modules/ROOT/partials/configuration/mentions_item_type.adoc
@@ -14,7 +14,7 @@ For information on the properties required for the user object provided to xref:
 
 *Possible values:* `+'name'+`, `+'profile'+`
 
-=== Example: Using `+mentions_item_type+`
+=== Example: using `+mentions_item_type+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/mentions_menu_complete.adoc
+++ b/modules/ROOT/partials/configuration/mentions_menu_complete.adoc
@@ -5,7 +5,7 @@ This option overrides the default logic for inserting the mention into the edito
 
 *Type:* `+Function+`
 
-=== Example: Using `+mentions_menu_complete+`
+=== Example: using `+mentions_menu_complete+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/mentions_menu_hover.adoc
+++ b/modules/ROOT/partials/configuration/mentions_menu_hover.adoc
@@ -5,7 +5,7 @@ This option enables you to provide an element to present next to the menu item b
 
 *Type:* `+Function+`
 
-=== Example: Using `+mentions_menu_hover+`
+=== Example: using `+mentions_menu_hover+`
 
 [source,js]
 ----
@@ -41,7 +41,7 @@ tinymce.init({
 
 If `+mentions_menu_hover+` is resolved with an object specifying the type and user details, a predefined hover card template will be used. To use the predefined template, set `+type+` to `+'profile'+`. For details on the user properties required for the `+profile+` template, see: xref:mentions.adoc#user-properties[User properties].
 
-==== Example: Using the `+'profile'+` template with `+mentions_menu_hover+`
+==== Example: using the `+'profile'+` template with `+mentions_menu_hover+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/mentions_min_chars.adoc
+++ b/modules/ROOT/partials/configuration/mentions_min_chars.adoc
@@ -7,7 +7,7 @@ This option specifies the number of characters a user needs to type after the "@
 
 *Default value:* `+1+`
 
-=== Example: Using `+mentions_min_chars+`
+=== Example: using `+mentions_min_chars+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/mentions_select.adoc
+++ b/modules/ROOT/partials/configuration/mentions_select.adoc
@@ -5,7 +5,7 @@ This option enables a hover card to be presented when a user hovers over a menti
 
 *Type:* `+Function+`
 
-=== Example: Using `+mentions_select+`
+=== Example: using `+mentions_select+`
 
 [source,js]
 ----
@@ -50,7 +50,7 @@ tinymce.init({
 
 If `+mentions_select+` is resolved with an object specifying the type and user details, a predefined hover card template will be used. To use the predefined template, set `+type+` to `+'profile'+`. For details on the user properties required for the `+profile+` template, see: xref:mentions.adoc#user-properties[User properties].
 
-==== Example: Using the `+'profile'+` template with `+mentions_select+`
+==== Example: using the `+'profile'+` template with `+mentions_select+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/mentions_selector.adoc
+++ b/modules/ROOT/partials/configuration/mentions_selector.adoc
@@ -5,7 +5,7 @@ This option enables you to provide a custom CSS selector that should match the e
 
 *Type:* `+Function+`
 
-=== Example: Using `+mentions_selector+`
+=== Example: using `+mentions_selector+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/menu.adoc
+++ b/modules/ROOT/partials/configuration/menu.adoc
@@ -12,7 +12,7 @@ If you would like to group these menu items, please insert a `+|+` pipe characte
 *Type:* `+Object+`
 
 [[example-the-tinymce-default-menu-items]]
-=== Example: The TinyMCE Default Menu Items
+=== Example: the TinyMCE Default Menu Items
 
 include::partial$configuration/defaultmenuitems.adoc[]
 

--- a/modules/ROOT/partials/configuration/menubar.adoc
+++ b/modules/ROOT/partials/configuration/menubar.adoc
@@ -13,7 +13,7 @@ To specify the menus that should appear on {productname}'s menu bar, the menubar
 
 include::partial$misc/admon-different-default-for-mobile.adoc[]
 
-=== Example: Customizing the menu bar
+=== Example: customizing the menu bar
 
 [source,js]
 ----
@@ -23,7 +23,7 @@ tinymce.init({
 });
 ----
 
-=== Example: Disabling/removing the menu bar
+=== Example: disabling/removing the menu bar
 
 To disable the menu bar, the menubar option should be provided a boolean value of `+false+`.
 

--- a/modules/ROOT/partials/configuration/mergetags_list.adoc
+++ b/modules/ROOT/partials/configuration/mergetags_list.adoc
@@ -25,7 +25,7 @@ IMPORTANT: If the `+mergetags_list+` option is not set, or contains no entries, 
 |menu |Array |required |The list of nested submenus and menu items.
 |===
 
-=== Example: Using `+mergetags_list+`
+=== Example: using `+mergetags_list+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/mergetags_prefix.adoc
+++ b/modules/ROOT/partials/configuration/mergetags_prefix.adoc
@@ -9,7 +9,7 @@ Whatever this option is set to, when it is typed, it triggers the {pluginname} a
 
 *Default value:* `+{{+`
 
-=== Example: Using `+mergetags_prefix+`
+=== Example: using `+mergetags_prefix+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/mergetags_suffix.adoc
+++ b/modules/ROOT/partials/configuration/mergetags_suffix.adoc
@@ -7,7 +7,7 @@ This option specifies the suffix to be attached to each merge tag.
 
 *Default value:* `+}}+`
 
-=== Example: Using `+mergetags_suffix+`
+=== Example: using `+mergetags_suffix+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/min_height.adoc
+++ b/modules/ROOT/partials/configuration/min_height.adoc
@@ -10,7 +10,7 @@ The *min_height* option has two kinds of behaviors depending on the state of the
 
 *Default value:* `+100+`
 
-=== Example: Using `+min_height+`
+=== Example: using `+min_height+`
 
 ifeval::["{plugincode}" != "autoresize"]
 [source,js]

--- a/modules/ROOT/partials/configuration/min_width.adoc
+++ b/modules/ROOT/partials/configuration/min_width.adoc
@@ -7,7 +7,7 @@ NOTE: This behavior is different from the xref:autoresize.adoc[`+autoresize+`] p
 
 *Type:* `+Number+`
 
-=== Example: Using `+min_width+`
+=== Example: using `+min_width+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/model.adoc
+++ b/modules/ROOT/partials/configuration/model.adoc
@@ -9,7 +9,7 @@ The name of the model should match the name of the folder within the models dire
 
 *Default value:* `'dom'`
 
-=== Example: Using `+model+`
+=== Example: using `+model+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/model_url.adoc
+++ b/modules/ROOT/partials/configuration/model_url.adoc
@@ -5,7 +5,7 @@ This option allows specifying the location of the `dom` model file. This is usef
 
 *Type:* `+String+`
 
-=== Example: Using `+model_url+`
+=== Example: using `+model_url+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/newline_behavior.adoc
+++ b/modules/ROOT/partials/configuration/newline_behavior.adoc
@@ -16,7 +16,7 @@ NOTE: This option changes the behavior of the `mceInsertNewLine` command. `inser
 
 *Default value:* `+'default'+`
 
-=== Example: Using `+newline_behavior+`
+=== Example: using `+newline_behavior+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/nonbreaking_force_tab.adoc
+++ b/modules/ROOT/partials/configuration/nonbreaking_force_tab.adoc
@@ -22,7 +22,7 @@ The `+nonbreaking_force_tab+` setting can break the following functionality:
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+nonbreaking_force_tab+`
+=== Example: using `+nonbreaking_force_tab+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/nonbreaking_wrap.adoc
+++ b/modules/ROOT/partials/configuration/nonbreaking_wrap.adoc
@@ -9,7 +9,7 @@ This option allows you to force {productname} to wrap non-breaking space charact
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+nonbreaking_wrap+`
+=== Example: using `+nonbreaking_wrap+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/noneditable_class.adoc
+++ b/modules/ROOT/partials/configuration/noneditable_class.adoc
@@ -9,7 +9,7 @@ Note that classes with the `+mceItem+` prefix are invisible within {productname}
 
 *Default value:* `+'mceNonEditable'+`
 
-=== Example: Using `+noneditable_class+`
+=== Example: using `+noneditable_class+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/noneditable_regexp.adoc
+++ b/modules/ROOT/partials/configuration/noneditable_regexp.adoc
@@ -7,7 +7,7 @@ NOTE: If elements are matched by the regular expression, the elements will be re
 
 *Type:* `+String+`
 
-=== Example: Using `+noneditable_regexp+`
+=== Example: using `+noneditable_regexp+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/object_resizing.adoc
+++ b/modules/ROOT/partials/configuration/object_resizing.adoc
@@ -13,7 +13,7 @@ This options allows you to turn on/off the resizing handles on images, tables or
 
 include::partial$misc/admon-different-default-for-mobile.adoc[]
 
-==== Example: Disable object resizing
+==== Example: disable object resizing
 
 [source,js]
 ----
@@ -31,7 +31,7 @@ tinymce.init({
 
 *Possible values:* `+true+`, `+false+`, `+img+`
 
-==== Example: Enable object resizing for images
+==== Example: enable object resizing for images
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/pagebreak_separator.adoc
+++ b/modules/ROOT/partials/configuration/pagebreak_separator.adoc
@@ -5,7 +5,7 @@
 
 *Default value:* `+'<!-- pagebreak -->'+`
 
-=== Example: Using `+pagebreak_separator+`
+=== Example: using `+pagebreak_separator+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/pagebreak_split_block.adoc
+++ b/modules/ROOT/partials/configuration/pagebreak_split_block.adoc
@@ -9,7 +9,7 @@ When enabled this option makes it easier to split block elements with a page bre
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+pagebreak_split_block+`
+=== Example: using `+pagebreak_split_block+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/paste_as_text.adoc
+++ b/modules/ROOT/partials/configuration/paste_as_text.adoc
@@ -9,7 +9,7 @@ This option enables you to set the default state of the `+Paste as text+` menu i
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+paste_as_text+`
+=== Example: using `+paste_as_text+`
 
 ifdef::plugincode[]
 [source,js,subs="attributes+"]

--- a/modules/ROOT/partials/configuration/paste_block_drop.adoc
+++ b/modules/ROOT/partials/configuration/paste_block_drop.adoc
@@ -16,7 +16,7 @@ Due to browser limitations, it is not possible to filter content that is dragged
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `{pasteblockdropname}`
+=== Example: using `{pasteblockdropname}`
 
 ifdef::plugincode[]
 [source,js,subs="attributes+"]

--- a/modules/ROOT/partials/configuration/paste_data_images.adoc
+++ b/modules/ROOT/partials/configuration/paste_data_images.adoc
@@ -11,7 +11,7 @@ Setting `+paste_data_images+` to `+true+` will allow the pasted images, while se
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+paste_data_images+`
+=== Example: using `+paste_data_images+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/paste_merge_formats.adoc
+++ b/modules/ROOT/partials/configuration/paste_merge_formats.adoc
@@ -9,7 +9,7 @@ This option enables the merge format feature when pasting content. This merges i
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+paste_merge_formats+`
+=== Example: using `+paste_merge_formats+`
 
 ifdef::plugincode[]
 [source,js,subs="attributes+"]

--- a/modules/ROOT/partials/configuration/paste_postprocess.adoc
+++ b/modules/ROOT/partials/configuration/paste_postprocess.adoc
@@ -7,7 +7,7 @@ This option enables you to modify the pasted content before it gets inserted int
 
 *Type:* `+Function+`
 
-=== Example: Using `+paste_postprocess+`
+=== Example: using `+paste_postprocess+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/paste_preprocess.adoc
+++ b/modules/ROOT/partials/configuration/paste_preprocess.adoc
@@ -7,7 +7,7 @@ This option enables you to modify the pasted content before it gets inserted int
 
 *Type:* `+Function+`
 
-=== Example: Using `+paste_preprocess+`
+=== Example: using `+paste_preprocess+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/paste_remove_styles_if_webkit.adoc
+++ b/modules/ROOT/partials/configuration/paste_remove_styles_if_webkit.adoc
@@ -9,7 +9,7 @@ This option allows you to disable {productname}'s default paste filters for webk
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+paste_remove_styles_if_webkit+`
+=== Example: using `+paste_remove_styles_if_webkit+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/paste_tab_spaces.adoc
+++ b/modules/ROOT/partials/configuration/paste_tab_spaces.adoc
@@ -7,7 +7,7 @@ This option controls how many spaces are used to represent a tab character in HT
 
 *Default value:* `+4+`
 
-=== Example: Using `+paste_tab_spaces+`
+=== Example: using `+paste_tab_spaces+`
 
 ifdef::plugincode[]
 [source,js,subs="attributes+"]

--- a/modules/ROOT/partials/configuration/paste_webkit_styles.adoc
+++ b/modules/ROOT/partials/configuration/paste_webkit_styles.adoc
@@ -9,7 +9,7 @@ This option allows you to specify styles you want to keep when pasting in WebKit
 
 *Possible values:* `+'none'+`, `+'all'+` or a space separated list of styles
 
-=== Example: Using `+paste_webkit_styles+`
+=== Example: using `+paste_webkit_styles+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/permanentpen_properties.adoc
+++ b/modules/ROOT/partials/configuration/permanentpen_properties.adoc
@@ -20,7 +20,7 @@ The default formats for Permanent Pen can be specified in the following configur
 }
 ----
 
-=== Example: Using `permanentpen_properties`
+=== Example: using `permanentpen_properties`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/placeholder.adoc
+++ b/modules/ROOT/partials/configuration/placeholder.adoc
@@ -7,7 +7,7 @@ NOTE: If the editor is initialized on a `+textarea+` element, the placeholder at
 
 *Type:* `+String+`
 
-=== Example: Using `+placeholder+`
+=== Example: using `+placeholder+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/plugins.adoc
+++ b/modules/ROOT/partials/configuration/plugins.adoc
@@ -10,7 +10,7 @@ The plugins can be provided as either:
 
 *Type:* `+String+` or `+Array+`
 
-=== Example: Using `+plugins+` with a string
+=== Example: using `+plugins+` with a string
 
 [source,js]
 ----
@@ -20,7 +20,7 @@ tinymce.init({
 });
 ----
 
-=== Example: Using `+plugins+` with an array
+=== Example: using `+plugins+` with an array
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/powerpaste_keep_unsupported_src.adoc
+++ b/modules/ROOT/partials/configuration/powerpaste_keep_unsupported_src.adoc
@@ -11,7 +11,7 @@ For example, browsers do not allow PowerPaste to access the file system. If your
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+powerpaste_keep_unsupported_src+`
+=== Example: using `+powerpaste_keep_unsupported_src+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/preview_styles.adoc
+++ b/modules/ROOT/partials/configuration/preview_styles.adoc
@@ -11,7 +11,7 @@ If unset the editor will preview the styles listed in the default value listed b
 
 *Possible values:* `+String+`, `+false+`
 
-=== Example: Using `+preview_styles+`
+=== Example: using `+preview_styles+`
 
 No preview of styles:
 

--- a/modules/ROOT/partials/configuration/promotion.adoc
+++ b/modules/ROOT/partials/configuration/promotion.adoc
@@ -11,7 +11,7 @@
 
 See xref:editor-premium-upgrade-promotion.adoc#premium-upgrade-promotion-defaults[Premium upgrade promotion defaults] for details.
 
-=== Example: Using `+promotion+`
+=== Example: using `+promotion+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/protect.adoc
+++ b/modules/ROOT/partials/configuration/protect.adoc
@@ -7,7 +7,7 @@ The option takes an array of regular expression that it will match the contents 
 
 *Type:* `+Array+`
 
-=== Example: Using `+protect+`
+=== Example: using `+protect+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/readonly.adoc
+++ b/modules/ROOT/partials/configuration/readonly.adoc
@@ -9,7 +9,7 @@ Setting the `+readonly+` option to `+true+` will initialize the editor in `+"rea
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+readonly+`
+=== Example: using `+readonly+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/referrer_policy.adoc
+++ b/modules/ROOT/partials/configuration/referrer_policy.adoc
@@ -10,7 +10,7 @@ Used for setting the level of referrer information sent when loading plugins and
 
 For a list of valid referrer policies (directives), see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy[MDN Web Docs - Referrer-Policy].
 
-=== Example: Using `+referrer_policy+`
+=== Example: using `+referrer_policy+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/relative_urls.adoc
+++ b/modules/ROOT/partials/configuration/relative_urls.adoc
@@ -12,7 +12,7 @@ For URLs with the same domain as the page containing the {productname} editor. I
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+relative_urls+`
+=== Example: using `+relative_urls+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/remove_trailing_brs.adoc
+++ b/modules/ROOT/partials/configuration/remove_trailing_brs.adoc
@@ -11,7 +11,7 @@ https://en.wikipedia.org/wiki/Gecko_(software)[Gecko] and https://en.wikipedia.o
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+remove_trailing_brs+`
+=== Example: using `+remove_trailing_brs+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/removed_menuitems.adoc
+++ b/modules/ROOT/partials/configuration/removed_menuitems.adoc
@@ -5,7 +5,7 @@ This option allows you to remove items from {productname}'s drop down menus. Thi
 
 *Type:* `+String+`
 
-=== Example: Using `+removed_menuitems+`
+=== Example: using `+removed_menuitems+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/resize.adoc
+++ b/modules/ROOT/partials/configuration/resize.adoc
@@ -16,7 +16,7 @@ When resizing is enabled, the editor can be resized by either:
 
 include::partial$misc/admon-different-default-for-mobile.adoc[]
 
-=== Example: Disabling editor resizing
+=== Example: disabling editor resizing
 
 [source,js]
 ----
@@ -26,7 +26,7 @@ tinymce.init({
 });
 ----
 
-=== Example: Enabling vertical and horizontal editor resizing
+=== Example: enabling vertical and horizontal editor resizing
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/resize_img_proportional.adoc
+++ b/modules/ROOT/partials/configuration/resize_img_proportional.adoc
@@ -12,7 +12,7 @@ When a user resizes an image in the editor, this option controls whether image i
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+resize_img_proportional+`
+=== Example: using `+resize_img_proportional+`
 
 To disable proportional image resizing:
 

--- a/modules/ROOT/partials/configuration/rtc_document_id.adoc
+++ b/modules/ROOT/partials/configuration/rtc_document_id.adoc
@@ -18,7 +18,7 @@ endif::[]
 
 *Type:* `+String+`
 
-=== Example: Using `+rtc_document_id+`
+=== Example: using `+rtc_document_id+`
 
 This example shows the minimum required configuration for the Real-Time Collaboration plugin, including the `+rtc_document_id+` option.
 

--- a/modules/ROOT/partials/configuration/rtc_encryption_provider.adoc
+++ b/modules/ROOT/partials/configuration/rtc_encryption_provider.adoc
@@ -35,7 +35,7 @@ endif::[]
 
 WARNING: Do not include secret or sensitive information in the key hint. The key hint is stored by the server in plain text.
 
-=== Example: Using `+rtc_encryption_provider+`
+=== Example: using `+rtc_encryption_provider+`
 
 This example shows the minimum required configuration for the Real-Time Collaboration plugin, including the `+rtc_encryption_provider+` option.
 

--- a/modules/ROOT/partials/configuration/rtc_token_provider.adoc
+++ b/modules/ROOT/partials/configuration/rtc_token_provider.adoc
@@ -48,7 +48,7 @@ endif::[]
 |`https://claims.tiny.cloud/rtc/role` |`+string+` |The possible role values are: `editor` or `viewer`. `viewer` will put the editor into readonly mode and `editor` (default) will let the user edit the document.
 |===
 
-=== Example: Using `+rtc_token_provider+`
+=== Example: using `+rtc_token_provider+`
 
 This example shows the minimum required configuration for the Real-Time Collaboration plugin, including the `+rtc_token_provider+` option.
 

--- a/modules/ROOT/partials/configuration/save_enablewhendirty.adoc
+++ b/modules/ROOT/partials/configuration/save_enablewhendirty.adoc
@@ -9,7 +9,7 @@ This option allows you to disable the save button until modifications have been 
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+save_enablewhendirty+`
+=== Example: using `+save_enablewhendirty+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/save_oncancelcallback.adoc
+++ b/modules/ROOT/partials/configuration/save_oncancelcallback.adoc
@@ -5,7 +5,7 @@ This option allows you to specify the function that will be executed when the ca
 
 *Type:* `+Function+`
 
-=== Example: Using `+save_oncancelcallback+`
+=== Example: using `+save_oncancelcallback+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/save_onsavecallback.adoc
+++ b/modules/ROOT/partials/configuration/save_onsavecallback.adoc
@@ -5,7 +5,7 @@ This option allows you to specify the function that will be executed when the sa
 
 *Type:* `+Function+`
 
-=== Example: Using `+save_onsavecallback+`
+=== Example: using `+save_onsavecallback+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/schema.adoc
+++ b/modules/ROOT/partials/configuration/schema.adoc
@@ -13,7 +13,7 @@ Also note that all event attributes are excluded by default since it's a bad pra
 
 *Possible values:* `+'html5'+`, `+'html4'+`, `+'html5-strict'+`
 
-=== Example: Using `+schema+`
+=== Example: using `+schema+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/selection_toolbar.adoc
+++ b/modules/ROOT/partials/configuration/selection_toolbar.adoc
@@ -9,7 +9,7 @@ To disable the Quick Selection toolbar, set `+quickbars_selection_toolbar+` to `
 
 *Default value:* `+'bold italic | quicklink h2 h3 blockquote'+`
 
-=== Example: Customizing the Quick Selection toolbar
+=== Example: customizing the Quick Selection toolbar
 
 [source,js]
 ----
@@ -20,7 +20,7 @@ tinymce.init({
 });
 ----
 
-=== Example: Disabling the Quick Selection toolbar
+=== Example: disabling the Quick Selection toolbar
 
 To disable the Quick Selection toolbar, set `+quickbars_selection_toolbar+` to `+false+`.
 

--- a/modules/ROOT/partials/configuration/selector.adoc
+++ b/modules/ROOT/partials/configuration/selector.adoc
@@ -9,7 +9,7 @@ For more information on the differences between regular and inline editing modes
 
 *Type:* `+String+`
 
-=== Example: Replace all textarea elements on the page
+=== Example: replace all textarea elements on the page
 
 [source,js]
 ----
@@ -18,7 +18,7 @@ tinymce.init({
 });
 ----
 
-=== Example: Replace a textarea element with id "editable"
+=== Example: replace a textarea element with id "editable"
 
 [source,js]
 ----
@@ -27,7 +27,7 @@ tinymce.init({
 });
 ----
 
-=== Example: Inline editing mode on a div element with id "editable"
+=== Example: inline editing mode on a div element with id "editable"
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/setup.adoc
+++ b/modules/ROOT/partials/configuration/setup.adoc
@@ -9,7 +9,7 @@ A common use case for this setting is to add editor events to {productname}. For
 
 *Type:* `+Function+`
 
-=== Example: Using `+setup+`
+=== Example: using `+setup+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/sidebar_show.adoc
+++ b/modules/ROOT/partials/configuration/sidebar_show.adoc
@@ -9,7 +9,7 @@ include::partial$misc/admon-iframe-only.adoc[]
 
 *Type:* `+String+`
 
-=== Example: Using `+sidebar_show+`
+=== Example: using `+sidebar_show+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/skin_url.adoc
+++ b/modules/ROOT/partials/configuration/skin_url.adoc
@@ -5,7 +5,7 @@ If you are using {productname} skins, this option enables you to specify the loc
 
 *Type:* `+String+`
 
-=== Example: Using `+skin_url+`
+=== Example: using `+skin_url+`
 
 [source,js,subs="attributes+"]
 ----

--- a/modules/ROOT/partials/configuration/smart_paste.adoc
+++ b/modules/ROOT/partials/configuration/smart_paste.adoc
@@ -14,7 +14,7 @@ To disable the `+smart_paste+` functionality, set `+smart_paste+` to `+false+`. 
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+smart_paste+`
+=== Example: using `+smart_paste+`
 
 ifdef::plugincode[]
 [source,js,subs="attributes+"]

--- a/modules/ROOT/partials/configuration/spellchecker_active.adoc
+++ b/modules/ROOT/partials/configuration/spellchecker_active.adoc
@@ -9,7 +9,7 @@ This option enables or disables the spell checker when the editor is loaded. Whe
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+spellchecker_active+`
+=== Example: using `+spellchecker_active+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/spellchecker_dialog.adoc
+++ b/modules/ROOT/partials/configuration/spellchecker_dialog.adoc
@@ -12,7 +12,7 @@ This option specifies the primary spell checking mode.
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+spellchecker_dialog+`
+=== Example: using `+spellchecker_dialog+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/spellchecker_ignore_list.adoc
+++ b/modules/ROOT/partials/configuration/spellchecker_ignore_list.adoc
@@ -7,7 +7,7 @@ NOTE: Languages specified as keys in the `+spellchecker_ignore_list+` object mus
 
 *Type:* `+Array+` or `+Object+`
 
-=== Example: Using `+spellchecker_ignore_list+` to ignore words in all languages
+=== Example: using `+spellchecker_ignore_list+` to ignore words in all languages
 
 [source,js]
 ----
@@ -18,7 +18,7 @@ tinymce.init({
 });
 ----
 
-=== Example: Using `+spellchecker_ignore_list+` for specific languages
+=== Example: using `+spellchecker_ignore_list+` for specific languages
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/spellchecker_language.adoc
+++ b/modules/ROOT/partials/configuration/spellchecker_language.adoc
@@ -7,7 +7,7 @@ This option specifies the default language used by Spell Checker Pro.
 
 *Default value:* `+'en_US'+`
 
-=== Example: Using `+spellchecker_language+`
+=== Example: using `+spellchecker_language+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/spellchecker_languages.adoc
+++ b/modules/ROOT/partials/configuration/spellchecker_languages.adoc
@@ -11,7 +11,7 @@ This option specifies the spellchecker languages that are available to the user,
 'English (United States)=en_US,English (United Kingdom)=en_GB,Danish=da,Dutch=nl,Finnish=fi,French=fr,German=de,Italian=it,Norwegian=nb,Portuguese=pt,Portuguese (Portugal)=pt_PT,Spanish=es,Swedish=sv'
 ----
 
-=== Example: Using `spellchecker_languages`
+=== Example: using `spellchecker_languages`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/spellchecker_on_load.adoc
+++ b/modules/ROOT/partials/configuration/spellchecker_on_load.adoc
@@ -11,7 +11,7 @@ This option runs the spellchecker when the contents of the editor is loaded.
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+spellchecker_on_load+`
+=== Example: using `+spellchecker_on_load+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/spellchecker_rpc_url.adoc
+++ b/modules/ROOT/partials/configuration/spellchecker_rpc_url.adoc
@@ -7,7 +7,7 @@ NOTE: `+spellchecker_rpc_url+` is *not* required when enabling this plugin via x
 
 *Type:* `+String+`
 
-=== Example: Using `+spellchecker_rpc_url+`
+=== Example: using `+spellchecker_rpc_url+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/statusbar.adoc
+++ b/modules/ROOT/partials/configuration/statusbar.adoc
@@ -13,7 +13,7 @@ To disable the status bar, the `+statusbar+` option should be provided with a bo
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+statusbar+`
+=== Example: using `+statusbar+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/style_formats.adoc
+++ b/modules/ROOT/partials/configuration/style_formats.adoc
@@ -51,7 +51,7 @@ style_formats: [
 ]
 ----
 
-=== Example: Using `+style_formats+`
+=== Example: using `+style_formats+`
 
 This example shows how to append 3 new style formats.
 

--- a/modules/ROOT/partials/configuration/style_formats_autohide.adoc
+++ b/modules/ROOT/partials/configuration/style_formats_autohide.adoc
@@ -7,7 +7,7 @@ This option enables auto hiding of styles that can't be applied to the current c
 
 *Default value:* `+false+`
 
-=== Example: Using `+style_formats_autohide+`
+=== Example: using `+style_formats_autohide+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/style_formats_merge.adoc
+++ b/modules/ROOT/partials/configuration/style_formats_merge.adoc
@@ -7,7 +7,7 @@ This option allows you to set whether {productname} should append custom styles 
 
 *Default value:* `+false+`
 
-=== Example: Using `+style_formats_merge+`
+=== Example: using `+style_formats_merge+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/suffix.adoc
+++ b/modules/ROOT/partials/configuration/suffix.adoc
@@ -5,7 +5,7 @@ This option allows the suffix of {productname} to be manually provided. By defau
 
 *Type:* `+String+`
 
-=== Example: Using `+suffix+`
+=== Example: using `+suffix+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/table_advtab.adoc
+++ b/modules/ROOT/partials/configuration/table_advtab.adoc
@@ -9,7 +9,7 @@ This option makes it possible to disable the advanced tab in the table dialog bo
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+table_advtab+`
+=== Example: using `+table_advtab+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/table_appearance_options.adoc
+++ b/modules/ROOT/partials/configuration/table_appearance_options.adoc
@@ -9,7 +9,7 @@ This option allows you to disable some of the options available to a user when i
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+table_appearance_options+`
+=== Example: using `+table_appearance_options+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/table_background_color_map.adoc
+++ b/modules/ROOT/partials/configuration/table_background_color_map.adoc
@@ -9,7 +9,7 @@ The xref:user-formatting-options.adoc#custom_colors[custom color picker] is not 
 
 *Default value:* See xref:user-formatting-options.adoc#color_map[`+color_map+` option]
 
-=== Example: Using `+table_background_color_map+`
+=== Example: using `+table_background_color_map+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/table_border_color_map.adoc
+++ b/modules/ROOT/partials/configuration/table_border_color_map.adoc
@@ -9,7 +9,7 @@ The xref:user-formatting-options.adoc#custom_colors[custom color picker] is not 
 
 *Default value:* See xref:user-formatting-options.adoc#color_map[`+color_map+` option]
 
-=== Example: Using `+table_border_color_map+`
+=== Example: using `+table_border_color_map+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/table_border_styles.adoc
+++ b/modules/ROOT/partials/configuration/table_border_styles.adoc
@@ -22,7 +22,7 @@ This option is used to specify a list of pre-defined cell border widths for quic
 ]
 ----
 
-=== Example: Using `table_border_styles`
+=== Example: using `table_border_styles`
 
 [source,js,subs="attributes+"]
 ----

--- a/modules/ROOT/partials/configuration/table_border_widths.adoc
+++ b/modules/ROOT/partials/configuration/table_border_widths.adoc
@@ -17,7 +17,7 @@ This option is used to specify a list of pre-defined cell border widths for quic
 ]
 ----
 
-=== Example: Using `table_border_widths`
+=== Example: using `table_border_widths`
 
 [source,js,subs="attributes+"]
 ----

--- a/modules/ROOT/partials/configuration/table_cell_advtab.adoc
+++ b/modules/ROOT/partials/configuration/table_cell_advtab.adoc
@@ -9,7 +9,7 @@ This option makes it possible to disable the advanced tab in the table cell dial
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+table_cell_advtab+`
+=== Example: using `+table_cell_advtab+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/table_cell_class_list.adoc
+++ b/modules/ROOT/partials/configuration/table_cell_class_list.adoc
@@ -5,7 +5,7 @@ This option enables you to specify a list of classes to present in the table cel
 
 *Type:* `+Array+`
 
-=== Example: Using `+table_cell_class_list+`
+=== Example: using `+table_cell_class_list+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/table_class_list.adoc
+++ b/modules/ROOT/partials/configuration/table_class_list.adoc
@@ -5,7 +5,7 @@ This option enables you to specify a list of classes to present in the table opt
 
 *Type:* `+Array+`
 
-=== Example: Using `+table_class_list+`
+=== Example: using `+table_class_list+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/table_clone_elements.adoc
+++ b/modules/ROOT/partials/configuration/table_clone_elements.adoc
@@ -5,7 +5,7 @@ This option enables you to specify which elements should be cloned as empty chil
 
 *Type:* `+String+`
 
-=== Example: Using `+table_clone_elements+`
+=== Example: using `+table_clone_elements+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/table_column_resizing.adoc
+++ b/modules/ROOT/partials/configuration/table_column_resizing.adoc
@@ -14,7 +14,7 @@ There are two settings:
 
 *Possible values:* `+'preservetable'+`, `+'resizetable'+`
 
-=== Example: Using `+table_column_resizing+`
+=== Example: using `+table_column_resizing+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/table_default_attributes.adoc
+++ b/modules/ROOT/partials/configuration/table_default_attributes.adoc
@@ -7,7 +7,7 @@ This option enables you to specify default attributes for inserted tables.
 
 *Default value:* `+{ border: '1' }+`
 
-=== Example: Using `+table_default_attributes+`
+=== Example: using `+table_default_attributes+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/table_default_styles.adoc
+++ b/modules/ROOT/partials/configuration/table_default_styles.adoc
@@ -7,7 +7,7 @@ This option enables you to specify the default styles for inserted tables.
 
 *Default value:* `+{ 'border-collapse': 'collapse', 'width': '100%' }+`
 
-=== Example: Using `+table_default_styles+`
+=== Example: using `+table_default_styles+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/table_grid.adoc
+++ b/modules/ROOT/partials/configuration/table_grid.adoc
@@ -15,7 +15,7 @@ NOTE: To configure the Table menu to include both the table picker and the table
 
 include::partial$misc/admon-different-default-for-mobile.adoc[]
 
-=== Example: Using `+table_grid+`
+=== Example: using `+table_grid+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/table_header_type.adoc
+++ b/modules/ROOT/partials/configuration/table_header_type.adoc
@@ -74,7 +74,7 @@ For example:
 
 *Possible values:* `+'section+`', `+'cells'+`, `+'sectionCells'+`, `+'auto'+`
 
-=== Example: Using `+table_header_type+`
+=== Example: using `+table_header_type+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/table_resize_bars.adoc
+++ b/modules/ROOT/partials/configuration/table_resize_bars.adoc
@@ -9,7 +9,7 @@ This option makes it possible to disable the ability to resize table columns and
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+table_resize_bars+`
+=== Example: using `+table_resize_bars+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/table_row_advtab.adoc
+++ b/modules/ROOT/partials/configuration/table_row_advtab.adoc
@@ -9,7 +9,7 @@ This option makes it possible to disable the advanced tab in the table row dialo
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+table_row_advtab+`
+=== Example: using `+table_row_advtab+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/table_row_class_list.adoc
+++ b/modules/ROOT/partials/configuration/table_row_class_list.adoc
@@ -5,7 +5,7 @@ This option enables you to specify a list of classes to present in the table row
 
 *Type:* `+Array+`
 
-=== Example: Using `+table_row_class_list+`
+=== Example: using `+table_row_class_list+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/table_sizing_mode.adoc
+++ b/modules/ROOT/partials/configuration/table_sizing_mode.adoc
@@ -16,7 +16,7 @@ This option accepts the following values:
 
 *Possible values:* `+'fixed'+`, `+'relative'+`, `+'responsive'+`, `+'auto'+`
 
-=== Example: Using `+table_sizing_mode+`
+=== Example: using `+table_sizing_mode+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/table_style_by_css.adoc
+++ b/modules/ROOT/partials/configuration/table_style_by_css.adoc
@@ -9,7 +9,7 @@ This option enables you to force the Table Properties dialog to use HTML5/CSS3 s
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+table_style_by_css+`
+=== Example: using `+table_style_by_css+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/table_tab_navigation.adoc
+++ b/modules/ROOT/partials/configuration/table_tab_navigation.adoc
@@ -9,7 +9,7 @@ This option enables you to disable the default tab between table cells feature. 
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+table_tab_navigation+`
+=== Example: using `+table_tab_navigation+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/table_toolbar.adoc
+++ b/modules/ROOT/partials/configuration/table_toolbar.adoc
@@ -11,7 +11,7 @@ To disable the table toolbar, set the value to an empty string.
 
 *Possible values:* Any toolbar button. For a list of predefined toolbar buttons, see: xref:available-toolbar-buttons.adoc[Toolbar Buttons Available for {productname}].
 
-=== Example: Default table_toolbar configuration
+=== Example: default table_toolbar configuration
 
 [source,js]
 ----
@@ -23,7 +23,7 @@ tinymce.init({
 });
 ----
 
-=== Example: Disable the table toolbar
+=== Example: disable the table toolbar
 
 To disable or remove the contextual table toolbar, set `+table_toolbar+` to an empty string.
 

--- a/modules/ROOT/partials/configuration/table_use_colgroups.adoc
+++ b/modules/ROOT/partials/configuration/table_use_colgroups.adoc
@@ -11,7 +11,7 @@ This option adds `+colgroup+` and `+col+` elements to new tables for specifying 
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Disable `+colgroup+` support using `+table_use_colgroups+`
+=== Example: disable `+colgroup+` support using `+table_use_colgroups+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/tableofcontents_class.adoc
+++ b/modules/ROOT/partials/configuration/tableofcontents_class.adoc
@@ -7,7 +7,7 @@ With `+tableofcontents_class+` you can change the class name that gets assigned 
 
 *Default value:* `+'mce-toc'+`
 
-=== Example: Using `+tableofcontents_class+`
+=== Example: using `+tableofcontents_class+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/tableofcontents_depth.adoc
+++ b/modules/ROOT/partials/configuration/tableofcontents_depth.adoc
@@ -7,7 +7,7 @@ By default headers in the content will be inspected only three levels deep, so -
 
 *Default value:* `+3+`
 
-=== Example: Using `+tableofcontents_depth+`
+=== Example: using `+tableofcontents_depth+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/tableofcontents_header.adoc
+++ b/modules/ROOT/partials/configuration/tableofcontents_header.adoc
@@ -7,7 +7,7 @@ Table of contents has a header and by default it will be marked up with `+H2+` t
 
 *Default value:* `+'h2'+`
 
-=== Example: Using `+tableofcontents_header+`
+=== Example: using `+tableofcontents_header+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/taborder.adoc
+++ b/modules/ROOT/partials/configuration/taborder.adoc
@@ -7,7 +7,7 @@ To configure `+tabindex+` for the {productname} editor, set the attribute on the
 
 In iframe (classic editor) mode, {productname} will copy the `+tabindex+` attribute from the target element to the editor's iframe, to allow this to work correctly.
 
-=== Example: Configuring tab order
+=== Example: configuring tab order
 
 [source,html]
 ----

--- a/modules/ROOT/partials/configuration/target.adoc
+++ b/modules/ROOT/partials/configuration/target.adoc
@@ -7,7 +7,7 @@ IMPORTANT: The `+selector+` option has precedence over `+target+`, so in order f
 
 *Type:* `+Node+`
 
-=== Example: Using `+target+`
+=== Example: using `+target+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/template_cdate_classes.adoc
+++ b/modules/ROOT/partials/configuration/template_cdate_classes.adoc
@@ -9,7 +9,7 @@ A creation date is one that is set if no previous date existed within the elemen
 
 *Default value:* `+'cdate'+`
 
-=== Example: Using `+template_cdate_classes+`
+=== Example: using `+template_cdate_classes+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/template_cdate_format.adoc
+++ b/modules/ROOT/partials/configuration/template_cdate_format.adoc
@@ -7,7 +7,7 @@ This option allows you to provide a date format that all 'creation' date templat
 
 *Default value:* `+'%Y-%m-%d'+`
 
-=== Example: Using `+template_cdate_format+`
+=== Example: using `+template_cdate_format+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/template_mdate_classes.adoc
+++ b/modules/ROOT/partials/configuration/template_mdate_classes.adoc
@@ -9,7 +9,7 @@ A modified date is one that is updated with each edit.
 
 *Default value:* `+'mdate'+`
 
-=== Example: Using `+template_mdate_classes+`
+=== Example: using `+template_mdate_classes+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/template_mdate_format.adoc
+++ b/modules/ROOT/partials/configuration/template_mdate_format.adoc
@@ -7,7 +7,7 @@ This option allows you to provide {productname} with a date/time format that all
 
 *Default value:* `+'%Y-%m-%d'+`
 
-=== Example: Using `+template_mdate_format+`
+=== Example: using `+template_mdate_format+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/template_preview_replace_values.adoc
+++ b/modules/ROOT/partials/configuration/template_preview_replace_values.adoc
@@ -5,7 +5,7 @@ This is an object containing items that will be replaced with their respective s
 
 *Type:* `+Object+`
 
-=== Example: Using `+template_preview_replace_values+`
+=== Example: using `+template_preview_replace_values+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/template_replace_values.adoc
+++ b/modules/ROOT/partials/configuration/template_replace_values.adoc
@@ -5,7 +5,7 @@ This is an object containing items that will be replaced with their respective s
 
 *Type:* `+Object+`
 
-=== Example: Using `+template_replace_values+`
+=== Example: using `+template_replace_values+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/template_selected_content_classes.adoc
+++ b/modules/ROOT/partials/configuration/template_selected_content_classes.adoc
@@ -7,7 +7,7 @@ When HTML elements in a template are assigned this class, the content of the ele
 
 *Default value:* `+'selcontent'+`
 
-=== Example: Using `+template_selected_content_classes+`
+=== Example: using `+template_selected_content_classes+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/text_color.adoc
+++ b/modules/ROOT/partials/configuration/text_color.adoc
@@ -12,7 +12,7 @@ By default, the number of rows and columns is dependent of the number of colors 
 
 *Type:* `+Integer+`
 
-==== Example: Using `+color_cols+`
+==== Example: using `+color_cols+`
 
 [source,js]
 ----
@@ -30,7 +30,7 @@ This option allows specifying a map of the text colors that will appear in the g
 
 *Type:* `+Array+`
 
-==== Example: Using `+color_map+`
+==== Example: using `+color_map+`
 
 [source,js]
 ----
@@ -92,7 +92,7 @@ This option allows disabling the custom color picker in all color swatches of th
 
 *Default value:* `+true+`
 
-==== Example: Using `+custom_colors+`
+==== Example: using `+custom_colors+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/text_patterns.adoc
+++ b/modules/ROOT/partials/configuration/text_patterns.adoc
@@ -46,7 +46,7 @@ This allows for patterns to be used to either apply a format or execute a comman
 
 NOTE: Inline patterns are executed on either pressing the *spacebar* or the *Enter* key.
 
-==== Example: Using inline patterns
+==== Example: using inline patterns
 
 [source,js]
 ----
@@ -80,7 +80,7 @@ The block patterns do not have an `+end+` property. This allows for patterns to 
 
 NOTE: Block patterns are only executed on *Enter*, *not* on pressing the *spacebar*.
 
-==== Example: Using block patterns
+==== Example: using block patterns
 
 [source,js]
 ----
@@ -123,7 +123,7 @@ Whether a replacement pattern inserts a block or inline element depends on what 
 
 NOTE: Replacement patterns are executed on either pressing the *spacebar* or the *Enter* key.
 
-==== Example: Using replacement patterns
+==== Example: using replacement patterns
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/text_patterns_lookup.adoc
+++ b/modules/ROOT/partials/configuration/text_patterns_lookup.adoc
@@ -5,7 +5,7 @@ This option allows the specification of a function that dynamically appends addi
 
 *Type:* `+Function+`
 
-=== Example: Using text_patterns_lookup
+=== Example: using text_patterns_lookup
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/theme.adoc
+++ b/modules/ROOT/partials/configuration/theme.adoc
@@ -9,7 +9,7 @@ The name of the theme should match the name of the folder within the themes dire
 
 *Default value:* `'silver'`
 
-=== Example: Using `+theme+`
+=== Example: using `+theme+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/theme_url.adoc
+++ b/modules/ROOT/partials/configuration/theme_url.adoc
@@ -5,7 +5,7 @@ If you are using {productname} themes, this option enables you to specify the lo
 
 *Type:* `+String+`
 
-=== Example: Using `+theme_url+`
+=== Example: using `+theme_url+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/tiny_pageembed_classes.adoc
+++ b/modules/ROOT/partials/configuration/tiny_pageembed_classes.adoc
@@ -28,7 +28,7 @@ The `+tiny_pageembed_classes+` takes an array of objects with `+text+` and `+val
 ]
 ----
 
-=== Example: Using `+tiny_pageembed_classes+`
+=== Example: using `+tiny_pageembed_classes+`
 
 [source,js]
 ----
@@ -43,7 +43,7 @@ tinymce.init({
 });
 ----
 
-=== Example: Disable select
+=== Example: disable select
 
 When the `+tiny_pageembed_classes+` value is set to an empty array, the size selection fields are not available and only exact sizes can be set. Use the following script to disable `+select+` using the `+tiny_pageembed_classes+` option:
 

--- a/modules/ROOT/partials/configuration/tinycomments_author.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_author.adoc
@@ -7,7 +7,7 @@ This option sets the author id to be used when creating or replying to comments.
 
 *Default value:* `+'Anon'+`
 
-=== Example: Using `+tinycomments_author+`
+=== Example: using `+tinycomments_author+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_author_avatar.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_author_avatar.adoc
@@ -12,7 +12,7 @@ IMPORTANT: The avatar will be stored alongside the embedded comment data when a 
 
 *Type:* `+String+`
 
-=== Example: Using `+tinycomments_author_avatar+`
+=== Example: using `+tinycomments_author_avatar+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_author_name.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_author_name.adoc
@@ -5,7 +5,7 @@ _Optional_ - This option sets the author's display name to be used when creating
 
 *Type:* `+String+`
 
-=== Example: Using `+tinycomments_author_name+`
+=== Example: using `+tinycomments_author_name+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_can_delete.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_can_delete.adoc
@@ -19,7 +19,7 @@ _Optional_ - This option sets the author permissions for _deleting comment conve
 
 The following example extends the default behavior to allow the author `<Admin user>` to delete other author's comment conversations by adding `|| currentAuthor === '<Admin user>'`.
 
-=== Example: Using `tinycomments_can_delete`
+=== Example: using `tinycomments_can_delete`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_can_delete_comment.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_can_delete_comment.adoc
@@ -18,7 +18,7 @@ _Optional_ - This option sets the author permissions for _deleting comments_. If
 
 The following example extends the default behavior to allow the author `<Admin user>` to delete other author's comments by adding `|| currentAuthor === '<Admin user>'`.
 
-=== Example: Using `tinycomments_can_delete_comment`
+=== Example: using `tinycomments_can_delete_comment`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_can_edit_comment.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_can_edit_comment.adoc
@@ -18,7 +18,7 @@ _Optional_ - This option sets the author permissions for _editing comments_. If 
 
 The following example extends the default behavior to allow the author `<Admin user>` to edit other author's comments by adding `|| currentAuthor === '<Admin user>'`.
 
-=== Example: Using `tinycomments_can_edit_comment`
+=== Example: using `tinycomments_can_edit_comment`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_can_resolve.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_can_resolve.adoc
@@ -5,7 +5,7 @@ _Optional_ - This option adds a _Resolve Conversation_ item to the dropdown menu
 
 *Type:* `+Function+`
 
-=== Example: Using `+tinycomments_can_resolve+`
+=== Example: using `+tinycomments_can_resolve+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/tinydrive_dropbox_app_key.adoc
+++ b/modules/ROOT/partials/configuration/tinydrive_dropbox_app_key.adoc
@@ -5,7 +5,7 @@ This option is used to specify the Dropbox API key for integrating Dropbox into 
 
 *Type:* `+String+`
 
-=== Example: Using `+tinydrive_dropbox_app_key+`
+=== Example: using `+tinydrive_dropbox_app_key+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/tinydrive_google_drive_client_id.adoc
+++ b/modules/ROOT/partials/configuration/tinydrive_google_drive_client_id.adoc
@@ -5,7 +5,7 @@ This option sets the Google Drive client ID for integrating Google Drive into {c
 
 *Type:* `+String+`
 
-=== Example: Using `+tinydrive_google_drive_client_id+`
+=== Example: using `+tinydrive_google_drive_client_id+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/tinydrive_google_drive_key.adoc
+++ b/modules/ROOT/partials/configuration/tinydrive_google_drive_key.adoc
@@ -5,7 +5,7 @@ This option sets the Google Drive API key for integrating Google Drive into {clo
 
 *Type:* `+String+`
 
-=== Example: Using `+tinydrive_google_drive_key+`
+=== Example: using `+tinydrive_google_drive_key+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/tinydrive_max_image_dimension.adoc
+++ b/modules/ROOT/partials/configuration/tinydrive_max_image_dimension.adoc
@@ -5,7 +5,7 @@ This option constrains the width and height of uploaded images. When specified, 
 
 *Type:* `+Number+`
 
-=== Example: Using `+tinydrive_max_image_dimension+`
+=== Example: using `+tinydrive_max_image_dimension+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/tinydrive_skin.adoc
+++ b/modules/ROOT/partials/configuration/tinydrive_skin.adoc
@@ -11,7 +11,7 @@ This option sets the skin applied to {cloudfilemanager}. The default skin includ
 
 If the `+tinydrive_skin+` option is not specified, {cloudfilemanager} will try and use the skin specified by the xref:editor-skin.adoc#skin[{productname} `+skin+` option] before falling back to the default "oxide" skin.
 
-=== Example: Using `+tinydrive_skin+`
+=== Example: using `+tinydrive_skin+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/tinydrive_upload_path.adoc
+++ b/modules/ROOT/partials/configuration/tinydrive_upload_path.adoc
@@ -13,7 +13,7 @@ It will produce a date-based structure within this path, such as: `+/uploads/{ye
 
 *Default value:* `+"/uploads"+`
 
-=== Example: Using `+tinydrive_upload_path+`
+=== Example: using `+tinydrive_upload_path+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/toolbar.adoc
+++ b/modules/ROOT/partials/configuration/toolbar.adoc
@@ -28,7 +28,7 @@ To specify labels to the grouped buttons that appear on {productname}'s toolbar,
 
 *Type:* `+Array+`
 
-===== Example: Adding toolbar group labels
+===== Example: adding toolbar group labels
 
 [source,js]
 ----
@@ -54,7 +54,7 @@ To disable the toolbar, the toolbar option should be provided a boolean value of
 
 *Possible values:* `+true+`, `+false+`
 
-==== Example: Disabling the toolbar
+==== Example: disabling the toolbar
 
 [source,js]
 ----
@@ -71,7 +71,7 @@ To specify multiple toolbars, the toolbar option should be provided with an arra
 
 *Type:* `+Array+`
 
-==== Example: Adding multiple toolbars
+==== Example: adding multiple toolbars
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/toolbar_groups.adoc
+++ b/modules/ROOT/partials/configuration/toolbar_groups.adoc
@@ -9,7 +9,7 @@ This option accepts an object, mapping the button name to the group configuratio
 
 *Type:* `+Object+`
 
-=== Example: Using `+toolbar_groups+`
+=== Example: using `+toolbar_groups+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/toolbar_location.adoc
+++ b/modules/ROOT/partials/configuration/toolbar_location.adoc
@@ -14,7 +14,7 @@ Setting this option to `+auto+`, positions the toolbar and menu bar either:
 
 *Possible values:* `+'auto'+`, `+'top'+`, `+'bottom'+`
 
-=== Example: Using `+toolbar_location+`
+=== Example: using `+toolbar_location+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/toolbar_n.adoc
+++ b/modules/ROOT/partials/configuration/toolbar_n.adoc
@@ -5,7 +5,7 @@ This option allows you to specify the buttons and the order that they will appea
 
 *Type:* `+String+`
 
-=== Example: Using `+toolbar(n)+`
+=== Example: using `+toolbar(n)+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/toolbar_sticky.adoc
+++ b/modules/ROOT/partials/configuration/toolbar_sticky.adoc
@@ -17,7 +17,7 @@ include::partial$misc/admon-iframe-only.adoc[]
 
 include::partial$misc/admon-different-default-for-mobile.adoc[]
 
-=== Example: Using `+toolbar_sticky+`
+=== Example: using `+toolbar_sticky+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/toolbar_sticky_offset.adoc
+++ b/modules/ROOT/partials/configuration/toolbar_sticky_offset.adoc
@@ -9,7 +9,7 @@ NOTE: This option requires the xref:toolbar-configuration-options.adoc#toolbar_s
 
 *Default value:* `+0+`
 
-=== Example: Using `+toolbar_sticky_offset+`
+=== Example: using `+toolbar_sticky_offset+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/type_ahead_urls.adoc
+++ b/modules/ROOT/partials/configuration/type_ahead_urls.adoc
@@ -9,7 +9,7 @@ This option controls whether the typeahead url field feature should be enabled o
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+typeahead_urls+`
+=== Example: using `+typeahead_urls+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/urlconverter_callback.adoc
+++ b/modules/ROOT/partials/configuration/urlconverter_callback.adoc
@@ -14,7 +14,7 @@ This function should return the converted URL as a string. This option is set to
 
 *Type:* `+Function+`
 
-=== Example: Using `+urlconverter_callback+`
+=== Example: using `+urlconverter_callback+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/valid_children.adoc
+++ b/modules/ROOT/partials/configuration/valid_children.adoc
@@ -20,7 +20,7 @@ This example shows you how to add `+style+` as a valid child of `+body+` and rem
 
 *Type:* `+String+`
 
-=== Example: Using `+valid_children+`
+=== Example: using `+valid_children+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/valid_elements.adoc
+++ b/modules/ROOT/partials/configuration/valid_elements.adoc
@@ -43,7 +43,7 @@ Use `+*[*]+` to include all elements and all attributes. This can be very useful
 
 *Type:* `+String+`
 
-=== Example: Using `+valid_elements+`
+=== Example: using `+valid_elements+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/valid_styles.adoc
+++ b/modules/ROOT/partials/configuration/valid_styles.adoc
@@ -7,7 +7,7 @@ By default, all styles are allowed unless `+valid_styles+` or `+invalid_styles+`
 
 *Type:* `+Object+`
 
-=== Example: Using `+valid_styles+`
+=== Example: using `+valid_styles+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/video_template_callback.adoc
+++ b/modules/ROOT/partials/configuration/video_template_callback.adoc
@@ -5,7 +5,7 @@ This option allows you to specify the function that will return the HTML embed c
 
 *Type:* `+String+`
 
-=== Example: Using `+video_template_callback+`
+=== Example: using `+video_template_callback+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/visual.adoc
+++ b/modules/ROOT/partials/configuration/visual.adoc
@@ -11,7 +11,7 @@ When set to `+false+`, the visual aids will be disabled when the editor loads. T
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+visual+`
+=== Example: using `+visual+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/visual_anchor_class.adoc
+++ b/modules/ROOT/partials/configuration/visual_anchor_class.adoc
@@ -5,7 +5,7 @@ This option enables you to configure a custom class to be added to anchors with 
 
 *Type:* `+String+`
 
-=== Example: Using `+visual_anchor_class+`
+=== Example: using `+visual_anchor_class+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/visual_table_class.adoc
+++ b/modules/ROOT/partials/configuration/visual_table_class.adoc
@@ -5,7 +5,7 @@ This option enables you to configure a custom class to be added to tables that h
 
 *Type:* `+String+`
 
-=== Example: Using `+visual_table_class+`
+=== Example: using `+visual_table_class+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/visualblocks_default_state.adoc
+++ b/modules/ROOT/partials/configuration/visualblocks_default_state.adoc
@@ -9,7 +9,7 @@ This option enables you to specify the default state of the Visual Blocks plugin
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+visualblocks_default_state+`
+=== Example: using `+visualblocks_default_state+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/visualchars_default_state.adoc
+++ b/modules/ROOT/partials/configuration/visualchars_default_state.adoc
@@ -9,7 +9,7 @@ This option enables specifying the default state of the Visual Characters plugin
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: Using `+visualchars_default_state+`
+=== Example: using `+visualchars_default_state+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/width.adoc
+++ b/modules/ROOT/partials/configuration/width.adoc
@@ -7,7 +7,7 @@ NOTE: {productname} sets the width in pixels if a number is provided. However, i
 
 *Type:* `+Number+` or `+String+`
 
-=== Example: Using `+width+`
+=== Example: using `+width+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/integrations/angular-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/angular-tech-ref.adoc
@@ -117,7 +117,7 @@ include::partial$misc/get-an-api-key.adoc[]
 
 *Default value:* `+'no-api-key'+`
 
-==== Example: Using `+apiKey+`
+==== Example: using `+apiKey+`
 
 [source,html]
 ----
@@ -165,7 +165,7 @@ The `+disabled+` property can dynamically switch the editor between a "disabled"
 
 *Possible values:* `+true+`, `+false+`
 
-==== Example: Using `+disabled+`
+==== Example: using `+disabled+`
 
 [source,html]
 ----
@@ -183,7 +183,7 @@ An id for the editor. Used for retrieving the editor instance using the `+tinymc
 
 *Default value:* Automatically generated https://tools.ietf.org/html/rfc4122[UUID]
 
-==== Example: Using `+id+`
+==== Example: using `+id+`
 
 [source,html]
 ----
@@ -203,7 +203,7 @@ For information on the {productname} selector (`+tinymce.init+`), see: xref:basi
 
 *Default value:* `+{ }+`
 
-==== Example: Using `+init+`
+==== Example: using `+init+`
 
 [source,html]
 ----
@@ -224,7 +224,7 @@ Initial content of the editor when the editor is initialized.
 
 *Default value:* `+' '+`
 
-==== Example: Using `+initialValue+`
+==== Example: using `+initialValue+`
 
 [source,html]
 ----
@@ -246,7 +246,7 @@ For information on inline mode, see: xref:inline-editor-options.adoc#inline[User
 
 *Possible values:* `+true+`, `+false+`
 
-==== Example: Using `+inline+`
+==== Example: using `+inline+`
 
 [source,html]
 ----
@@ -264,7 +264,7 @@ For information on adding plugins to {productname}, see: xref:work-with-plugins.
 
 *Type:* `+String+` or `+Array+`
 
-==== Example: Using `+plugins+`
+==== Example: using `+plugins+`
 
 [source,html]
 ----
@@ -284,7 +284,7 @@ Used to specify the format of the content emitted by the `+tinymce-angular+` com
 
 *Possible values:* `+'html'+`, `+'text'+`
 
-==== Example: Using `+outputFormat+`
+==== Example: using `+outputFormat+`
 
 [source,html]
 ----
@@ -302,7 +302,7 @@ Only valid when xref:inline[`+<editor [inline]="true"></editor>+`]. Used to defi
 
 *Default value:* `+'div'+`
 
-==== Example: Using `+tagName+`
+==== Example: using `+tagName+`
 
 [source,html]
 ----
@@ -323,7 +323,7 @@ For information setting the toolbar for {productname}, see: xref:toolbar-configu
 
 *Possible values:* See xref:available-toolbar-buttons.adoc[Toolbar Buttons Available for {productname}].
 
-==== Example: Using `+toolbar+`
+==== Example: using `+toolbar+`
 
 [source,html]
 ----
@@ -358,7 +358,7 @@ Used to specify the events that trigger the `+NgModelChange+` to emit.
 
 *Possible values:* A space separated list of TinyMCE editor events.
 
-==== Example: Using `+modelEvents+`
+==== Example: using `+modelEvents+`
 
 [source,html]
 ----
@@ -484,7 +484,7 @@ Used to provide an allow-list of valid events to trigger from the editor to the 
 
 *Possible values:* A comma separated list of events to allow.
 
-==== Example: Using `+allowedEvents+`
+==== Example: using `+allowedEvents+`
 
 [source,html]
 ----
@@ -504,7 +504,7 @@ Used to block a list of events from the `+tinymce-angular+` component.
 
 *Possible values:* A comma separated list of events to ignore.
 
-==== Example: Using `+ignoreEvents+`
+==== Example: using `+ignoreEvents+`
 
 [source,html]
 ----

--- a/modules/ROOT/partials/integrations/react-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/react-tech-ref.adoc
@@ -169,7 +169,7 @@ include::partial$misc/get-an-api-key.adoc[]
 
 *Default value:* `+'no-api-key'+`
 
-==== Example: Using `+apiKey+`
+==== Example: using `+apiKey+`
 
 [source,jsx]
 ----
@@ -220,7 +220,7 @@ The `+disabled+` prop can dynamically switch the editor between a "disabled" (re
 
 *Possible values:* `+true+`, `+false+`
 
-==== Example: Using `+disabled+`
+==== Example: using `+disabled+`
 
 [source,jsx]
 ----
@@ -238,7 +238,7 @@ An id for the editor. Used for retrieving the editor instance using the `+tinymc
 
 *Default value:* Automatically generated https://tools.ietf.org/html/rfc4122[UUID]
 
-==== Example: Using `+id+`
+==== Example: using `+id+`
 
 [source,jsx]
 ----
@@ -263,7 +263,7 @@ When using `+tinymce-react+`:
 
 *Default value:* `+{ }+`
 
-==== Example: Using `+init+`
+==== Example: using `+init+`
 
 [source,jsx]
 ----
@@ -288,7 +288,7 @@ IMPORTANT: Ensure that this is *not* updated by `+onEditorChange+` or the editor
 
 *Default value:* `+''+`
 
-==== Example: Using static `+initialValue+`
+==== Example: using static `+initialValue+`
 
 [source,jsx]
 ----
@@ -297,7 +297,7 @@ IMPORTANT: Ensure that this is *not* updated by `+onEditorChange+` or the editor
 />
 ----
 
-==== Example: Using asynchronous `+initialValue+`
+==== Example: using asynchronous `+initialValue+`
 
 [source,jsx]
 ----
@@ -327,7 +327,7 @@ For information on inline mode, see: xref:inline-editor-options.adoc#inline[User
 
 *Possible values:* `+true+`, `+false+`
 
-==== Example: Using `+inline+`
+==== Example: using `+inline+`
 
 [source,jsx]
 ----
@@ -360,7 +360,7 @@ This option was used to specify the format of the content produced by the
 xref:oneditorchange[`+onEditorChange+`] event, however as it did not change the
 input format it was almost impossible to use correctly.
 
-==== Example: Replacing usage of `+outputFormat+`
+==== Example: replacing usage of `+outputFormat+`
 
 [source,jsx]
 ----
@@ -393,7 +393,7 @@ For information on adding plugins to {productname}, see: xref:work-with-plugins.
 
 *Type:* `+String+` or `+Array+`
 
-==== Example: Using `+plugins+`
+==== Example: using `+plugins+`
 
 [source,jsx]
 ----
@@ -416,7 +416,7 @@ enforced unless it changes.
 
 *Default value:* `200`
 
-==== Example: Using `+rollback+`
+==== Example: using `+rollback+`
 
 [source,jsx]
 ----
@@ -469,7 +469,7 @@ This Boolean attribute is set to indicate to a browser that the script is meant 
 
 
 [[example-loading-siteproductname-asynchronously]]
-==== Example: Loading {productname} asynchronously
+==== Example: loading {productname} asynchronously
 
 [source,jsx]
 ----
@@ -477,7 +477,7 @@ This Boolean attribute is set to indicate to a browser that the script is meant 
 ----
 
 [[example-delaying-load-of-siteproductname-for-500-milliseconds]]
-==== Example: Delaying load of {productname} for 500 milliseconds
+==== Example: delaying load of {productname} for 500 milliseconds
 
 [source,jsx]
 ----
@@ -493,7 +493,7 @@ Only valid when xref:inline[`+<Editor inline={true} />+`]. Used to define the HT
 
 *Default value:* `+'div'+`
 
-==== Example: Using `+tagName+`
+==== Example: using `+tagName+`
 
 [source,jsx]
 ----
@@ -510,7 +510,7 @@ Only valid when the editor is in classic (iframe) mode. Sets the `+name+` attrib
 
 *Type:* `+String+`
 
-==== Example: Using `+textareaName+`
+==== Example: using `+textareaName+`
 
 [source,jsx]
 ----
@@ -533,7 +533,7 @@ For information setting the toolbar for {productname}, see: xref:toolbar-configu
 
 *Possible values:* See xref:available-toolbar-buttons.adoc[Toolbar Buttons Available for {productname}].
 
-==== Example: Using `+toolbar+`
+==== Example: using `+toolbar+`
 
 [source,jsx]
 ----
@@ -550,7 +550,7 @@ Use the `+tinymceScriptSrc+` prop to specify an external version of {productname
 
 *Type:* `+String+`
 
-==== Example: Using `+tinymceScriptSrc+`
+==== Example: using `+tinymceScriptSrc+`
 
 [source,jsx]
 ----
@@ -583,7 +583,7 @@ To provide visual feedback to the user when the content is ready to be saved, us
 
 include::partial$misc/concept-dirty-state.adoc[]
 
-=== Example: Functional uncontrolled component with save button and dirty state
+=== Example: functional uncontrolled component with save button and dirty state
 
 [source,jsx]
 ----
@@ -625,7 +625,7 @@ The `+value+` prop is used to set and re-set the editor content. If it is not up
 
 The `+onEditorChange+` prop is used to provide an event handler that will be run when any change is made to the editor content. Changes to the editor must be applied to the `+value+` prop within _200 milliseconds_ to prevent the changes being rolled back.
 
-=== Example: Functional controlled component
+=== Example: functional controlled component
 
 [source,jsx]
 ----
@@ -642,7 +642,7 @@ function MyComponent({initialValue}) {
 }
 ----
 
-=== Example: Class controlled component
+=== Example: class controlled component
 
 [source,jsx]
 ----
@@ -678,7 +678,7 @@ class MyComponent extends React.Component {
 
 When the editor must be restricted to avoid invalid states, such as exceeding a maximum length, then a handler for `+onBeforeAddUndo+` must be added to avoid those states in the undo history.
 
-=== Example: Limited length controlled component
+=== Example: limited length controlled component
 
 [source,jsx]
 ----

--- a/modules/ROOT/partials/integrations/vue-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/vue-tech-ref.adoc
@@ -115,7 +115,7 @@ include::partial$misc/get-an-api-key.adoc[]
 
 *Default value:* `+'no-api-key'+`
 
-==== Example: Using `+api-key+`
+==== Example: using `+api-key+`
 
 [source,html]
 ----
@@ -164,7 +164,7 @@ The `+disabled+` property can dynamically switch the editor between a "disabled"
 
 *Possible values:* `+true+`, `+false+`
 
-==== Example: Using `+disabled+`
+==== Example: using `+disabled+`
 
 [source,html]
 ----
@@ -182,7 +182,7 @@ An id for the editor. Used for retrieving the editor instance using the `+tinymc
 
 *Default value:* Automatically generated https://tools.ietf.org/html/rfc4122[UUID]
 
-==== Example: Using `+id+`
+==== Example: using `+id+`
 
 [source,html]
 ----
@@ -202,7 +202,7 @@ For information on the {productname} selector (`+tinymce.init+`), see: xref:basi
 
 *Default value:* `+'{ }'+`
 
-==== Example: Using `+init+`
+==== Example: using `+init+`
 
 [source,html]
 ----
@@ -223,7 +223,7 @@ Initial content of the editor when the editor is initialized.
 
 *Default value:* `+' '+`
 
-==== Example: Using `+initial-value+`
+==== Example: using `+initial-value+`
 
 [source,html]
 ----
@@ -245,7 +245,7 @@ For information on inline mode, see: xref:inline-editor-options.adoc#inline[User
 
 *Possible values:* `+true+`, `+false+`
 
-==== Example: Using `+inline+`
+==== Example: using `+inline+`
 
 [source,html]
 ----
@@ -265,7 +265,7 @@ For a list of available {productname} events, see: xref:events.adoc#editor-core-
 
 *Default value:* `+'change keyup undo redo'+`.
 
-==== Example: Using `+model-events+`
+==== Example: using `+model-events+`
 
 [source,html]
 ----
@@ -285,7 +285,7 @@ Used to specify the format of the content emitted via the `+input+` event. This 
 
 *Possible values:* `+'html'+`, `+'text'+`
 
-==== Example: Using `+output-format+`
+==== Example: using `+output-format+`
 
 [source,html]
 ----
@@ -303,7 +303,7 @@ For information on adding plugins to {productname}, see: xref:work-with-plugins.
 
 *Type:* `+String+` or `+Array+`
 
-==== Example: Using `+plugins+`
+==== Example: using `+plugins+`
 
 [source,html]
 ----
@@ -321,7 +321,7 @@ Only valid when xref:inline[`+<editor :inline=true />+`]. Used to define the HTM
 
 *Default value:* `+'div'+`
 
-==== Example: Using `+tag-name+`
+==== Example: using `+tag-name+`
 
 [source,html]
 ----
@@ -342,7 +342,7 @@ For information setting the toolbar for {productname}, see: xref:toolbar-configu
 
 *Possible values:* See xref:available-toolbar-buttons.adoc[Toolbar Buttons Available for {productname}].
 
-==== Example: Using `+toolbar+`
+==== Example: using `+toolbar+`
 
 [source,html]
 ----
@@ -359,7 +359,7 @@ Use the `+tinymce-script-src+` prop to specify an external version of TinyMCE to
 
 *Type:* `+String+`
 
-==== Example: Using `+tinymce-script-src+`
+==== Example: using `+tinymce-script-src+`
 
 [source,html]
 ----

--- a/modules/ROOT/partials/integrations/webcomponent-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/webcomponent-quick-start.adoc
@@ -102,7 +102,7 @@ endif::[]
 +
 The default {productname} editor will load at this location if the page is opened in a web browser.
 
-== Example: Adding the TinyMCE Web Component to an HTML page
+== Example: adding the TinyMCE Web Component to an HTML page
 
 The following example shows the {productname} Web Component in an HTML page, with:
 

--- a/modules/ROOT/partials/misc/url-handling.adoc
+++ b/modules/ROOT/partials/misc/url-handling.adoc
@@ -15,11 +15,11 @@ tinymce.init({
 
 Example: `+http://www.example.com/path1/path2/file.htm+` >> `+path2/file.htm+`
 
-==== Example: Relative URLs on links and images
+==== Example: relative URLs on links and images
 
 liveDemo::url-conversion-relative-1[]
 
-==== Example: Relative URLs on links and images to a specific page
+==== Example: relative URLs on links and images to a specific page
 
 liveDemo::url-conversion-relative-2[]
 
@@ -39,11 +39,11 @@ tinymce.init({
 
 Example: `+path2/file.htm+` >> `+/path1/path2/file.htm+`
 
-==== Example: Absolute URLs on links and images
+==== Example: absolute URLs on links and images
 
 liveDemo::url-conversion-absolute-1[]
 
-==== Example: Absolute URLs and including domain on links and images
+==== Example: absolute URLs and including domain on links and images
 
 liveDemo::url-conversion-absolute-2[]
 

--- a/modules/ROOT/partials/plugins/spellchecker-content_langs.adoc
+++ b/modules/ROOT/partials/plugins/spellchecker-content_langs.adoc
@@ -5,7 +5,7 @@ include::partial$configuration/content_langs_base.adoc[]
 
 *Type:* `+Array+`
 
-=== Example: Using `+content_langs+` to change spelling dictionaries
+=== Example: using `+content_langs+` to change spelling dictionaries
 
 The Spell Checker Pro plugin will use the `+code+` property to determine which dictionary to use on the content, unless the `+customCode+` property is available. The language tag specified by `+customCode+` overrides the spelling dictionary, to allow for non-standard languages such as the medical dictionaries provided with Spell Checker Pro. For all languages, ensure that:
 


### PR DESCRIPTION
Related Ticket: [DOC-1858](https://ephocks.atlassian.net/browse/DOC-1858)

Description of Changes:
selection regex: `(= Example: )([A-Z]{1})`
replacement: `\1\L\2`

In plainer English: set all the words following ‘Example:’ in a sub-head so the initial character is now lower case, not upper case.

NB: an exception was made for the two examples where a Proper Noun — TinyMCE — was the following word.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
