### PR TITLE
DOC-1889: restructure inline css documentation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1889: restructured `inline-css.adoc`.
+
 ### 2032-02-22
 
 - DOC-1913: added `6.3.2-release-note.adoc`. Added outline to this file.

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -36,6 +36,7 @@
 ***** xref:webcomponent-pm.adoc[Using a package manager]
 ***** xref:webcomponent-zip.adoc[Using a .zip package]
 **** xref:swing.adoc[Java Swing]
+**** xref:shadow-dom.adoc[Shadow DOM]
 **** xref:jquery-pm.adoc[jQuery]
 **** xref:bootstrap-zip.adoc[Bootstrap]
 **** xref:django-zip.adoc[Django]

--- a/modules/ROOT/pages/inline-css.adoc
+++ b/modules/ROOT/pages/inline-css.adoc
@@ -174,19 +174,7 @@ Although neither {productname} nor the {pluginname} plugin are supported, when a
 
 * CSS specified by the `xref:add-css-options.adoc#content_style[content_style]` option
 
-as expected.
-
-
-==== Classic mode
-
-A {productname} editor in classic mode assumes it is _not_ operating in a shadow root. If a {productname} editor in classic mode is contained within a shadow root, CSS applied to the editor’s content may work as expected but is not guaranteed to do so.
-
-
-==== Inline mode
-
-When a {productname} editor in inline mode is contained within a shadow root, tags pointing to CSS declarations — either `<link>` tags pointing to stylesheet files or `<style>` tags containing specific CSS examples — are added as children of the shadow root. These tags do not need to be contained with the `<head>` tag.
-
-As well, when {productname} is working in inline mode, {pluginname} checks if the editor is inside a shadow root. If it finds it is, {pluginname} does not look for CSS declarations outside the shadow root.
+as expected, whether running in xref:use-tinymce-classic.adoc[Classic mode] or xref:use-tinymce-inline.adoc[Inline mode].
 
 
 == Options

--- a/modules/ROOT/pages/inline-css.adoc
+++ b/modules/ROOT/pages/inline-css.adoc
@@ -54,7 +54,9 @@ For example:
 +
 [source,html]
 ----
-p::first-line { color: blue; }
+p::first-line {
+  color: blue;
+}
 ----
 
 . https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule[@ rules].

--- a/modules/ROOT/pages/inline-css.adoc
+++ b/modules/ROOT/pages/inline-css.adoc
@@ -187,27 +187,6 @@ When a {productname} editor in inline mode is contained within a shadow root, ta
 As well, when {productname} is working in inline mode, {pluginame} checks if the editor is inside a shadow root. If it finds it is, {pluginame} does not look for CSS declarations outside the shadow root.
 
 
-// * some pseudo-class selectors. See the specification for more details
-// (https://notion.so/tinycloud/Technical-specification-7c16d4522d1241ba9e7364880eab3e51#94b1d13ff444492bbfce789f7876f39c)
-// 
-// 2. Vogue only supports `@import` @-rules at this stage.
-// 
-// See the Jira ticket: https://ephocks.atlassian.net/browse/TINY-9265
-// 
-// see the tech spec for @-rule support:
-// https://notion.so/tinycloud/Technical-specification-7c16d4522d1241ba9e7364880eab3e51#555fede3a4ff4a26ad5efdf72bc1af6f.
-
-// This plugin allows extracting the content of the editor with CSS inlined.
-// Support classic and inline modes. Can be used in shadow dom. 
-// Should be able to extract CSS from the stylesheets defined via
-// `content_css` and `font_css` options, and CSS styles defined via `style_css` option.
-
-
-// There is only one API: `getContent()`.
-// Regarding to the events, it dispatches `InlineCSS` event.
-// I think it is OK to document this event even though its purpose isn’t really for the user’s usage.
-
-
 == Options
 
 The following configuration options affect the behavior of the {pluginname} plugin.

--- a/modules/ROOT/pages/inline-css.adoc
+++ b/modules/ROOT/pages/inline-css.adoc
@@ -77,9 +77,9 @@ xref:use-tinymce-classic.adoc[Classic or iframe mode] is a sandbox. Consequently
 
 CSS can be specified in classic mode in the following ways:
 
