### PR TITLE
DOC-1875: added linked CVE number and attribution to XSS vulnerability section of 6.3 Release Notes.

### DIFF
--- a/modules/ROOT/pages/6.3-release-notes.adoc
+++ b/modules/ROOT/pages/6.3-release-notes.adoc
@@ -615,6 +615,10 @@ As of {productname} 6.3, HTML being provided to the DOM for presentation in {pro
 
 This sanitizing closes the XSS vulnerability.
 
+CVE: https://cve.org/CVERecord?id=CVE-2022-23494[CVE-2022-23494].
+
+NOTE: Tiny Technologies would like to thank https://p4rkjw.com/[P4rkJW] for discovering this vulnerability.
+
 [[known-issues]]
 == Known issues
 

--- a/modules/ROOT/pages/6.3-release-notes.adoc
+++ b/modules/ROOT/pages/6.3-release-notes.adoc
@@ -615,7 +615,7 @@ As of {productname} 6.3, HTML being provided to the DOM for presentation in {pro
 
 This sanitizing closes the XSS vulnerability.
 
-CVE: https://cve.org/CVERecord?id=CVE-2022-23494[CVE-2022-23494].
+CVE: https://www.cve.org/CVERecord?id=CVE-2022-23494[CVE-2022-23494].
 
 NOTE: Tiny Technologies would like to thank https://p4rkjw.com/[P4rkJW] for discovering this vulnerability.
 


### PR DESCRIPTION
Related ticket: [DOC-1875](https://ephocks.atlassian.net/browse/DOC-1875)

Description of Changes:
* Added linked CVE number and attribution to XSS vulnerability section of _6.3 Release Notes_.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
