### PR TITLE
DOC-1867: add notes re setting `autoresize_bottom_margin` in relation to `margin-bottom` values.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+DOC-1867: added notes regarding setting `autoresize_bottom_margin` in relation to values for `margin-bottom` to `autoresize_bottom_margin.adoc`.
+
 ### 2032-02-22
 
 - DOC-1913: added `6.3.2-release-note.adoc`. Added outline to this file.

--- a/modules/ROOT/pages/6.3-release-notes.adoc
+++ b/modules/ROOT/pages/6.3-release-notes.adoc
@@ -618,7 +618,7 @@ tinymce.init({
 });
 ----
 
-With this update, {productname} now checkes for the `resize` function going into a loop. And, if it does so, the function treats the margin bottom as always 0 instead of the `autoresize_bottom_margin` value. This changes the `min-height` of HTML and Body and prevents the infinite resizing.
+With this update, {productname} now checks for the `resize` function going into a loop. And, if it does so, the function treats the margin bottom as always 0 instead of the `autoresize_bottom_margin` value. This changes the `min-height` of HTML and Body and prevents the infinite resizing.
 
 
 [[security-fixes]]

--- a/modules/ROOT/partials/configuration/autoresize_bottom_margin.adoc
+++ b/modules/ROOT/partials/configuration/autoresize_bottom_margin.adoc
@@ -15,3 +15,24 @@ tinymce.init({
   autoresize_bottom_margin: 50
 });
 ----
+
+As of version 6.3, {productname} checks for the {productname} resize function entering a loop.
+
+If the function is detected as doing so, the document’s `+margin-bottom+` value is set to 0, instead of whatever value is assigned to `autoresize_bottom_margin`.
+
+This prevents an xref:6.3-release-notes.adoc#the-autoresize-plugin-caused-the-editor-area-to-infinitely-resize-when-content_css-was-set-to-document[infinite resizing bug from presenting].
+
+To prevent the resize function from even entering this loop, `+autoresize_bottom_margin+` must be set to a value less than any `+margin-bottom+` value set for the document.
+
+Alternatively, if `+margin-bottom+` is set by a CSS declaration, set `+autoresize_bottom_margin+` to `0`.
+
+=== Example: setting `+autoresize_bottom_margin+` to zero because `+margin-bottom+` is set elsewhere
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  plugins: 'autoresize',
+  autoresize_bottom_margin: 0
+});
+----


### PR DESCRIPTION
Ticket: DOC-1867: add notes re setting `autoresize_bottom_margin` in relation to `margin-bottom` values.



Changes:
* Typo correction in the 6.3 Release Notes: s/checkes/checks/.
* added notes regarding setting `autoresize_bottom_margin` in relation to values for `margin-bottom` to `autoresize_bottom_margin.adoc`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
