### PR TITLE
DOC-1950, Add note to migration guide re newline_behavior being a workable alternative to the now-deprecated padd_empty_with_br option.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+### 2023-04-13
+
+- DOC-1950: Added note `6.0-release-notes-summary.adoc` re setting `newline_behavior` to `linebreak` to get equivalent functionality to the, now-deprecated, `padd_empty_with_br` option.
 
 ### 2023-04-11
 

--- a/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
+++ b/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
@@ -242,7 +242,7 @@ The following elements were previously deprecated and have, with this release, b
 
 | `non_empty_elements`                  | Schema option |
 
-| `padd_empty_with_br`                  | Option        |
+| `padd_empty_with_br`                  | Option        | Set the xref:content-behavior-options.adoc#newline_behavior[`newline_behavior`] option to `linebreak` for equivalent behavior.
 
 | `requestAnimationFrame`               | API           | From `Delay`.
 

--- a/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
+++ b/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
@@ -242,7 +242,7 @@ The following elements were previously deprecated and have, with this release, b
 
 | `non_empty_elements`                  | Schema option |
 
-| `padd_empty_with_br`                  | Option        | Set the xref:content-behavior-options.adoc#newline_behavior[`newline_behavior`] option to `linebreak` for equivalent behavior.
+| `padd_empty_with_br`                  | Option        | Set the xref:content-behavior-options.adoc#newline_behavior[`newline_behavior` option] to `linebreak` for equivalent behavior.
 
 | `requestAnimationFrame`               | API           | From `Delay`.
 


### PR DESCRIPTION
Ticket: DOC-1950, Add note to migration guide re `newline_behavior` being a workable alternative to the now-deprecated `padd_empty_with_br` option.

Changes:
* Added note re setting `newline_behavior` to `linebreak` to get equivalent functionality to the, now-deprecated, `padd_empty_with_br` option.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [ ] Documentation Team Lead has reviewed
