### PR TITLE
DOC-1948: 6.4.1 release notes post-release follow-up

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1948: Update entries for TINY-8872, TINY-9364, and TINY-9459 in 6.4.1 release notes.
 
 ### 2023-04-11
 

--- a/modules/ROOT/pages/6.3-release-notes.adoc
+++ b/modules/ROOT/pages/6.3-release-notes.adoc
@@ -599,28 +599,6 @@ In previous versions of {productname}, when running on Firefox and after pressin
 
 This error has been corrected in {productname} 6.3. When running {productname} 6.3 on Firefox and creating a merge tag using `mceInsertContent`, pressing Enter or Return to generate the desired merge tag moves the insertion point to the end of said newly-created merge tag, as expected.
 
-=== The `autoresize` plugin caused the editor area to infinitely resize when `content_css` was set to `document`
-
-The `document` skin’s CSS aligns the bottom of the content area to the bottom of the editor, but does not set anything for `autoresize_bottom_margin`. As a consequence the {productname} editor takes the default value for this attribute: 50.
-
-Simulaneously, everytime the `resize` function calculated the editor size it added this `autoresize_bottom_margin` value.
-
-Since, however, the aligning CSS sets the bottom of the content area to a value incrementally less than the `autoresize_bottom_margin` value, the `resize` function went into a loop.
-
-Consequently, and as per the example below, if a {productname} instance was setup with the xref:autoresize.adoc[Autoresize] plugin active and `content_css` set to `document`, the editor increased its height indefinitely.
-
-[source,js]
-----
-tinymce.init({
-  selector: 'textarea',
-  plugins: 'autoresize',
-  content_css: 'document',
-});
-----
-
-With this update, {productname} now checks for the `resize` function going into a loop. And, if it does so, the function treats the margin bottom as always 0 instead of the `autoresize_bottom_margin` value. This changes the `min-height` of HTML and Body and prevents the infinite resizing.
-
-
 [[security-fixes]]
 == Security fixes
 

--- a/modules/ROOT/pages/6.4.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.1-release-notes.adoc
@@ -792,7 +792,7 @@ In {productname} 6.4.1, table is no longer selectable or editable by table UI an
 === Table commands were modifying tables in a noneditable root element
 //#TINY-9459
 
-In previous versions of {productname}, tables within a `contenteditable="false"` root element could unexpectedly be modified using commands.
+In previous {productname} versions, tables within a root element with a `contenteditable="false"` attribute could be unexpectedly modified using commands.
 
 {productname} 6.4.1 now blocks all table commands when the selection is in a table in a `contenteditable="false"` root, thereby preventing unwanted modifications.
 

--- a/modules/ROOT/pages/6.4.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.1-release-notes.adoc
@@ -1043,7 +1043,7 @@ In {productname} 6.4.1, this issue has been resolved. Any pre-formatted elements
 === Editor increases the height indefinitely when using autoresize with content_css document
 //#TINY-8872
 
-The `document` skin’s CSS aligns the bottom of the content area to the bottom of the editor, but does not set anything for `autoresize_bottom_margin`. As a consequence the {productname} editor takes the default value for this attribute: 50. Simultaneously, every time the `resize` function calculated the editor size it added this `autoresize_bottom_margin` value.
+The document skin’s CSS aligns the bottom of the content area to the bottom of the editor, but does not set anything for `autoresize_bottom_margin`. As a consequence the {productname} editor takes the default value for this attribute: 50. Simultaneously, every time the `resize` function calculated the editor size it added this `autoresize_bottom_margin` value.
 
 Since, the aligning CSS sets the bottom of the content area to a value incrementally less than the `autoresize_bottom_margin` value, the `resize` function went into a loop.
 

--- a/modules/ROOT/pages/6.4.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.1-release-notes.adoc
@@ -617,11 +617,9 @@ As a result, the `onSetup` function for custom group toolbar buttons now runs co
 === An element could be dropped onto the descendants of an element with a `contenteditable="false"` attribute
 //#TINY-9364
 
-In {productname} 6.0, the drag and drop `config` did not check some conditions surrounding element placements using either a drag or drop action.  This affected users running {productname} 6.0, which would effectively allow descendants of `contenteditable="false"` element to be dropped into another `contenteditable="false"` element.
+In versions of {productname} since version 6.0, elements were allowed to be dropped onto descendants of `contenteditable="false"` elements.
 
-Fixes were made to ensure that `dragging or dropping` onto `contenteditable="false"` element targets on all browsers is `disabled`. This also includes when the drop target cursor is inside the `contenteditable="true"` element, or just before it.
-
-{productname} 6.4.1, now prevents the user from having the ability to drag and drop any descendants of a `contenteditable=false element` within another `contenteditable="false"` element.
+In {productname} 6.4.1, changes were made to prevent any descendant of a `contenteditable="false"` element from being a valid drop target. Now, elements are unable to be dropped onto any descendant of a `contenteditable="false"` element across all browsers.
 
 === Checkmark did not show in menu color swatches
 //#TINY-9395