-. the `content_css` option
+. The `content_css` option
 +
-Setting the `xref:add-css-options#content_css[content_css] option automatically creates the `<link>` tag and puts it in the {productname} document’s `<head>`.
+Setting the xref:add-css-options.adoc#content_css[`content_css`] option automatically creates the `<link>` tag and puts it in the {productname} document’s `<head>`.
 +
 NOTE: This is the only supported way of adding a stylesheet to {productname} in Classic mode. 
 

--- a/modules/ROOT/pages/inline-css.adoc
+++ b/modules/ROOT/pages/inline-css.adoc
@@ -83,7 +83,13 @@ Setting the xref:add-css-options.adoc#content_css[`content_css`] option automati
 +
 NOTE: This is the only supported way of adding a stylesheet to {productname} in Classic mode. 
 
-. A CSS stylesheet specified in the `<head>` of the iframe.
+. The `content_style` option
++
+Setting the xref:add-css-options.adoc#content_style[`content_style`] option automatically creates the `<style>` tag and puts it in the {productname} document’s `<head>`.
++
+NOTE: This is the only supported way of adding a `<style>` tag to {productname} in Classic mode. 
+
+. A CSS stylesheet specified in the `<head>` of the iframe with a `<link>` tag.
 +
 For example:
 +
@@ -91,8 +97,6 @@ For example:
 ----
 <link rel="stylesheet" href="styles.css">
 ----
-
-. A `<link>` tag pointing to a stylesheet can also be manually inserted in the iframe `<head>`.
 
 . A `<style>` tag in the `<head>` of the iframe.
 +
@@ -102,8 +106,6 @@ For example:
 ----
 <style>p { color: red; }</style>
 ----
-
-. A `<style>` tag can also be manually inserted in the iframe `<head>`.
 
 . `style` attributes applied to specific elements within a document. That is, inline CSS
 

--- a/modules/ROOT/pages/inline-css.adoc
+++ b/modules/ROOT/pages/inline-css.adoc
@@ -43,7 +43,9 @@ For example:
 +
 [source,html]
 ----
-button:hover { color: blue; }
+button:hover {
+  color: blue;
+}
 ----
 
 . https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements[Pseudo-elements].

--- a/modules/ROOT/pages/inline-css.adoc
+++ b/modules/ROOT/pages/inline-css.adoc
@@ -118,13 +118,13 @@ xref:use-tinymce-inline.adoc[Inline mode] is not sandboxed. Consequently, any sp
 
 CSS can be specified in inline mode in the following ways:
 
-. the `content_css` option
+. The `content_css` option
 +
 Setting the xref:add-css-options.adoc#content_css[`content_css`] option automatically creates the `<link>` tag and puts it in the {productname} document’s `<head>`.
 +
 NOTE: This is not recommended.
 
-. A CSS stylesheet specified in the `<head>` of the document.
+. A CSS stylesheet specified in the `<head>` of the document with a `<link>` tag.
 +
 For example:
 +
@@ -134,8 +134,6 @@ For example:
 <link rel="stylesheet" href="styles.css">
 </head>
 ----
-
-. A `<link>` tag pointing to a stylesheet can also be manually inserted in the document `<head>`.
 
 . A CSS stylesheet specified in the `<body>` of the document.
 +

--- a/modules/ROOT/pages/inline-css.adoc
+++ b/modules/ROOT/pages/inline-css.adoc
@@ -37,55 +37,151 @@ tinymce.init({
 
 The {pluginname} plugin does not support
 
-. https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes[Pseudo-classes] (for example `button:hover { color: blue; }`).
-. https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements[Pseudo-elements] (for example `p::first-line { color: blue; }`)
-. https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule[@ rules] (for example `@media (screen)`)
+. https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes[Pseudo-classes].
++
+For example:
++
+[source,html]
+----
+button:hover { color: blue; }
+----
+
+. https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements[Pseudo-elements].
++
+For example:
++
+[source,html]
+----
+p::first-line { color: blue; }
+----
+
+. https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule[@ rules].
++
+For example:
++
+[source,html]
+----
+@media (screen)
+----
+
 . The `!important` property.
 
-=== Iframe mode is fully supported with some notable limitations
 
-Since iframe is a sandbox, specifying CSS is reasonably constrained at this stage. 
+=== Classic or iframe mode support
 
-CSS styling information can be specified in several places for iframe mode:
+xref:use-tinymce-classic.adoc[Classic or iframe mode] is a sandbox. Consequently, specifying CSS is constrained. 
 
-* A CSS stylesheet that is specified in the `<head>` of the iframe document i.e. `<link rel="stylesheet" href="styles.css">`
-** The supported way to add a stylesheet in {productname} is using the `content_css` option which automatically creates the `<link>` tag and puts it in the `<head>` of the document.
-** The user can also manually insert a stylesheet link in the <head> of the `iframe`.
-* A `<style>` tag in the `<head>` of the `iframe` document i.e. `<style>p { color: red; }</style>`
-** The supported way to add a style tag in {productname}, is using the `content_style` option which automatically creates the `<style>` tag and puts in the head of the document
-** The user can manually insert a style tag in the <head> of the `iframe`.
-* A `style` attribute on an element within the content i.e. inline CSS
+CSS can be specified in classic mode in the following ways:
 
-It is worth noting that by default, {productname} does not support having a `<style>` tags as part of the body HTML content.
+. the `content_css` option
++
+Setting the `xref:add-css-options#content_css[content_css] option automatically creates the `<link>` tag and puts it in the {productname} document’s `<head>`.
++
+NOTE: This is the only supported way of adding a stylesheet to {productname} in Classic mode. 
 
