### PR TITLE
Ticket: DOC-1900, document the new toolbar buttons api functions; setText and setIcon.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1900: added documentation of `setText` and `setIcon` functions to `custom-*-toolbar-button.adoc` files.
+
 ### 2023-03-15
 
 - DOC-1930: added the TinyMCE 6.4-specific changes to `changelog.adoc`.

--- a/modules/ROOT/pages/custom-basic-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-basic-toolbar-button.adoc
@@ -26,6 +26,9 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |Name |Value |Description
 |isEnabled |`+() => boolean+` |Checks if the button is enabled.
 |setEnabled |`+(state: boolean) => void+` |Sets the button's enabled state.
+3+|include::partial$misc/admon-requires-6.4v.adoc[]
+|setText |`+(text: string) => void+` |Sets the text label to display.
+|setIcon |`+(icon: string) => void+` |Sets the icon of the button.
 |===
 
 == Basic button example and explanation

--- a/modules/ROOT/pages/custom-group-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-group-toolbar-button.adoc
@@ -27,6 +27,9 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |Name |Value |Description
 |isEnabled |`+() => boolean+` |Checks if the button is enabled.
 |setEnabled |`+(state: boolean) => void+` |Sets the button's enabled state.
+3+|include::partial$misc/admon-requires-6.4v.adoc[]
+|setText |`+(text: string) => void+` |Sets the text label to display.
+|setIcon |`+(icon: string) => void+` |Sets the icon of the button.
 |===
 
 == Group toolbar button example and explanation

--- a/modules/ROOT/pages/custom-menu-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-menu-toolbar-button.adoc
@@ -28,6 +28,9 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |Name |Value |Description
 |isEnabled |`+() => boolean+` |Checks if the button is enabled.
 |setEnabled |`+(state: boolean) => void+` |Sets the button's enabled state.
+3+|include::partial$misc/admon-requires-6.4v.adoc[]
+|setText |`+(text: string) => void+` |Sets the text label to display.
+|setIcon |`+(icon: string) => void+` |Sets the icon of the button.
 |===
 
 == Menu button example and explanation

--- a/modules/ROOT/pages/custom-split-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-split-toolbar-button.adoc
@@ -30,6 +30,9 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |setEnabled |`+(state: boolean) => void+` |Sets the button's enabled state.
 |isActive |`+() => boolean+` |Checks the button's toggle state.
 |setActive |`+(state: boolean) => void+` |Sets the button's toggle state.
+3+|include::partial$misc/admon-requires-6.4v.adoc[]
+|setText |`+(text: string) => void+` |Sets the text label to display.
+|setIcon |`+(icon: string) => void+` |Sets the icon of the button.
 |===
 
 [[split-button-example-and-explanation]]

--- a/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
@@ -29,6 +29,9 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |setEnabled |`+(state: boolean) => void+` |Sets the button's enabled state.
 |isActive |`+() => boolean+` |Checks if the button is `+on+`.
 |setActive |`+(state: boolean) => void+` |Sets the button's toggle state.
+3+|include::partial$misc/admon-requires-6.4v.adoc[]
+|setText |`+(text: string) => void+` |Sets the text label to display.
+|setIcon |`+(icon: string) => void+` |Sets the icon of the button.
 |===
 
 == Toggle button example and explanation


### PR DESCRIPTION
Ticket: DOC-1900, document the new toolbar buttons api functions; setText and setIcon.

Changes:
* Added documentation of `setText` and `setIcon` functions to `custom-*-toolbar-button.adoc` files.
* Also added required include:: statement to `admon-requires-6.4v.adoc`.


Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
