### PR TITLE
DOC-1955: changelog.adoc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1955: added the TinyMCE 6.4.2 specific changes to changelog.adoc.
+
 ### 2023-04-19
 - DOC-1170: updated `language_url.adoc` to document the `language: '<language-file-pack-name>'` requirement and to make other language explicit where it was implicatory.
 - DOC-1947: typos, copy-edits and mark-up corrections across multiple files: `builtinformats.adoc`; `contextform.adoc`; `formats.adoc`; `supported-versions.adoc`; and `valid_children.adoc`.

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -6,7 +6,15 @@ NOTE: This is the {productname} Community version changelog. For information abo
 
 == 6.4.2 - 2023-04-26
 
-
+=== Fixed
+* The editor would display a notification error when it fails to retirieve a blob image uri.
+* Menu buttons would have the Tabstopping behaviour in toolbar.
+* The `urlinput` dialog component would not open the typeahead dropdown when the input value was reset to an empty string.
+* Fixed the mouse pointer style from a text cursor to a default arrow pointer when hovering over the tree dialog component items.
+* Enabled variant of togglable `tox-button` and `tox-button--secondary` now supports `hover/active/focus/disabled` states.
+* Setting an invalid unit in the `fontsizeinput` would change it do the default value instead of reverting it back to the previous valid value.
+* Selection was not correctly scrolled horizontally into view when using the `selection.scrollIntoView` API.
+* Context toolbars displayed the incorrect status for the `advlist` plugin buttons.
 
 == 6.4.1 - 2023-03-29
 

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -12,7 +12,7 @@ NOTE: This is the {productname} Community version changelog. For information abo
 * Menu buttons would have the Tabstopping behaviour in toolbar.
 * The editor would display a notification error when it fails to retirieve a blob image uri.
 * Setting an invalid unit in the `fontsizeinput` would change it do the default value instead of reverting it back to the previous valid value.
-* The urlinput dialog component would not open the typeahead dropdown when the input value was reset to an empty string.
+* The `urlinput` dialog component would not open the typeahead dropdown when the input value was reset to an empty string.
 * When dragging image elements and dropping the image in the editor the `dragend` event would sometimes not fire on firefox.
 * Context toolbars displayed the incorrect status for the advlist plugin buttons.
 

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -8,14 +8,14 @@ NOTE: This is the {productname} Community version changelog. For information abo
 
 === Fixed
 
-* Selection was not correctly scrolled horizontally into view when using the `selection.scrollIntoView` API.
-* Tab navigation no longer incorrectly stops at menu buttons within toolbar groups.
 * The editor displayed a notification error when it failed to retrieve a blob image uri.
-* Setting an invalid unit in the `fontsizeinput` changed it to the default value instead of reverting it to the previous, and valid, value.
+* Tab navigation no longer incorrectly stops at menu buttons within toolbar groups.
 * The `urlinput` dialog component would not open the type-ahead dropdown when the input value was reset to an empty string.
-* When dragging image elements and dropping the image in the editor the `dragend` event would sometimes not fire on Firefox.
+* Setting an invalid unit in the `fontsizeinput` changed it to the default value instead of reverting it to the previous, and valid, value.
+* Selection was not correctly scrolled horizontally into view when using the `selection.scrollIntoView` API.
 * Context toolbars displayed the incorrect status for the `advlist` plugin buttons.
 * The image would not be inserted when the `quickimage` button was used on Chrome.
+* When dragging image elements and dropping the image in the editor the `dragend` event would sometimes not fire on Firefox.
 
 == 6.4.1 - 2023-03-29
 

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -9,13 +9,13 @@ NOTE: This is the {productname} Community version changelog. For information abo
 === Fixed
 
 * Selection was not correctly scrolled horizontally into view when using the `selection.scrollIntoView` API.
