### PR TITLE
DOC-1913: 6.3.2-release-notes.adoc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1913: added `6.3.2-release-note.adoc`. Added outline to this file.
+
 ### 2023-01-20
 
 - DOC-1898: added changelog file, `changelog.md`, to the TinyMCE Documentation project. Entries for several month’s changes dating back from this initial creation date added to the file.

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -394,7 +394,9 @@
 *** TinyMCE 6.3.2
 **** xref:6.3.2-release-notes.adoc#overview[Overview]
 **** xref:6.3.2-release-notes.adoc#accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]
+**** xref:6.3.2-release-notes.adoc:accompanying-premium-self-hosted-server-side-component-changes[Accompanying Premium self-hosted server-side component changes]
 **** xref:6.3.2-release-notes.adoc#bug-fix[Bug fix]
+**** xref:6.3.2-release-notes.adoc:security-fixes[Security fixes]
 *** TinyMCE 6.3
 **** xref:6.3-release-notes.adoc#overview[Overview]
 **** xref:6.3-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -393,7 +393,6 @@
 ** xref:release-notes.adoc[Release notes for TinyMCE 6]
 *** TinyMCE 6.3.2
 **** xref:6.3.2-release-notes.adoc#overview[Overview]
-**** xref:6.3.2-release-notes.adoc#accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]
 **** xref:6.3.2-release-notes.adoc:accompanying-premium-self-hosted-server-side-component-changes[Accompanying Premium self-hosted server-side component changes]
 **** xref:6.3.2-release-notes.adoc#bug-fix[Bug fix]
 **** xref:6.3.2-release-notes.adoc:security-fixes[Security fixes]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -395,8 +395,6 @@
 **** xref:6.3.2-release-notes.adoc#overview[Overview]
 **** xref:6.3.2-release-notes.adoc#accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]
 **** xref:6.3.2-release-notes.adoc#bug-fix[Bug fix]
-//**** xref:6.3.2-release-notes.adoc#security-fixes[Security fixes]
-//**** xref:6.3.2-release-notes.adoc#known-issues[Known issues]
 *** TinyMCE 6.3
 **** xref:6.3-release-notes.adoc#overview[Overview]
 **** xref:6.3-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -391,6 +391,15 @@
 ** xref:tinymce-and-cors.adoc[Cross-Origin Resource Sharing (CORS)]
 * Release information
 ** xref:release-notes.adoc[Release notes for TinyMCE 6]
+*** TinyMCE 6.3.2
+**** xref:6.3.2-release-notes.adoc#overview[Overview]
+**** xref:6.3.2-release-notes.adoc#accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]
+**** xref:6.3.2-release-notes.adoc#improvements[Improvements]
+**** xref:6.3.2-release-notes.adoc#additions[Additions]
+**** xref:6.3.2-release-notes.adoc#changes[Changes]
+**** xref:6.3.2-release-notes.adoc#bug-fixes[Bug fixes]
+**** xref:6.3.2-release-notes.adoc#security-fixes[Security fixes]
+**** xref:6.3.2-release-notes.adoc#known-issues[Known issues]
 *** TinyMCE 6.3
 **** xref:6.3-release-notes.adoc#overview[Overview]
 **** xref:6.3-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -394,12 +394,9 @@
 *** TinyMCE 6.3.2
 **** xref:6.3.2-release-notes.adoc#overview[Overview]
 **** xref:6.3.2-release-notes.adoc#accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]
-**** xref:6.3.2-release-notes.adoc#improvements[Improvements]
-**** xref:6.3.2-release-notes.adoc#additions[Additions]
-**** xref:6.3.2-release-notes.adoc#changes[Changes]
-**** xref:6.3.2-release-notes.adoc#bug-fixes[Bug fixes]
-**** xref:6.3.2-release-notes.adoc#security-fixes[Security fixes]
-**** xref:6.3.2-release-notes.adoc#known-issues[Known issues]
+**** xref:6.3.2-release-notes.adoc#bug-fix[Bug fix]
+//**** xref:6.3.2-release-notes.adoc#security-fixes[Security fixes]
+//**** xref:6.3.2-release-notes.adoc#known-issues[Known issues]
 *** TinyMCE 6.3
 **** xref:6.3-release-notes.adoc#overview[Overview]
 **** xref:6.3-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]

