### PR TITLE
DOC-1968: Enabled buttons in the quickbar menu is not shown as active

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1968: Added `enabled buttons in the quickbar menu is not shown as active` to staging.
 - DOC-1935: added `6.4.2-release-notes.adoc`. Added outline to this file for staging.
 
 ### 2023-04-19

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -79,7 +79,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 == The contextual toolbar displayed the status of Advanced List Premium plugin icons incorrectly.
 
-In previous versions of {productname}, the quickbar button handler setup for the Open Source plugin, xref:list.adoc[Lists], was different to the quickbar button handler setup for the Premium plugin, xref:advlist.adoc[Advanced Lists].
+In previous versions of {productname}, the quickbar button handler setup for the Open Source plugin, xref:lists.adoc[Lists], was different to the quickbar button handler setup for the Premium plugin, xref:advlist.adoc[Advanced Lists].
 
 As a consequence, when a {productname} instance included the Advanced Lists Premium plugin, the contextual toolbar did not display button status on the toolbar correctly.
 

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -81,7 +81,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 In previous versions of {productname}, the `advlist` quickbar button handler setup varied from the setup for the `list` handler.
 
-As a consequence the `advlist` quickbar button would not talk to the correct status.
+As a consequence the `advlist` quickbar button would not show the correct status.
 
 To fix this, changes were made to align the setup handler for the `advlist` to match the settings for the `list` handler, which now ensures the status is correctly rendered.
 

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -76,6 +76,16 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 // {productname} 6.4.2 also includes the following bug fixes:
 
+//The editor displayed a notification error when it failed to retrieve a blob image uri.
+
+== Context toolbars displayed the incorrect status for the advlist plugin buttons.
+
+In previous versions of {productname}, the `advlist` quickbar button handler setup varied from the setup for the `list` handler.
+
+As a consequence the `advlist` quickbar button would not talk to the correct status.
+
+To fix this, changes were made to align the setup handler for the `advlist` to match the settings for the `list` handler, which now ensures the status is correctly rendered.
+
 
 // [[security-fixes]]
 // == Security fixes

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -76,7 +76,6 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 // {productname} 6.4.2 also includes the following bug fixes:
 
-//The editor displayed a notification error when it failed to retrieve a blob image uri.
 
 == Context toolbars displayed the incorrect status for the advlist plugin buttons.
 

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -77,13 +77,13 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 // {productname} 6.4.2 also includes the following bug fixes:
 
 
-== Context toolbars displayed the incorrect status for the advlist plugin buttons.
+== The contextual toolbar displayed the status of Advanced List Premium plugin icons incorrectly.
 
-In previous versions of {productname}, the `advlist` quickbar button handler setup varied from the setup for the `list` handler.
+In previous versions of {productname}, the quickbar button handler setup for the Open Source plugin, xref:list.adoc[Lists], was different to the quickbar button handler setup for the Premium plugin, xref:advlist.adoc[Advanced Lists].
 
-As a consequence the `advlist` quickbar button would not show the correct status.
+As a consequence, when a {productname} instance included the Advanced Lists Premium plugin, the contextual toolbar did not display button status on the toolbar correctly.
 
-To fix this, changes were made to align the setup handler for the `advlist` to match the settings for the `list` handler, which now ensures the status is correctly rendered.
+With this update, the setup handler for the Advanced Lists Premium plugin now matches the setup handler settings for the Open Source Lists plugin. And toolbar icon state is now correctly rendered on the contextual toolbar.
 
 
 // [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-1968: Enabled buttons in the quickbar menu is not shown as active

Changes:
* Added documentation to release-notes for `Enabled buttons in the quickbar menu is not shown as active`

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
