### PR TITLE
removed paste plugin references

### DIFF
--- a/_includes/configuration/help_tabs.md
+++ b/_includes/configuration/help_tabs.md
@@ -15,7 +15,7 @@ If `help_tabs` is not configured, any tabs defined using `addTab` will be displa
 ```js
 tinymce.init({
   selector: 'textarea',
-  plugins: 'help link table paste code emoticons',
+  plugins: 'help link table code emoticons',
   toolbar: 'help addTab',
   help_tabs: [
     'shortcuts', // the default shortcuts tab

--- a/_includes/configuration/images_file_types.md
+++ b/_includes/configuration/images_file_types.md
@@ -17,7 +17,7 @@ This option configures which image file formats are accepted by the editor. Chan
 ```js
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  plugins: 'image paste',
+  plugins: 'image',
   images_file_types: 'jpg,svg,webp'
 });
 ```

--- a/_includes/configuration/paste_as_text.md
+++ b/_includes/configuration/paste_as_text.md
@@ -15,6 +15,7 @@ This option enables you to set the default state of the `Paste as text` menu ite
 
 #### Example: Using `paste_as_text`
 
+{% if plugin == "powerpaste" %}
 ```js
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
@@ -24,4 +25,14 @@ tinymce.init({
   paste_as_text: true
 });
 ```
+{% else %}
+```js
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  menubar: 'edit',
+  toolbar: 'paste',
+  paste_as_text: true
+});
+```
+{% endif %}
 

--- a/_includes/configuration/paste_block_drop.md
+++ b/_includes/configuration/paste_block_drop.md
@@ -18,6 +18,7 @@ Due to browser limitations, it is not possible to filter content that is dragged
 #### Example: Using `powerpaste_block_drop`
 {% endif %}
 
+{% if plugin == "powerpaste" %}
 ```js
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
@@ -25,3 +26,11 @@ tinymce.init({
   {{plugin}}_block_drop: false
 });
 ```
+{% else %}
+```js
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  {{plugin}}_block_drop: false
+});
+```
+{% endif %}

--- a/_includes/configuration/paste_convert_word_fake_lists.md
+++ b/_includes/configuration/paste_convert_word_fake_lists.md
@@ -15,7 +15,6 @@ This option lets you disable the logic that converts list like paragraph structu
 ```js
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  plugins: 'paste',
   menubar: 'edit',
   toolbar: 'paste',
   paste_convert_word_fake_lists: false

--- a/_includes/configuration/paste_data_images.md
+++ b/_includes/configuration/paste_data_images.md
@@ -17,7 +17,6 @@ For example, Firefox enables you to paste images directly into any `contentEdita
 ```js
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  plugins: 'paste',
   menubar: 'edit',
   toolbar: 'paste',
   paste_data_images: true

--- a/_includes/configuration/paste_enable_default_filters.md
+++ b/_includes/configuration/paste_enable_default_filters.md
@@ -13,7 +13,6 @@ This option allows you to disable {{site.productname}}'s default paste filters w
 ```js
 tinymce.init({
   selector: 'textarea',  // change this value according to your html
-  plugins: 'paste',
   menubar: 'edit',
   toolbar: 'paste',
   paste_enable_default_filters: false

--- a/_includes/configuration/paste_filter_drop.md
+++ b/_includes/configuration/paste_filter_drop.md
@@ -13,7 +13,6 @@ This option allows developers to disable the default drop filters when set to `f
 ```js
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  plugins: 'paste',
   paste_filter_drop: false
 });
 ```

--- a/_includes/configuration/paste_merge_formats.md
+++ b/_includes/configuration/paste_merge_formats.md
@@ -17,6 +17,7 @@ This option enables the merge format feature of the {{pluginname}} plugin. This 
 
 #### Example: Using `paste_merge_formats`
 
+{% if plugin == "powerpaste" %}
 ```js
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
@@ -24,3 +25,13 @@ tinymce.init({
   paste_merge_formats: false
 });
 ```
+{% else %}
+```js
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  paste_merge_formats: false
+});
+```
+{% endif %}
+
+

--- a/_includes/configuration/paste_postprocess.md
+++ b/_includes/configuration/paste_postprocess.md
@@ -10,7 +10,6 @@ This option enables you to modify the pasted content before it gets inserted int
 ```js
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  plugins: 'paste',
   menubar: 'edit',
   toolbar: 'paste',
   paste_postprocess: function(plugin, args) {

--- a/_includes/configuration/paste_preprocess.md
+++ b/_includes/configuration/paste_preprocess.md
@@ -10,7 +10,6 @@ This option enables you to modify the pasted content before it gets inserted int
 ```js
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  plugins: 'paste',
   menubar: 'edit',
   toolbar: 'paste',
   paste_preprocess: function(plugin, args) {

--- a/_includes/configuration/paste_remove_styles_if_webkit.md
+++ b/_includes/configuration/paste_remove_styles_if_webkit.md
@@ -13,7 +13,6 @@ This option allows you to disable {{site.productname}}'s default paste filters f
 ```js
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  plugins: 'paste',
   menubar: 'edit',
   toolbar: 'paste',
   paste_remove_styles_if_webkit: false

--- a/_includes/configuration/paste_retain_style_properties.md
+++ b/_includes/configuration/paste_retain_style_properties.md
@@ -11,7 +11,6 @@ This option allows you to specify which styles you want to retain when pasting c
 ```js
 tinymce.init({
   selector: 'textarea',  // change this value according to your html
-  plugins: 'paste',
   menubar: 'edit',
   toolbar: 'paste',
   paste_retain_style_properties: 'color font-size'

--- a/_includes/configuration/paste_tab_spaces.md
+++ b/_includes/configuration/paste_tab_spaces.md
@@ -17,6 +17,7 @@ This option controls how many spaces are used to represent a tab character in HT
 
 #### Example: Using `paste_tab_spaces`
 
+{% if plugin == "powerpaste" %}
 ```js
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
@@ -24,3 +25,11 @@ tinymce.init({
   paste_tab_spaces: 2
 });
 ```
+{% else %}
+```js
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  paste_tab_spaces: 2
+});
+```
+{% endif %}

--- a/_includes/configuration/paste_webkit_styles.md
+++ b/_includes/configuration/paste_webkit_styles.md
@@ -9,7 +9,6 @@ This option allows you to specify styles you want to keep when pasting in WebKit
 ```js
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  plugins: 'paste',
   menubar: 'edit',
   toolbar: 'paste',
   paste_webkit_styles: 'color font-size'

--- a/_includes/configuration/paste_word_valid_elements.md
+++ b/_includes/configuration/paste_word_valid_elements.md
@@ -13,7 +13,6 @@ This option enables you to configure the `valid_elements` specific to MS Office.
 ```js
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  plugins: 'paste',
   menubar: 'edit',
   toolbar: 'paste',
   paste_word_valid_elements: 'b,strong,i,em,h1,h2'

--- a/_includes/integrations/angular-quick-start.md
+++ b/_includes/integrations/angular-quick-start.md
@@ -71,7 +71,7 @@ This procedure requires:
         plugins: [
           'advlist autolink lists link image charmap print preview anchor',
           'searchreplace visualblocks code fullscreen',
-          'insertdatetime media table paste code help wordcount'
+          'insertdatetime media table code help wordcount'
         ],
         toolbar:
           'undo redo | formatselect | bold italic backcolor | \

--- a/_includes/integrations/angular-tech-ref.md
+++ b/_includes/integrations/angular-tech-ref.md
@@ -186,7 +186,7 @@ For information on the {{site.productname}} selector (`tinymce.init`), see: [Bas
 <editor
   [init]="{% raw %}{{% endraw %}
     plugins: [
-     'lists link image paste help wordcount'
+     'lists link image help wordcount'
     ],
     toolbar: 'undo redo | formatselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | help'
   {% raw %}}{% endraw %}"

--- a/_includes/integrations/expressjs-quick-start.md
+++ b/_includes/integrations/expressjs-quick-start.md
@@ -91,7 +91,7 @@ This procedure requires:
       plugins: [
         'advlist autolink lists link image charmap print preview anchor',
         'searchreplace visualblocks code fullscreen',
-        'insertdatetime media table paste code help wordcount'
+        'insertdatetime media table code help wordcount'
       ],
       toolbar: 'undo redo | formatselect | ' +
       'bold italic backcolor | alignleft aligncenter ' +

--- a/_includes/integrations/react-quick-start.md
+++ b/_includes/integrations/react-quick-start.md
@@ -60,7 +60,7 @@ This procedure requires:
               plugins: [
                 'advlist autolink lists link image charmap print preview anchor',
                 'searchreplace visualblocks code fullscreen',
-                'insertdatetime media table paste code help wordcount'
+                'insertdatetime media table code help wordcount'
               ],
               toolbar: 'undo redo | formatselect | ' +
               'bold italic backcolor | alignleft aligncenter ' +

--- a/_includes/integrations/react-tech-ref.md
+++ b/_includes/integrations/react-tech-ref.md
@@ -262,7 +262,7 @@ When using `tinymce-react`:
 <Editor
   init={% raw %}{{{% endraw %}
     plugins: [
-     'lists link image paste help wordcount'
+     'lists link image help wordcount'
     ],
     toolbar: 'undo redo | formatselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | help'
   {% raw %}}}{% endraw %}

--- a/_includes/integrations/vue-quick-start.md
+++ b/_includes/integrations/vue-quick-start.md
@@ -111,7 +111,7 @@ This procedure requires:
             plugins: [
               'advlist autolink lists link image charmap print preview anchor',
               'searchreplace visualblocks code fullscreen',
-              'insertdatetime media table paste code help wordcount'
+              'insertdatetime media table code help wordcount'
             ],
             toolbar:
               'undo redo | formatselect | bold italic backcolor | \

--- a/_includes/integrations/vue-tech-ref.md
+++ b/_includes/integrations/vue-tech-ref.md
@@ -184,7 +184,7 @@ For information on the {{site.productname}} selector (`tinymce.init`), see: [Bas
 <editor
   :init="{% raw %}{{% endraw %}
     plugins: [
-     'lists link image paste help wordcount'
+     'lists link image help wordcount'
     ],
     toolbar: 'undo redo | formatselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | help'
   {% raw %}}{% endraw %}"

--- a/_includes/live-demos/basic-conf/index.js
+++ b/_includes/live-demos/basic-conf/index.js
@@ -5,7 +5,7 @@ tinymce.init({
   plugins: [
     'advlist autolink link image lists charmap print preview hr anchor pagebreak',
     'searchreplace wordcount visualblocks code fullscreen insertdatetime media nonbreaking',
-    'table emoticons template paste help'
+    'table emoticons template help'
   ],
   toolbar: 'undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | ' +
     'bullist numlist outdent indent | link image | print preview media fullscreen | ' +

--- a/_includes/live-demos/basic-example/index.js
+++ b/_includes/live-demos/basic-example/index.js
@@ -5,7 +5,7 @@ tinymce.init({
   plugins: [
     'advlist autolink lists link image charmap print preview anchor',
     'searchreplace visualblocks code fullscreen',
-    'insertdatetime media table paste code help wordcount'
+    'insertdatetime media table code help wordcount'
   ],
   toolbar: 'undo redo | formatselect | ' +
   'bold italic backcolor | alignleft aligncenter ' +

--- a/_includes/live-demos/comments-callback/example.js
+++ b/_includes/live-demos/comments-callback/example.js
@@ -185,7 +185,7 @@ function tinycomments_lookup({ conversationUid }, done, fail) {
 tinymce.init({
   selector: 'textarea#comments-callback',
   height: 800,
-  plugins: 'paste code tinycomments help lists',
+  plugins: 'code tinycomments help lists',
   toolbar:
     'undo redo | formatselect | ' +
     'bold italic backcolor | alignleft aligncenter ' +

--- a/_includes/live-demos/comments-callback/index.js
+++ b/_includes/live-demos/comments-callback/index.js
@@ -646,7 +646,7 @@ tinymce.ScriptLoader.loadScripts(
     tinymce.init({
       selector: 'textarea#comments-callback',
       height: 800,
-      plugins: 'paste code tinycomments help lists',
+      plugins: 'code tinycomments help lists',
       toolbar:
         'undo redo | formatselect | ' +
         'bold italic backcolor | alignleft aligncenter ' +

--- a/_includes/live-demos/comments-embedded/index.js
+++ b/_includes/live-demos/comments-embedded/index.js
@@ -11,7 +11,7 @@ tinymce.init({
       items: 'addcomment showcomments deleteallconversations'
     }
   },
-  plugins: 'paste code tinycomments',
+  plugins: 'code tinycomments',
   tinycomments_mode: 'embedded',
   tinycomments_author: currentAuthor,
   tinycomments_can_resolve: function (req, done, fail) {

--- a/_includes/live-demos/dark-mode/index.js
+++ b/_includes/live-demos/dark-mode/index.js
@@ -7,7 +7,7 @@ tinymce.init({
   plugins: [
     'advlist autolink lists link image charmap print preview anchor',
     'searchreplace visualblocks code fullscreen',
-    'insertdatetime media table paste code help wordcount'
+    'insertdatetime media table code help wordcount'
   ],
   toolbar: 'undo redo | formatselect | bold italic backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | removeformat | help | fullscreen code',
   content_style: {{site.liveDemoIframeCSSStyles}}

--- a/_includes/live-demos/export/index.js
+++ b/_includes/live-demos/export/index.js
@@ -1,6 +1,6 @@
 tinymce.init({
   selector: 'textarea#export',
-  plugins: 'export pagebreak code emoticons image table paste lists advlist checklist link hr charmap directionality',
+  plugins: 'export pagebreak code emoticons image table lists advlist checklist link hr charmap directionality',
   toolbar: 'export pagebreak | formatselect fontselect fontsizeselect bold italic underline strikethrough forecolor backcolor subscript superscript | alignleft aligncenter alignright alignjustify indent outdent rtl ltr | bullist numlist checklist | emoticons image table link hr charmap',
   height: 500,
   toolbar_mode: 'sliding',

--- a/_includes/live-demos/image-tools/index.js
+++ b/_includes/live-demos/image-tools/index.js
@@ -4,7 +4,7 @@ tinymce.init({
   plugins: [
     'advlist autolink lists link image charmap print preview anchor',
     'searchreplace visualblocks code fullscreen',
-    'insertdatetime media table paste imagetools wordcount'
+    'insertdatetime media table imagetools wordcount'
   ],
   toolbar: 'insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image',
   content_style: {{site.liveDemoIframeCSSStyles}}

--- a/_includes/live-demos/open-source-plugins/index.js
+++ b/_includes/live-demos/open-source-plugins/index.js
@@ -2,7 +2,7 @@ var useDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
 
 tinymce.init({
   selector: 'textarea#open-source-plugins',
-  plugins: 'print preview paste importcss searchreplace autolink autosave save directionality code visualblocks visualchars fullscreen image link media template codesample table charmap hr pagebreak nonbreaking anchor toc insertdatetime advlist lists wordcount imagetools textpattern noneditable help charmap quickbars emoticons',
+  plugins: 'print preview importcss searchreplace autolink autosave save directionality code visualblocks visualchars fullscreen image link media template codesample table charmap hr pagebreak nonbreaking anchor toc insertdatetime advlist lists wordcount imagetools textpattern noneditable help charmap quickbars emoticons',
   imagetools_cors_hosts: ['picsum.photos'],
   menubar: 'file edit view insert format tools table help',
   toolbar: 'undo redo | bold italic underline strikethrough | fontselect fontsizeselect formatselect | alignleft aligncenter alignright alignjustify | outdent indent |  numlist bullist | forecolor backcolor removeformat | pagebreak | charmap emoticons | fullscreen  preview save print | insertfile image media template link anchor codesample | ltr rtl',

--- a/general-configuration-guide/basic-setup.md
+++ b/general-configuration-guide/basic-setup.md
@@ -205,7 +205,7 @@ The following example is a basic {{site.productname}} configuration.
     plugins: [
       'advlist autolink link image lists charmap print preview hr anchor pagebreak',
       'searchreplace wordcount visualblocks visualchars code fullscreen insertdatetime media nonbreaking',
-      'table emoticons template paste help'
+      'table emoticons template help'
     ],
     toolbar: 'undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | ' +
       'bullist numlist outdent indent | link image | print preview media fullscreen | ' +
@@ -248,7 +248,7 @@ Selects the plugins to be included on load.
 plugins: [
   'advlist autolink link image lists charmap print preview hr anchor pagebreak',
   'searchreplace wordcount visualblocks visualchars code fullscreen insertdatetime media nonbreaking',
-  'table emoticons template paste help'
+  'table emoticons template help'
 ],
 ```
 

--- a/integrations/jquery.md
+++ b/integrations/jquery.md
@@ -85,7 +85,7 @@ To load a TinyMCE editor similar to the [Basic example]({{site.baseurl}}/demo/ba
         plugins: [
           'advlist autolink lists link image charmap print preview anchor',
           'searchreplace visualblocks code fullscreen',
-          'insertdatetime media table paste code help wordcount'
+          'insertdatetime media table code help wordcount'
         ],
         toolbar: 'undo redo | formatselect | bold italic backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | removeformat | help'
       });

--- a/integrations/rails.md
+++ b/integrations/rails.md
@@ -31,7 +31,7 @@ This procedure creates a [basic Ruby on Rails application](https://guides.rubyon
         plugins: [
           'advlist autolink lists link image charmap print preview anchor',
           'searchreplace visualblocks code fullscreen',
-          'insertdatetime media table paste code help wordcount'
+          'insertdatetime media table code help wordcount'
         ],
           toolbar: 'undo redo | formatselect | ' +
           ' bold italic backcolor | alignleft aligncenter ' +
@@ -73,7 +73,7 @@ This procedure creates a [basic Ruby on Rails application](https://guides.rubyon
         plugins: [
           'advlist autolink lists link image charmap print preview anchor',
           'searchreplace visualblocks code fullscreen',
-          'insertdatetime media table paste code help wordcount'
+          'insertdatetime media table code help wordcount'
         ],
           toolbar: 'undo redo | formatselect | ' +
           'bold italic backcolor | alignleft aligncenter ' +
@@ -140,7 +140,7 @@ This procedure creates a [basic Ruby on Rails application](https://guides.rubyon
       plugins:
         - advlist autolink lists link image charmap print preview anchor
         - searchreplace visualblocks code fullscreen
-        - insertdatetime media table paste code help wordcount
+        - insertdatetime media table code help wordcount
       ```
 
 3. Add the following lines within the `<head>` element of `app/views/layouts/application.html.erb` to automatically include {{site.productname}} on pages using the `application` layout:

--- a/plugins/opensource/paste.md
+++ b/plugins/opensource/paste.md
@@ -12,6 +12,8 @@ controls: toolbar button, menu item
 
 > Looking for more advanced Microsoft Word importing and pasting? Try the [PowerPaste]({{site.baseurl}}/plugins/premium/powerpaste/) plugin.
 
+> **Note:** The functionality of this plugin has been included in core of TinyMCE since version 6.0.0 and it is no longer required to include `paste` as part of the plugins. 
+
 This plugin will filter/cleanup content pasted from Microsoft Word. The power of the plugin is in its options, so please take the time to learn more about them below.
 
 The plugin also adds a menu item `Paste as text` under the `Edit` menu dropdown and a toolbar button.
@@ -23,7 +25,6 @@ The plugin also adds a menu item `Paste as text` under the `Edit` menu dropdown 
 ```js
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  plugins: 'paste',
   menubar: 'edit',
   toolbar: 'paste pastetext'
 });


### PR DESCRIPTION
Ticket: No ticket, don't know how to open a ticket, could not find it in the Contribution guidelines

Changes:
* Removes `paste` plugin references from all the documentation examples
* Adds a note to the `paste` plugin page that it has been part of the core package since 6.0.0

Pre-checks:
- [ ] Branch prefixed with `feature/6/` or `hotfix/6/`
- [ ] Changelog entry added
- [ ] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [ ] Files has been included where required (if applicable)
- [ ] Files removed have been deleted, not just excluded from the build (if applicable)
- [ ] (New product features only) Release Note added

I did not tick any checkboxes above as it is neither a feature nor a hotfix and the changelog of 6.0.0 already includes the plugins being moved to core package. The documentation should have been updated on version 6.0.0 2 years ago when the change to move paste into the core was done.

Here are list of tasks that are just closed while the documentation stayed as it is, misleading:
- https://github.com/tinymce/tinymce/issues/7685
- https://github.com/tinymce/tinymce/issues/8378

Review:
- [ ] Documentation Team Lead has reviewed