--- a/modules/ROOT/pages/6.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.2-release-notes.adoc
@@ -187,7 +187,7 @@ The new versions of the server-side services provide updates for the Java-based 
 
 include::partial$misc/supported-application-servers.adoc[]
 
-. Replace the existing server-side `.war` files with the `.war` files bundled with {productname} vnumtxt or later.
+. Replace the existing server-side `.war` files with the `.war` files bundled with {productname} 6.2 or later.
 
 For information on:
 

--- a/modules/ROOT/pages/6.3.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.3.2-release-notes.adoc
@@ -65,7 +65,7 @@ The new versions of the server-side services provide updates for the Java-based 
 
 include::partial$misc/supported-application-servers.adoc[]
 
-. Replace the existing server-side `.war` files with the `.war` files bundled with {productname} vnumtxt or later.
+. Replace the existing server-side `.war` files with the `.war` files bundled with {productname} 6.3.2 or later.
 
 For information on:
 

--- a/modules/ROOT/pages/6.3.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.3.2-release-notes.adoc
@@ -12,12 +12,9 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 {productname} 6.3.2 was released for {enterpriseversion} and {cloudname} on Wednesday, March 1^st^, 2023. It includes {productname} 6.3.2. These release notes provide an overview of the changes for {productname} 6.3.2:
 
 * xref:accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]
-* xref:improvements[Improvements]
-* xref:additions[Additions]
-* xref:changes[Changes]
 * xref:bug-fixes[Bug fixes]
-* xref:security-fixes[Security fixes]
-* xref:known-issues[Known issues]
+//* xref:security-fixes[Security fixes]
+//* xref:known-issues[Known issues]
 
 [[accompanying-premium-skins-and-icon-packs-changes]]
 == Accompanying Premium Skins and Icon Packs changes
@@ -32,46 +29,63 @@ The **Premium Skins and Icon Packs** were rebuilt to pull in the changes also in
 
 For information on using premium skins and icon packs, see: xref:premium-skins-and-icons.adoc[Premium Skins and Icon Packs].
 
-[[improvements]]
-== Improvements
-
-{productname} 6.3.2 also includes the following improvements
-
-=== improvement
-
-Explanatory text.
-
-
-[[additions]]
-== Additions
-
-{productname} 6.3.2 also includes the following additions:
-
-=== addition
-
-Explanatory text.
-
-
-[[changes]]
-== Changes
-
-{productname} 6.3.2 also incorporates the following changes:
-
-=== change
-
-Explanatory text.
-
-
 [[bug-fixes]]
 == Bug fixes
 
 {productname} 6.3.2 also includes the following bug fixes:
 
-=== bug fix
+=== An element could be dropped onto the decendants of a noneditable element
 