-=== Inline mode is supported with some notable limitations
+. A CSS stylesheet specified in the `<head>` of the iframe.
++
+For example:
++
+[source,html]
+----
+<link rel="stylesheet" href="styles.css">
+----
 
-As `inline` mode for {productname} editor is not sandboxed and as a result, any CSS specified on the main page can have an effect on how the editor content looks. 
+. A `<link>` tag pointing to a stylesheet can also be manually inserted in the iframe `<head>`.
 
-CSS styling information can be specified in several places for inline mode:
+. A `<style>` tag in the `<head>` of the iframe.
++
+For example:
++
+[source,html]
+----
+<style>p { color: red; }</style>
+----
 
-* A CSS stylesheet that is specified in the `<head>` of the page i.e. `<link rel="stylesheet" href="styles.css">`
-** Adding a stylesheet in {productname}, can be done by using the `content_css` option which automatically creates the `<link>` tag in the <head> of the page.
-*** It is recommended to not use the `content_css` option though and just **manually** include the stylesheets.
-*** The user can also manually insert a stylesheet link in the <head> of the page.
-* A CSS stylesheet that is specified in the `<body>` of the page i.e. `<link rel="stylesheet" href="styles.css">`
-** This is not recommended by https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link[MDN], but some browsers do allow it
-* A `<style>` in the `<head>` of the page i.e. `<style>p { color: red; }</style>`
-** To add a `<style>` in {productname} is by using the `content_style` option which automatically creates the `<style>` tag in the <head> of the document
-** The user can also manually put a `<style>` tag in the <head> of the page.
-* A `<style>` in the `<body>` of the page
-** As noted in the `Classic iframe` section, this should not be done, but some browsers will still allow it.
-* A `style` attribute on an {productname} element within the content i.e. inline CSS
+. A `<style>` tag can also be manually inserted in the iframe `<head>`.
 
-=== Shadow DOM is supported but **not** officially, with some notable limitations
+. `style` attributes applied to specific elements within a document. That is, inline CSS
 
-Shadow DOM is **not** officially supported by {productname}, but the feature will work when an editor running in `inline` or `iframe` is contained within a shadow root. 
+NOTE: By default, {productname} does not support `<style>` tags in the document `<body>`.
 
