### PR TITLE
DOC-1946: corrections to two demo index.js files

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+### 2023-04-13
+
+- DOC-1946: Replaced soft-deprecated `ch` option with supported `trigger` option in `…/live-demos/autocompleter-autocompleteitem/index.js` and `…/live-demos/autocompleter-cardmenuitem/index.js`.
 
 ### 2023-04-11
 

--- a/modules/ROOT/examples/live-demos/autocompleter-autocompleteitem/index.js
+++ b/modules/ROOT/examples/live-demos/autocompleter-autocompleteitem/index.js
@@ -24,7 +24,7 @@ tinymce.init({
 
     /* An autocompleter that allows you to insert special characters */
     editor.ui.registry.addAutocompleter('specialchars', {
-      ch: ':',
+      trigger: ':',
       minChars: 1,
       columns: 'auto',
       onAction: onAction,

--- a/modules/ROOT/examples/live-demos/autocompleter-cardmenuitem/index.js
+++ b/modules/ROOT/examples/live-demos/autocompleter-cardmenuitem/index.js
@@ -27,7 +27,7 @@ tinymce.init({
      * Items are built using the CardMenuItem.
      */
     editor.ui.registry.addAutocompleter('specialchars_cardmenuitems', {
-      ch: '-',
+      trigger: '-',
       minChars: 1,
       columns: 1,
       highlightOn: ['char_name'],


### PR DESCRIPTION
DOC-1946: remove deprecated `ch` parameter and use `trigger` in autocompleter examples

Changes:
* Replaced soft-deprecated option with currently supported option in two index.js files.
	* Change:
		* s/ch/trigger/.
	* Changed files:
		1. `/modules/ROOT/examples/live-demos/autocompleter-autocompleteitem/index.js`
		2. `/modules/ROOT/examples/live-demos/autocompleter-cardmenuitem/index.js`

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