-Explanatory text.
+// https://ephocks.atlassian.net/browse/TINY-9364
+In {productname} 6.0, the drag and drop `config` did not check some conditions surrounding element placements using either a grag or drop action.  This affected users running {productname} 6.0, which would affectivly allow decendants of *noneditable elements* to be dropped into another *noneditable element*.
+
+Fixes were made to ensure that `dragging | dropping` onto *noneditable element* targets on all browsers is `disabled`. This also includes when the drop target cursor is inside the contenteditable element, or just before it.
+
+In {productname} 6.4, now prevents the user from having the ability to drag and drop any descendants of a `contenteditable=false element` within another *noneditable element*.
+
+=== Toolbar split buttons in advlist plugin to show the correct state when the cursor is in a checklist
+
+// https://ephocks.atlassian.net/browse/TINY-5167
+In previous versions of {productname}, when a cursor was placed within a checklist item, the icon for both the checklist and the bullet list would show as `active`. This created UX issues, as having both buttons showing a `active` state was confusing for the user, specifically for navigation purposes when using checklists from the `advlist` plugin.
+
+To fix this issue, {productname} added improvements to the list configuration to checks a new set of conditionals which would determine if the `node` selected matched the parent `node` within the checklist. If the match returns as `true`, the (api) will set only the checklist icon to a `active` state.
+
+As a result, the checklist `icon` in {productname} 6.4, related to the `advlist` plugin will only appear in a `active` state, when the `node` checklist meets the new conditions implemented.
+
+=== Removed a workaround for ensuring stylesheets are loaded in an outdated version of webkit
+
+// https://ephocks.atlassian.net/browse/TINY-9433
+In certain webkit browsers the onload event wasn't supported due to an old `bug` within {productname}. A workaround was implemented that manually checked that `stylesheets` were being loaded rather than relying on the event being triggered. Due to this `bug`, a fixed was applied to the onload event, to ensure that it is now supported by webkit.
+
+The previous workaround has now been removed and replaced with the native browser event.
+
+In {productname} 6.4, the onload event `error` that stopped stylesheets to load have now been fixed with the new native browser implementation.
+
+=== Color picker dialog would not update the preview color if the hex input value was prefixed with # symbol
+
+// https://ephocks.atlassian.net/browse/TINY-9457
+In previous versions of {productname}, the preview sample box within the color picker dialod would not render. This issue could be replicated when a hex `value` was prefixed with a `#` symbol before the hex `value`.
+
+Example of a `incorrect` vs `correct` value input:
+
+* *`#BDE123`*: Incorrect hex value input.
+* *`BDE123`*: Correct hex value input.
+
+In order to fix this bug, {productname} 6.4, not detects if the user inserts a `#` symbol before the hex `value`, which removes the leading `#` prefix before rendering to the color picker component.
+
+In {productname} 6.4, the color picker works as expected when using hex `values`.
+
+=== Clicking on a disabled split button will no longer call the onAction callback
+
+// https://ephocks.atlassian.net/browse/TINY-9504
+A bug was found in versions of {productname} prior to the 6.4 release, that would call the `onAction` callback for *split buttons* regardless of the action being `disabled`. This meant it was possible for the user to emit the `onAction` call wether or not the `disable` function was enabled or not.
+
+As a fix to the issue, {productname} 6.4 introduced a new conditional check to identify *if* the button is `enabled` or `disabled`. If the button is set to `enabled` then {productname} executes the secondary check, which will identify wether or not the button is a *split button*.  Split buttons are classified as “special buttons”,  as they are unique and require both `advlists` and `dropdowns` to function, this makes them more complex than traditional buttons.
+
+In {productname} 6.4, clicking on a disabled split button won't call the `onAction` callback anymore.
 
 
+////
 [[security-fixes]]
 == Security fixes
 
@@ -92,5 +106,4 @@ There are several known issues in {productname} 6.3.2.
 === known issue
 
 Explanatory text.
-
-
+////

--- a/modules/ROOT/pages/6.3.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.3.2-release-notes.adoc
@@ -87,7 +87,7 @@ All 3 server-side components have been updated to include dependency updates add
 * https://nvd.nist.gov/vuln/detail/CVE-2023-22465[CVE-2022-41881]
 
 
-This updates include both Medium and High severity vulnerability fixes.
+This update includes both Medium and High severity vulnerability fixes.
 
 For information on the server-side components updates, see: xref:#accompanying-premium-self-hosted-server-side-component-changes[Accompanying Premium self-hosted server-side component changes].
 

--- a/modules/ROOT/pages/6.3.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.3.2-release-notes.adoc
@@ -12,7 +12,9 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 {productname} 6.3.2 was released for {enterpriseversion} and {cloudname} on Wednesday, March 1^st^, 2023. It includes {productname} 6.3.2. These release notes provide an overview of the changes for {productname} 6.3.2:
 
 * xref:accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]
+* xref:accompanying-premium-self-hosted-server-side-component-changes[Accompanying Premium self-hosted server-side component changes]
 * xref:bug-fix[Bug fix]
+* xref:security-fixes[Security fixes]
 
 [[accompanying-premium-skins-and-icon-packs-changes]]
 == Accompanying Premium Skins and Icon Packs changes
@@ -27,6 +29,51 @@ The **Premium Skins and Icon Packs** were rebuilt to pull in the changes also in
 
 For information on using premium skins and icon packs, see: xref:premium-skins-and-icons.adoc[Premium Skins and Icon Packs].
 
