### PR TITLE
DOC-1899: Add missing `include::` statement to `advcode.adoc`

### DIFF
--- a/modules/ROOT/pages/advcode.adoc
+++ b/modules/ROOT/pages/advcode.adoc
@@ -34,6 +34,8 @@ tinymce.init({
 });
 ----
 
+include::partial$configuration/advcode.adoc[]
+
 include::partial$misc/advcode-shortcuts.adoc[]
 
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]

--- a/modules/ROOT/partials/configuration/advcode.adoc
+++ b/modules/ROOT/partials/configuration/advcode.adoc
@@ -9,7 +9,7 @@ Type : `boolean`,
 
 Default: false
 
-== Example: Basic setup
+== Example: basic setup
 
 [source,js]
 ----


### PR DESCRIPTION
Ticket: DOC-1899. Add missing `include::` statement to `advcode.adoc`

Changes:
* `/tinymce-docs/modules/ROOT/partials/configuration/advcode.adoc` was added as part of the 6.3 docs.
* `include::partial$configuration/advcode.adoc[]` (pointing to the above) was not added to `/tinymce-docs/modules/ROOT/pages/advcode.adoc`.
* It has been now.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
