### PR TITLE
DOC-1887: added material re responsible disclosure and reporter credit to Reporting TinyMCE security issues section.

### DIFF
--- a/modules/ROOT/pages/a11ychecker.adoc
+++ b/modules/ROOT/pages/a11ychecker.adoc
@@ -205,7 +205,7 @@ xref:a11ychecker_html_version[HTML version]:: HTML4 and HTML5
 
 WCAG 2.1 specification:: https://www.w3.org/WAI/WCAG21/Techniques/general/G95.html[G95 - Providing short text alternatives that provide a brief description of the non-text content].
 
-include::partial$misc/admon-accessibility-rule-i3-can-also-be-applied.adoc[]
+include::partial$misc/admon-acessibility-rule-i3-can-also-be-applied.adoc[]
 
 [[I2]]
 === I2 - Image `+alt+` text is not the image filename
@@ -222,7 +222,7 @@ xref:a11ychecker_html_version[HTML version]:: HTML4 and HTML5
 
 WCAG 2.1 specification:: https://www.w3.org/WAI/WCAG21/Techniques/general/G95.html[G95 - Providing short text alternatives that provide a brief description of the non-text content].
 
-include::partial$misc/admon-accessibility-rule-i3-can-also-be-applied.adoc[]
+include::partial$misc/admon-acessibility-rule-i3-can-also-be-applied.adoc[]
 
 [[I3]]
 === I3 - Image `+alt+` text is not greater than 100 characters

--- a/modules/ROOT/pages/a11ychecker.adoc
+++ b/modules/ROOT/pages/a11ychecker.adoc
@@ -205,7 +205,7 @@ xref:a11ychecker_html_version[HTML version]:: HTML4 and HTML5
 
 WCAG 2.1 specification:: https://www.w3.org/WAI/WCAG21/Techniques/general/G95.html[G95 - Providing short text alternatives that provide a brief description of the non-text content].
 
-include::partial$misc/admon-acessibility-rule-i3-can-also-be-applied.adoc[]
+include::partial$misc/admon-accessibility-rule-i3-can-also-be-applied.adoc[]
 
 [[I2]]
 === I2 - Image `+alt+` text is not the image filename
@@ -222,7 +222,7 @@ xref:a11ychecker_html_version[HTML version]:: HTML4 and HTML5
 
 WCAG 2.1 specification:: https://www.w3.org/WAI/WCAG21/Techniques/general/G95.html[G95 - Providing short text alternatives that provide a brief description of the non-text content].
 
-include::partial$misc/admon-acessibility-rule-i3-can-also-be-applied.adoc[]
+include::partial$misc/admon-accessibility-rule-i3-can-also-be-applied.adoc[]
 
 [[I3]]
 === I3 - Image `+alt+` text is not greater than 100 characters

--- a/modules/ROOT/pages/security.adoc
+++ b/modules/ROOT/pages/security.adoc
@@ -25,7 +25,15 @@ NOTE: The following is _general_ security advice that may be relevant to a websi
 [[reporting-tinymce-security-issues]]
 == [[reportingtinymcesecurityissues]] Reporting TinyMCE security issues
 
-{companyname} values the work of security researchers in improving the security of technology products worldwide. We welcome researchers who wish to responsibly disclose vulnerabilities in our products or systems. Note that we do not offer any “bug bounty” program or any form of payment for disclosed vulnerabilities. If you would like to report a vulnerability, please email `+infosec@tiny.cloud+`.
+{companyname} values the work of security researchers in improving the security of technology products worldwide. We welcome researchers who wish to responsibly disclose vulnerabilities in our products or systems.
+
+Note that we do not offer any “bug bounty” program or any form of payment for disclosed vulnerabilities.
+
+To report a potential security vulnerability, contact our Security team at mailto:infosec@tiny.cloud[infosec@tiny.cloud,Potential vulnerability report].
+
+In line with the United States National Infrastructure Advisory Council (NIAC) https://dhs.gov/xlibrary/assets/vdwgreport.pdf[Vulnerability Disclosure Framework] (PDF link), Tiny requests community members reporting potential security vulnerabilities maintain the confidentiality of their report and discovery until Tiny has investigated the issue and taken action to fix it.
+
+Tiny will communicate with you regarding the status of your report and will, with your permission, publicly attribute the security issue’s discovery to you after the issue has been fixed and disclosed.
 
 [[what-we-do-to-maintain-security-for-tinymce]]
 == What we do to maintain security for TinyMCE


### PR DESCRIPTION
Related ticket: [DOC-1887](https://ephocks.atlassian.net/browse/DOC-1887)

Description of Changes:
* added material re responsible disclosure and reporter credit to Reporting TinyMCE security issues section.
* Also turned report e-mail address into e-mail macro so the text is now a clickable link.
* NB: added text is based on edits also supplied for updating `security.md` as per [TINY-9487](https://ephocks.atlassian.net/browse/TINY-9487).

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed


[DOC-1887]: https://ephocks.atlassian.net/browse/DOC-1887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TINY-9487]: https://ephocks.atlassian.net/browse/TINY-9487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