-When an `iframe` mode editor is contained with a shadow root, the editor content can be styled the same way, where the expected behavior for the `feature` is that it should not have to consider if the editor is in a shadow root. When an `inline` editor is contained within a shadow root, the stylesheet (`<link>` tags) and `<style>` tags are added directly as children of the shadow root and do not need to be contained within a `<head>` tag. 
 
-When in `inline mode`, the feature checks if the editor is inside a shadow root to ensure it does not try to get `<styles>` that are outside the shadow root.
+=== Inline mode support
 
-When an editor is in a shadow root, the feature should still support getting the stylesheets specified via the `content_css` option as well as the CSS styles specified via  the`content_style` option.
+xref:use-tinymce-inline.adoc[Inline mode] is not sandboxed. Consequently, any specified CSS can effect how editor content presents. 
+
+CSS can be specified in inline mode in the following ways:
+
+. the `content_css` option
++
+Setting the `xref:add-css-options#content_css[content_css]` option automatically creates the `<link>` tag and puts it in the {productname} document’s `<head>`.
++
+NOTE: This is not recommended.
+
+. A CSS stylesheet specified in the `<head>` of the document.
++
+For example:
++
+[source,html]
+----
+<head>
+<link rel="stylesheet" href="styles.css">
+</head>
+----
+
+. A `<link>` tag pointing to a stylesheet can also be manually inserted in the document `<head>`.
+
+. A CSS stylesheet specified in the `<body>` of the document.
++
+For example:
++
+[source,html]
+----
+<body>
+<link rel="stylesheet" href="styles.css">
+</body>
+----
++
+IMPORTANT: This is https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link[not recommended]. Some browsers allow it, however, and it is, as a consequence, honored by {productname} when presented.
+
+. A `<style>` tag in the `<head>` of the document.
++
+For example:
++
+[source,html]
+----
+<style>p { color: red; }</style>
+----
+
+. A `<style>` tag can also be manually inserted in the document `<head>`.
+
+. `style` attributes applied to specific elements within a document. That is, inline CSS
+
+NOTE: By default, {productname} does not support `<style>` tags in the document `<body>`.
+
+
+=== Shadow DOM support
+
+IMPORTANT: Although the {pluginname} will likely work when an editor running in classic or inline mode is contained within a shadow root, Shadow DOM is **not** currently supported by {companynameformal}.
+
+When a {productname} instance is in a shadow root, the {pluginame} should still support
+
+* CSS specified by the `xref:add-css-options#content_css[content_css]` option; and
+
+* CSS specified by the `xref:add-css-options/#content_style[content_style]` option.
+
+
+==== Classic mode
+
+When a {productname} editor in classic mode is contained within a shadow root, CSS applied to the editor’s content will work as expected if the editor can also safely assume it is not operating in a shadow root.
+
+
+==== Inline mode
+
+When a {productname} editor in inline mode is contained within a shadow root, tags pointing to CSS declarations — either `<link>` tags pointing to stylesheet files or `<style>` tags containing specific CSS examples — are added as children of the shadow root. These tags do not need to be contained with the `<head>` tag.
+
+As well, when {productname} is working in inline mode, {pluginame} checks if the editor is inside a shadow root. If it finds it is, {pluginame} does not look for CSS declarations outside the shadow root.
+
 
 // * some pseudo-class selectors. See the specification for more details
 // (https://notion.so/tinycloud/Technical-specification-7c16d4522d1241ba9e7364880eab3e51#94b1d13ff444492bbfce789f7876f39c)

--- a/modules/ROOT/pages/inline-css.adoc
+++ b/modules/ROOT/pages/inline-css.adoc
@@ -166,9 +166,9 @@ IMPORTANT: Although the {pluginname} will likely work when an editor running in 
 
 When a {productname} instance is in a shadow root, the {pluginame} should still support
 
-* CSS specified by the `xref:add-css-options#content_css[content_css]` option; and
+* CSS specified by the `xref:add-css-options.adoc#content_css[content_css]` option; and
 
-* CSS specified by the `xref:add-css-options/#content_style[content_style]` option.
+* CSS specified by the `xref:add-css-options.adoc/#content_style[content_style]` option.
 
 
 ==== Classic mode