+[[accompanying-premium-self-hosted-server-side-component-changes]]
+== Accompanying Premium self-hosted server-side component changes
+
+The {productname} 6.3.2 release includes accompanying changes affecting the {productname} **self-hosted** services for the following plugins:
+
+* Enhanced Media Embed plugin (`mediaembed`)
+* Export plugin (`export`)
+* Enhanced Image Editing plugin (`editimage`)
+* Link Checker plugin (`linkchecker`)
+* Spell Checker Pro plugin (`tinymcespellchecker`)
+* Spelling Autocorrect plugin (`autocorrect`)
+
+For information on:
+
+* The Enhanced Media Embed plugin, see: xref:introduction-to-mediaembed.adoc[Enhanced Media Embed plugin].
+* The Export plugin, see: xref:export.adoc[Export plugin].
+* The Enhanced Image Editing plugin, see: xref:editimage.adoc[Enhanced Image Editing plugin].
+* The Link Checker plugin, see: xref:linkchecker.adoc[Link Checker plugin].
+* The Spell Checker Pro plugin, see: xref:introduction-to-tiny-spellchecker.adoc[Spell Checker Pro plugin].
+* The Spelling Autocorrect plugin, see: xref:autocorrect.adoc[Spelling Autocorrect plugin].
+* Deploying the server-side components, see: xref:introduction-to-premium-selfhosted-services.adoc[Server-side component installation].
+
+The Java server-side components have been updated to the following versions:
+
+* `ephox-hyperlinking.war`: 2.105.14
+* `ephox-image-proxy.war`: 2.106.5
+* `ephox-spelling.war`: 2.118.7
+
+=== Updating the self-hosted server-side components
+
+The new versions of the server-side services provide updates for the Java-based server-side components. To deploy the updated version of the server-side components:
+
+. Update your Java Application Server to the minimum required version:
+
+include::partial$misc/supported-application-servers.adoc[]
+
+. Replace the existing server-side `.war` files with the `.war` files bundled with {productname} vnumtxt or later.
+
+For information on:
+
+* Deploying the server-side components, see: xref:introduction-to-premium-selfhosted-services.adoc[Server-side component installation].
+* Deploying the server-side components using Docker, see: xref:bundle-intro-setup.adoc[Containerized service deployments].
+
+include::partial$misc/admon-no-functionality-changes-in-updated-server-side-components.adoc[]
+
 [[bug-fix]]
 == Bug fix
 
@@ -40,3 +87,22 @@ In certain webkit browsers the onload event wasn't supported due to an old `bug`
 The previous workaround has now been removed and replaced with the native browser event.
 
 In {productname} 6.4, the onload event `error` that stopped stylesheets to load have now been fixed with the new native browser implementation.
+
+
+[[security-fixes]]
+== Security fixes
+
+{productname} 6.3.2 includes a fix for the following security issues:
+
+All 3 server-side components have been updated to include dependency updates addressing the following security issues. 
+
+* https://nvd.nist.gov/vuln/detail/CVE-2022-41881[CVE-2022-41881]
+* https://nvd.nist.gov/vuln/detail/CVE-2022-41915[CVE-2022-41881]
+* https://nvd.nist.gov/vuln/detail/CVE-2023-22465[CVE-2022-41881]
+
+
+This updates include both Medium and High severity vulnerability fixes.
+
+For information on the server-side components updates, see: xref:#accompanying-premium-self-hosted-server-side-component-changes[Accompanying Premium self-hosted server-side component changes].
+
+include::partial$misc/admon-no-functionality-changes-in-updated-server-side-components.adoc[]

--- a/modules/ROOT/pages/6.3.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.3.2-release-notes.adoc
@@ -1,0 +1,96 @@
+= TinyMCE 6.3.2
+:navtitle: TinyMCE 6.3.2
+:description: Release notes for TinyMCE 6.3.2
+:keywords: releasenotes, new, changes, bugfixes
+:page-toclevels: 1
+
+include::partial$misc/admon-releasenotes-for-stable.adoc[]
+
+[[overview]]
+== Overview
+
+{productname} 6.3.2 was released for {enterpriseversion} and {cloudname} on Wednesday, March 1^st^, 2023. It includes {productname} 6.3.2. These release notes provide an overview of the changes for {productname} 6.3.2:
+
+* xref:accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]
+* xref:improvements[Improvements]
+* xref:additions[Additions]
+* xref:changes[Changes]
+* xref:bug-fixes[Bug fixes]
+* xref:security-fixes[Security fixes]
+* xref:known-issues[Known issues]
+
+[[accompanying-premium-skins-and-icon-packs-changes]]
+== Accompanying Premium Skins and Icon Packs changes
+
+The {productname} 6.3.2 release includes an accompanying release of the **Premium Skins and Icon Packs**.
+
+=== Premium Skins and Icon Packs
+
+The **Premium Skins and Icon Packs** release includes the following updates:
+
+The **Premium Skins and Icon Packs** were rebuilt to pull in the changes also incorporated into the default {productname} 6.3.2 skin, Oxide.
+
+For information on using premium skins and icon packs, see: xref:premium-skins-and-icons.adoc[Premium Skins and Icon Packs].
+
+[[improvements]]
+== Improvements
+
+{productname} 6.3.2 also includes the following improvements
+
+=== improvement
+
+Explanatory text.
+
+
+[[additions]]
+== Additions
+
+{productname} 6.3.2 also includes the following additions:
+
+=== addition
+
+Explanatory text.
+
+
+[[changes]]
+== Changes
+
+{productname} 6.3.2 also incorporates the following changes:
+
+=== change
+
+Explanatory text.
+
+
+[[bug-fixes]]
+== Bug fixes
+
+{productname} 6.3.2 also includes the following bug fixes:
+
+=== bug fix
+
+Explanatory text.
+
+
+[[security-fixes]]
+== Security fixes
+
+{productname} 6.3.2 includes a fix for the following security issue:
+
+=== security fix
+
+Explanatory text.
+
+
+[[known-issues]]
+== Known issues
+
+This section describes issues that users of {productname} 6.3.2 may encounter and possible workarounds for these issues.
+
+There are several known issues in {productname} 6.3.2.
+
+=== known issue
+
+Explanatory text.
+
+

