### PR TITLE
DOC-1932, update release_5_legacy-docs.yml to enable 5.x docs build to add the RTC EOL message to RTC pages in the 5.x docs

### DIFF
--- a/.github/workflows/release_5_legacy_docs.yml
+++ b/.github/workflows/release_5_legacy_docs.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build:
     name: Build Docs and Deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Ticket: DOC-1932, Add the RTC EOL message to RTC pages in the TinyMCE 5.x documentation

Changes:
* release_5_legacy-docs.yml updated. `runs on` updated to switch away from deprecated value, `ubuntu-18.04`, to `ubuntu-22.04` as per the suggestions in the github support article ‘[The Ubuntu 18.04 Actions runner image will begin deprecation on 2022/08/08 and will be fully unsupported by 2023/04/03](https://github.com/actions/runner-images/issues/6002)’.


Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`

Review:
- [x] Documentation Team Lead has reviewed