--- a/modules/ROOT/pages/inline-css.adoc
+++ b/modules/ROOT/pages/inline-css.adoc
@@ -166,7 +166,7 @@ NOTE: By default, {productname} does not support `<style>` tags in the document 
 
 === Shadow DOM support
 
-IMPORTANT: {productname} currently assumes it is _not_ operating in a Shadow DOM. Consequently, Shadow DOMs are **not** supported by {productname} or any {productname} plugins.
+IMPORTANT: Running a {productname} instance inside a Shadow DOM is xref:shadow-dom.adoc[not supported].
 
 Although neither {productname} nor the {pluginname} plugin are supported, when a {productname} instance is in a shadow root, the {pluginname} will likely still present
 

--- a/modules/ROOT/pages/inline-css.adoc
+++ b/modules/ROOT/pages/inline-css.adoc
@@ -166,7 +166,7 @@ NOTE: By default, {productname} does not support `<style>` tags in the document 
 
 === Shadow DOM support
 
-IMPORTANT: Although the {pluginname} will likely work when an editor running in classic or inline mode is contained within a shadow root, Shadow DOM is **not** currently supported by {productname}.
+IMPORTANT: Although the {pluginname} plugin will likely work when an editor running in classic or inline mode is contained within a shadow root, Shadow DOM is **not** currently supported by {productname}.
 
 When a {productname} instance is in a shadow root, the {pluginame} should still support
 

--- a/modules/ROOT/pages/inline-css.adoc
+++ b/modules/ROOT/pages/inline-css.adoc
@@ -41,7 +41,7 @@ The {pluginname} plugin does not support
 +
 For example:
 +
