### PR TITLE
DOC-1883: Updated the workflow runner to use ubuntu 20.04

### DIFF
--- a/.github/workflows/feature_6_docs.yml
+++ b/.github/workflows/feature_6_docs.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Build Docs and Deploy
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:

--- a/.github/workflows/release_6_docs.yml
+++ b/.github/workflows/release_6_docs.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Build Docs and Deploy
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:

--- a/.github/workflows/staging_6_docs.yml
+++ b/.github/workflows/staging_6_docs.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Build Docs and Deploy
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:


### PR DESCRIPTION


Related Ticket: DOC-1883

Description of Changes:
* https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
