### PR TITLE
DOC-1918: changelog.adoc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+### 2032-02-22
+
+- DOC-1918: added the TinyMCE 6.3.2-specific change to `changelog.adoc`.
+
 ### 2023-01-20
 
 - DOC-1898: added changelog file, `changelog.md`, to the TinyMCE Documentation project. Entries for several month’s changes dating back from this initial creation date added to the file.

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -4,6 +4,11 @@
 
 NOTE: This is the {productname} Community version changelog. For information about the latest {cloudname} or {enterpriseversion} Release, see: xref:release-notes.adoc[{productname} Release Notes].
 
+== 6.3.2 - 2023-02-22
+
+=== Fixed
+* Removed a workaround for ensuring stylesheets are loaded in an outdated version of WebKit.
+
 == 6.3.1 - 2022-12-06
 
 === Fixed


### PR DESCRIPTION
Ticket: DOC-1918, Add the TinyMCE 6.3.2-specific changes to `changelog.adoc` so this file matches changelog.md on GitHub.

Changes:
* Added 6.3.2-specific change to changelog.adoc for the community release of 6.3.2.
* Also edited changelog.md (the docs-suite’s own changelog file) to note this addition.


Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
~- [ ] `modules/ROOT/nav.adoc` has been updated (if applicable)~
~- [ ] Files has been included where required (if applicable)~
~- [ ] Files removed have been deleted, not just excluded from the build (if applicable)~
~- [ ] (New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