-[source,html]
+[source,css]
 ----
 button:hover {
   color: blue;

--- a/modules/ROOT/pages/inline-css.adoc
+++ b/modules/ROOT/pages/inline-css.adoc
@@ -168,7 +168,7 @@ NOTE: By default, {productname} does not support `<style>` tags in the document 
 
 IMPORTANT: Running a {productname} instance inside a Shadow DOM is xref:shadow-dom.adoc[not supported].
 
-Although neither {productname} nor the {pluginname} plugin are supported, when a {productname} instance is in a shadow root, the {pluginname} will likely still present
+Although running neither {productname} nor the {pluginname} plugin in a Shadow DOM is supported, when a {productname} instance _is_ in a shadow root, the {pluginname} will likely still present
 
 * CSS specified by the `xref:add-css-options.adoc#content_css[content_css]` option; and
 

--- a/modules/ROOT/pages/inline-css.adoc
+++ b/modules/ROOT/pages/inline-css.adoc
@@ -118,7 +118,7 @@ CSS can be specified in inline mode in the following ways:
 
 . the `content_css` option
 +
-Setting the `xref:add-css-options#content_css[content_css]` option automatically creates the `<link>` tag and puts it in the {productname} document’s `<head>`.
+Setting the xref:add-css-options.adoc#content_css[`content_css`] option automatically creates the `<link>` tag and puts it in the {productname} document’s `<head>`.
 +
 NOTE: This is not recommended.
 

--- a/modules/ROOT/pages/inline-css.adoc
+++ b/modules/ROOT/pages/inline-css.adoc
@@ -166,18 +166,20 @@ NOTE: By default, {productname} does not support `<style>` tags in the document 
 
 === Shadow DOM support
 
-IMPORTANT: Although the {pluginname} plugin will likely work when an editor running in classic or inline mode is contained within a shadow root, Shadow DOM is **not** currently supported by {productname}.
+IMPORTANT: {productname} currently assumes it is _not_ operating in a Shadow DOM. Consequently, Shadow DOMs are **not** supported by {productname} or any {productname} plugins.
 
-When a {productname} instance is in a shadow root, the {pluginname} should still support
+Although neither {productname} nor the {pluginname} plugin are supported, when a {productname} instance is in a shadow root, the {pluginname} will likely still present
 
 * CSS specified by the `xref:add-css-options.adoc#content_css[content_css]` option; and
 
-* CSS specified by the `xref:add-css-options.adoc#content_style[content_style]` option.
+* CSS specified by the `xref:add-css-options.adoc#content_style[content_style]` option
+
+as expected.
 
 
 ==== Classic mode
 
-When a {productname} editor in classic mode is contained within a shadow root, CSS applied to the editor’s content will work as expected if the editor can also safely assume it is not operating in a shadow root.
+A {productname} editor in classic mode assumes it is _not_ operating in a shadow root. If a {productname} editor in classic mode is contained within a shadow root, CSS applied to the editor’s content may work as expected but is not guaranteed to do so.
 
 
 ==== Inline mode

--- a/modules/ROOT/pages/inline-css.adoc
+++ b/modules/ROOT/pages/inline-css.adoc
@@ -52,7 +52,7 @@ button:hover {
 +
 For example:
 +
-[source,html]
+[source,css]
 ----
 p::first-line {
   color: blue;

--- a/modules/ROOT/pages/inline-css.adoc
+++ b/modules/ROOT/pages/inline-css.adoc
@@ -166,7 +166,7 @@ NOTE: By default, {productname} does not support `<style>` tags in the document 
 
 === Shadow DOM support
 
-IMPORTANT: Although the {pluginname} will likely work when an editor running in classic or inline mode is contained within a shadow root, Shadow DOM is **not** currently supported by {companynameformal}.
+IMPORTANT: Although the {pluginname} will likely work when an editor running in classic or inline mode is contained within a shadow root, Shadow DOM is **not** currently supported by {productname}.
 
 When a {productname} instance is in a shadow root, the {pluginame} should still support
 

--- a/modules/ROOT/pages/inline-css.adoc
+++ b/modules/ROOT/pages/inline-css.adoc
@@ -168,7 +168,7 @@ When a {productname} instance is in a shadow root, the {pluginame} should still 
 
 * CSS specified by the `xref:add-css-options.adoc#content_css[content_css]` option; and
 
-* CSS specified by the `xref:add-css-options.adoc/#content_style[content_style]` option.
+* CSS specified by the `xref:add-css-options.adoc#content_style[content_style]` option.
 
 
 ==== Classic mode

--- a/modules/ROOT/pages/inline-css.adoc
+++ b/modules/ROOT/pages/inline-css.adoc
@@ -168,7 +168,7 @@ NOTE: By default, {productname} does not support `<style>` tags in the document 
 
 IMPORTANT: Although the {pluginname} plugin will likely work when an editor running in classic or inline mode is contained within a shadow root, Shadow DOM is **not** currently supported by {productname}.
 
-When a {productname} instance is in a shadow root, the {pluginame} should still support
+When a {productname} instance is in a shadow root, the {pluginname} should still support
 
 * CSS specified by the `xref:add-css-options.adoc#content_css[content_css]` option; and
 
@@ -184,7 +184,7 @@ When a {productname} editor in classic mode is contained within a shadow root, C
 
 When a {productname} editor in inline mode is contained within a shadow root, tags pointing to CSS declarations — either `<link>` tags pointing to stylesheet files or `<style>` tags containing specific CSS examples — are added as children of the shadow root. These tags do not need to be contained with the `<head>` tag.
 
-As well, when {productname} is working in inline mode, {pluginame} checks if the editor is inside a shadow root. If it finds it is, {pluginame} does not look for CSS declarations outside the shadow root.
+As well, when {productname} is working in inline mode, {pluginname} checks if the editor is inside a shadow root. If it finds it is, {pluginname} does not look for CSS declarations outside the shadow root.
 
 
 == Options

--- a/modules/ROOT/pages/shadow-dom.adoc
+++ b/modules/ROOT/pages/shadow-dom.adoc
@@ -3,11 +3,11 @@
 :description: Running TinyMCE in a Shadow DOM
 :keywords: Shadow DOM Web Components
 
-== Running TinyMCE in a Shadow DOM
+== Running {productname} in a Shadow DOM
 
-IMPORTANT: Running a TinyMCE instance inside a Shadow DOM is not, currently, supported.
+IMPORTANT: Running a {productname} instance inside a Shadow DOM is not, currently, supported.
 
-Running a TinyMCE instance — whether in xref:use-tinymce-classic.adoc[classic mode] or xref:use-tinymce-inline.adoc[inline mode] — inside a Shadow DOM will, likely, work.
+Running a {productname} instance — whether in xref:use-tinymce-classic.adoc[classic mode] or xref:use-tinymce-inline.adoc[inline mode] — inside a Shadow DOM will, likely, work.
 
 For example:
 
@@ -40,8 +40,7 @@ For example:
 </script>
 ----
 
-But TinyMCE does not, currently, check its host node for evidence it is inside a Shadow DOM (eg, checking for the `#shadow-root` string immediately before the host node’s opening tag).
+But {productname} does not, currently, check its host node for evidence it is inside a Shadow DOM (eg, checking for the `#shadow-root` string immediately before the host node’s opening tag).
 
-If a Shadow DOM operates identically to a standard DOM, a TinyMCE instance will likely work as expected.
+Consequently, while a {productname} instance will likely work as expected inside a Shadow DOM, {productname} instances are not, currently, supported inside Shadow DOMs.
 
-Nonetheless, TinyMCE instances are not, currently, supported inside Shadow DOMs.

--- a/modules/ROOT/pages/shadow-dom.adoc
+++ b/modules/ROOT/pages/shadow-dom.adoc
@@ -30,12 +30,12 @@ For example:
     // Note: use ‘target’ to specify the node the TinyMCE editor instance replaces.
     // Do not use ‘selector’.
     target: node,
-	plugins: [
-		"advlist autolink lists link image charmap print preview anchor",
-		"searchreplace visualblocks code fullscreen",
-		"insertdatetime media table help"
-	].join(' '),
-	toolbar: "insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image"
+    plugins: [
+        "advlist autolink lists link image charmap print preview anchor",
+        "searchreplace visualblocks code fullscreen",
+        "insertdatetime media table help"
+    ].join(' '),
+    toolbar: "insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image"
   });
 </script>
 ----

--- a/modules/ROOT/pages/shadow-dom.adoc
+++ b/modules/ROOT/pages/shadow-dom.adoc
@@ -1,0 +1,47 @@
+= Running TinyMCE in a Shadow DOM
+:navtitle: Shadow DOM
+:description: Running TinyMCE in a Shadow DOM
+:keywords: Shadow DOM Web Components
+
+== Running TinyMCE in a Shadow DOM
+
+IMPORTANT: Running a TinyMCE instance inside a Shadow DOM is not, currently, supported.
+
+Running a TinyMCE instance — whether in xref:use-tinymce-classic.adoc[classic mode] or xref:use-tinymce-inline.adoc[inline mode] — inside a Shadow DOM will, likely, work.
+
+For example:
+
+[source,html]
+----
+<div id="shadow-host"></div>
+
+<script type="text/javascript">
+
+  const shadowHost = document.getElementById('shadow-host');
+
+  // Note: Closed shadow roots are not currently, even experimentally supported.
+  const shadow = shadowHost.attachShadow({mode: 'open'}); 
+
+  const node = document.createElement('textarea');
+  node.value = 'Text added to the <em>TinyMCE</em> editor instance <strong>on loading.</strong>';
+  shadow.appendChild(node);
+
+  tinymce.init({
+    // Note: use ‘target’ to specify the node the TinyMCE editor instance replaces.
+    // Do not use ‘selector’.
+    target: node,
+	plugins: [
+		"advlist autolink lists link image charmap print preview anchor",
+		"searchreplace visualblocks code fullscreen",
+		"insertdatetime media table help"
+	].join(' '),
+	toolbar: "insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image"
+  });
+</script>
+----
+
+But TinyMCE does not, currently, check its host node for evidence it is inside a Shadow DOM (eg, checking for the `#shadow-root` string immediately before the host node’s opening tag).
+
+If a Shadow DOM operates identically to a standard DOM, a TinyMCE instance will likely work as expected.
+
+Nonetheless, TinyMCE instances are not, currently, supported inside Shadow DOMs.


### PR DESCRIPTION
Ticket: DOC-1889: restructure inline css documentation

Changes:
* Restructured inline css documentation.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
