### PR TITLE
DOC-1857: Typo Tuesday 01

### DIFF
--- a/modules/ROOT/partials/configuration/toolbar_mode.adoc
+++ b/modules/ROOT/partials/configuration/toolbar_mode.adoc
@@ -3,7 +3,7 @@
 
 The `+toolbar_mode+` option is used to extend the toolbar to accommodate the overflowing toolbar buttons. This option is useful for small screens or small editor frames.
 
-When the toolbar_mode is set to `+'floating'+` or `+sliding+`, the editor will move toolbar buttons to the toolbar drawer based on:
+When the toolbar_mode is set to `+'floating'+` or `+'sliding'+`, the editor will move toolbar buttons to the toolbar drawer based on:
 
 * The defined toolbar groups.
 * The width of the editor.

--- a/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
+++ b/modules/ROOT/partials/misc/inline-formatting-of-list-bullets.adoc
@@ -22,7 +22,7 @@ IMPORTANT: If, after applying inline-formatting, a partial selection of the now 
 
 === PowerPaste Premium plugin support
 
-Users of the xref:introduction-to-powerpaste.adoc[PowerPaste] Premium plugi] should note, this plugin does not, currently, support inline-formatted bullets or list numbers.
+Users of the xref:introduction-to-powerpaste.adoc[PowerPaste] Premium plugin should note, this plugin does not, currently, support inline-formatted bullets or list numbers.
 
 Inline-formatting, as applied to the bullets or list numbers, is lost when such material is copied and pasted using the PowerPaste plugin.
 


### PR DESCRIPTION
Related Ticket: [DOC-1857](https://ephocks.atlassian.net/browse/DOC-1857)

Description of Changes:
Typo Tuesday 01: typo corrections and copy-edits.

Typo 1: `inline-formatting-of-list-bullets.adoc`: s/plugi]/plugin/.
Typo 2: `toolbar_mode.adoc`: s/`+'floating'+` or `+sliding+`/`+'floating'+` or `+'sliding'+`/.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
