### PR TITLE
DOC-1886: corrected documented default values for advlist_bullet_styles

### DIFF
--- a/modules/ROOT/partials/configuration/advlist_bullet_styles.adoc
+++ b/modules/ROOT/partials/configuration/advlist_bullet_styles.adoc
@@ -5,11 +5,11 @@ This option allows you to include specific unordered list item markers in the de
 
 *Type:* `+String+`
 
-*Default value:* `+'default,circle,disc,square'+`
+*Default value:* `+'default,circle,square'+`
 
 *Possible values:*
 
-* `+default+`: the browser's default style
+* `+default+`: the browser’s default style
 * `+circle+`: a hollow circle
 * `+disc+`: a filled circle
 * `+square+`: a filled square


### PR DESCRIPTION
Related ticket: [DOC-1886](https://ephocks.atlassian.net/browse/DOC-1886)

Description of Changes:
* corrected documented default values for advlist_bullet_styles.
* also a typographic copy-edit.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
