### PR TITLE
DOC-1932: Add the RTC EOL message to RTC pages in the TinyMCE 5.x documentation

### DIFF
--- a/_includes/configuration/indentation.md
+++ b/_includes/configuration/indentation.md
@@ -6,7 +6,7 @@ The **indentation** option defaults to 30px but can be any value.
 
 **Type:** `String`
 
-**Default Value:** `30px`
+**Default Value:** `40px`
 
 ### Example: Using `indentation`
 

--- a/_includes/rtc/admon-rtc-eol.md
+++ b/_includes/rtc/admon-rtc-eol.md
@@ -1,0 +1,1 @@
+    > **Important**: TinyMCE’s Real-time Collaboration (RTC) plugin will be retired and deactivated on December 31, 2023, and is no longer available for purchase.

--- a/rtc/configuration/index.md
+++ b/rtc/configuration/index.md
@@ -17,4 +17,6 @@ type: folder
   {% endif %}
 {% endfor %}
 
+{% include rtc/admon-rtc-eol.md %}
+
 {% include index.html links=links %}

--- a/rtc/configuration/rtc-options-overview.md
+++ b/rtc/configuration/rtc-options-overview.md
@@ -8,6 +8,8 @@ keywords: rtc configuration
 
 {% assign pluginname = "Real-time Collaboration (RTC)" %}
 {% assign plugincode = "rtc" %}
+{% include rtc/admon-rtc-eol.md %}
+
 
 ## Configuration style
 

--- a/rtc/encryption.md
+++ b/rtc/encryption.md
@@ -6,6 +6,8 @@ description: Useful information for setting up encryption for RTC
 keywords: rtc encrypt decrypt key rotate signature
 ---
 
+{% include rtc/admon-rtc-eol.md %}
+
 {{site.productname}} Real-time Collaboration (RTC) uses encryption keys to encrypt content before sending it to collaborators through the RTC server to provide end-to-end encryption. This is different from the use of JWTs for RTC, which are used to verify that your servers have allowed the user to access and collaborate on the content.
 
 > **Caution**: The advice on this page does not guarantee a secure connection. If data secrecy is important for your users, please consult a security professional.

--- a/rtc/events.md
+++ b/rtc/events.md
@@ -6,6 +6,8 @@ description: List of all available RTC specific events.
 keywords: rtc events
 ---
 
+{% include rtc/admon-rtc-eol.md %}
+
 ## `RtcClientConnected`
 
 When a user joins a real-time collaboration session, the `RtcClientConnected` event is fired on existing {{site.productname}} instances in the session and provides the user information of the newly joined user to other editors in the session.

--- a/rtc/getting-started.md
+++ b/rtc/getting-started.md
@@ -9,6 +9,8 @@ keywords: rtc
 {% assign pluginname = "Real-time Collaboration (RTC)" %}
 {% assign plugincode = "rtc" %}
 
+{% include rtc/admon-rtc-eol.md %}
+
 {{site.requires_5_9v}}
 
 This procedure will assist with setting up {{site.productname}} with real-time collaboration.

--- a/rtc/how-the-rtc-plugin-encrypts-content.md
+++ b/rtc/how-the-rtc-plugin-encrypts-content.md
@@ -6,4 +6,6 @@ description: Useful information for understanding how encryption is used with RT
 keywords: rtc encrypt decrypt key signature
 ---
 
+{% include rtc/admon-rtc-eol.md %}
+
 {% include rtc/rtc-how-rtc-encryption-works.md %}

--- a/rtc/index.md
+++ b/rtc/index.md
@@ -12,4 +12,6 @@ type: folder
   {% endif %}
 {% endfor %}
 
+{% include rtc/admon-rtc-eol.md %}
+
 {% include index.html links=links %}

--- a/rtc/introduction.md
+++ b/rtc/introduction.md
@@ -6,6 +6,8 @@ description: What is RTC and what can it do
 keywords: rtc introduction overview
 ---
 
+{% include rtc/admon-rtc-eol.md %}
+
 {{site.requires_5_9v}}
 
 {% include rtc/rtc-description.md %}

--- a/rtc/jwt-authentication.md
+++ b/rtc/jwt-authentication.md
@@ -8,6 +8,8 @@ keywords: jwt authentication
 
 {% assign pluginname = "Real-time Collaboration (RTC)" %}
 {% assign plugincode = "rtc" %}
+{% include rtc/admon-rtc-eol.md %}
+
 ## Introduction
 
 Real-time Collaboration (RTC) requires setting up JSON Web Token (JWT) authentication. This is to ensure that only authenticated users will be able to access and collaborate on documents.

--- a/rtc/rtc-supported-functionality.md
+++ b/rtc/rtc-supported-functionality.md
@@ -6,6 +6,8 @@ description: Information on what TinyMCE functionality is, and is not, supported
 keywords: rtc support functionality
 ---
 
+{% include rtc/admon-rtc-eol.md %}
+
 ## Browser support
 
 The Real-time Collaboration (RTC) plugin supports the latest desktop versions of:

--- a/rtc/rtc-troubleshooting.md
+++ b/rtc/rtc-troubleshooting.md
@@ -6,6 +6,8 @@ description: Useful information for troubleshooting issues with the RTC plugin.
 keywords: rtc faq trouble troubleshoot troubleshooting bug
 ---
 
+{% include rtc/admon-rtc-eol.md %}
+
 This documentation is in progress. Please contact us with any suggestions you think should be here.
 
 ## Common error messages


### PR DESCRIPTION
Ticket: DOC-1932: Add the RTC EOL message to RTC pages in the TinyMCE 5.x documentation

Changes:
* Added `admon-rtc-eol.md` to `/_includes/rtc/`.
* Added EOL announcement text to `admon-rtc-eol.md`.
* Added include statement pointing to `admon-rtc-eol.md` to every RTC-related file.
* Typo correction for an incorrect default value.

Pre-checks:
- [x] Branch prefixed with `feature/5/` or `hotfix/5/`
- [x] Files has been included where required (if applicable)

Review:
- [x] Documentation Team Lead has reviewed
