### PR TITLE
DOC-1960: The urlinput dialog component would not open the type-ahead dropdown when the input value was reset to an empty string.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1960: added `The urlinput dialog component would not open the type-ahead dropdown when the input value was reset to an empty string.` to staging.
 - DOC-1935: added `6.4.2-release-notes.adoc`. Added outline to this file for staging.
 
 ### 2023-04-19

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -76,6 +76,15 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 // {productname} 6.4.2 also includes the following bug fixes:
 
+=== The urlinput dialog component would not open the type-ahead dropdown when the input value was reset to an empty string.
+
+In previous versions of {productname}, a console error would be thrown when resetting the `Source` field of the **Insert Media** dialog.
+
+As a consequence, the dropdown list with the url suggestion would not expand.
+
+To fix this issue, {productname}, updated the code for the `urlinput` component that is responsible for gathering the correct dropdown items.
+
+As a result, the dropdown list with URL suggestions now expands even on the empty Source field and the browser console is cleaned out of errors.
 
 // [[security-fixes]]
 // == Security fixes

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -78,13 +78,13 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 === The `urlinput` dialog component would not open the type-ahead dropdown when the input value was reset to an empty string.
 
-In previous versions of {productname}, a console error would be thrown when resetting the `Source` field of the **Insert Media** dialog.
+In previous versions of {productname}, a console error was thrown when the _Source_ field of the *Insert Media* dialog was reset.
 
-As a consequence, the dropdown list with the URL suggestions would not expand.
+As a consequence, the dropdown list of suggested URLs did not expand.
 
-To fix this issue, {productname}, updated the code for the `urlinput` component that is responsible for gathering the correct dropdown items.
+To fix this issue, the code for the `urlinput` component that is responsible for gathering the correct dropdown items was updated.
 
-As a result, the dropdown list with URL suggestions now expands even on the empty `Source` field, and the browser console is cleaned out of errors.
+As a result, the URL suggestions dropdown list now expands even on the empty _Source_ field. As well, the host browser’s console no longer returns errors.
 
 // [[security-fixes]]
 // == Security fixes

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -84,7 +84,7 @@ As a consequence, the dropdown list with the URL suggestions would not expand.
 
 To fix this issue, {productname}, updated the code for the `urlinput` component that is responsible for gathering the correct dropdown items.
 
-As a result, the dropdown list with URL suggestions now expands even on the empty Source field and the browser console is cleaned out of errors.
+As a result, the dropdown list with URL suggestions now expands even on the empty `Source` field, and the browser console is cleaned out of errors.
 
 // [[security-fixes]]
 // == Security fixes

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -76,7 +76,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 // {productname} 6.4.2 also includes the following bug fixes:
 
-=== The urlinput dialog component would not open the type-ahead dropdown when the input value was reset to an empty string.
+=== The `urlinput` dialog component would not open the type-ahead dropdown when the input value was reset to an empty string.
 
 In previous versions of {productname}, a console error would be thrown when resetting the `Source` field of the **Insert Media** dialog.
 

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -80,7 +80,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 In previous versions of {productname}, a console error would be thrown when resetting the `Source` field of the **Insert Media** dialog.
 
-As a consequence, the dropdown list with the url suggestion would not expand.
+As a consequence, the dropdown list with the URL suggestions would not expand.
 
 To fix this issue, {productname}, updated the code for the `urlinput` component that is responsible for gathering the correct dropdown items.
 


### PR DESCRIPTION
Ticket: DOC-1960: The `urlinput` dialog component would not open the type-ahead dropdown when the input value was reset to an empty string.

Changes:
* added `DOC-1960: The urlinput dialog component would not open the type-ahead dropdown when the input value was reset to an empty string.` to staging.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
