### PR TITLE
DOC-1959: Redial would, in some situations, cause select elements not to have an initial value selected when they should have.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1959: added `Redial would, in some situations, cause select elements not to have an initial value selected when they should have.` to staging.
 - DOC-1935: added `6.4.2-release-notes.adoc`. Added outline to this file for staging.
 
 ### 2023-04-19

--- a/modules/ROOT/pages/6.4.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.1-release-notes.adoc
@@ -1112,4 +1112,4 @@ After conducting a thorough investigation into the new **Advanced Template** plu
 
 We have identified that the "Insert link" dialog is an example of a dialog that does **not work** correctly in this regard, while the "Insert image" dialog functions as expected. These issues were discovered while examining mobile performance within the new **Advanced Template** plugin, and we are working to address them in order to provide a smoother and more user-friendly experience.
 
-Unfortunately, at this time there is no known workarounds for the issue with dialogs.
+Unfortunately, at this time there is no known workaround for the issue with dialogs.

--- a/modules/ROOT/pages/6.4.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.1-release-notes.adoc
@@ -1096,6 +1096,8 @@ There are several known issues in {productname} 6.4.1.
 
 In previous versions of {productname}, a bug was discovered that encountered an issue with the **Accessibility Checker** dropdown. When switching between different issues, the dropdown would not re-populate on existing viewed issues.
 
+NOTE: this issue xref:6.4.2-release-notes.adoc[is addressed] in {productname} 6.4.2.
+
 === Bug with Table Icon in more drawer
 //#TINY-9723
 

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -76,13 +76,13 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 // {productname} 6.4.2 also includes the following bug fixes:
 
-=== Redial would, in some situations, cause select elements not to have an initial value selected when they should have.
+=== Redial would, in some circumstances, cause elements to not have an initial value selected when they should have.
 
-In previous versions of {productname}, the browser did not like switching child elements within the accessibility checker dropdown menu.
+In previous versions of {productname}, the host browser did not properly manage switching child elements when the Accessibility Checker dialog was visible.
 
-As a consequence, the dropdown menu would return without anything being selected by default in some situations.
+As a consequence, the dropdown menu in this dialog would, in some circumstances, present without one of the dropdown menu’s options being selected by default.
 
-To fix this issue, if not explicitly set as empty by the user, {productname} will now populate the element unless user decides otherwise.
+To fix this issue {productname} now populates the element with a default value, unless this menu is explicitly configured as empty by the particular {productname} instance’s configuration.
 
 // [[security-fixes]]
 // == Security fixes

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -84,6 +84,8 @@ As a consequence, the dropdown menu in this dialog would, in some circumstances,
 
 To fix this issue {productname} now populates the element with a default value, unless this menu is explicitly configured as empty by the particular {productname} instance’s configuration.
 
+NOTE: this change also addresses xref:6.4.1-release-notes.adoc#known-issues[a known issue] in the xref:a11ychecker.adoc[Accessibility Checker Premium plugin].
+
 // [[security-fixes]]
 // == Security fixes
 

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -76,6 +76,13 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 // {productname} 6.4.2 also includes the following bug fixes:
 
+=== Redial would, in some situations, cause select elements not to have an initial value selected when they should have.
+
+In previous versions of {productname}, the browser did not like switching child elements within the accessibility checker dropdown menu.
+
+As a consequence, the dropdown menu would return without anything being selected by default in some situations.
+
+To fix this issue, if not explicitly set as empty by the user, {productname} will now populate the element unless user decides otherwise.
 
 // [[security-fixes]]
 // == Security fixes


### PR DESCRIPTION
Ticket: DOC-1959: Redial would, in some situations, cause select elements not to have an initial value selected when they should have.

Changes:
* added `DOC-1959: Redial would, in some situations, cause select elements not to have an initial value selected when they should have.` to staging.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable~)
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
