### PR TITLE
DOC-1965: The editor displayed a notification error when it failed to retrieve a blob image uri.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
-- DOC-1965: added `The image would not be inserted when the quickimage button was used on Chrome.` to staging.
+- DOC-1965: added `The editor displayed a notification error when it failed to retrieve a blob image uri.` to staging.
 - DOC-1935: added `6.4.2-release-notes.adoc`. Added outline to this file for staging.
 
 ### 2023-04-19

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
-- DOC-1965: added `The editor displayed a notification error when it failed to retrieve a blob image uri.` to staging.
+- DOC-1965: added `The editor displayed a notification error when it failed to retrieve a blob image uri.` to staging 6.4.2.
 - DOC-1935: added `6.4.2-release-notes.adoc`. Added outline to this file for staging.
 
 ### 2023-04-19

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1965: added `The image would not be inserted when the quickimage button was used on Chrome.` to staging.
 - DOC-1935: added `6.4.2-release-notes.adoc`. Added outline to this file for staging.
 
 ### 2023-04-19

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -76,7 +76,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 // {productname} 6.4.2 also includes the following bug fixes:
 
-=== The image would not be inserted when the quickimage button was used on Chrome.
+=== The editor displayed a notification error when it failed to retrieve a blob image uri.
 
 In previous versions of {productname}, a console error would be thrown when resetting the `Source` field of the **Insert Media** dialog.
 

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -80,7 +80,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 In previous versions of {productname}, when the editor contained an image with an invalid or unreachable blob url, it would display an error notification banner within the editor viewport which would impact on the user experience.
 
-A fix was applied in {productname} 6.4.2, which saw the removal of the error notification banner as a broken image would be visiblly apparent to the user.
+A fix was applied in {productname} 6.4.2, which saw the removal of the error notification banner as a broken image would be visibly apparent to the user.
 
 // [[security-fixes]]
 // == Security fixes

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -78,9 +78,9 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 === The editor displayed a notification error when it failed to retrieve a blob image uri.
 
-In previous versions of {productname}, when the editor contained an image with an invalid or unreachable blob url, it would display an error notification banner within the editor viewport which would impact on the user experience.
+In previous versions of {productname}, when the editor contained an image with an invalid or unreachable blob url, it displayed an error notification banner within the editor viewport which impacted the user experience.
 
-A fix was applied in {productname} 6.4.2, which saw the removal of the error notification banner as a broken image would be visibly apparent to the user.
+For {productname} 6.4.2 the error notification banner has been removed: the visible broken image icon is notification enough for the end-user.
 
 // [[security-fixes]]
 // == Security fixes

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -76,6 +76,15 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 // {productname} 6.4.2 also includes the following bug fixes:
 
+=== The image would not be inserted when the quickimage button was used on Chrome.
+
+In previous versions of {productname}, a console error would be thrown when resetting the `Source` field of the **Insert Media** dialog.
+
+As a consequence, the dropdown list with the url suggestion would not expand.
+
+To fix this issue, {productname}, updated the code for the `urlinput` component that is responsible for gathering the correct dropdown items.
+
+As a result, the dropdown list with URL suggestions now expands even on the empty Source field and the browser console is cleaned out of errors.
 
 // [[security-fixes]]
 // == Security fixes

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -78,13 +78,9 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 === The editor displayed a notification error when it failed to retrieve a blob image uri.
 
-In previous versions of {productname}, a console error would be thrown when resetting the `Source` field of the **Insert Media** dialog.
+In previous versions of {productname}, when the editor contained an image with an invalid or unreachable blob url, it would display an error notification banner within the editor viewport which would impact on the user experience.
 
-As a consequence, the dropdown list with the url suggestion would not expand.
-
-To fix this issue, {productname}, updated the code for the `urlinput` component that is responsible for gathering the correct dropdown items.
-
-As a result, the dropdown list with URL suggestions now expands even on the empty Source field and the browser console is cleaned out of errors.
+A fix was applied in {productname} 6.4.2, which saw the removal of the error notification banner as a broken image would be visiblly apparent to the user.
 
 // [[security-fixes]]
 // == Security fixes


### PR DESCRIPTION
Ticket: DOC-1965: The editor displayed a notification error when it failed to retrieve a blob image uri.

Changes:
* Added `DOC-1965: The editor displayed a notification error when it failed to retrieve a blob image uri.` to staging.
* Reflective of `Replace error notification from promise rejection in unavailable blob images with exempt data attribute`

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
