### PR TITLE
DOC-1874: Structural ‘typo’ in 6.x Changelog as presented in the 6.x docs

### DIFF
--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -62,17 +62,17 @@ NOTE: This is the {productname} Community version changelog. For information abo
 * Added `allow` as a valid attribute for the `iframe` element in the editor schema.
 * New `search` field in the `MenuButton` that shows a search field at the top of the menu, and refetches items when the search field updates.
 
+=== Changed
+* The `@menubar-row-separator-color` oxide variable no longer affects the divider between the Menubar and Toolbar. It only controls the color of the separator lines drawn in multiline Menubars.
+* The `@toolbar-separator-color` oxide variable now affects the color of the separator between the Menubar and Toolbar only.
+* Available Premium plugins, which are listed by name in the Help dialog, are no longer translated.
+
 === Improved
 * The formatter can now apply a format to a `contenteditable="false"` element by wrapping it. Configurable using the `format_noneditable_selector` option.
 * The autocompleter now supports a multiple character trigger using the new `trigger` configuration.
 * The formatter now applies some inline formats, such as color and font size, to list item elements when the entire item content is selected.
 * The installed and available plugin lists in the Help dialog are now sorted alphabetically.
 * Alignment can now be applied to more types of embedded media elements.
-
-=== Changed
-* The `@menubar-row-separator-color` oxide variable no longer affects the divider between the Menubar and Toolbar. It only controls the color of the separator lines drawn in multiline Menubars.
-* The `@toolbar-separator-color` oxide variable now affects the color of the separator between the Menubar and Toolbar only.
-* Available Premium plugins, which are listed by name in the Help dialog, are no longer translated.
 
 === Fixed
 * The Autolink plugin did not work when text nodes in the content were fragmented.
@@ -124,12 +124,6 @@ NOTE: This is the {productname} Community version changelog. For information abo
 * New `removeAttributeFilter` and `removeNodeFilter` functions added to the DomParser and DOM Serializer APIs.
 * New `dispatchChange` function added to the UndoManager API to fire the change with current editor status as level and current undoManager layer as lastLevel.
 
-=== Improved
-* Clearer focus states for buttons while navigating with a keyboard.
-* Support annotating certain block elements directly when using the editor's Annotation API.
-* The `mceLink` command can now take the value `{ dialog: true }` to always open the link dialog.
-* All help dialog links to `https://www.tiny.cloud` now include `rel="noopener"` to avoid potential security issues.
-
 === Changed
 * The `end_container_on_empty_block` option can now take a string of blocks, allowing the exiting of a blockquote element by pressing Enter or Return twice.
 * The default value for `end_container_on_empty_block` option has been changed to `'blockquote'`.
@@ -139,6 +133,12 @@ NOTE: This is the {productname} Community version changelog. For information abo
 * Custom elements are now treated as non-empty elements by the schema.
 * The autocompleter's menu HTML element is now positioned instead of the wrapper.
 * Choice menu items will now use the `'menuitemradio'` aria role to better reflect that only a single item can be active.
+
+=== Improved
+* Clearer focus states for buttons while navigating with a keyboard.
+* Support annotating certain block elements directly when using the editor's Annotation API.
+* The `mceLink` command can now take the value `{ dialog: true }` to always open the link dialog.
+* All help dialog links to `https://www.tiny.cloud` now include `rel="noopener"` to avoid potential security issues.
 
 === Fixed
 * Some Template plugin option values were not escaped properly when doing replacement lookups with Regular Expressions.
@@ -227,22 +227,6 @@ NOTE: This is the {productname} Community version changelog. For information abo
 * New `buttonType` property on dialog button components, supporting `toolbar` style in addition to `primary` and `secondary`.
 * The `tabindex` attribute is now copied from the target element to the iframe.
 
