### PR TITLE
DOC-1952: Fix incorrect include placement for partials

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+### 2023-04-14
+- DOC-1952: Moved the `include` statements to separate lines in the API sections of multiple custom UI component pages to display the admonition correctly.
 ### 2023-04-13
 
 - DOC-1946: Replaced soft-deprecated `ch` option with supported `trigger` option in `…/live-demos/autocompleter-autocompleteitem/index.js` and `…/live-demos/autocompleter-cardmenuitem/index.js`.
@@ -146,4 +148,3 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 - DOC-1824: updates to template files with no reader-visible changes. Typo correction in `nav.adoc`, the file that generates the TinyMCE documentation’s Table of Contents navigation sidebar. ID markup added to two files to prevent IDEs from complaining about their absence. Again, no reader-visible changes. And the [Accompanying Premium self-hosted server-side component changes](https://tiny.cloud/docs/tinymce/6/6.2-release-notes/#accompanying-premium-self-hosted-server-side-component-changes) and [Security fixes](https://tiny.cloud/docs/tinymce/6/6.2-release-notes/#security-fixes) sections were added back to the *6.2 Release Notes*.
 - DOC-1816: markup corrections to prevent asciidoctor warnings. No reader-visible changes.
-

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -410,9 +410,9 @@
 **** xref:6.4.1-release-notes.adoc#known-issues[Known issues]
 *** TinyMCE 6.3.2
 **** xref:6.3.2-release-notes.adoc#overview[Overview]
-**** xref:6.3.2-release-notes.adoc:accompanying-premium-self-hosted-server-side-component-changes[Accompanying Premium self-hosted server-side component changes]
+**** xref:6.3.2-release-notes.adoc#accompanying-premium-self-hosted-server-side-component-changes[Accompanying Premium self-hosted server-side component changes]
 **** xref:6.3.2-release-notes.adoc#bug-fix[Bug fix]
-**** xref:6.3.2-release-notes.adoc:security-fixes[Security fixes]
+**** xref:6.3.2-release-notes.adoc#security-fixes[Security fixes]
 *** TinyMCE 6.3
 **** xref:6.3-release-notes.adoc#overview[Overview]
 **** xref:6.3-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]

--- a/modules/ROOT/pages/6.4.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.1-release-notes.adoc
@@ -65,7 +65,7 @@ This update adds a new **Dark/light mode** button to toggle between either dark 
 
 This update adds a new **Fullscreen** button to toggle between fullscreen and dialog modes.
 
-NOTE: For the Advanced Code Editor to offer a full-screen mode, it requires the xref:fullscreen.adoc[Full screen] plugin and requires {pluginname} to be running in xref:advcode.adoc#advcode_inline[inline mode].
+NOTE: For the Advanced Code Editor to offer a full-screen mode, it requires the xref:fullscreen.adoc[Full screen] plugin and to be running in xref:advcode.adoc#advcode_inline[inline mode].
 
 NOTE: For the Advanced Code Editor to offer a **Copy** button, it requires a https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts[*secure contexts*].
 

--- a/modules/ROOT/pages/custom-basic-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-basic-toolbar-button.adoc
@@ -26,7 +26,8 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |Name |Value |Description
 |isEnabled |`+() => boolean+` |Checks if the button is enabled.
 |setEnabled |`+(state: boolean) => void+` |Sets the button's enabled state.
-3+|include::partial$misc/admon-requires-6.4v.adoc[]
+3+|
+include::partial$misc/admon-requires-6.4v.adoc[]
 |setText |`+(text: string) => void+` |Sets the text label to display.
 |setIcon |`+(icon: string) => void+` |Sets the icon of the button.
 |===

--- a/modules/ROOT/pages/custom-group-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-group-toolbar-button.adoc
@@ -27,7 +27,8 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |Name |Value |Description
 |isEnabled |`+() => boolean+` |Checks if the button is enabled.
 |setEnabled |`+(state: boolean) => void+` |Sets the button's enabled state.
-3+|include::partial$misc/admon-requires-6.4v.adoc[]
+3+|
+include::partial$misc/admon-requires-6.4v.adoc[]
 |setText |`+(text: string) => void+` |Sets the text label to display.
 |setIcon |`+(icon: string) => void+` |Sets the icon of the button.
 |===

--- a/modules/ROOT/pages/custom-menu-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-menu-toolbar-button.adoc
@@ -28,7 +28,8 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |Name |Value |Description
 |isEnabled |`+() => boolean+` |Checks if the button is enabled.
 |setEnabled |`+(state: boolean) => void+` |Sets the button's enabled state.
-3+|include::partial$misc/admon-requires-6.4v.adoc[]
+3+|
+include::partial$misc/admon-requires-6.4v.adoc[]
 |setText |`+(text: string) => void+` |Sets the text label to display.
 |setIcon |`+(icon: string) => void+` |Sets the icon of the button.
 |===

--- a/modules/ROOT/pages/custom-split-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-split-toolbar-button.adoc
@@ -30,7 +30,8 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |setEnabled |`+(state: boolean) => void+` |Sets the button's enabled state.
 |isActive |`+() => boolean+` |Checks the button's toggle state.
 |setActive |`+(state: boolean) => void+` |Sets the button's toggle state.
-3+|include::partial$misc/admon-requires-6.4v.adoc[]
+3+|
+include::partial$misc/admon-requires-6.4v.adoc[]
 |setText |`+(text: string) => void+` |Sets the text label to display.
 |setIcon |`+(icon: string) => void+` |Sets the icon of the button.
 |===

--- a/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
@@ -29,7 +29,8 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |setEnabled |`+(state: boolean) => void+` |Sets the button's enabled state.
 |isActive |`+() => boolean+` |Checks if the button is `+on+`.
 |setActive |`+(state: boolean) => void+` |Sets the button's toggle state.
-3+|include::partial$misc/admon-requires-6.4v.adoc[]
+3+|
+include::partial$misc/admon-requires-6.4v.adoc[]
 |setText |`+(text: string) => void+` |Sets the text label to display.
 |setIcon |`+(icon: string) => void+` |Sets the icon of the button.
 |===

--- a/modules/ROOT/partials/configuration/highlight_on_focus.adoc
+++ b/modules/ROOT/partials/configuration/highlight_on_focus.adoc
@@ -1,7 +1,7 @@
 [[highlight_on_focus]]
 == `+highlight_on_focus+`
 
-include::partial/$misc/admon-requires-6.4v.adoc[]
+include::partial$misc/admon-requires-6.4v.adoc[]
 
 The `+highlight_on_focus+` option adds a blue outline to an instantiated {productname} editor when that editor is made the input focus. When using the `oxide-dark` skin, the outline is white.
 

--- a/modules/ROOT/partials/misc/admon-requires-6.4v.adoc.
+++ b/modules/ROOT/partials/misc/admon-requires-6.4v.adoc.
@@ -1,1 +1,0 @@
-NOTE: This feature is only available for {productname} 6.4 and later.


### PR DESCRIPTION
Ticket: DOC-1952

Changes:
* The partials weren't loading because they weren't being included on separate lines
* There was a duplicate partial with no file extension because it ended in `.adoc.`, so that was removed
* When building and testing there were a number of missing reference errors, so those have been fixed as well
* There was an unintentional `{pluginname}` in the 6.4.1 release notes, so that was removed.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] ~Files has been included where required (if applicable)~
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
