### PR TITLE
DOC-1922, Add a list of the typograf’s typography rules subset that we, in fact, support to the Advanced Typography documentation.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1922: Added a new section, ‘Advanced Typography plugin rules’, to `advanced-typography.adoc`.
+
 ### 2032-02-22
 
 - DOC-1913: added `6.3.2-release-note.adoc`. Added outline to this file.

--- a/modules/ROOT/pages/advanced-typography.adoc
+++ b/modules/ROOT/pages/advanced-typography.adoc
@@ -15,7 +15,47 @@ The {pluginname} plugin, depending on its setting, can replace common typewriter
 
 For example, if English-language typography rules are set, the {pluginname} plugin can automatically replace an open-hyphen (`-`) with an em-dash (`—`). And it can automatically replace the teardrop apostrophe (`'`) with opening and closing quote marks (`‘` and `’`).
 
-NOTE: The {pluginname} plugin rules are sourced from the https://github.com/typograf/typograf[typograf] library.
+== Advanced Typography plugin rules
+
+The {pluginname} plugin rules are sourced from the https://github.com/typograf/typograf[typograf] library.
+
+However, the {pluginname} plugin only uses a sub-set of all the rules available in this library.
+
+Of the library’s full https://github.com/typograf/typograf/blob/dev/docs/RULES.en-US.md[Rules of typograf] list, the {pluginname} plugin uses the following:
+
+* common/space/delBeforePunctuation
+* common/space/afterComma
+* common/space/afterColon
+* common/space/delBetweenExclamationMarks
+* common/space/afterExclamationMark
+* common/space/afterQuestionMark
+* common/space/afterSemicolon
+* common/space/beforeBracket
+* common/space/bracket
+* common/space/delBeforeDot
+* common/space/delBeforePercent
+* common/space/squareBracket
+* common/number/mathSigns
+* common/number/times
+* common/number/fraction
+* common/symbols/arrow
+* common/symbols/cf
+* common/symbols/copy
+* common/punctuation/delDoublePunctuation
+* common/punctuation/hellip
+* common/nbsp/afterSectionMark
+* common/punctuation/quote
+* en-US/dash/main
+* common/nbsp/afterParagraphMark
+* common/nbsp/afterShortWord
+* common/nbsp/beforeShortLastNumber
+* common/nbsp/beforeShortLastWord
+* common/nbsp/dpi
+* common/punctuation/apostrophe
+
+No other typograf rules are used and the {pluginname} plugin cannot be configured to use any typograf rules other than those listed above.
+
+NOTE: The {pluginname} plugin affects text only. It does not modify the underlying HTML markup.
 
 == Interactive example
 


### PR DESCRIPTION
Ticket: DOC-1922, Add a list of the typograf’s typography rules subset that we, in fact, support to the Advanced Typography documentation.

Changes:
* Added new section:
	* listing the specific sub-set of typograf rules used by the Advanced Typography plugin;
	* noting that the Advanced Typography plugin cannot be configured to use any other rules; and 
	* also noting the Advanced Typography plugin affects only text, and does not touch the underlying HTML markup.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
~- [ ] `modules/ROOT/nav.adoc` has been updated (if applicable)~
~- [ ] Files has been included where required (if applicable)~
~- [ ] Files removed have been deleted, not just excluded from the build (if applicable)~
~- [ ] (New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