-* Menu buttons would have the Tabstopping behaviour in toolbar.
-* The editor would display a notification error when it fails to retirieve a blob image uri.
-* Setting an invalid unit in the `fontsizeinput` would change it do the default value instead of reverting it back to the previous valid value.
-* The `urlinput` dialog component would not open the typeahead dropdown when the input value was reset to an empty string.
-* When dragging image elements and dropping the image in the editor the `dragend` event would sometimes not fire on firefox.
-* Context toolbars displayed the incorrect status for the advlist plugin buttons.
-* The image would not be inserted when using the `quickimage` button on Chrome.
+* Tab navigation no longer incorrectly stops at menu buttons within toolbar groups
+* The editor displayed a notification error when it failed to retrieve a blob image uri.
+* Setting an invalid unit in the `fontsizeinput` changed it to the default value instead of reverting it to the previous, and valid, value.
+* The `urlinput` dialog component would not open the type-ahead dropdown when the input value was reset to an empty string.
+* When dragging image elements and dropping the image in the editor the `dragend` event would sometimes not fire on Firefox.
+* Context toolbars displayed the incorrect status for the `advlist` plugin buttons.
+* The image would not be inserted when the `quickimage` button was used on Chrome.
 
 == 6.4.1 - 2023-03-29
 

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -4,6 +4,9 @@
 
 NOTE: This is the {productname} Community version changelog. For information about the latest {cloudname} or {enterpriseversion} Release, see: xref:release-notes.adoc[{productname} Release Notes].
 
+== 6.4.2 - 2023-04-26
+
+
 
 == 6.4.1 - 2023-03-29
 

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -8,17 +8,13 @@ NOTE: This is the {productname} Community version changelog. For information abo
 
 === Fixed
 
-* When dragging image elements and dropping the image in the editor the `dragend` event would sometimes not fire on firefox.
-* `deleteallconversations` menu item was enabled before any comments were added.
+* Selection was not correctly scrolled horizontally into view when using the selection.scrollIntoView API.
 * Menu buttons would have the Tabstopping behaviour in toolbar.
 * The editor would display a notification error when it fails to retirieve a blob image uri.
-* Menu buttons would have the Tabstopping behaviour in toolbar.
-* The `urlinput` dialog component would not open the typeahead dropdown when the input value was reset to an empty string.
-* Fixed the mouse pointer style from a text cursor to a default arrow pointer when hovering over the tree dialog component items.
-* Enabled variant of togglable `tox-button` and `tox-button--secondary` now supports `hover/active/focus/disabled` states.
-* Setting an invalid unit in the `fontsizeinput` would change it do the default value instead of reverting it back to the previous valid value.
-* Selection was not correctly scrolled horizontally into view when using the `selection.scrollIntoView` API.
-* Context toolbars displayed the incorrect status for the `advlist` plugin buttons.
+* Setting an invalid unit in the fontsizeinput would change it do the default value instead of reverting it back to the previous valid value.
+* The urlinput dialog component would not open the typeahead dropdown when the input value was reset to an empty string.
+* When dragging image elements and dropping the image in the editor the `dragend` event would sometimes not fire on firefox.
+* Context toolbars displayed the incorrect status for the advlist plugin buttons.
 
 == 6.4.1 - 2023-03-29
 

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -9,7 +9,7 @@ NOTE: This is the {productname} Community version changelog. For information abo
 === Fixed
 
 * Selection was not correctly scrolled horizontally into view when using the `selection.scrollIntoView` API.
-* Tab navigation no longer incorrectly stops at menu buttons within toolbar groups
+* Tab navigation no longer incorrectly stops at menu buttons within toolbar groups.
 * The editor displayed a notification error when it failed to retrieve a blob image uri.
 * Setting an invalid unit in the `fontsizeinput` changed it to the default value instead of reverting it to the previous, and valid, value.
 * The `urlinput` dialog component would not open the type-ahead dropdown when the input value was reset to an empty string.

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -15,6 +15,7 @@ NOTE: This is the {productname} Community version changelog. For information abo
 * The `urlinput` dialog component would not open the typeahead dropdown when the input value was reset to an empty string.
 * When dragging image elements and dropping the image in the editor the `dragend` event would sometimes not fire on firefox.
 * Context toolbars displayed the incorrect status for the advlist plugin buttons.
