### PR TITLE
DOC-1964:  menu item was enabled before any comments were added.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1964: added `deleteallconversations` menu item was enabled before any comments were added.` to staging.
 - DOC-1935: added `6.4.2-release-notes.adoc`. Added outline to this file for staging.
 
 ### 2023-04-19

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -76,6 +76,11 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 // {productname} 6.4.2 also includes the following bug fixes:
 
+=== `deleteallconversations` menu item was enabled before any comments were added.
+
+In previous versions of {productname}, the menu button for `deleteallconversations` was not disabled when the comment dialog was empty.
+
+To fix this issue, the menu button will now be `disabled` if the comments section within the menu verifies no content is present.
 
 // [[security-fixes]]
 // == Security fixes

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -76,11 +76,13 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 // {productname} 6.4.2 also includes the following bug fixes:
 
-=== `deleteallconversations` menu item was enabled before any comments were added.
+=== The ‘Comments > Delete all conversations’ menu item was enabled even when no comments were added
 
-In previous versions of {productname}, the menu button for `deleteallconversations` was not disabled when the comment dialog was empty.
+In previous versions of {productname}, if the Premium plugin, xref:introduction-to-tiny-comments.adoc[Tiny Comments] was also running, {productname} did not check the state of the comments section.
 
-To fix this issue, the menu button will now be `disabled` if the comments section within the menu verifies no content is present.
+Consequently, the _Comments > Delete all conversations_ menu item was not disabled even when the comments section was empty.
+
+With this update, if xref:introduction-to-tiny-comments.adoc[Tiny Comments] is running, {productname} now checks the comments section state and this menu item is now, as expected, disabled when the {productname} comments section contains no comments.
 
 // [[security-fixes]]
 // == Security fixes


### PR DESCRIPTION
Ticket: DOC-1964:  menu item was enabled before any comments were added.

Changes:
* added `DOC-1964:  menu item was enabled before any comments were added.` to staging.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
