### PR TITLE
DOC-1890: fixed two markup typos in a11ychecker.adoc

### DIFF
--- a/modules/ROOT/pages/a11ychecker.adoc
+++ b/modules/ROOT/pages/a11ychecker.adoc
@@ -205,7 +205,7 @@ xref:a11ychecker_html_version[HTML version]:: HTML4 and HTML5
 
 WCAG 2.1 specification:: https://www.w3.org/WAI/WCAG21/Techniques/general/G95.html[G95 - Providing short text alternatives that provide a brief description of the non-text content].
 
-include::partial$misc/admon-acessibility-rule-i3-can-also-be-applied.adoc[]
+include::partial$misc/admon-accessibility-rule-i3-can-also-be-applied.adoc[]
 
 [[I2]]
 === I2 - Image `+alt+` text is not the image filename
@@ -222,7 +222,7 @@ xref:a11ychecker_html_version[HTML version]:: HTML4 and HTML5
 
 WCAG 2.1 specification:: https://www.w3.org/WAI/WCAG21/Techniques/general/G95.html[G95 - Providing short text alternatives that provide a brief description of the non-text content].
 
-include::partial$misc/admon-acessibility-rule-i3-can-also-be-applied.adoc[]
+include::partial$misc/admon-accessibility-rule-i3-can-also-be-applied.adoc[]
 
 [[I3]]
 === I3 - Image `+alt+` text is not greater than 100 characters


### PR DESCRIPTION
Related ticket: [DOC-1890](https://ephocks.atlassian.net/browse/DOC-1890)

Description of Changes:
* Fixed two markup typos in a11ychecker.adoc

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
