### PR TITLE
DOC-1873: Typo in 5.x docs navigation tree

### DIFF
--- a/release-notes/release-notes5107.md
+++ b/release-notes/release-notes5107.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: TinyMCE 5.10.7
-title_nav: TinyMCE v5.10.7
+title_nav: TinyMCE 5.10.7
 description: Release notes for TinyMCE 5.10.7
 keywords: releasenotes bugfixes security advisory
 ---


### PR DESCRIPTION
Related Ticket: [DOC-1873](https://ephocks.atlassian.net/browse/DOC-1873)

Description of Changes:
* Remove extraneous ‘v’ from release-notes5107.md’s title_nav value

Pre-checks:
- [x] Branch prefixed with `feature/5/` or `hotfix/5/`
~- [ ] `modules/ROOT/nav.adoc` has been updated (if applicable)~
~- [ ] Files has been included where required (if applicable)~
~- [ ] Files removed have been deleted, not just excluded from the build (if applicable)~
~- [ ] (New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
