### PR TITLE
DOC-1892: `fontsizeinput` and `font_size_input_default_unit` documentation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1892: `fontsizeinput` documentation added to `core-toolbar-buttons.adoc`; `font_size_input_default_unit.adoc` added to `/modules/ROOT/partials/configuration/`' and xref to this new file added to `user-formatting-options.adoc`.
+
 ### 2032-02-22
 
 - DOC-1913: added `6.3.2-release-note.adoc`. Added outline to this file.

--- a/modules/ROOT/examples/live-demos/full-featured/index.js
+++ b/modules/ROOT/examples/live-demos/full-featured/index.js
@@ -161,7 +161,7 @@ tinymce.ScriptLoader.loadScripts(['https://cdn.jsdelivr.net/npm/faker@5/dist/fak
       }
     },
     menubar: 'file edit view insert format tools table tc help',
-    toolbar: 'undo redo | bold italic underline strikethrough | fontfamily fontsize fontsizeinput blocks | alignleft aligncenter alignright alignjustify | outdent indent |  numlist bullist checklist | forecolor backcolor casechange permanentpen formatpainter removeformat | pagebreak | charmap emoticons | fullscreen  preview save print | insertfile image media pageembed template link anchor codesample | a11ycheck ltr rtl | showcomments addcomment | footnotes | mergetags',
+    toolbar: 'undo redo | bold italic underline strikethrough | fontfamily fontsize blocks | alignleft aligncenter alignright alignjustify | outdent indent |  numlist bullist checklist | forecolor backcolor casechange permanentpen formatpainter removeformat | pagebreak | charmap emoticons | fullscreen  preview save print | insertfile image media pageembed template link anchor codesample | a11ycheck ltr rtl | showcomments addcomment | footnotes | mergetags',
     toolbar_sticky: true,
     toolbar_sticky_offset: isSmallScreen ? 102 : 108,
     autosave_ask_before_unload: true,

--- a/modules/ROOT/examples/live-demos/full-featured/index.js
+++ b/modules/ROOT/examples/live-demos/full-featured/index.js
@@ -161,7 +161,7 @@ tinymce.ScriptLoader.loadScripts(['https://cdn.jsdelivr.net/npm/faker@5/dist/fak
       }
     },
     menubar: 'file edit view insert format tools table tc help',
-    toolbar: 'undo redo | bold italic underline strikethrough | fontfamily fontsize blocks | alignleft aligncenter alignright alignjustify | outdent indent |  numlist bullist checklist | forecolor backcolor casechange permanentpen formatpainter removeformat | pagebreak | charmap emoticons | fullscreen  preview save print | insertfile image media pageembed template link anchor codesample | a11ycheck ltr rtl | showcomments addcomment | footnotes | mergetags',
+    toolbar: 'undo redo | bold italic underline strikethrough | fontfamily fontsize fontsizeinput blocks | alignleft aligncenter alignright alignjustify | outdent indent |  numlist bullist checklist | forecolor backcolor casechange permanentpen formatpainter removeformat | pagebreak | charmap emoticons | fullscreen  preview save print | insertfile image media pageembed template link anchor codesample | a11ycheck ltr rtl | showcomments addcomment | footnotes | mergetags',
     toolbar_sticky: true,
     toolbar_sticky_offset: isSmallScreen ? 102 : 108,
     autosave_ask_before_unload: true,

--- a/modules/ROOT/pages/user-formatting-options.adoc
+++ b/modules/ROOT/pages/user-formatting-options.adoc
@@ -8,6 +8,8 @@ include::partial$configuration/font_family_formats.adoc[]
 
 include::partial$configuration/font_size_formats.adoc[]
 
+include::partial$configuration/font_size_input_default_unit.adoc[]
+
 include::partial$configuration/line_height_formats.adoc[]
 
 include::partial$configuration/indentation.adoc[]