-=== Improved
-* New default theme styling for TinyMCE 6 facelift with old skin available as `tinymce-5` and `tinymce-5-dark`.
-* The default height of editor has been increased from `200px` to `400px` to improve the usability of the editor.
-* The upload results returned from the `editor.uploadImages()` API now includes a `removed` flag, reflecting if the image was removed after a failed upload.
-* The `ScriptLoader`, `StyleSheetLoader`, `AddOnManager`, `PluginManager` and `ThemeManager` APIs will now return a `Promise` when loading resources instead of using callbacks.
-* A `ThemeLoadError` event is now fired if the theme fails to load.
-* The `BeforeSetContent` event will now include the actual serialized content when passing in an `AstNode` to the `editor.setContent` API.
-* Improved support for placing the caret before or after noneditable elements within the editor.
-* Calls to `editor.selection.setRng` now update the caret position bookmark used when focus is returned to the editor.
-* The `emoticon` plugin dialog, toolbar and menu item has been updated to use the more accurate `Emojis` term.
-* The dialog `redial` API will now only rerender the changed components instead of the whole dialog.
-* The dialog API `setData` method now uses a deep merge algorithm to support partial nested objects.
-* The dialog spec `initialData` type is now `Partial<T>` to match the underlying implementation details.
-* Notifications no longer require a timeout to disable the close button.
-* The editor theme is now fetched in parallel with the icons, language pack and plugins.
-
 === Changed
 * TinyMCE is now MIT licensed.
 * Moved the `paste` plugin's functionality to TinyMCE core.
@@ -303,6 +287,22 @@ NOTE: This is the {productname} Community version changelog. For information abo
 * The default value for the `schema` option has been changed to `html5`.
 * The default value for the `table_style_by_css` option has been changed to `true`.
 * The default value for the `table_use_colgroups` option has been changed to `true`.
+
+=== Improved
+* New default theme styling for TinyMCE 6 facelift with old skin available as `tinymce-5` and `tinymce-5-dark`.
+* The default height of editor has been increased from `200px` to `400px` to improve the usability of the editor.
+* The upload results returned from the `editor.uploadImages()` API now includes a `removed` flag, reflecting if the image was removed after a failed upload.
+* The `ScriptLoader`, `StyleSheetLoader`, `AddOnManager`, `PluginManager` and `ThemeManager` APIs will now return a `Promise` when loading resources instead of using callbacks.
+* A `ThemeLoadError` event is now fired if the theme fails to load.
+* The `BeforeSetContent` event will now include the actual serialized content when passing in an `AstNode` to the `editor.setContent` API.
+* Improved support for placing the caret before or after noneditable elements within the editor.
+* Calls to `editor.selection.setRng` now update the caret position bookmark used when focus is returned to the editor.
+* The `emoticon` plugin dialog, toolbar and menu item has been updated to use the more accurate `Emojis` term.
+* The dialog `redial` API will now only rerender the changed components instead of the whole dialog.
+* The dialog API `setData` method now uses a deep merge algorithm to support partial nested objects.
+* The dialog spec `initialData` type is now `Partial<T>` to match the underlying implementation details.
+* Notifications no longer require a timeout to disable the close button.
+* The editor theme is now fetched in parallel with the icons, language pack and plugins.
 
 === Fixed
 * The object returned from the `editor.fire()` API was incorrect if the editor had been removed.

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -22,15 +22,15 @@ NOTE: This is the {productname} Community version changelog. For information abo
 * New `getTransparentElements` function added to `tinymce.html.Schema` to return a map object of transparent HTML elements.
 * Added `ToggleToolbarDrawer` event to subscribe to toolbar’s opening and closing.
 
-=== Changed
-* Transparent elements, like anchors, are now allowed in the root of the editor body if they contain blocks.
-* Colorswatch keyboard navigation now starts on currently selected color if present in the colorswatch.
-* `setContent` is now allowed to accept any custom keys and values as a second options argument.
-
 === Improved
 * Transparent elements, like anchors, can now contain block elements.
 * Colorswatch now displays a checkmark for selected color.
 * Color picker dialog now starts on the appropriate color for the cursor position.
+
+=== Changed
+* Transparent elements, like anchors, are now allowed in the root of the editor body if they contain blocks.
+* Colorswatch keyboard navigation now starts on currently selected color if present in the colorswatch.
+* `setContent` is now allowed to accept any custom keys and values as a second options argument.
 
 === Fixed
 * Parsing media content would cause a memory leak, which for example occurred when using the `getContent` API.
@@ -62,17 +62,17 @@ NOTE: This is the {productname} Community version changelog. For information abo
 * Added `allow` as a valid attribute for the `iframe` element in the editor schema.
 * New `search` field in the `MenuButton` that shows a search field at the top of the menu, and refetches items when the search field updates.
 
