### PR TITLE
DOC-1962: The image would not be inserted when the quickimage button was used on Chrome.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1962: added `=== The image would not be inserted when the quickimage button was used on Chrome.` to staging.
 - DOC-1935: added `6.4.2-release-notes.adoc`. Added outline to this file for staging.
 
 ### 2023-04-19

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -82,7 +82,7 @@ A regression was discovered in {productname} 6.4.0 when the macOS version of Goo
 
 As a consequence, although selecting the `quickimage` toolbar button presented the macOS-native *NSOpenPanel* dialogue box as expected, images selected from this dialogue box were not inserted into the {productname} document.
 
-For this upate, the regression has been correct. In {productname} 6.4.2, local images selected after the `quickimage` button is selected are added to the {productname} document, as expected.
+For this upate, the regression has been corrected. In {productname} 6.4.2, local images selected after the `quickimage` button is selected are added to the {productname} document, as expected.
 
 // [[security-fixes]]
 // == Security fixes

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -76,15 +76,13 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 // {productname} 6.4.2 also includes the following bug fixes:
 
-=== The image would not be inserted when the `quickimage` button was used on Chrome.
+=== The `quickimage` toolbar button failed to insert images selected from the local computer when running on Google Chrome for macOS 
 
-In previous versions of {productname}, on MacOS Chrome, the editor `focusin` event would occur before the `change` event for a file input.
+A regression was discovered in {productname} 6.4.0 when the macOS version of Google Chrome was the host browser: the `focusin` editor event occurred before the `change` event for a file input.
 
-As a consequence, images could not be inserted via `quickimage` button of `quickbar` plugin.
+As a consequence, although selecting the `quickimage` toolbar button presented the macOS-native *NSOpenPanel* dialogue box as expected, images selected from this dialogue box were not inserted into the {productname} document.
 
-To fix this, the handling of `focusin` events was delayed in order to give a time slot for the `change` event to be handled.
-
-As a result, the `quickimage` button functionality in {productname} 6.4.2, has now been returned to its working state.
+For this upate, the regression has been correct. In {productname} 6.4.2, local images selected after the `quickimage` button is selected are added to the {productname} document, as expected.
 
 // [[security-fixes]]
 // == Security fixes

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -76,7 +76,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 // {productname} 6.4.2 also includes the following bug fixes:
 
-=== The image would not be inserted when the quickimage button was used on Chrome.
+=== The image would not be inserted when the `quickimage` button was used on Chrome.
 
 In previous versions of {productname}, on MacOS Chrome, the editor `focusin` event would occur before the change event for a file input.
 

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -76,6 +76,15 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 // {productname} 6.4.2 also includes the following bug fixes:
 
+=== The image would not be inserted when the quickimage button was used on Chrome.
+
+In previous versions of {productname}, on MacOS Chrome, the editor `focusin` event would occur before the change event for a file input.
+
+As a consequence, images could not be inserted via `quickimage` button of quickbar plugin.
+
+To fix this, the handling of `focusin` events was delayed in order to give a time slot for the change event to be handled.
+
+As a result, the `quickimage` button functionality in {productname} 6.4.2, has now been returned to its working state.
 
 // [[security-fixes]]
 // == Security fixes

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -80,7 +80,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 In previous versions of {productname}, on MacOS Chrome, the editor `focusin` event would occur before the `change` event for a file input.
 
-As a consequence, images could not be inserted via `quickimage` button of quickbar plugin.
+As a consequence, images could not be inserted via `quickimage` button of `quickbar` plugin.
 
 To fix this, the handling of `focusin` events was delayed in order to give a time slot for the change event to be handled.
 

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -78,7 +78,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 === The image would not be inserted when the `quickimage` button was used on Chrome.
 
-In previous versions of {productname}, on MacOS Chrome, the editor `focusin` event would occur before the change event for a file input.
+In previous versions of {productname}, on MacOS Chrome, the editor `focusin` event would occur before the `change` event for a file input.
 
 As a consequence, images could not be inserted via `quickimage` button of quickbar plugin.
 

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -82,7 +82,7 @@ In previous versions of {productname}, on MacOS Chrome, the editor `focusin` eve
 
 As a consequence, images could not be inserted via `quickimage` button of `quickbar` plugin.
 
-To fix this, the handling of `focusin` events was delayed in order to give a time slot for the change event to be handled.
+To fix this, the handling of `focusin` events was delayed in order to give a time slot for the `change` event to be handled.
 
 As a result, the `quickimage` button functionality in {productname} 6.4.2, has now been returned to its working state.
 


### PR DESCRIPTION
Ticket: DOC-1962: The image would not be inserted when the quickimage button was used on Chrome.

Changes:
* added `DOC-1962: The image would not be inserted when the quickimage button was used on Chrome.` to staging.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