--- a/modules/ROOT/pages/6.3.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.3.2-release-notes.adoc
@@ -13,8 +13,6 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 * xref:accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]
 * xref:bug-fix[Bug fix]
-//* xref:security-fixes[Security fixes]
-//* xref:known-issues[Known issues]
 
 [[accompanying-premium-skins-and-icon-packs-changes]]
 == Accompanying Premium Skins and Icon Packs changes
@@ -42,26 +40,3 @@ In certain webkit browsers the onload event wasn't supported due to an old `bug`
 The previous workaround has now been removed and replaced with the native browser event.
 
 In {productname} 6.4, the onload event `error` that stopped stylesheets to load have now been fixed with the new native browser implementation.
-
-////
-[[security-fixes]]
-== Security fixes
-
-{productname} 6.3.2 includes a fix for the following security issue:
-
-=== security fix
-
-Explanatory text.
-
-
-[[known-issues]]
-== Known issues
-
-This section describes issues that users of {productname} 6.3.2 may encounter and possible workarounds for these issues.
-
-There are several known issues in {productname} 6.3.2.
-
-=== known issue
-
-Explanatory text.
-////

--- a/modules/ROOT/pages/6.3.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.3.2-release-notes.adoc
@@ -15,11 +15,6 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 * xref:bug-fix[Bug fix]
 * xref:security-fixes[Security fixes]
 
-[[accompanying-premium-skins-and-icon-packs-changes]]
-== Accompanying Premium Skins and Icon Packs changes
-
-The {productname} 6.3.2 release includes an accompanying release of the **Premium Skins and Icon Packs**.
-
 [[accompanying-premium-self-hosted-server-side-component-changes]]
 == Accompanying Premium self-hosted server-side component changes
 

--- a/modules/ROOT/pages/6.3.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.3.2-release-notes.adoc
@@ -12,7 +12,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 {productname} 6.3.2 was released for {enterpriseversion} and {cloudname} on Wednesday, March 1^st^, 2023. It includes {productname} 6.3.2. These release notes provide an overview of the changes for {productname} 6.3.2:
 
 * xref:accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]
-* xref:bug-fixes[Bug fixes]
+* xref:bug-fix[Bug fix]
 //* xref:security-fixes[Security fixes]
 //* xref:known-issues[Known issues]
 
@@ -29,28 +29,10 @@ The **Premium Skins and Icon Packs** were rebuilt to pull in the changes also in
 
 For information on using premium skins and icon packs, see: xref:premium-skins-and-icons.adoc[Premium Skins and Icon Packs].
 
-[[bug-fixes]]
-== Bug fixes
+[[bug-fix]]
+== Bug fix
 
