### PR TITLE
DOC-1961: Enabled variant of toggleable `tox-button` and `tox-button—​secondary`: it now supports `hover/active/focus/disabled` states.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
-- DOC-1961: added `Enabled variant of toggleable `tox-button` and `tox-button—​secondary`: it now supports `hover/active/focus/disabled` states.` to staging.
+- DOC-1961: added Enabled variant of toggleable `tox-button` and `tox-button—​secondary`: it now supports `hover/active/focus/disabled` states. to staging.
 - DOC-1935: added `6.4.2-release-notes.adoc`. Added outline to this file for staging.
 
 ### 2023-04-19

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1961: added `Enabled variant of toggleable `tox-button` and `tox-button—​secondary`: it now supports `hover/active/focus/disabled` states.` to staging.
 - DOC-1935: added `6.4.2-release-notes.adoc`. Added outline to this file for staging.
 
 ### 2023-04-19

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -76,13 +76,13 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 // {productname} 6.4.2 also includes the following bug fixes:
 
-=== Enabled variant of toggleable `tox-button` and `tox-button—​secondary`: it now supports `hover/active/focus/disabled` states.
+=== The `tox-button` and `tox-button-secondary` buttons now support the `hover`, `active`, `focus`, and `disabled` states.
 
-In previous versions of {productname}, the class `--enabled` for `tox-button--secondary` was not defined.
+In previous versions of {productname}, the `--enabled` css class for `tox-button` and `tox-button-secondary` was not defined.
 
-As a consequence, when the button was enabled it wasn't rendered correctly.
+As a consequence, some {productname} toolbar buttons did not render all their possible states as expected when they were selected so as to enable UI option the button represents.
 
-To fix this issue, the class `--enabled` for `tox-button--secondary` has now been defined in {productname} 6.4.2, which now allows the button to render correctly when enabled.
+With this update, the `--enabled` css class has been definded. And {productname} toolbar buttons render all their  possible states as expected when the UI option a button represents is activated.
 
 // [[security-fixes]]
 // == Security fixes

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -76,6 +76,13 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 // {productname} 6.4.2 also includes the following bug fixes:
 
+=== Enabled variant of toggleable `tox-button` and `tox-button—​secondary`: it now supports `hover/active/focus/disabled` states.
+
+In previous versions of {productname}, the class `--enabled` for `tox-button--secondary` was not defined.
+
+As a consequence, when the button was enabled it wasn't rendered correctly.
+
+To fix this issue, the class `--enabled` for `tox-button--secondary` has now been defined in {productname} 6.4.2, which now allows the button to render correctly when enabled.
 
 // [[security-fixes]]
 // == Security fixes

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -82,7 +82,7 @@ In previous versions of {productname}, the `--enabled` css class for `tox-button
 
 As a consequence, some {productname} toolbar buttons did not render all their possible states as expected when they were selected so as to enable UI option the button represents.
 
-With this update, the `--enabled` css class has been definded. And {productname} toolbar buttons render all their  possible states as expected when the UI option a button represents is activated.
+With this update, the `--enabled` css class has been defined. And {productname} toolbar buttons render all their  possible states as expected when the UI option a button represents is activated.
 
 // [[security-fixes]]
 // == Security fixes


### PR DESCRIPTION
Ticket: DOC-1961: Enabled variant of toggleable `tox-button` and `tox-button—​secondary`: it now supports `hover/active/focus/disabled` states.

Changes:
* added `Enabled variant of toggleable `tox-button` and `tox-button—​secondary`: it now supports `hover/active/focus/disabled` states.` to staging.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