--- a/modules/ROOT/partials/configuration/font_size_input_default_unit.adoc
+++ b/modules/ROOT/partials/configuration/font_size_input_default_unit.adoc
@@ -1,0 +1,14 @@
+[[font_size_input_default_unit]]
+== `+font_size_input_default_unit+`
+
+This option sets the default unit of measure for typeface sizes as input in, for example, the `fontsizeinput` toolbar button’s text-entry field.
+
+Numbers entered in the `fontsizeinput` toolbar without a qualifying unit of measure will be calculated using the unit of measure set.
+
+*Type:* `+String+`
+
+*Default value:* `+pt+`
+
+*Possible values:* `+pt+`, `+px+`, `+em+`, `+cm+`, `+mm+`
+
+NOTE: If `font_size_input_default_unit` is set to an invalid unit (ie, any string other than one of the *possible values* listed above), the setting is ignored. In such a case, numbers entered in the `fontsizeinput` toolbar without a qualifying unit of measure are also ignored.

--- a/modules/ROOT/partials/configuration/font_size_input_default_unit.adoc
+++ b/modules/ROOT/partials/configuration/font_size_input_default_unit.adoc
@@ -1,11 +1,9 @@
 [[font_size_input_default_unit]]
 == `+font_size_input_default_unit+`
 
-This option sets the default unit of measure for typeface sizes as input in, for example, the `fontsizeinput` toolbar button’s text-entry field.
+This option sets the default unit of measure for typeface sizes as input in, for example, the `xref:available-toolbar-buttons.adoc#the-core-toolbar-buttons[fontsizeinput]` toolbar button’s text-entry field.
 
 Numbers entered in the `fontsizeinput` toolbar without a qualifying unit of measure will be calculated using the unit of measure set.
-
-This option is commonly used in conjunction with the `xref:available-toolbar-buttons.adoc#the-core-toolbar-buttons[fontsizeinput]` toolbar button.
 
 *Type:* `+String+`
 

--- a/modules/ROOT/partials/configuration/font_size_input_default_unit.adoc
+++ b/modules/ROOT/partials/configuration/font_size_input_default_unit.adoc
@@ -5,7 +5,7 @@ This option sets the default unit of measure for typeface sizes as input in, for
 
 Numbers entered in the `fontsizeinput` toolbar without a qualifying unit of measure will be calculated using the unit of measure set.
 
-This option is commonly used in conjunction with the `fontsizeinput` xref:available-toolbar-buttons.adoc#the-core-toolbar-buttons[toolbar button].
+This option is commonly used in conjunction with the `xref:available-toolbar-buttons.adoc#the-core-toolbar-buttons[fontsizeinput]` toolbar button.
 
 *Type:* `+String+`
 

--- a/modules/ROOT/partials/configuration/font_size_input_default_unit.adoc
+++ b/modules/ROOT/partials/configuration/font_size_input_default_unit.adoc
@@ -12,3 +12,15 @@ Numbers entered in the `fontsizeinput` toolbar without a qualifying unit of meas
 *Possible values:* `+pt+`, `+px+`, `+em+`, `+cm+`, `+mm+`
 
 NOTE: If `font_size_input_default_unit` is set to an invalid value (ie, any string other than one of the *possible values* listed above), the setting is ignored. In such a case, numbers entered in the `fontsizeinput` toolbar without a qualifying unit of measure are also ignored.
+
+
+=== Example: using `+font_size_input_default_unit+`
+
+[source,js]
+----
+tinymce.init({
+    selector: "textarea",
+    toolbar: "fontsizeinput",
+    font_size_input_default_unit: "pt"
+});
+----

--- a/modules/ROOT/partials/configuration/font_size_input_default_unit.adoc
+++ b/modules/ROOT/partials/configuration/font_size_input_default_unit.adoc
@@ -5,6 +5,8 @@ This option sets the default unit of measure for typeface sizes as input in, for
 
 Numbers entered in the `fontsizeinput` toolbar without a qualifying unit of measure will be calculated using the unit of measure set.
 
+This option is commonly used in conjunction with the `fontsizeinput` xref:available-toolbar-buttons.adoc#the-core-toolbar-buttons[toolbar button].
+
 *Type:* `+String+`
 
 *Default value:* `+pt+`
