### PR TITLE
DOC-1963: Setting an invalid unit in the  changed it to the default value instead of reverting it to the previous, and valid, value.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1963: added `Setting an invalid unit in the `fontsizeinput` changed it to the default value instead of reverting it to the previous, and valid, value.` to staging.
 - DOC-1935: added `6.4.2-release-notes.adoc`. Added outline to this file for staging.
 
 ### 2023-04-19

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
-- DOC-1963: added `Setting an invalid unit in the `fontsizeinput` changed it to the default value instead of reverting it to the previous, and valid, value.` to staging.
+- DOC-1963: added Setting an invalid unit in the `fontsizeinput` changed it to the default value instead of reverting it to the previous, and valid, value. to staging.
 - DOC-1935: added `6.4.2-release-notes.adoc`. Added outline to this file for staging.
 
 ### 2023-04-19

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -76,6 +76,13 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 // {productname} 6.4.2 also includes the following bug fixes:
 
+=== Setting an invalid unit in the `fontsizeinput` changed it to the default value instead of reverting it to the previous, and valid, value.
+
+In previous versions of {productname}, when an invalid unit was inserted into the `fontsizeinput` component, the value would not parse resulting in both the value and unit been set to default (0 and pt). 
+
+As a consequence of this action, the invalid unit would set its value to `opt`.
+
+In {productname} 6.4.2, when inserting and invalid value into the `fontsizeinput`, the value will revert back to the previous valid value.
 
 // [[security-fixes]]
 // == Security fixes

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -78,11 +78,11 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 === Setting an invalid unit in the `fontsizeinput` changed it to the default value instead of reverting it to the previous, and valid, value.
 
-In previous versions of {productname}, when an invalid unit was inserted into the `fontsizeinput` component, the value would not parse resulting in both the value and unit been set to default (0 and pt). 
+In previous versions of {productname}, when an invalid value was entered into the `fontsizeinput` toolbar component, the value was not parsed and both the value and unit were set to their default values: _0_ and _pt_ respectively. 
 
-As a consequence of this action, the invalid unit would set its value to `0pt`.
+As a consequence, entering an invalid value set selected text, or the insertion point, to _0pt_.
 
-In {productname} 6.4.2, when inserting and invalid value into the `fontsizeinput`, the value will revert back to the previous valid value.
+In {productname} 6.4.2, if an invalid string is entered in the `fontsizeinput` entry field, the `fontsizeinput` value reverts to the previous, valid, value.
 
 // [[security-fixes]]
 // == Security fixes

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -80,7 +80,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 In previous versions of {productname}, when an invalid unit was inserted into the `fontsizeinput` component, the value would not parse resulting in both the value and unit been set to default (0 and pt). 
 
-As a consequence of this action, the invalid unit would set its value to `opt`.
+As a consequence of this action, the invalid unit would set its value to `0pt`.
 
 In {productname} 6.4.2, when inserting and invalid value into the `fontsizeinput`, the value will revert back to the previous valid value.
 


### PR DESCRIPTION
Ticket: DOC-1963: Setting an invalid unit in the  changed it to the default value instead of reverting it to the previous, and valid, value.

Changes:
* added `DOC-1963: Setting an invalid unit in the  changed it to the default value instead of reverting it to the previous, and valid, value.` to staging.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
