### PR TITLE
DOC-1931: Add missing space in table column heading on Spell Checker Pro page

### DIFF
--- a/modules/ROOT/partials/misc/spellchecker-languages.adoc
+++ b/modules/ROOT/partials/misc/spellchecker-languages.adoc
@@ -5,7 +5,7 @@ The following languages are supported for the Spell Checker Pro plugin. All of t
 
 [cols="2,^1,^1,^1",options="header"]
 |===
-|Language |Code |Pre-packaged with{productname} |Supported Hunspell dictionaries
+|Language |Code |Pre-packaged with {productname} |Supported Hunspell dictionaries
 |Afrikaans (South Africa) |af_ZA |{cross} |{tick}
 |English (Australia) |en_AU |{cross} |{tick}
 |English (Canada) |en_CA |{cross} |{tick}


### PR DESCRIPTION
Ticket: DOC-1931, Missing space in "Supported languages" table heading on Spell Checker Pro page.

Changes:
* "withTinyMCE" -> "with TinyMCE"

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] ~Changelog entry added~
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
