### PR TITLE
DOC-1929: Add an include file to `/partial/misc/` re RTC no longer being sold or supported and `include::` said file appropriately

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1929: added `admon-rtc-eol.adoc` to `/modules/partials/misc` and added `include::` statements pointing to this across the RTC documentation chapters.
+
 ### 2023-03-15
 
 - DOC-1930: added the TinyMCE 6.4-specific changes to `changelog.adoc`.

--- a/modules/ROOT/pages/how-the-rtc-plugin-encrypts-content.adoc
+++ b/modules/ROOT/pages/how-the-rtc-plugin-encrypts-content.adoc
@@ -3,6 +3,6 @@
 :description: Useful information for understanding how encryption is used with RTC
 :keywords: rtc, encrypt, decrypt, key, signature
 
-include::$partial/misc/admon-rtc-eol.adoc[]
+include::partial$/misc/admon-rtc-eol.adoc[]
 
 include::partial$rtc/rtc-how-rtc-encryption-works.adoc[]

--- a/modules/ROOT/pages/how-the-rtc-plugin-encrypts-content.adoc
+++ b/modules/ROOT/pages/how-the-rtc-plugin-encrypts-content.adoc
@@ -3,4 +3,6 @@
 :description: Useful information for understanding how encryption is used with RTC
 :keywords: rtc, encrypt, decrypt, key, signature
 
+include::$partial/misc/admon-rtc-eol.adoc[]
+
 include::partial$rtc/rtc-how-rtc-encryption-works.adoc[]

--- a/modules/ROOT/pages/rtc-encryption.adoc
+++ b/modules/ROOT/pages/rtc-encryption.adoc
@@ -5,6 +5,8 @@
 :pluginname: Real-Time Collaboration (RTC)
 :plugincode: rtc
 
+include::$partial/misc/admon-rtc-eol.adoc[]
+
 {productname} {pluginname} uses encryption keys to encrypt content before sending it to collaborators through the RTC server to provide end-to-end encryption. This is different from the use of JWTs for RTC, which are used to verify that your servers have allowed the user to access and collaborate on the content.
 
 CAUTION: The advice on this page does not guarantee a secure connection. If data secrecy is important for your users, please consult a security professional.

--- a/modules/ROOT/pages/rtc-encryption.adoc
+++ b/modules/ROOT/pages/rtc-encryption.adoc
@@ -5,7 +5,7 @@
 :pluginname: Real-Time Collaboration (RTC)
 :plugincode: rtc
 
-include::$partial/misc/admon-rtc-eol.adoc[]
+include::partial$/misc/admon-rtc-eol.adoc[]
 
 {productname} {pluginname} uses encryption keys to encrypt content before sending it to collaborators through the RTC server to provide end-to-end encryption. This is different from the use of JWTs for RTC, which are used to verify that your servers have allowed the user to access and collaborate on the content.
 

--- a/modules/ROOT/pages/rtc-events.adoc
+++ b/modules/ROOT/pages/rtc-events.adoc
@@ -3,7 +3,7 @@
 :description: List of all available RTC specific events.
 :keywords: rtc, events
 
-include::$partial/misc/admon-rtc-eol.adoc[]
+include::partial$/misc/admon-rtc-eol.adoc[]
 
 == `+RtcClientConnected+`
 

--- a/modules/ROOT/pages/rtc-events.adoc
+++ b/modules/ROOT/pages/rtc-events.adoc
@@ -3,6 +3,8 @@
 :description: List of all available RTC specific events.
 :keywords: rtc, events
 
+include::$partial/misc/admon-rtc-eol.adoc[]
+
 == `+RtcClientConnected+`
 
 When a user joins a real-time collaboration session, the `+RtcClientConnected+` event is fired on existing {productname} instances in the session and provides the user information of the newly joined user to other editors in the session.

--- a/modules/ROOT/pages/rtc-getting-started.adoc
+++ b/modules/ROOT/pages/rtc-getting-started.adoc
@@ -6,6 +6,8 @@
 :plugincode: rtc
 :numberedHeading: true
 
+include::$partial/misc/admon-rtc-eol.adoc[]
+
 This procedure will assist with setting up {productname} with real-time collaboration.
 
 [IMPORTANT]

--- a/modules/ROOT/pages/rtc-getting-started.adoc
+++ b/modules/ROOT/pages/rtc-getting-started.adoc
@@ -6,7 +6,7 @@
 :plugincode: rtc
 :numberedHeading: true
 
