### PR TITLE
DOC-1932: Add the RTC EOL message to RTC pages in the TinyMCE 5.x documentation

### DIFF
--- a/_includes/rtc/admon-rtc-eol.md
+++ b/_includes/rtc/admon-rtc-eol.md
@@ -1,1 +1,1 @@
-    > **Important**: TinyMCE’s Real-time Collaboration (RTC) plugin will be retired and deactivated on December 31, 2023, and is no longer available for purchase.
+> **Important**: TinyMCE’s Real-time Collaboration (RTC) plugin will be retired and deactivated on December 31, 2023, and is no longer available for purchase.

--- a/rtc/index.md
+++ b/rtc/index.md
@@ -5,13 +5,13 @@ title_nav: Real-time Collaboration (RTC)
 description: The TinyMCE Real-time Collaboration plugin
 type: folder
 ---
+{% include rtc/admon-rtc-eol.md %}
+
 {% assign navigation = site.data.nav %}
 {% for entry in navigation %}
   {% if entry.url == "rtc" %}
     {% assign links = entry.pages %}
   {% endif %}
 {% endfor %}
-
-{% include rtc/admon-rtc-eol.md %}
 
 {% include index.html links=links %}


### PR DESCRIPTION
Ticket: DOC-1932, Add the RTC EOL message to RTC pages in the TinyMCE 5.x documentation.

Changes:
* Markup typo correction. Removed leading spaces.
* Moved include statement pointing to `admon-rtc-eol.md` from below the nav table to above the nav table.

Pre-checks:
- [x] Branch prefixed with `feature/5/` or `hotfix/5/`

Review:
- [x] Documentation Team Lead has reviewed