-{productname} 6.3.2 also includes the following bug fixes:
-
-=== An element could be dropped onto the decendants of a noneditable element
-
-// https://ephocks.atlassian.net/browse/TINY-9364
-In {productname} 6.0, the drag and drop `config` did not check some conditions surrounding element placements using either a grag or drop action.  This affected users running {productname} 6.0, which would affectivly allow decendants of *noneditable elements* to be dropped into another *noneditable element*.
-
-Fixes were made to ensure that `dragging | dropping` onto *noneditable element* targets on all browsers is `disabled`. This also includes when the drop target cursor is inside the contenteditable element, or just before it.
-
-In {productname} 6.4, now prevents the user from having the ability to drag and drop any descendants of a `contenteditable=false element` within another *noneditable element*.
-
-=== Toolbar split buttons in advlist plugin to show the correct state when the cursor is in a checklist
-
-// https://ephocks.atlassian.net/browse/TINY-5167
-In previous versions of {productname}, when a cursor was placed within a checklist item, the icon for both the checklist and the bullet list would show as `active`. This created UX issues, as having both buttons showing a `active` state was confusing for the user, specifically for navigation purposes when using checklists from the `advlist` plugin.
-
-To fix this issue, {productname} added improvements to the list configuration to checks a new set of conditionals which would determine if the `node` selected matched the parent `node` within the checklist. If the match returns as `true`, the (api) will set only the checklist icon to a `active` state.
-
-As a result, the checklist `icon` in {productname} 6.4, related to the `advlist` plugin will only appear in a `active` state, when the `node` checklist meets the new conditions implemented.
+{productname} 6.3.2 also includes the following bug fix:
 
 === Removed a workaround for ensuring stylesheets are loaded in an outdated version of webkit
 
@@ -60,30 +42,6 @@ In certain webkit browsers the onload event wasn't supported due to an old `bug`
 The previous workaround has now been removed and replaced with the native browser event.
 
 In {productname} 6.4, the onload event `error` that stopped stylesheets to load have now been fixed with the new native browser implementation.
-
-=== Color picker dialog would not update the preview color if the hex input value was prefixed with # symbol
-
-// https://ephocks.atlassian.net/browse/TINY-9457
-In previous versions of {productname}, the preview sample box within the color picker dialod would not render. This issue could be replicated when a hex `value` was prefixed with a `#` symbol before the hex `value`.
-
-Example of a `incorrect` vs `correct` value input:
-
-* *`#BDE123`*: Incorrect hex value input.
-* *`BDE123`*: Correct hex value input.
-
-In order to fix this bug, {productname} 6.4, not detects if the user inserts a `#` symbol before the hex `value`, which removes the leading `#` prefix before rendering to the color picker component.
-
-In {productname} 6.4, the color picker works as expected when using hex `values`.
-
-=== Clicking on a disabled split button will no longer call the onAction callback
-
-// https://ephocks.atlassian.net/browse/TINY-9504
-A bug was found in versions of {productname} prior to the 6.4 release, that would call the `onAction` callback for *split buttons* regardless of the action being `disabled`. This meant it was possible for the user to emit the `onAction` call wether or not the `disable` function was enabled or not.
-
-As a fix to the issue, {productname} 6.4 introduced a new conditional check to identify *if* the button is `enabled` or `disabled`. If the button is set to `enabled` then {productname} executes the secondary check, which will identify wether or not the button is a *split button*.  Split buttons are classified as “special buttons”,  as they are unique and require both `advlists` and `dropdowns` to function, this makes them more complex than traditional buttons.
-
-In {productname} 6.4, clicking on a disabled split button won't call the `onAction` callback anymore.
-
 
 ////
 [[security-fixes]]

--- a/modules/ROOT/pages/6.3.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.3.2-release-notes.adoc
@@ -11,7 +11,6 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 {productname} 6.3.2 was released for {enterpriseversion} and {cloudname} on Wednesday, March 1^st^, 2023. It includes {productname} 6.3.2. These release notes provide an overview of the changes for {productname} 6.3.2:
 
-* xref:accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]
 * xref:accompanying-premium-self-hosted-server-side-component-changes[Accompanying Premium self-hosted server-side component changes]
 * xref:bug-fix[Bug fix]
 * xref:security-fixes[Security fixes]
@@ -20,14 +19,6 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 == Accompanying Premium Skins and Icon Packs changes
 
 The {productname} 6.3.2 release includes an accompanying release of the **Premium Skins and Icon Packs**.
-
-=== Premium Skins and Icon Packs
-
-The **Premium Skins and Icon Packs** release includes the following updates:
-
-The **Premium Skins and Icon Packs** were rebuilt to pull in the changes also incorporated into the default {productname} 6.3.2 skin, Oxide.
-
-For information on using premium skins and icon packs, see: xref:premium-skins-and-icons.adoc[Premium Skins and Icon Packs].
 
 [[accompanying-premium-self-hosted-server-side-component-changes]]
 == Accompanying Premium self-hosted server-side component changes