@@ -24,3 +26,5 @@ tinymce.init({
     font_size_input_default_unit: "pt"
 });
 ----
+
+

--- a/modules/ROOT/partials/configuration/font_size_input_default_unit.adoc
+++ b/modules/ROOT/partials/configuration/font_size_input_default_unit.adoc
@@ -11,4 +11,4 @@ Numbers entered in the `fontsizeinput` toolbar without a qualifying unit of meas
 
 *Possible values:* `+pt+`, `+px+`, `+em+`, `+cm+`, `+mm+`
 
-NOTE: If `font_size_input_default_unit` is set to an invalid unit (ie, any string other than one of the *possible values* listed above), the setting is ignored. In such a case, numbers entered in the `fontsizeinput` toolbar without a qualifying unit of measure are also ignored.
+NOTE: If `font_size_input_default_unit` is set to an invalid value (ie, any string other than one of the *possible values* listed above), the setting is ignored. In such a case, numbers entered in the `fontsizeinput` toolbar without a qualifying unit of measure are also ignored.

--- a/modules/ROOT/partials/configuration/font_size_input_default_unit.adoc
+++ b/modules/ROOT/partials/configuration/font_size_input_default_unit.adoc
@@ -21,7 +21,7 @@ NOTE: If `font_size_input_default_unit` is set to an invalid value (ie, any stri
 [source,js]
 ----
 tinymce.init({
-    selector: "textarea",
+    selector: "textarea",  // change this value according to your HTML
     toolbar: "fontsizeinput",
     font_size_input_default_unit: "pt"
 });

--- a/modules/ROOT/partials/toolbar-button-ids/core-toolbar-buttons.adoc
+++ b/modules/ROOT/partials/toolbar-button-ids/core-toolbar-buttons.adoc
@@ -14,9 +14,8 @@
 |`+cut+` |Cuts the current selection into clipboard.
 |`+fontfamily+` |Dropdown list with font families to apply to selection.
 |`+fontsize+` |Dropdown list with font sizes to apply to selection. +
-The `+fontsize+` and `+fontsizeinput+` toolbar buttons should not be used together.
-|`+fontsizeinput+` |Text entry input field to change font size of selection or current insertion point. Also provides increase and decrease font size buttons on either side of said input field. +
-The `+fontsize+` and `+fontsizeinput+` toolbar buttons should not be used together.
+The `+fontsize+` and `+fontsizeinput+` toolbar buttons should not be placed in a xref:toolbar-configuration-options.adoc#toolbar_groups[toolbar group] together or otherwise presented together.
+|`+fontsizeinput+` |Text entry input field to change font size of selection or current insertion point. Also provides increase and decrease font size buttons on either side of said input field.The `+fontsize+` and `+fontsizeinput+` toolbar buttons should not be placed in a xref:toolbar-configuration-options.adoc#toolbar_groups[toolbar group] together or otherwise presented together.
 |`+forecolor+` |Applies foreground/text color to selection.
 |`+h1+` |Changes current line to the "Heading 1" style.
 |`+h2+` |Changes current line to the "Heading 2" style.

--- a/modules/ROOT/partials/toolbar-button-ids/core-toolbar-buttons.adoc
+++ b/modules/ROOT/partials/toolbar-button-ids/core-toolbar-buttons.adoc
@@ -13,8 +13,10 @@
 |`+copy+` |Copies the current selection into clipboard.
 |`+cut+` |Cuts the current selection into clipboard.
 |`+fontfamily+` |Dropdown list with font families to apply to selection.
-|`+fontsize+` |Dropdown list with font sizes to apply to selection.
-|`+fontsizeinput+` |Text entry input field to change font size of selection or current insertion point. Also provides increase and decrease font size buttons on either side of said input field.
+|`+fontsize+` |Dropdown list with font sizes to apply to selection. +
+The `+fontsize+` and `+fontsizeinput+` toolbar buttons should not be used together.
+|`+fontsizeinput+` |Text entry input field to change font size of selection or current insertion point. Also provides increase and decrease font size buttons on either side of said input field. +
+The `+fontsize+` and `+fontsizeinput+` toolbar buttons should not be used together.
 |`+forecolor+` |Applies foreground/text color to selection.
 |`+h1+` |Changes current line to the "Heading 1" style.
 |`+h2+` |Changes current line to the "Heading 2" style.

--- a/modules/ROOT/partials/toolbar-button-ids/core-toolbar-buttons.adoc
+++ b/modules/ROOT/partials/toolbar-button-ids/core-toolbar-buttons.adoc
@@ -15,7 +15,8 @@
 |`+fontfamily+` |Dropdown list with font families to apply to selection.
 |`+fontsize+` |Dropdown list with font sizes to apply to selection. +
 The `+fontsize+` and `+fontsizeinput+` toolbar buttons should not be placed in a xref:toolbar-configuration-options.adoc#toolbar_groups[toolbar group] together or otherwise presented together.
-|`+fontsizeinput+` |Text entry input field to change font size of selection or current insertion point. Also provides increase and decrease font size buttons on either side of said input field.The `+fontsize+` and `+fontsizeinput+` toolbar buttons should not be placed in a xref:toolbar-configuration-options.adoc#toolbar_groups[toolbar group] together or otherwise presented together.
+|`+fontsizeinput+` |Text entry input field to change font size of selection or current insertion point. Also provides increase and decrease font size buttons on either side of said input field. +
+The `+fontsize+` and `+fontsizeinput+` toolbar buttons should not be placed in a xref:toolbar-configuration-options.adoc#toolbar_groups[toolbar group] together or otherwise presented together.
 |`+forecolor+` |Applies foreground/text color to selection.
 |`+h1+` |Changes current line to the "Heading 1" style.
 |`+h2+` |Changes current line to the "Heading 2" style.

--- a/modules/ROOT/partials/toolbar-button-ids/core-toolbar-buttons.adoc
+++ b/modules/ROOT/partials/toolbar-button-ids/core-toolbar-buttons.adoc
@@ -16,6 +16,7 @@
 |`+fontsize+` |Dropdown list with font sizes to apply to selection. +
 The `+fontsize+` and `+fontsizeinput+` toolbar buttons should not be placed in a xref:toolbar-configuration-options.adoc#toolbar_groups[toolbar group] together or otherwise presented together.
 |`+fontsizeinput+` |Text entry input field to change font size of selection or current insertion point. Also provides increase and decrease font size buttons on either side of said input field. +
+This toolbar button is commonly used in conjunction with the `xref:user-formatting-options.adoc#font_size_input_default_unit[font_size_input_default]` configuration option. +
 The `+fontsize+` and `+fontsizeinput+` toolbar buttons should not be placed in a xref:toolbar-configuration-options.adoc#toolbar_groups[toolbar group] together or otherwise presented together.
 |`+forecolor+` |Applies foreground/text color to selection.
 |`+h1+` |Changes current line to the "Heading 1" style.

--- a/modules/ROOT/partials/toolbar-button-ids/core-toolbar-buttons.adoc
+++ b/modules/ROOT/partials/toolbar-button-ids/core-toolbar-buttons.adoc
@@ -14,6 +14,7 @@
 |`+cut+` |Cuts the current selection into clipboard.
 |`+fontfamily+` |Dropdown list with font families to apply to selection.
 |`+fontsize+` |Dropdown list with font sizes to apply to selection.
+|`+fontsizeinput+` |Text entry input field to change font size of selection or current insertion point. Also provides increase and decrease font size buttons on either side of said input field.
 |`+forecolor+` |Applies foreground/text color to selection.
 |`+h1+` |Changes current line to the "Heading 1" style.
 |`+h2+` |Changes current line to the "Heading 2" style.


### PR DESCRIPTION
Ticket: DOC-1892: `fontsizeinput` and `font_size_input_default_unit` documentation

Changes:
* `fontsizeinput` and `font_size_input_default_unit` documentation

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