-include::$partial/misc/admon-rtc-eol.adoc[]
+include::partial$/misc/admon-rtc-eol.adoc[]
 
 This procedure will assist with setting up {productname} with real-time collaboration.
 

--- a/modules/ROOT/pages/rtc-introduction.adoc
+++ b/modules/ROOT/pages/rtc-introduction.adoc
@@ -3,6 +3,8 @@
 :description: What is RTC and what can it do
 :keywords: rtc, introduction, overview
 
+include::$partial/misc/admon-rtc-eol.adoc[]
+
 include::partial$rtc/rtc-description.adoc[]
 
 == Interactive example

--- a/modules/ROOT/pages/rtc-introduction.adoc
+++ b/modules/ROOT/pages/rtc-introduction.adoc
@@ -3,7 +3,7 @@
 :description: What is RTC and what can it do
 :keywords: rtc, introduction, overview
 
-include::$partial/misc/admon-rtc-eol.adoc[]
+include::partial$/misc/admon-rtc-eol.adoc[]
 
 include::partial$rtc/rtc-description.adoc[]
 

--- a/modules/ROOT/pages/rtc-jwt-authentication.adoc
+++ b/modules/ROOT/pages/rtc-jwt-authentication.adoc
@@ -5,6 +5,8 @@
 :pluginname: Real-Time Collaboration (RTC)
 :plugincode: rtc
 
+include::$partial/misc/admon-rtc-eol.adoc[]
+
 == Introduction
 
 Real-Time Collaboration (RTC) requires setting up JSON Web Token (JWT) authentication. This is to ensure that only authenticated users will be able to access and collaborate on documents.

--- a/modules/ROOT/pages/rtc-jwt-authentication.adoc
+++ b/modules/ROOT/pages/rtc-jwt-authentication.adoc
@@ -5,7 +5,7 @@
 :pluginname: Real-Time Collaboration (RTC)
 :plugincode: rtc
 
-include::$partial/misc/admon-rtc-eol.adoc[]
+include::partial$/misc/admon-rtc-eol.adoc[]
 
 == Introduction
 

--- a/modules/ROOT/pages/rtc-options-optional.adoc
+++ b/modules/ROOT/pages/rtc-options-optional.adoc
@@ -5,6 +5,8 @@
 :pluginname: Real-Time Collaboration (RTC)
 :plugincode: rtc
 
+include::$partial/misc/admon-rtc-eol.adoc[]
+
 This section covers the recommended and optional configuration options for the RTC plugin. None of these options are required but assist with creating a consistent user experience between your application and {productname} {pluginname}.
 
 == Recommended options

--- a/modules/ROOT/pages/rtc-options-optional.adoc
+++ b/modules/ROOT/pages/rtc-options-optional.adoc
@@ -5,7 +5,7 @@
 :pluginname: Real-Time Collaboration (RTC)
 :plugincode: rtc
 
-include::$partial/misc/admon-rtc-eol.adoc[]
+include::partial$/misc/admon-rtc-eol.adoc[]
 
 This section covers the recommended and optional configuration options for the RTC plugin. None of these options are required but assist with creating a consistent user experience between your application and {productname} {pluginname}.
 

--- a/modules/ROOT/pages/rtc-options-overview.adoc
+++ b/modules/ROOT/pages/rtc-options-overview.adoc
@@ -5,7 +5,7 @@
 :pluginname: Real-Time Collaboration (RTC)
 :plugincode: rtc
 
-include::$partial/misc/admon-rtc-eol.adoc[]
+include::partial$/misc/admon-rtc-eol.adoc[]
 
 == Configuration style
 

--- a/modules/ROOT/pages/rtc-options-overview.adoc
+++ b/modules/ROOT/pages/rtc-options-overview.adoc
@@ -5,6 +5,8 @@
 :pluginname: Real-Time Collaboration (RTC)
 :plugincode: rtc
 
+include::$partial/misc/admon-rtc-eol.adoc[]
+
 == Configuration style
 
 The {pluginname} plugin uses promise-based "provider" functions to support a variety of configuration scenarios including asynchronously fetching data from a server. Function input parameters are provided as an object, allowing unused fields to be omitted.