-=== Changed
-* The `@menubar-row-separator-color` oxide variable no longer affects the divider between the Menubar and Toolbar. It only controls the color of the separator lines drawn in multiline Menubars.
-* The `@toolbar-separator-color` oxide variable now affects the color of the separator between the Menubar and Toolbar only.
-* Available Premium plugins, which are listed by name in the Help dialog, are no longer translated.
-
 === Improved
 * The formatter can now apply a format to a `contenteditable="false"` element by wrapping it. Configurable using the `format_noneditable_selector` option.
 * The autocompleter now supports a multiple character trigger using the new `trigger` configuration.
 * The formatter now applies some inline formats, such as color and font size, to list item elements when the entire item content is selected.
 * The installed and available plugin lists in the Help dialog are now sorted alphabetically.
 * Alignment can now be applied to more types of embedded media elements.
+
+=== Changed
+* The `@menubar-row-separator-color` oxide variable no longer affects the divider between the Menubar and Toolbar. It only controls the color of the separator lines drawn in multiline Menubars.
+* The `@toolbar-separator-color` oxide variable now affects the color of the separator between the Menubar and Toolbar only.
+* Available Premium plugins, which are listed by name in the Help dialog, are no longer translated.
 
 === Fixed
 * The Autolink plugin did not work when text nodes in the content were fragmented.
@@ -124,6 +124,12 @@ NOTE: This is the {productname} Community version changelog. For information abo
 * New `removeAttributeFilter` and `removeNodeFilter` functions added to the DomParser and DOM Serializer APIs.
 * New `dispatchChange` function added to the UndoManager API to fire the change with current editor status as level and current undoManager layer as lastLevel.
 
+=== Improved
+* Clearer focus states for buttons while navigating with a keyboard.
+* Support annotating certain block elements directly when using the editor's Annotation API.
+* The `mceLink` command can now take the value `{ dialog: true }` to always open the link dialog.
+* All help dialog links to `https://www.tiny.cloud` now include `rel="noopener"` to avoid potential security issues.
+
 === Changed
 * The `end_container_on_empty_block` option can now take a string of blocks, allowing the exiting of a blockquote element by pressing Enter or Return twice.
 * The default value for `end_container_on_empty_block` option has been changed to `'blockquote'`.
@@ -133,12 +139,6 @@ NOTE: This is the {productname} Community version changelog. For information abo
 * Custom elements are now treated as non-empty elements by the schema.
 * The autocompleter's menu HTML element is now positioned instead of the wrapper.
 * Choice menu items will now use the `'menuitemradio'` aria role to better reflect that only a single item can be active.
-
-=== Improved
-* Clearer focus states for buttons while navigating with a keyboard.
-* Support annotating certain block elements directly when using the editor's Annotation API.
-* The `mceLink` command can now take the value `{ dialog: true }` to always open the link dialog.
-* All help dialog links to `https://www.tiny.cloud` now include `rel="noopener"` to avoid potential security issues.
 
 === Fixed
 * Some Template plugin option values were not escaped properly when doing replacement lookups with Regular Expressions.
@@ -227,6 +227,22 @@ NOTE: This is the {productname} Community version changelog. For information abo
 * New `buttonType` property on dialog button components, supporting `toolbar` style in addition to `primary` and `secondary`.
 * The `tabindex` attribute is now copied from the target element to the iframe.
 
+=== Improved
+* New default theme styling for TinyMCE 6 facelift with old skin available as `tinymce-5` and `tinymce-5-dark`.
+* The default height of editor has been increased from `200px` to `400px` to improve the usability of the editor.
+* The upload results returned from the `editor.uploadImages()` API now includes a `removed` flag, reflecting if the image was removed after a failed upload.
+* The `ScriptLoader`, `StyleSheetLoader`, `AddOnManager`, `PluginManager` and `ThemeManager` APIs will now return a `Promise` when loading resources instead of using callbacks.
+* A `ThemeLoadError` event is now fired if the theme fails to load.
+* The `BeforeSetContent` event will now include the actual serialized content when passing in an `AstNode` to the `editor.setContent` API.
+* Improved support for placing the caret before or after noneditable elements within the editor.
+* Calls to `editor.selection.setRng` now update the caret position bookmark used when focus is returned to the editor.
+* The `emoticon` plugin dialog, toolbar and menu item has been updated to use the more accurate `Emojis` term.
+* The dialog `redial` API will now only rerender the changed components instead of the whole dialog.
+* The dialog API `setData` method now uses a deep merge algorithm to support partial nested objects.
+* The dialog spec `initialData` type is now `Partial<T>` to match the underlying implementation details.
+* Notifications no longer require a timeout to disable the close button.
+* The editor theme is now fetched in parallel with the icons, language pack and plugins.
+
 === Changed
 * TinyMCE is now MIT licensed.
 * Moved the `paste` plugin's functionality to TinyMCE core.