+* The image would not be inserted when using the `quickimage` button on Chrome.
 
 == 6.4.1 - 2023-03-29
 

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -7,6 +7,10 @@ NOTE: This is the {productname} Community version changelog. For information abo
 == 6.4.2 - 2023-04-26
 
 === Fixed
+
+* When dragging image elements and dropping the image in the editor the `dragend` event would sometimes not fire on firefox.
+* `deleteallconversations` menu item was enabled before any comments were added.
+* Menu buttons would have the Tabstopping behaviour in toolbar.
 * The editor would display a notification error when it fails to retirieve a blob image uri.
 * Menu buttons would have the Tabstopping behaviour in toolbar.
 * The `urlinput` dialog component would not open the typeahead dropdown when the input value was reset to an empty string.

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -11,7 +11,7 @@ NOTE: This is the {productname} Community version changelog. For information abo
 * Selection was not correctly scrolled horizontally into view when using the `selection.scrollIntoView` API.
 * Menu buttons would have the Tabstopping behaviour in toolbar.
 * The editor would display a notification error when it fails to retirieve a blob image uri.
-* Setting an invalid unit in the fontsizeinput would change it do the default value instead of reverting it back to the previous valid value.
+* Setting an invalid unit in the `fontsizeinput` would change it do the default value instead of reverting it back to the previous valid value.
 * The urlinput dialog component would not open the typeahead dropdown when the input value was reset to an empty string.
 * When dragging image elements and dropping the image in the editor the `dragend` event would sometimes not fire on firefox.
 * Context toolbars displayed the incorrect status for the advlist plugin buttons.

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -11,11 +11,13 @@ NOTE: This is the {productname} Community version changelog. For information abo
 * The editor displayed a notification error when it failed to retrieve a blob image uri.
 * Tab navigation no longer incorrectly stops at menu buttons within toolbar groups.
 * The `urlinput` dialog component would not open the type-ahead dropdown when the input value was reset to an empty string.
+* Redial would, in some situations, cause select elements not to have an initial value selected when they should have.
+* Fixed the mouse pointer style from a text cursor to a default arrow pointer when hovering over the tree dialog component items.
+* Enabled variant of toggleable `tox-button` and `tox-button--secondary`: it now supports `hover`/`active`/`focus`/`disabled` states.
 * Setting an invalid unit in the `fontsizeinput` changed it to the default value instead of reverting it to the previous, and valid, value.
 * Selection was not correctly scrolled horizontally into view when using the `selection.scrollIntoView` API.
 * Context toolbars displayed the incorrect status for the `advlist` plugin buttons.
 * The image would not be inserted when the `quickimage` button was used on Chrome.
-* When dragging image elements and dropping the image in the editor the `dragend` event would sometimes not fire on Firefox.
 
 == 6.4.1 - 2023-03-29
 

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -8,7 +8,7 @@ NOTE: This is the {productname} Community version changelog. For information abo
 
 === Fixed
 
-* Selection was not correctly scrolled horizontally into view when using the selection.scrollIntoView API.
+* Selection was not correctly scrolled horizontally into view when using the `selection.scrollIntoView` API.
 * Menu buttons would have the Tabstopping behaviour in toolbar.
 * The editor would display a notification error when it fails to retirieve a blob image uri.
 * Setting an invalid unit in the fontsizeinput would change it do the default value instead of reverting it back to the previous valid value.


### PR DESCRIPTION
Ticket: DOC-1955, Tiny 6.4.2 Community docs release.

Changes:
* added the TinyMCE 6.4.2 specific changes to changelog.adoc.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
