### PR TITLE
DOC-1909: Re-write Supported Mobile Platforms section to match the Browser Compatibility section approach

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1909: re-wrote the Supported Mobile Platforms section to match the Browser Compatibility section language, tying supported platforms to release recency rather than specific version numbers.
+
 ### 2023-01-20
 
 - DOC-1898: added changelog file, `changelog.md`, to the TinyMCE Documentation project. Entries for several month’s changes dating back from this initial creation date added to the file.

--- a/modules/ROOT/partials/misc/mobile-platform-compatibility.adoc
+++ b/modules/ROOT/partials/misc/mobile-platform-compatibility.adoc
@@ -1,30 +1,20 @@
 == Supported Mobile Platforms
 
-{productname} mobile is tested against, and is designed to run on the following mobile operating system and browser combinations:
+{productname} mobile is tested against, and is designed to run on, the default browser running on a currently vendor-supported version of both Android and iOS.
 
 [cols="1,1",options="header"]
 |===
-|Operating System |Browser
+|Operating System |Default browser
 
 |Android
 |Chrome
 
 |iOS
-| Safari
+|Safari
 |===
 
-{productname} supports the current and penultimate pairings of these combinations.
+Google supports the current and two previous versions of Android.
 
-////
-This matches Apple’s approach. They have long supported both the current and penultimate (previous) version of iOS.
+Apple supports the current and previous versions of iOS.
 
-However it does not match Google’s approach to Android.
-
-As of this note, Android 14 is the current version, but Google supports Android back to version 10.
-
-NB: Google’s support is not more generous than Apple’s, despite superficial appearances.
-
-In terms of what hardware remains supported by the software support approach used by both companies, Apple is ahead. Because Apple supports a much greater percentage of extant devices with each iOS update
-
-Google, by contrast, drops support for many more devices with OS updates.
-////
+NOTE: By default, both Android and iOS automatically update both the operating system and default browser. Consequently, {productname} mobile is only supported on the most recent releases of each supported operating system and browser combination.

--- a/modules/ROOT/partials/misc/mobile-platform-compatibility.adoc
+++ b/modules/ROOT/partials/misc/mobile-platform-compatibility.adoc
@@ -1,4 +1,4 @@
-== Supported Mobile Platforms (1)
+== Supported Mobile Platforms
 
 {productname} mobile is tested against, and is designed to run on, the default browser running on a currently vendor-supported version of both Android and iOS.
 
@@ -16,24 +16,5 @@
 Google supports the current and two previous versions of Android.
 
 Apple supports the current and previous versions of iOS.
-
-NOTE: By default, both Android and iOS automatically update both the operating system and default browser. Consequently, {productname} mobile is only supported on the most recent releases of each supported operating system and browser combination.
-
-
-
-== Supported Mobile Platforms (2)
-
-{productname} mobile is tested against, and is designed to run on, the default browser running on a the current and previous versions of both Android and iOS.
-
-[cols="1,1",options="header"]
-|===
-|Operating System |Default browser
-
-|Android
-|Chrome
-
-|iOS
-|Safari
-|===
 
 NOTE: By default, both Android and iOS automatically update both the operating system and default browser. Consequently, {productname} mobile is only supported on the most recent releases of each supported operating system and browser combination.

--- a/modules/ROOT/partials/misc/mobile-platform-compatibility.adoc
+++ b/modules/ROOT/partials/misc/mobile-platform-compatibility.adoc
@@ -1,4 +1,4 @@
-== Supported Mobile Platforms
+== Supported Mobile Platforms (1)
 
 {productname} mobile is tested against, and is designed to run on, the default browser running on a currently vendor-supported version of both Android and iOS.
 
@@ -16,5 +16,24 @@
 Google supports the current and two previous versions of Android.
 
 Apple supports the current and previous versions of iOS.
+
+NOTE: By default, both Android and iOS automatically update both the operating system and default browser. Consequently, {productname} mobile is only supported on the most recent releases of each supported operating system and browser combination.
+
+
+
+== Supported Mobile Platforms (2)
+
+{productname} mobile is tested against, and is designed to run on, the default browser running on a the current and previous versions of both Android and iOS.
+
+[cols="1,1",options="header"]
+|===
+|Operating System |Default browser
+
+|Android
+|Chrome
+
+|iOS
+|Safari
+|===
 
 NOTE: By default, both Android and iOS automatically update both the operating system and default browser. Consequently, {productname} mobile is only supported on the most recent releases of each supported operating system and browser combination.