@@ -288,22 +304,6 @@ NOTE: This is the {productname} Community version changelog. For information abo
 * The default value for the `table_style_by_css` option has been changed to `true`.
 * The default value for the `table_use_colgroups` option has been changed to `true`.
 
-=== Improved
-* New default theme styling for TinyMCE 6 facelift with old skin available as `tinymce-5` and `tinymce-5-dark`.
-* The default height of editor has been increased from `200px` to `400px` to improve the usability of the editor.
-* The upload results returned from the `editor.uploadImages()` API now includes a `removed` flag, reflecting if the image was removed after a failed upload.
-* The `ScriptLoader`, `StyleSheetLoader`, `AddOnManager`, `PluginManager` and `ThemeManager` APIs will now return a `Promise` when loading resources instead of using callbacks.
-* A `ThemeLoadError` event is now fired if the theme fails to load.
-* The `BeforeSetContent` event will now include the actual serialized content when passing in an `AstNode` to the `editor.setContent` API.
-* Improved support for placing the caret before or after noneditable elements within the editor.
-* Calls to `editor.selection.setRng` now update the caret position bookmark used when focus is returned to the editor.
-* The `emoticon` plugin dialog, toolbar and menu item has been updated to use the more accurate `Emojis` term.
-* The dialog `redial` API will now only rerender the changed components instead of the whole dialog.
-* The dialog API `setData` method now uses a deep merge algorithm to support partial nested objects.
-* The dialog spec `initialData` type is now `Partial<T>` to match the underlying implementation details.
-* Notifications no longer require a timeout to disable the close button.
-* The editor theme is now fetched in parallel with the icons, language pack and plugins.
-
 === Fixed
 * The object returned from the `editor.fire()` API was incorrect if the editor had been removed.
 * The `editor.selection.getContent()` API did not respect the `no_events` argument.
@@ -321,6 +321,12 @@ NOTE: This is the {productname} Community version changelog. For information abo
 * Dialogs could not be opened in inline mode before the editor had been rendered.
 * Clicking on menu items could cause an unexpected console warning if the `onAction` function caused the menu to close.
 * Fixed various color and contrast issues for the dark skins.
+
+=== Deprecated
+* The dialog button component's `primary` property has been deprecated and will be removed in the next major release. Use the new `buttonType` property instead.
+* The `fire()` function of `tinymce.Editor`, `tinymce.dom.EventUtils`, `tinymce.dom.DOMUtils`, `tinymce.util.Observable` and `tinymce.util.EventDispatcher` has been deprecated and will be removed in the next major release. Use the `dispatch()` function instead.
+* The `content` property on the `SetContent` event has been deprecated and will be removed in the next major release.
+* The return value of the `editor.setContent` API has been deprecated and will be removed in the next major release.
 
 === Removed
 * Removed support for Microsoft Internet Explorer 11.
@@ -365,9 +371,3 @@ NOTE: This is the {productname} Community version changelog. For information abo
 * Removed the deprecated `fullpage`, `spellchecker`, `bbcode`, `legacyoutput`, `colorpicker`, `contextmenu` and `textcolor` plugins.
 * Removed the undocumented `editor.editorCommands.hasCustomCommand` API.
 * Removed the undocumented `mceResetDesignMode`, `mceRepaint` and `mceBeginUndoLevel` commands.
-
-=== Deprecated
-* The dialog button component's `primary` property has been deprecated and will be removed in the next major release. Use the new `buttonType` property instead.
-* The `fire()` function of `tinymce.Editor`, `tinymce.dom.EventUtils`, `tinymce.dom.DOMUtils`, `tinymce.util.Observable` and `tinymce.util.EventDispatcher` has been deprecated and will be removed in the next major release. Use the `dispatch()` function instead.
-* The `content` property on the `SetContent` event has been deprecated and will be removed in the next major release.
-* The return value of the `editor.setContent` API has been deprecated and will be removed in the next major release.


### PR DESCRIPTION
Related Ticket: [DOC-1874](https://ephocks.atlassian.net/browse/DOC-1874)

Description of Changes:
The sub-section order in other 6.x releases not match 6.3 order.


Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
