### PR TITLE
DOC-1958: Tab navigation no longer incorrectly stops at menu buttons within toolbar groups.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1958: added `Tab navigation no longer incorrectly stops at menu buttons within toolbar groups.` to staging.
 - DOC-1935: added `6.4.2-release-notes.adoc`. Added outline to this file for staging.
 
 ### 2023-04-19

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -76,6 +76,16 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 // {productname} 6.4.2 also includes the following bug fixes:
 
+=== Tab navigation no longer incorrectly stops at menu buttons within toolbar groups.
+
+In previous versions of {productname}, having a menu button in the “more” floating toolbar, would cause issues with the navigation behaviour.
+
+As a consquence, Tabbing would stop at the menu button, rather than stopping at the toolbar groups **first** button.
+
+To fix this issue, {productname} removed `tabstopping` capability for menu buttons when they are rendered inside toolbar.
+
+As a result, Tabbing now correctly stops only at the **first** button within the toolbar group.
+
 
 // [[security-fixes]]
 // == Security fixes

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -82,7 +82,7 @@ In previous versions of {productname}, having a menu button in the “more” fl
 
 As a consequence, Tabbing stopped at the menu button, rather than stopping at the toolbar group’s first button.
 
-To fix this issue, {productname} removed `tabstopping` capability for menu buttons when they are rendered inside toolbar.
+To fix this issue, {productname} removed *tabstopping* capability for menu buttons when they are rendered inside toolbar.
 
 As a result, Tabbing now correctly stops at the first button within a toolbar group.
 

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -77,14 +77,11 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 // {productname} 6.4.2 also includes the following bug fixes:
 
 === Tab navigation no longer incorrectly stops at menu buttons within toolbar groups.
+In previous versions of {productname}, menu buttons were assigned an internal attribute.
 
-In previous versions of {productname}, having a menu button in the “more” floating toolbar, would cause issues with the navigation behaviour.
+When the More toolbar button — … — was opened, and the, now-visible, floating toolbar contained a menu button, using the Tab key to navigate through the floating toolbar icons would, because of this attribute and in some circumstances, stop progressing through the toolbar and, sometimes, enter a selection loop.
 
-As a consequence, Tabbing stopped at the menu button, rather than stopping at the toolbar group’s first button.
-
-To fix this issue, {productname} removed *tabstopping* capability for menu buttons when they are rendered inside toolbar.
-
-As a result, Tabbing now correctly stops at the first button within a toolbar group.
+For this update this internal attribute has been removed and using the Tab key to activate floating toolbar icons progresses through these icons as expected.
 
 
 // [[security-fixes]]

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -80,7 +80,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 In previous versions of {productname}, having a menu button in the “more” floating toolbar, would cause issues with the navigation behaviour.
 
-As a consquence, Tabbing would stop at the menu button, rather than stopping at the toolbar groups **first** button.
+As a consequence, Tabbing stopped at the menu button, rather than stopping at the toolbar group’s first button.
 
 To fix this issue, {productname} removed `tabstopping` capability for menu buttons when they are rendered inside toolbar.
 

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -84,7 +84,7 @@ As a consequence, Tabbing stopped at the menu button, rather than stopping at th
 
 To fix this issue, {productname} removed `tabstopping` capability for menu buttons when they are rendered inside toolbar.
 
-As a result, Tabbing now correctly stops only at the **first** button within the toolbar group.
+As a result, Tabbing now correctly stops at the first button within a toolbar group.
 
 
 // [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-1958: Tab navigation no longer incorrectly stops at menu buttons within toolbar groups.

Changes:
* added `DOC-1958: Tab navigation no longer incorrectly stops at menu buttons within toolbar groups.` to staging.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