--- a/modules/ROOT/partials/misc/mobile-platform-compatibility.adoc
+++ b/modules/ROOT/partials/misc/mobile-platform-compatibility.adoc
@@ -1,6 +1,6 @@
 == Supported Mobile Platforms
 
-{productname} mobile is tested against, and is designed to run on, the default browser running on a currently vendor-supported version of both Android and iOS.
+{productname} mobile is tested against, and is designed to run on, the default browser running on either the current or penultimate version of either Android and iOS.
 
 [cols="1,1",options="header"]
 |===
@@ -13,8 +13,22 @@
 |Safari
 |===
 
-Google supports the current and two previous versions of Android.
+By default, both Google and Apple automatically update their operating systems and their default browsers.
 
-Apple supports the current and previous versions of iOS.
+Android and iOS, again by default, automatically update themselves with patches, security fixes, and minor updates. However, major updates — that is updates from one major version of the operating system to the next major version — are announced but not installed without user or system administrator input.
 
-NOTE: By default, both Android and iOS automatically update both the operating system and default browser. Consequently, {productname} mobile is only supported on the most recent releases of each supported operating system and browser combination.
+The default browser on each operating system is similarly updated with patches, security fixes, and minor updates. Unlike with the operating system, however, major updates — that is updates from one major version of the default browser to the next major version — are also automatically installed by default.
+
+Consequently, {companynameformal} only supports {productname} mobile on the most recent release of each of the four supported operating system and browser combinations.
+
+That is, {productname} mobile is supported on
+
+* the most recent release of the current version of Android in combination with the most recent release of Chrome for the current version of Android;
+
+* the most recent release of the penultimate version of Android in combination with the most recent release of Chrome for the penultimate version of Android.
+
+* the most recent release of the current version of iOS in combination with the most recent release of Safari for the current version of iOS.
+
+* the most recent release of the penultimate version of iOS in combination with the most recent release of Safari for the the penultimate version of iOS.
+
+However, {productname} mobile is not supported on any beta or other pre-production releases of either the mobile operating system or its default browser.

--- a/modules/ROOT/partials/misc/mobile-platform-compatibility.adoc
+++ b/modules/ROOT/partials/misc/mobile-platform-compatibility.adoc
@@ -1,12 +1,30 @@
 == Supported Mobile Platforms
 
-{productname} mobile is designed to run on iOS Safari and Android Chrome. {productname} mobile is tested on the following platforms:
+{productname} mobile is tested against, and is designed to run on the following mobile operating system and browser combinations:
 
-[cols="^,^,^",options="header"]
+[cols="1,1",options="header"]
 |===
-|OS |Browser |Device
-|Android 11 |Chrome |Mobile phone
-|Android 12 |Chrome |Mobile phone
-|iOS/iPadOS 14 |Safari |iPhone/iPad
-|iOS/iPadOS 15 |Safari |iPhone/iPad
+|Operating System |Browser
+
+|Android
+|Chrome
+
+|iOS
+| Safari
 |===
+
+{productname} supports the current and penultimate pairings of these combinations.
+
+////
+This matches Apple’s approach. They have long supported both the current and penultimate (previous) version of iOS.
+
+However it does not match Google’s approach to Android.
+
+As of this note, Android 14 is the current version, but Google supports Android back to version 10.
+
+NB: Google’s support is not more generous than Apple’s, despite superficial appearances.
+
+In terms of what hardware remains supported by the software support approach used by both companies, Apple is ahead. Because Apple supports a much greater percentage of extant devices with each iOS update
+
+Google, by contrast, drops support for many more devices with OS updates.
+////


### PR DESCRIPTION
Ticket: DOC-1909, Re-write Supported Mobile Platforms section to match the Browser Compatibility section approach.

Changes:
* Re-written to fulfill the brief. This PR presents two suggested re-writes.
	* both use language that doesn’t require this page be constantly updated as new Android and iOS versions are released.
	* The first ties our support to the versions the two vendors — Google and Apple, respectively — support.
		* In particular, this ties our support to Google’s habit of supporting the current, penultimate and ante-penultimate versions of Android.
	* The second re-write sets our support to the current and penultimate versions (which, without explicitly saying so, apes Apple’s approach for iOS).
* Choosing which is to be published is now a key aspect of any Pull Request reviews and comments.


Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
