### PR TITLE
DOC-1967: Fixed the mouse pointer style from a text cursor to a default arrow pointer when hovering over the tree dialog component items.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1967: added `Fixed the mouse pointer style from a text cursor to a default arrow pointer when hovering over the tree dialog component items.` to staging.
 - DOC-1935: added `6.4.2-release-notes.adoc`. Added outline to this file for staging.
 
 ### 2023-04-19

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -76,13 +76,15 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 // {productname} 6.4.2 also includes the following bug fixes:
 
-=== Fixed the mouse pointer style from a text cursor to a default arrow pointer when hovering over the tree dialog component items.
+=== When hovering over tree dialog components the moust pointer rendered incorrectly.
 
-In previous versions of {productname}, while hovering over tree dialog component items, the mouse pointer style would render incorrectly.
+In previous versions of {productname}, when hovering over tree dialog component items, the mouse pointer style rendered incorrectly.
 
-As a consequence, the mouse pointer would render as a text cursor rather than the default arrow pointer.
+Specifically, the mouse pointer rendered as an I-beam pointer rather than the default arrow pointer.
 
 In {productname} 6.4.2, the styles for tree component items have been updated to correct this issue.
+
+NOTE: as of {productname} 6.4.2, tree components are only used as part of the xref:advanced-templates.adoc[Advanced Templates] Premium plugin.
 
 // [[security-fixes]]
 // == Security fixes

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -76,6 +76,13 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 // {productname} 6.4.2 also includes the following bug fixes:
 
+=== Fixed the mouse pointer style from a text cursor to a default arrow pointer when hovering over the tree dialog component items.
+
+In previous versions of {productname} while hovering over tree dialog component items, the mouse pointer style would render incorrectly.
+
+As a consequence, the mouse pointer would render as a text cursor rather than the default arrow pointer.
+
+In {productname} 6.4.2, the styles for tree component items have been updated to corrected this issue.
 
 // [[security-fixes]]
 // == Security fixes

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -76,7 +76,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 // {productname} 6.4.2 also includes the following bug fixes:
 
-=== When hovering over tree dialog components the moust pointer rendered incorrectly.
+=== When hovering over tree dialog components the mouse pointer rendered incorrectly.
 
 In previous versions of {productname}, when hovering over tree dialog component items, the mouse pointer style rendered incorrectly.
 

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -78,7 +78,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 === Fixed the mouse pointer style from a text cursor to a default arrow pointer when hovering over the tree dialog component items.
 
-In previous versions of {productname} while hovering over tree dialog component items, the mouse pointer style would render incorrectly.
+In previous versions of {productname}, while hovering over tree dialog component items, the mouse pointer style would render incorrectly.
 
 As a consequence, the mouse pointer would render as a text cursor rather than the default arrow pointer.
 

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -82,7 +82,7 @@ In previous versions of {productname} while hovering over tree dialog component 
 
 As a consequence, the mouse pointer would render as a text cursor rather than the default arrow pointer.
 
-In {productname} 6.4.2, the styles for tree component items have been updated to corrected this issue.
+In {productname} 6.4.2, the styles for tree component items have been updated to correct this issue.
 
 // [[security-fixes]]
 // == Security fixes


### PR DESCRIPTION
Ticket: DOC-1967: Fixed the mouse pointer style from a text cursor to a default arrow pointer when hovering over the tree dialog component items.

Changes:
* Added `DOC-1967: Fixed the mouse pointer style from a text cursor to a default arrow pointer when hovering over the tree dialog component items.` to staging.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