--- a/modules/ROOT/pages/6.3.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.3.2-release-notes.adoc
@@ -92,7 +92,7 @@ In {productname} 6.3, the onload event `error` that stopped stylesheets to load 
 [[security-fixes]]
 == Security fixes
 
-{productname} 6.3.2 includes fixes for the following security issuess:
+{productname} 6.3.2 includes fixes for the following security issues:
 
 All 3 server-side components have been updated to include dependency updates addressing the following security issues. 
 

--- a/modules/ROOT/pages/6.3.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.3.2-release-notes.adoc
@@ -74,6 +74,7 @@ For information on:
 
 include::partial$misc/admon-no-functionality-changes-in-updated-server-side-components.adoc[]
 
+
 [[bug-fix]]
 == Bug fix
 
@@ -81,12 +82,11 @@ include::partial$misc/admon-no-functionality-changes-in-updated-server-side-comp
 
 === Removed a workaround for ensuring stylesheets are loaded in an outdated version of webkit
 
-// https://ephocks.atlassian.net/browse/TINY-9433
 In certain webkit browsers the onload event wasn't supported due to an old `bug` within {productname}. A workaround was implemented that manually checked that `stylesheets` were being loaded rather than relying on the event being triggered. Due to this `bug`, a fixed was applied to the onload event, to ensure that it is now supported by webkit.
 
 The previous workaround has now been removed and replaced with the native browser event.
 
-In {productname} 6.4, the onload event `error` that stopped stylesheets to load have now been fixed with the new native browser implementation.
+In {productname} 6.3, the onload event `error` that stopped stylesheets to load have now been fixed with the new native browser implementation.
 
 
 [[security-fixes]]

--- a/modules/ROOT/pages/6.3.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.3.2-release-notes.adoc
@@ -92,7 +92,7 @@ In {productname} 6.3, the onload event `error` that stopped stylesheets to load 
 [[security-fixes]]
 == Security fixes
 
-{productname} 6.3.2 includes a fix for the following security issues:
+{productname} 6.3.2 includes fixes for the following security issuess:
 
 All 3 server-side components have been updated to include dependency updates addressing the following security issues. 
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -11,7 +11,7 @@ This section lists the releases for {productname} 6 and the changes made in each
 
 a|
 [.lead]
-xref:6.3.2-release-notes.adoc#overview[{productname} 6.3]
+xref:6.3.2-release-notes.adoc#overview[{productname} 6.3.2]
 
 Release notes for {productname} 6.3.2
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -11,6 +11,13 @@ This section lists the releases for {productname} 6 and the changes made in each
 
 a|
 [.lead]
+xref:6.3.2-release-notes.adoc#overview[{productname} 6.3]
+
+Release notes for {productname} 6.3.2
+
+
+a|
+[.lead]
 xref:6.3-release-notes.adoc#overview[{productname} 6.3]
 
 Release notes for {productname} 6.3
@@ -60,7 +67,7 @@ Release notes for {productname} 6.0
 //    odd.
 // 2. Prepend the inline comment markup to this element
 //    when the number of cells in the table is even.
-a|
+//a|
 
 |===
 

--- a/modules/ROOT/partials/misc/admon-no-functionality-changes-in-updated-server-side-components.adoc
+++ b/modules/ROOT/partials/misc/admon-no-functionality-changes-in-updated-server-side-components.adoc
@@ -1,0 +1,1 @@
+NOTE: there are no functionality changes in these updated server-side components.

--- a/modules/ROOT/partials/misc/admon-no-functionality-changes-in-updated-server-side-components.adoc
+++ b/modules/ROOT/partials/misc/admon-no-functionality-changes-in-updated-server-side-components.adoc
@@ -1,1 +1,1 @@
-NOTE: there are no functionality changes in these updated server-side components.
+NOTE: There are no functionality changes in these updated server-side components.


### PR DESCRIPTION
Ticket: DOC-1913, TinyMCE 6.3.2 Enterprise docs release

Changes:
* Added `6.3.2-release-notes.adoc`
	* Added documentation of the single change to this.
* Added entries linking to 6.3.2 release notes sections to `nav.adoc`.
* Added table cell linking to 6.3.2 release notes to `release-notes.adoc`.
* Added entry for this work to tinymce-docs changelog file.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