--- a/modules/ROOT/pages/rtc-options-required.adoc
+++ b/modules/ROOT/pages/rtc-options-required.adoc
@@ -5,7 +5,7 @@
 :pluginname: Real-Time Collaboration (RTC)
 :plugincode: rtc
 
-include::$partial/misc/admon-rtc-eol.adoc[]
+include::partial$/misc/admon-rtc-eol.adoc[]
 
 The following options are required to use the Real-Time Collaboration (RTC) plugin:
 

--- a/modules/ROOT/pages/rtc-options-required.adoc
+++ b/modules/ROOT/pages/rtc-options-required.adoc
@@ -5,6 +5,8 @@
 :pluginname: Real-Time Collaboration (RTC)
 :plugincode: rtc
 
+include::$partial/misc/admon-rtc-eol.adoc[]
+
 The following options are required to use the Real-Time Collaboration (RTC) plugin:
 
 * xref:rtc_document_id[`+rtc_document_id+`]

--- a/modules/ROOT/pages/rtc-supported-functionality.adoc
+++ b/modules/ROOT/pages/rtc-supported-functionality.adoc
@@ -5,6 +5,8 @@
 :pluginname: Real-Time Collaboration (RTC)
 :plugincode: rtc
 
+include::$partial/misc/admon-rtc-eol.adoc[]
+
 == Browser support
 
 The Real-Time Collaboration (RTC) plugin supports the latest desktop versions of:

--- a/modules/ROOT/pages/rtc-supported-functionality.adoc
+++ b/modules/ROOT/pages/rtc-supported-functionality.adoc
@@ -5,7 +5,7 @@
 :pluginname: Real-Time Collaboration (RTC)
 :plugincode: rtc
 
-include::$partial/misc/admon-rtc-eol.adoc[]
+include::partial$/misc/admon-rtc-eol.adoc[]
 
 == Browser support
 

--- a/modules/ROOT/pages/rtc-troubleshooting.adoc
+++ b/modules/ROOT/pages/rtc-troubleshooting.adoc
@@ -3,6 +3,8 @@
 :description: Useful information for troubleshooting issues with the RTC plugin.
 :keywords: rtc, faq, trouble, troubleshoot, troubleshooting, bug
 
+include::$partial/misc/admon-rtc-eol.adoc[]
+
 This documentation is in progress. Please contact us with any suggestions you think should be here.
 
 == Common error messages

--- a/modules/ROOT/pages/rtc-troubleshooting.adoc
+++ b/modules/ROOT/pages/rtc-troubleshooting.adoc
@@ -3,7 +3,7 @@
 :description: Useful information for troubleshooting issues with the RTC plugin.
 :keywords: rtc, faq, trouble, troubleshoot, troubleshooting, bug
 
-include::$partial/misc/admon-rtc-eol.adoc[]
+include::partial$/misc/admon-rtc-eol.adoc[]
 
 This documentation is in progress. Please contact us with any suggestions you think should be here.
 

--- a/modules/ROOT/partials/misc/admon-rtc-eol.adoc
+++ b/modules/ROOT/partials/misc/admon-rtc-eol.adoc
@@ -1,2 +1,1 @@
-IMPORTANT: As of {productname} 6.4, the Real-Time Collaboration (RTC) Premium Plugin is no longer available for sale. This documentation remains available for existing users of the RTC Plugin. The RTC Plugin will be removed from {cloudname} as of version 7.0.
-
+IMPORTANT: TinyMCE’s Real-time Collaboration (RTC) plugin will be retired and deactivated on December 31, 2023, and is no longer available for purchase.

--- a/modules/ROOT/partials/misc/admon-rtc-eol.adoc
+++ b/modules/ROOT/partials/misc/admon-rtc-eol.adoc
@@ -1,0 +1,2 @@
+IMPORTANT: As of {productname} 6.4, the Real-Time Collaboration (RTC) Premium Plugin is no longer available for sale. This documentation remains available for existing users of the RTC Plugin. The RTC Plugin will be removed from {cloudname} as of version 7.0.
+


### PR DESCRIPTION
Ticket: DOC-1929: Add an include file to `/partial/misc/` re RTC no longer being sold or supported and `include::` said file appropriately.

Changes:
* Added `admon-rtc-eol.adoc` to `/modules/partials/misc/`.
* Added draft copy to `admon-rtc-eol.adoc` re rtc being removed from sale.
* Added `include::` statements to all RTC-related docs pages.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] Files has been included where required (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
