### PR TITLE
DOC-1170: Update `language_url` description and example

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,8 +6,11 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1170: updated `language_url.adoc` to document the `language: '<language-file-pack-name>'` requirement and to make other language explicit where it was implicatory.
+
 ### 2023-04-14
 - DOC-1952: Moved the `include` statements to separate lines in the API sections of multiple custom UI component pages to display the admonition correctly.
+
 ### 2023-04-13
 
 - DOC-1946: Replaced soft-deprecated `ch` option with supported `trigger` option in `…/live-demos/autocompleter-autocompleteitem/index.js` and `…/live-demos/autocompleter-cardmenuitem/index.js`.

--- a/modules/ROOT/partials/configuration/language_url.adoc
+++ b/modules/ROOT/partials/configuration/language_url.adoc
@@ -3,7 +3,7 @@
 
 When using the xref:ui-localization.adoc#language[`+language+`] option to set the user interface language you can place language pack(s) in a directory other than the default. If you do this, however, you must add the `language_url` option to your configuration and set this option to a path pointing to the language file(s) location.
 
-We recommend pointing to this file using a relative path URL beginning with the absolute path reference character, `+/+`. That is, we recommend pointing to this file using a path that extends from the root of your web application. We do not recommend pointing to this file using a relative path that does not extend from your web application’s root and, consequently, relies on context for safe path resolution.
+We recommend the path URL be relative to the root of your web application, i.e. beginning with the absolute path reference character `+/+`. It is best to avoid relying on application context for safe path resolution of language packs.
 
 Also, the `+language+` option must also be set and must be set to the name of the language pack file being loaded.
 

--- a/modules/ROOT/partials/configuration/language_url.adoc
+++ b/modules/ROOT/partials/configuration/language_url.adoc
@@ -3,7 +3,7 @@
 
 When using the xref:ui-localization.adoc#language[`+language+`] option to set the user interface language you can place language pack(s) in a directory other than the default. If you do this, however, you must add the `language_url` option to your configuration and set this option to a path pointing to the language file(s) location.
 
-We recommend the path URL be relative to the web application’s root. That is, beginning with the absolute path reference character `+/+`. Avoid relying on application context for safe path resolution of language packs.
+We recommend the path URL be relative to the web application’s root. That is, begin with the absolute path reference character `+/+`. Avoid relying on application context for safe path resolution of language packs.
 
 Also, the `+language+` option must also be set and must be set to the name of the language pack file being loaded.
 

--- a/modules/ROOT/partials/configuration/language_url.adoc
+++ b/modules/ROOT/partials/configuration/language_url.adoc
@@ -3,7 +3,7 @@
 
 When using the xref:ui-localization.adoc#language[`+language+`] option to set the user interface language you can place language pack(s) in a directory other than the default. If you do this, however, you must add the `language_url` option to your configuration and set this option to a path pointing to the language file(s) location.
 
-We recommend pointing to this file using a standard path beginning with the absolute path reference character, `+/+`. That is, we recommend pointing to this file using a path that extends from the root of your web application. We do not recommend pointing to this file using a path that does not extend from your web application’s root and, consequently, relies on context for safe path resolution.
+We recommend pointing to this file using a relative path URL beginning with the absolute path reference character, `+/+`. That is, we recommend pointing to this file using a path that extends from the root of your web application. We do not recommend pointing to this file using a relative path that does not extend from your web application’s root and, consequently, relies on context for safe path resolution.
 
 Also, the `+language+` option must also be set and must be set to the name of the language pack file being loaded.
 

--- a/modules/ROOT/partials/configuration/language_url.adoc
+++ b/modules/ROOT/partials/configuration/language_url.adoc
@@ -3,7 +3,7 @@
 
 When using the xref:ui-localization.adoc#language[`+language+`] option to set the user interface language you can place language pack(s) in a directory other than the default. If you do this, however, you must add the `language_url` option to your configuration and set this option to a path pointing to the language file(s) location.
 
-We recommend the path URL be relative to the root of your web application, i.e. beginning with the absolute path reference character `+/+`. It is best to avoid relying on application context for safe path resolution of language packs.
+We recommend the path URL be relative to the web application’s root. That is, beginning with the absolute path reference character `+/+`. Avoid relying on application context for safe path resolution of language packs.
 
 Also, the `+language+` option must also be set and must be set to the name of the language pack file being loaded.
 

--- a/modules/ROOT/partials/configuration/language_url.adoc
+++ b/modules/ROOT/partials/configuration/language_url.adoc
@@ -1,17 +1,23 @@
 [[language_url]]
 == `+language_url+`
 
-When using the xref:ui-localization.adoc#language[`+language+`] option to set the user interface language you may choose to place any language pack(s) in a directory other than the default. If you do this you need to provide a simple URL to where the language file is located. We recommend using a site absolute URL.
+When using the xref:ui-localization.adoc#language[`+language+`] option to set the user interface language you can place language pack(s) in a directory other than the default. If you do this, however, you must add the `language_url` option to your configuration and set this option to a path pointing to the language file(s) location.
+
+We recommend pointing to this file using a standard path beginning with the absolute path reference character, `+/+`. That is, we recommend pointing to this file using a path that extends from the root of your web application. We do not recommend pointing to this file using a path that does not extend from your web application’s root and, consequently, relies on context for safe path resolution.
+
+Also, the `+language+` option must also be set and must be set to the name of the language pack file being loaded.
 
 *Type:* `+String+`
 
 === Example: using `+language_url+`
 
+
 [source,js]
 ----
 tinymce.init({
-  selector: 'textarea',  // change this value according to your HTML
-  language_url: '/languages/fi.js'  // site absolute URL
+  selector: 'textarea', // change this value according to your HTML
+  language_url: '/path/to/language/pack/fi.js', // path from the root of your web application — / — to the language pack(s)
+  language: 'fi'  // the name of the language pack file
 });
 ----
 


### PR DESCRIPTION
DOC-1170, update `language_url` description and example. 

Changes:
* Re-write of both the description and example to
		1. explicitly note that `language: ‘<language-file-pack-name>’` must be set; and
		2. replace language that relied on common implication and assumption with language that sets out specifically and explicitly what we recommend.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