--- a/modules/ROOT/pages/6.4.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.1-release-notes.adoc
@@ -792,15 +792,11 @@ In {productname} 6.4.1, table is no longer selectable or editable by table UI an
 === Table commands were modifying tables in a noneditable root element
 //#TINY-9459
 
-In versions of {productname}, prior to 6.4.1, tables could be modified by using `execCommands` when tables are placed within a `contenteditable="false"` root element.
+In previous versions of {productname}, tables within a `contenteditable="false"` root element could unexpectedly be modified using commands.
 
-As a consequence, a bug was identified that by using the `execCommands`, which are provided by {productname}, the user could modify the table element regardless of it being nested within a `contenteditable="false"` root element.
+{productname} 6.4.1 now blocks all table commands when the selection is in a table in a `contenteditable="false"` root, thereby preventing unwanted modifications.
 
-To fix this bug, {productname} 6.4.1, made improvements to the DOM `Commands` API that now blocks all Table UI actions via the `execCommands` when a `contenteditable="false"` element selection is highlighted inside a `contenteditable="false"` root.
-
-As a result, `contenteditable="false"` elements such as tables cannot have their properties overridden by using the `execCommands`.
-
-_(Readmore about editorCommands xref:editor-command-identifiers.adoc[here])_
+_xref:editor-command-identifiers.adoc[Read more on editor commands]_
 
 === Fake carets were rendered for noneditable elements and tables in a noneditable root element
 //#TINY-9459

--- a/modules/ROOT/pages/6.4.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.1-release-notes.adoc
@@ -1049,9 +1049,22 @@ In {productname} 6.4.1, this issue has been resolved. Any pre-formatted elements
 === Editor increases the height indefinitely when using autoresize with content_css document
 //#TINY-8872
 
-In previous versions of {productname}, It was discovered that the editor had some issues with the autoresize function when using content_css documents, which caused the editor to have a indefinite height when content was being added.
+The `document` skin’s CSS aligns the bottom of the content area to the bottom of the editor, but does not set anything for `autoresize_bottom_margin`. As a consequence the {productname} editor takes the default value for this attribute: 50. Simultaneously, every time the `resize` function calculated the editor size it added this `autoresize_bottom_margin` value.
 
-To fix this issue, {productname} 6.4.1 fixed this issue by addressing the conflict between the document skin's CSS and the autoresize bottom margin setting. After this fix, the resize function now checks for loops and considers the margin bottom as always set to 0 instead of autoresize bottom margin, which ensutes that the editor's height is calculated correctly. 
+Since, the aligning CSS sets the bottom of the content area to a value incrementally less than the `autoresize_bottom_margin` value, the `resize` function went into a loop.
+
+Consequently, and as per the example below, if a {productname} instance was setup with the xref:autoresize.adoc[Autoresize] plugin active and `content_css` set to `document`, the editor increased its height indefinitely.
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',
+  plugins: 'autoresize',
+  content_css: 'document',
+});
+----
+
+{productname} 6.4.1 fixed this issue by addressing the conflict between the `document` skin's CSS and the `autoresize_bottom_margin` setting. With this update, TinyMCE now checks for the resize function going into a loop. And, if it does so, the function treats the margin bottom as always 0 instead of the `autoresize_bottom_margin` value. This changes the min-height of HTML and Body and prevents the infinite resizing.
 
 === Plugin - Search and Replace - Throws a JS console error if you search for a string that doesn't exist and try to click on the preferences button.
 //#TINY-9686

--- a/modules/ROOT/pages/6.4.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.1-release-notes.adoc
@@ -1058,7 +1058,7 @@ tinymce.init({
 });
 ----
 
-{productname} 6.4.1 fixed this issue by addressing the conflict between the `document` skin's CSS and the `autoresize_bottom_margin` setting. With this update, TinyMCE now checks for the resize function going into a loop. And, if it does so, the function treats the margin bottom as always 0 instead of the `autoresize_bottom_margin` value. This changes the min-height of HTML and Body and prevents the infinite resizing.
+{productname} 6.4.1 fixed this issue by addressing the conflict between the `document` skin's CSS and the `autoresize_bottom_margin` setting. With this update, TinyMCE now checks for the resize function going into a loop. And, if it does so, the function treats the margin bottom as always 0 instead of the `autoresize_bottom_margin` value. This changes the min-height of the editor and prevents the infinite resizing.
 
 === Plugin - Search and Replace - Throws a JS console error if you search for a string that doesn't exist and try to click on the preferences button.
 //#TINY-9686

--- a/modules/ROOT/pages/6.4.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.1-release-notes.adoc
@@ -617,7 +617,7 @@ As a result, the `onSetup` function for custom group toolbar buttons now runs co
 === An element could be dropped onto the descendants of an element with a `contenteditable="false"` attribute
 //#TINY-9364
 
