### PR TITLE
DOC-1957: Selection was not correctly scrolled horizontally into view when using the  API.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1957: added `Selection was not correctly scrolled horizontally into view when using the `selection.scrollIntoView` API.` to staging.
 - DOC-1935: added `6.4.2-release-notes.adoc`. Added outline to this file for staging.
 
 ### 2023-04-19

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -78,11 +78,11 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 === Selection was not correctly scrolled horizontally into view when using the `selection.scrollIntoView` API.
 
-In previous versions of {productname}, the function `scrollToMarker` calculated how much should be scrolled vertically, but the calculation for for the horizontal scroll, was set to the position `left` of the marker.
+In previous versions of {productname}, the `scrollToMarker` function manually calculated how much should be scrolled vertically. The horizontal scroll amount, however, was set to a specific value: left of the marker.
 
-As a consequence of this, in some situations the horizontal scroll would not scroll to the correct position.
+As a consequence, in some circumstances {productname} editor instances did not scroll to the correct horizontal position.
 
-To fix this, instead of manually calculating the vertical and horizontal position, {productname} 6.4.2 now uses a native `scrollIntoView` to move the scroll to the marker.
+To fix this, instead of manually calculating the vertical and horizontal marker position, {productname} 6.4.2 now uses a native `scrollIntoView` function to keep the marker in the viewport.
 
 // [[security-fixes]]
 // == Security fixes

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -76,6 +76,13 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 // {productname} 6.4.2 also includes the following bug fixes:
 
+=== Selection was not correctly scrolled horizontally into view when using the `selection.scrollIntoView` API.
+
+In previous versions of {productname}, the function `scrollToMarker` calculated how much should be scrolled vertically, but the calculation for for the horizontal scroll, was set to the position `left` of the marker.
+
+As a consequence of this, in some situations the horizontal scroll would not scroll to the correct position.
+
+To fix this, instead of manually calculating the vertical and horizontal position, {productname} 6.4.2 now uses a native `scrollIntoView` to move the scroll to the marker.
 
 // [[security-fixes]]
 // == Security fixes


### PR DESCRIPTION
Ticket: DOC-1957: Selection was not correctly scrolled horizontally into view when using the  API.

Changes:
* added `DOC-1957: Selection was not correctly scrolled horizontally into view when using the  API.` to staging.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable~)
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
