### PR TITLE
DOC-1906: update Merge Tags docs to note prefix and suffix characters must be different.

### DIFF
--- a/modules/ROOT/partials/configuration/mergetags_prefix.adoc
+++ b/modules/ROOT/partials/configuration/mergetags_prefix.adoc
@@ -20,3 +20,5 @@ tinymce.init({
   mergetags_prefix: '{{'
 });
 ----
+
+IMPORTANT: Whatever character or characters are set as the Merge Tags prefix, it or they must be different to the characters set as the Merge Tags suffix. For example, if the Merge Tags prefix is set to `%`, the Merge Tags suffix cannot also be `%`.

--- a/modules/ROOT/partials/configuration/mergetags_suffix.adoc
+++ b/modules/ROOT/partials/configuration/mergetags_suffix.adoc
@@ -18,3 +18,5 @@ tinymce.init({
   mergetags_suffix: '}}'
 });
 ----
+
+IMPORTANT: Whatever character or characters are set as the Merge Tags suffix, it or they must be different to the characters set as the Merge Tags prefix. For example, if the Merge Tags suffix is set to `%`, the Merge Tags prefix cannot also be `%`.


### PR DESCRIPTION
Ticket: DOC-1906, update Merge Tags docs to note prefix and suffix characters must be different.

Changes:
* Added IMPORTANT admonition to both partials regarding the necessity of Merge Tags prefixes and suffixes being different characters or strings.
* **Editorial note**
	* A single partial, set to included in both files included in this edit, was abandoned as wordy and complicated.
	* As presented, these two admonitions are nearly identical and very close to each other on the published page.
	* The close focus most people have when reading documentation, however, justifies the near-repetition.
		* Most people, when reading the material on suffixes will not, for example, pay any attention to the prefixes documentation even though it is only a few paragraphs above it on the screen.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`

Review:
- [x] Documentation Team Lead has reviewed