-In versions of {productname} since version 6.0, elements were allowed to be dropped onto descendants of `contenteditable="false"` elements.
+In {productname} 6.0 and later, elements could be dropped onto descendants of an element with a `contenteditable=false` attribute.
 
 In {productname} 6.4.1, changes were made to prevent any descendant of a `contenteditable="false"` element from being a valid drop target. Now, elements are unable to be dropped onto any descendant of a `contenteditable="false"` element across all browsers.
 

--- a/modules/ROOT/pages/6.4.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.1-release-notes.adoc
@@ -619,7 +619,7 @@ As a result, the `onSetup` function for custom group toolbar buttons now runs co
 
 In {productname} 6.0 and later, elements could be dropped onto descendants of an element with a `contenteditable=false` attribute.
 
-In {productname} 6.4.1, changes were made to prevent any descendant of a `contenteditable="false"` element from being a valid drop target. Now, elements are unable to be dropped onto any descendant of a `contenteditable="false"` element across all browsers.
+In {productname} 6.4.1, changes were made to prevent descendants of an element with a `contenteditable="false"` attribute from being a valid drop target. As of this release, elements cannot be dropped onto such descendant elements across all supported browsers.
 
 === Checkmark did not show in menu color swatches
 //#TINY-9395

--- a/modules/ROOT/pages/6.4.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.1-release-notes.adoc
@@ -794,7 +794,7 @@ In {productname} 6.4.1, table is no longer selectable or editable by table UI an
 
 In previous {productname} versions, tables within a root element with a `contenteditable="false"` attribute could be unexpectedly modified using commands.
 
-{productname} 6.4.1 now blocks all table commands when the selection is in a table in a `contenteditable="false"` root, thereby preventing unwanted modifications.
+{productname} 6.4.1 now blocks all table commands when the selection is in a table which is, itself, within an element with a `contenteditable="false"` attribute set, preventing unwanted modifications.
 
 _xref:editor-command-identifiers.adoc[Read more on editor commands]_
 

--- a/modules/ROOT/pages/6.4.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.1-release-notes.adoc
@@ -1058,7 +1058,7 @@ tinymce.init({
 });
 ----
 
-{productname} 6.4.1 fixed this issue by addressing the conflict between the `document` skin's CSS and the `autoresize_bottom_margin` setting. With this update, TinyMCE now checks for the resize function going into a loop. And, if it does so, the function treats the margin bottom as always 0 instead of the `autoresize_bottom_margin` value. This changes the min-height of the editor and prevents the infinite resizing.
+{productname} 6.4.1 fixed this issue by addressing the conflict between the document skin’s CSS and the `autoresize_bottom_margin` setting. With this update, TinyMCE now checks for the resize function going into a loop. And, if it does so, the function treats the margin bottom as always 0 instead of the `autoresize_bottom_margin` value. This changes the min-height of the editor and prevents the infinite resizing.
 
 === Plugin - Search and Replace - Throws a JS console error if you search for a string that doesn't exist and try to click on the preferences button.
 //#TINY-9686

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -96,7 +96,7 @@ NOTE: This is the {productname} Community version changelog. For information abo
 * Opening a menu button in the footer of a dialog after a redial threw an error.
 * After closing a view, the `more...` toolbar button disappeared if the editor had `toolbar_mode: 'sliding'` and the toolbar was opened.
 * Inline dialogs would open partially off screen when the toolbar had a small width.
-* The `autoresize` plugin used to cause infinite resizing when `content_css` is set to `document`.
+* The `autoresize` plugin would cause infinite resizing when `content_css` is set to `document`.
 
 == 6.3.2 - 2023-02-22
 

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -96,7 +96,7 @@ NOTE: This is the {productname} Community version changelog. For information abo
 * Opening a menu button in the footer of a dialog after a redial threw an error.
 * After closing a view, the `more...` toolbar button disappeared if the editor had `toolbar_mode: 'sliding'` and the toolbar was opened.
 * Inline dialogs would open partially off screen when the toolbar had a small width.
-* The `autoresize` plugin would cause infinite resizing when `content_css` is set to `document`.
+* The `autoresize` plugin would cause infinite resizing when `content_css` was set to `document`.
 
 == 6.3.2 - 2023-02-22
 

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -96,6 +96,7 @@ NOTE: This is the {productname} Community version changelog. For information abo
 * Opening a menu button in the footer of a dialog after a redial threw an error.
 * After closing a view, the `more...` toolbar button disappeared if the editor had `toolbar_mode: 'sliding'` and the toolbar was opened.
 * Inline dialogs would open partially off screen when the toolbar had a small width.
+* The `autoresize` plugin used to cause infinite resizing when `content_css` is set to `document`.
 
 == 6.3.2 - 2023-02-22
 


### PR DESCRIPTION
Ticket: DOC-1948, 6.4.1 release notes post-release follow-up.

Changes:
Update release notes for:
* TINY-8872
* TINY-9364
* TINY-9459

Remove TINY-8872 entry from 6.3 release notes. Add changelog entry for TINY-8872 in changelog.adoc under 6.4.0.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
