### PR TITLE
DOC-1953: Docs for the new `advtemplate_templates` option.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1953: new file, `/modules/ROOT/partials/configuration/advtemplate_templates.adoc`, added. Documentation of new Advanced Template plugin option, `advtemplate_templates`, added to new file.
+
 ### 2023-05-03
 
 - DOC-1971: Updates to `staging` prior to `release` 6.4.2.

--- a/modules/ROOT/examples/live-demos/advtemplate-predefined/index.html
+++ b/modules/ROOT/examples/live-demos/advtemplate-predefined/index.html
@@ -1,0 +1,10 @@
+<textarea id="advanced-template-predefined">
+  <h3>Inserting a template</h3>
+  <p>To insert a template</p>
+  <ol>
+    <li>select <strong>Insert template...</strong> from the <strong>Insert</strong> menu or<br />
+    select the <strong>Insert template</strong> toolbar button.</li>
+    <li>select the template to add to the TinyMCE document from the <strong>Templates</strong> dialog that presents.</li>
+    <li>click <strong>Insert</strong> or press <strong>Return</strong>.</li>
+  </ol>
+</textarea>

--- a/modules/ROOT/examples/live-demos/advtemplate-predefined/index.html
+++ b/modules/ROOT/examples/live-demos/advtemplate-predefined/index.html
@@ -1,8 +1,8 @@
 <textarea id="advanced-template-predefined">
   <h3>Inserting a template</h3>
-  <p>To insert a template</p>
+  <p>To insert a template:</p>
   <ol>
-    <li>select <strong>Insert template...</strong> from the <strong>Insert</strong> menu or<br />
+    <li>select <strong>Insert template…</strong> from the <strong>Insert</strong> menu or<br />
     select the <strong>Insert template</strong> toolbar button.</li>
     <li>select the template to add to the TinyMCE document from the <strong>Templates</strong> dialog that presents.</li>
     <li>click <strong>Insert</strong> or press <strong>Return</strong>.</li>

--- a/modules/ROOT/examples/live-demos/advtemplate-predefined/index.html
+++ b/modules/ROOT/examples/live-demos/advtemplate-predefined/index.html
@@ -2,7 +2,7 @@
   <h3>Inserting a template</h3>
   <p>To insert a template:</p>
   <ol>
-    <li>select <strong>Insert template…</strong> from the <strong>Insert</strong> menu or<br />
+    <li>select <strong>Template…</strong> from the <strong>Insert</strong> menu or<br />
     select the <strong>Insert template</strong> toolbar button.</li>
     <li>select the template to add to the TinyMCE document from the <strong>Templates</strong> dialog that presents.</li>
     <li>click <strong>Insert</strong> or press <strong>Return</strong>.</li>

--- a/modules/ROOT/examples/live-demos/advtemplate-predefined/index.js
+++ b/modules/ROOT/examples/live-demos/advtemplate-predefined/index.js
@@ -1,0 +1,57 @@
+const advtemplate_templates = [
+  {
+    title: 'Quick replies',
+    items: [
+      {
+        title: 'Message received',
+        content: '<p dir="ltr">Hey {{Customer.FirstName}}!</p>\n<p dir="ltr">Just a quick note to say we&rsquo;ve received your message, and will get back to you within 48 hours.</p>\n<p dir="ltr">For reference, your ticket number is: {{Ticket.Number}}</p>\n<p dir="ltr">Should you have any questions in the meantime, just reply to this email and it will be attached to this ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Regards,</p>\n<p dir="ltr">{{Agent.FirstName}}</p>'
+      },
+      {
+        title: 'Thanks for the feedback',
+        content: '<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p dir="ltr">We appreciate you taking the time to provide feedback on {{Product.Name}}.</p>\n<p dir="ltr">It sounds like it wasn&rsquo;t able to fully meet your expectations, for which we apologize. Rest assured our team looks at each piece of feedback and uses it to decide what to focus on next with {{Product.Name}}.</p>\n<p dir="ltr"><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best, and let us know if there&rsquo;s anything else we can do to help.</p>\n<p dir="ltr">-{{Agent.FirstName}}</p>'
+      },
+      {
+        title: 'Still working on case',
+        content: '<p dir="ltr"><img src="https://lh4.googleusercontent.com/-H7w_COxrsy2fVpjO6RRnoBsujhaLyg6AXux5zidqmQ_ik1mrE6BtnaTUdWYQuVbtKpviRqQiuPBOHNGUsEXvrRliEHc4-hKDrCLgQQ9Co-MI4uY2ehUvYtU1nn3EeS0WiUzST-7MQB2Z5YFXrMDwRk" width="320" height="240"></p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p dir="ltr">Just a quick note to let you know we&rsquo;re still working on your case. It&rsquo;s taking a bit longer than we hoped, but we&rsquo;re aiming to get you an answer in the next 48 hours.</p>\n<p dir="ltr">Stay tuned,</p>\n<p dir="ltr">{{Agent.FirstName}}</p>'
+      }
+    ]
+  },
+  {
+    title: 'Closing tickets',
+    items: [
+      {
+        title: 'Closing ticket',
+        content: '<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p dir="ltr">We haven&rsquo;t heard back from you in over a week, so we have gone ahead and closed your ticket number {{Ticket.Number}}.</p>\n<p dir="ltr">If you&rsquo;re still running into issues, not to worry, just reply to this email and we will re-open your ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best,</p>\n<p dir="ltr">{{Agent.FirstName}}</p>'
+      },
+      {
+        title: 'Post-call survey',
+        content: '<p dir="ltr">Hey {{Customer.FirstName}}!</p>\n<p dir="ltr">&nbsp;</p>\n<p dir="ltr">How did we do?</p>\n<p dir="ltr">If you have a few moments, we&rsquo;d love you to fill out our post-support survey: {{Survey.Link}}</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks in advance!<br>{{Company.Name}} Customer Support</p>'
+      }
+    ]
+  },
+  {
+    title: 'Product support',
+    items: [
+      {
+        title: 'How to find model number',
+        content: '<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">My name is {{Agent.FirstName}} and I will be glad to assist you today.</p>\n<p dir="ltr">To troubleshoot your issue, we first need your model number, which can be found on the underside of your product beneath the safety warning label.&nbsp;</p>\n<p dir="ltr">It should look something like the following: XX.XXXXX.X</p>\n<p dir="ltr">Once you send it over, I will advise on next steps.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks!</p>\n<p dir="ltr">{{Agent.FirstName}}</p>'
+      },
+      {
+        title: 'Support escalation',
+        content: '<p dir="ltr"><img src="https://lh3.googleusercontent.com/z4hleIymnERrS9OQQMBwmkqVne8kYZA0Kly9Ny64pp4fi47CWWUy30Q0-UkjGf-K-50zrfR-wltHUTbExzZ7VUSUAUG60Fll5f2E0UZcKjKoa-ZVlIcuOoe-RRckFWqiihUOfVds7pXtM8Y59uy2hpw" width="295" height="295"></p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p dir="ltr">We have escalated your ticket {{Ticket.Number}} to second-level support.</p>\n<p dir="ltr">You should hear back from the new agent on your case, {{NewAgent.FirstName}}, shortly.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks,</p>\n<p dir="ltr">{{Company.Name}} Customer Support</p>'
+      }
+    ]
+  }
+];
+
+tinymce.init({
+  selector: "textarea#advanced-template-predefined",
+    plugins: [
+        "advlist", "anchor", "autolink", "charmap", "code", "fullscreen", 
+        "help", "image", "insertdatetime", "link", "lists", "media", 
+        "preview", "searchreplace", "table", "visualblocks", "advtemplate"
+    ],
+  contextmenu: 'advtemplate',
+  toolbar: "inserttemplate undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
+  advtemplate_templates
+});

--- a/modules/ROOT/examples/live-demos/advtemplate/index.js
+++ b/modules/ROOT/examples/live-demos/advtemplate/index.js
@@ -254,7 +254,6 @@ const advtemplate_get_template = async (id) => {
   try {
     const [template ] = store.getTemplate(id)
     return template
-	console.log('template', template)
   } catch (e) {
     console.error(e)
   }

--- a/modules/ROOT/examples/live-demos/advtemplate/index.js
+++ b/modules/ROOT/examples/live-demos/advtemplate/index.js
@@ -165,7 +165,7 @@ const create = (data = []) => {
   }
 
   const deleteTemplate = (id) => {
-    const [template, categoryId] = getTemplate(id)
+    const [, categoryId] = getTemplate(id)
     const parent = getParent(categoryId)
     parent.items = filterOut(parent.items, id)
     delete templateIndex[id]

--- a/modules/ROOT/examples/live-demos/advtemplate/index.js
+++ b/modules/ROOT/examples/live-demos/advtemplate/index.js
@@ -1,58 +1,325 @@
-const advtemplate_templates = [
+const data = [
   {
-    id: '1',
     title: 'Quick replies',
     items: [
       {
-        id: '2',
         title: 'Message received',
-        content: '<p dir="ltr"></p>\n<p dir="ltr">Just a quick note to say we&rsquo;ve received your message, and will get back to you within 48 hours.</p>\n<p dir="ltr">For reference, your ticket number is: </p>\n<p dir="ltr">Should you have any questions in the meantime, just reply to this email and it will be attached to this ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Regards,</p>\n<p dir="ltr"></p>'
+        content: '<p dir="ltr">Hey {{Customer.FirstName}}!</p>\n<p dir="ltr">Just a quick note to say we&rsquo;ve received your message, and will get back to you within 48 hours.</p>\n<p dir="ltr">For reference, your ticket number is: {{Ticket.Number}}</p>\n<p dir="ltr">Should you have any questions in the meantime, just reply to this email and it will be attached to this ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Regards,</p>\n<p dir="ltr">{{Agent.FirstName}}</p>'
       },
       {
-        id: '3',
         title: 'Thanks for the feedback',
-        content: '<p dir="ltr">,</p>\n<p dir="ltr">We appreciate you taking the time to provide feedback on .</p>\n<p dir="ltr">It sounds like it wasn&rsquo;t able to fully meet your expectations, for which we apologize. Rest assured our team looks at each piece of feedback and uses it to decide what to focus on next with .</p>\n<p dir="ltr"><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best, and let us know if there&rsquo;s anything else we can do to help.</p>\n<p dir="ltr">-</p>'
+        content: '<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p dir="ltr">We appreciate you taking the time to provide feedback on {{Product.Name}}.</p>\n<p dir="ltr">It sounds like it wasn&rsquo;t able to fully meet your expectations, for which we apologize. Rest assured our team looks at each piece of feedback and uses it to decide what to focus on next with {{Product.Name}}.</p>\n<p dir="ltr"><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best, and let us know if there&rsquo;s anything else we can do to help.</p>\n<p dir="ltr">-{{Agent.FirstName}}</p>'
       },
       {
-        id: '6',
         title: 'Still working on case',
-        content: '<p dir="ltr"><img src="https://lh4.googleusercontent.com/-H7w_COxrsy2fVpjO6RRnoBsujhaLyg6AXux5zidqmQ_ik1mrE6BtnaTUdWYQuVbtKpviRqQiuPBOHNGUsEXvrRliEHc4-hKDrCLgQQ9Co-MI4uY2ehUvYtU1nn3EeS0WiUzST-7MQB2Z5YFXrMDwRk" width="320" height="240"></p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">,</p>\n<p dir="ltr">Just a quick note to let you know we&rsquo;re still working on your case. It&rsquo;s taking a bit longer than we hoped, but we&rsquo;re aiming to get you an answer in the next 48 hours.</p>\n<p dir="ltr">Stay tuned,</p>\n<p dir="ltr"></p>'
+        content: '<p dir="ltr"><img src="https://lh4.googleusercontent.com/-H7w_COxrsy2fVpjO6RRnoBsujhaLyg6AXux5zidqmQ_ik1mrE6BtnaTUdWYQuVbtKpviRqQiuPBOHNGUsEXvrRliEHc4-hKDrCLgQQ9Co-MI4uY2ehUvYtU1nn3EeS0WiUzST-7MQB2Z5YFXrMDwRk" width="320" height="240"></p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p dir="ltr">Just a quick note to let you know we&rsquo;re still working on your case. It&rsquo;s taking a bit longer than we hoped, but we&rsquo;re aiming to get you an answer in the next 48 hours.</p>\n<p dir="ltr">Stay tuned,</p>\n<p dir="ltr">{{Agent.FirstName}}</p>'
       }
     ]
   },
   {
-    id: '4',
     title: 'Closing tickets',
     items: [
       {
-        id: '7',
         title: 'Closing ticket',
-        content: '<p dir="ltr">Hi ,</p>\n<p dir="ltr">We haven&rsquo;t heard back from you in over a week, so we have gone ahead and closed your ticket, .</p>\n<p dir="ltr">If you&rsquo;re still running into issues, reply to this email and we will re-open the ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best,</p>\n<p dir="ltr"></p>'
+        content: '<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p dir="ltr">We haven&rsquo;t heard back from you in over a week, so we have gone ahead and closed your ticket number {{Ticket.Number}}.</p>\n<p dir="ltr">If you&rsquo;re still running into issues, not to worry, just reply to this email and we will re-open your ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best,</p>\n<p dir="ltr">{{Agent.FirstName}}</p>'
       },
       {
-        id: '8',
         title: 'Post-call survey',
-        content: '<p dir="ltr">Hey !</p>\n<p dir="ltr">&nbsp;</p>\n<p dir="ltr">How did we do?</p>\n<p dir="ltr">If you have a few moments, we&rsquo;d love you to fill out our post-support survey: </p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks in advance!<br> Customer Support</p>'
+        content: '<p dir="ltr">Hey {{Customer.FirstName}}!</p>\n<p dir="ltr">&nbsp;</p>\n<p dir="ltr">How did we do?</p>\n<p dir="ltr">If you have a few moments, we&rsquo;d love you to fill out our post-support survey: {{Survey.Link}}</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks in advance!<br>{{Company.Name}} Customer Support</p>'
       }
     ]
   },
   {
-    id: '5',
     title: 'Product support',
     items: [
       {
-        id: '9',
-        title: 'How to find the model number',
-        content: '<p dir="ltr">,</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">My name is  and I will be assisting you today.</p>\n<p dir="ltr">To troubleshoot your issue, we first need the model number</p>\n<p>This can be found on the underside of your product immediately below the safety warning label.&nbsp;</p>\n<p dir="ltr">It should look something like the following: XX.XXXXX.X</p>\n<p dir="ltr">Once you send it over, I will advise on the next steps.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks!</p>\n<p dir="ltr"></p>'
+        title: 'How to find model number',
+        content: '<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">My name is {{Agent.FirstName}} and I will be glad to assist you today.</p>\n<p dir="ltr">To troubleshoot your issue, we first need your model number, which can be found on the underside of your product beneath the safety warning label.&nbsp;</p>\n<p dir="ltr">It should look something like the following: XX.XXXXX.X</p>\n<p dir="ltr">Once you send it over, I will advise on next steps.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks!</p>\n<p dir="ltr">{{Agent.FirstName}}</p>'
       },
       {
-        id: '10',
         title: 'Support escalation',
-        content: '<p dir="ltr"><img src="https://lh3.googleusercontent.com/z4hleIymnERrS9OQQMBwmkqVne8kYZA0Kly9Ny64pp4fi47CWWUy30Q0-UkjGf-K-50zrfR-wltHUTbExzZ7VUSUAUG60Fll5f2E0UZcKjKoa-ZVlIcuOoe-RRckFWqiihUOfVds7pXtM8Y59uy2hpw" width="295" height="295"></p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">,</p>\n<p dir="ltr">We have escalated your ticket  to second-level support.</p>\n<p dir="ltr">You should hear back from the new agent on your case, , shortly.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks,</p>\n<p dir="ltr"> Customer Support</p>'
+        content: '<p dir="ltr"><img src="https://lh3.googleusercontent.com/z4hleIymnERrS9OQQMBwmkqVne8kYZA0Kly9Ny64pp4fi47CWWUy30Q0-UkjGf-K-50zrfR-wltHUTbExzZ7VUSUAUG60Fll5f2E0UZcKjKoa-ZVlIcuOoe-RRckFWqiihUOfVds7pXtM8Y59uy2hpw" width="295" height="295"></p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p dir="ltr">We have escalated your ticket {{Ticket.Number}} to second-level support.</p>\n<p dir="ltr">You should hear back from the new agent on your case, {{NewAgent.FirstName}}, shortly.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks,</p>\n<p dir="ltr">{{Company.Name}} Customer Support</p>'
       }
     ]
   }
 ];
+
+
+class StoreError extends Error {
+  constructor(status, message) {
+    super(message);
+    this.name = "StoreError";
+    this.status = status
+  }
+}
+
+const isStoreError = (e) =>
+  e instanceof StoreError
+
+
+const create = (data = []) => {
+  const store = {
+    items: []
+  }
+
+  let id = 0;
+  const genId = () => (++id).toString()
+  const categoryIndex = {}
+  const templateIndex = {}
+
+  const isNonEmptyString = (value) =>
+    typeof value === 'string' && value.length > 0
+
+  const isPositiveInteger = (str) => {
+    const number = Number(str);
+    return Number.isInteger(number) && number > 0
+  }
+
+  const isValidId = (value) =>
+  isNonEmptyString(value) && isPositiveInteger(value)
+
+  const validate = (value, predicate, message) => {
+    if (predicate(value)) {
+      return
+    } else {
+      throw new StoreError(400, message)
+    }
+  }
+
+  const validateId = (id) =>
+    validate(id, isValidId, `Invalid "id" parameter: ${id}`)
+
+  const validateTitle = (title) =>
+    validate(title, isNonEmptyString, `Invalid "title" parameter: ${title}`)
+
+  const getParent = (id) =>
+    typeof id === 'undefined' ? store : getCategory(id);
+
+  const filterOut = (items, id) =>
+    items.filter((item) => item.id !== id)
+
+  const list = () => {
+    const resp = [...store.items]
+    return resp
+  }
+
+  const getCategory = (id) => {
+    validate(id, isValidId, `Invalid "id" parameter: ${id}`)
+    const category = categoryIndex[id]
+    if (typeof category !== 'undefined'){
+      return category
+    } else {
+      throw new StoreError(404, 'Category not found')
+    }
+  }
+
+  const getTemplate = (id) => {
+    validateId(id)
+    const res = templateIndex[id]
+    if (typeof res !== 'undefined'){
+      return res
+    } else {
+      throw new StoreError(404, 'Template not found')
+    }
+  }
+
+  const createCategory = (title) => {
+    validateTitle(title)
+
+    const id = genId()
+    const category = {
+      id,
+      title,
+      items: []
+    }
+    categoryIndex[id] = category;
+    store.items = [...store.items, category]
+    return category
+  }
+
+  const createTemplate = (title, content, categoryId) => {
+    validateTitle(title)
+    validate(content, isNonEmptyString, `Invalid "content" parameter: ${content}`)
+    const id = genId()
+    const template = {
+      id,
+      title,
+      content,
+    }
+    const parent = getParent(categoryId)
+    parent.items = [...parent.items, template]
+    templateIndex[id] = [template, categoryId];
+    return template
+  }
+
+  const renameCategory = (id, title) => {
+    validateTitle(title)
+    const category = getCategory(id)
+    category.title = title;
+  }
+
+  const renameTemplate = (id, title) => {
+    validateTitle(title)
+    const [template] = getTemplate(id)
+    template.title = title;
+  }
+
+  const deleteTemplate = (id) => {
+    const [template, categoryId] = getTemplate(id)
+    const parent = getParent(categoryId)
+    parent.items = filterOut(parent.items, id)
+    delete templateIndex[id]
+  }
+
+  const deleteCategory = (id) => {
+    const category = getCategory(id);
+    category.items.forEach((template) => deleteTemplate(template.id))
+    store.items = filterOut(store.items, id)
+    delete categoryIndex[category.id]
+  }
+
+  const moveTemplate = (id, newCategoryId) => {
+    const [template, categoryId] = getTemplate(id)
+    if (categoryId === newCategoryId) {
+      return
+    }
+    const oldParent = getParent(categoryId)
+    const newParent = getParent(newCategoryId)
+    newParent.items = [...newParent.items, template]
+    oldParent.items = filterOut(oldParent.items, id)
+    templateIndex[id] = [template, newCategoryId]
+  }
+
+  const moveCategoryItems = (id, newCategoryId) => {
+    const oldCategory = getCategory(id)
+    if (id === newCategoryId) {
+      return
+    }
+    oldCategory.items.forEach((item) => moveTemplate(item.id, newCategoryId))
+  }
+
+  const load = (items, id) => {
+    for (const item of items) {
+      if (item.items) {
+        const category = createCategory(item.title);
+        load(item.items, category.id );
+      } else {
+        createTemplate(item.title, item.content, id);
+      }
+    }
+  };
+
+  load(data);
+
+  return {
+    list,
+    getTemplate,
+    createCategory,
+    createTemplate,
+    renameCategory,
+    renameTemplate,
+    deleteTemplate,
+    deleteCategory,
+    moveTemplate,
+    moveCategoryItems,
+  }
+}
+
+
+const store = create(data);
+const advtemplate_list = async () => store.list()
+
+
+const advtemplate_create_category = async (title) => {
+  try {
+    return store.createCategory(title)
+  } catch (e) {
+    console.error(e)
+    throw new Error('Failed to create category')
+  }
+}
+  
+
+const advtemplate_create_template = async (title, content, categoryId) => {
+  try {
+    return store.createTemplate(title, content, categoryId)
+  } catch (e) {
+    console.error(e)
+    throw new Error('Failed to create template')
+  }
+}
+  
+
+const advtemplate_get_template = async (id) => {
+  try {
+    const [template ] = store.getTemplate(id)
+    return template
+	console.log('template', template)
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+const advtemplate_rename_category = async (id, title) => {
+  try {
+    store.renameCategory(id, title)
+    return {}
+  } catch (e) {
+    console.error(e)
+    throw new Error('Failed to rename category')
+  }
+}
+  
+const advtemplate_rename_template = async (id, title) => {
+  try {
+    store.renameTemplate(id, title)
+    return {}
+  } catch (e) {
+    console.error(e)
+    throw new Error('Failed to rename template')
+  }
+}
+
+const advtemplate_delete_category = async (id) => {
+  try {
+    store.deleteCategory(id)
+    return {}
+  } catch (e) {
+    console.error(e)
+    throw new Error('Failed to delete category')
+  }
+}
+
+const advtemplate_delete_template = async (id) => {
+  try {
+    store.deleteTemplate(id)
+    return {}
+  } catch (e) {
+    console.error(e)
+    throw new Error('Failed to delete template')
+  }
+}
+
+
+const advtemplate_move_template = async (id, categoryId) => {
+  try {
+    store.moveTemplate(id, categoryId)
+    return {}
+  } catch (e) {
+    console.error(e)
+    throw new Error('Failed to move template')
+  }
+}
+
+const advtemplate_move_category_items = async (id, categoryId) => {
+  try {
+    store.moveCategoryItems(id, categoryId)
+    return {}
+  } catch (e) {
+    console.error(e)
+    throw new Error('Failed to move category items')
+  }
+}
 
 tinymce.init({
   selector: "textarea#advanced-template",
@@ -61,7 +328,19 @@ tinymce.init({
         "help", "image", "insertdatetime", "link", "lists", "media", 
         "preview", "searchreplace", "table", "visualblocks", "advtemplate"
     ],
-	advtemplate_templates,
   contextmenu: 'advtemplate',
-  toolbar: "addtemplate inserttemplate | undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image"
+  toolbar: "addtemplate inserttemplate | undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
+  advtemplate_list,
+	advtemplate_get_template,
+	
+	advtemplate_create_category,
+	advtemplate_create_template,
+	
+	advtemplate_rename_category,
+	advtemplate_move_category_items,
+	advtemplate_delete_category,
+	
+	advtemplate_rename_template,
+	advtemplate_move_template,
+	advtemplate_delete_template,
 });

--- a/modules/ROOT/images/icons/template-add.svg
+++ b/modules/ROOT/images/icons/template-add.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M9 12v4H5a2 2 0 0 0-2 2v3h9.3a6 6 0 0 1-.3-2H5v-1h7a6 6 0 0 1 .8-2H11v-5l-.8-.6a3 3 0 1 1 3.6 0l-.8.6v4.7a6 6 0 0 1 2-1.9V12a5 5 0 1 0-6 0Z"></path>
+  <path d="M18 15c.5 0 1 .4 1 .9V18h2a1 1 0 0 1 .1 2H19v2a1 1 0 0 1-2 .1V20h-2a1 1 0 0 1-.1-2H17v-2c0-.6.4-1 1-1Z"></path>
+</svg>

--- a/modules/ROOT/pages/advanced-templates.adoc
+++ b/modules/ROOT/pages/advanced-templates.adoc
@@ -22,8 +22,8 @@ IMPORTANT: This initial {pluginname} release does not support template editing. 
 === Inserting a template
 To insert a template
 
-. Select *Template...* from the *Insert* menu or
-. Select the *Insert template* image:icons/template.svg[Insert template] toolbar button.
+. Select *Template…* from the *Insert* menu or +
+  Select the *Insert template* image:icons/template.svg[Insert template] toolbar button.
 . Select the template to add to the TinyMCE document from the _Templates_ dialog that presents.
 . Click *Insert* or press *Return*.
 
@@ -46,51 +46,60 @@ Then, in the _New template_ dialog that presents
 === Adding a new category
 To add a new category
 
-. Select *Template...* from the *Insert* menu to open _Templates_ dialog.
-. Click on the *New category* button in the footer. This will pop up the *New category* form.
+. Select *Template…* from the *Insert* menu to open the _Templates_ dialog.
+. Click on the *New category* button in the dialog footer. +
+  The *New category* form will pop up.
 . In the *New category* form, enter the name of the new category you want to add.
 . Click the *Save* button to submit the form.
-. After saving, the new category should appear in the Tree component of the _Templates_ dialog.
+. After saving, the new category will appear in the Tree component of the _Templates_ dialog.
 
 === Searching for templates
 To search for a template
 
-. Select *Template...* from the *Insert* menu to open _Templates_ dialog.
+. Select *Template…* from the *Insert* menu to open the _Templates_ dialog.
 . Enter the name of the template you are searching for in the *Search* field.
-. As you type, the dialog will update and display a list of matching templates in the Tree component of the dialog.
+. As you type, the displayed list of matching templates updates in real-time in the dialog’s Tree component.
 
 === Template list management
 To manage the template list
 
-. Select *Template...* from the *Insert* menu to open _Templates_ dialog.
-. Select the template or the category that you want to modify.
-. Click on the three dots menu for the selected item. This will open the actions menu.
-. From the actions menu, choose the appropriate operation based on your needs:
+. Select *Template…* from the *Insert* menu to open the _Templates_ dialog.
+. Select the template or the category you want to modify.
+. Click on the three dots menu for the selected item. +
+  The *actions* menu will open.
+. From the *actions* menu, choose the appropriate operation based on your requirements:
   * Rename category/template.
   * Move template to another category.
   * Move all category items to another category.
   * Delete template/category.
 
 == Interactive examples
-There are two approaches to using the Advanced Template Premium plugin:
 
-. _Fixed Template List._
-For users who work with a fixed template list that does not require modification, you can provide the list directly through the editor init configuration using the xref:advtemplate_templates[`+advtemplate_templates+` option]. Please refer to this interactive xref:#predifined-list-config-example[example] for guidance on this approach.
+There are two approaches to using the Advanced Template Premium plugin: fixed template lists and user-modifiable template lists.
 
-. _User-Modifiable Template List._
-If the template list is intended to be modified by the user, the plugin should be configured with functional options to enable communication with a remote template storage service. Please refer to this interactive xref:#remote-config-example[example] for guidance on configuring the plugin to support user-modifiable template lists.
+=== Fixed template lists
+
+For users who work with a fixed template list that does not require modification, you can provide a list directly through the {productname} init configuration using the xref:advtemplate_templates[`+advtemplate_templates+` option].
+
+The interactive xref:#predefined-list-config-example[predefined list example] provides guidance for this approach.
+
+=== User-modifiable template lists
+
+If the intention is for the template list to be end-user modifiable, the {pluginname} plugin should be configured with options to enable communication with a remote Template storage service.
+
+The interactive xref:#remote-config-example[remote storage configuration example] provides guidance on configuring the {pluginname} plugin to support user-modifiable template lists.
 
 [[remote-config-example]]
 === Configuring the Advanced Template plugin to interact with a remote backend service via REST API.
 liveDemo::{plugincode}[]
 
-[[predifined-list-config-example]]
+[[predefined-list-config-example]]
 === Configuring the Advanced Template plugin to use a static list of predefined templates.
 liveDemo::{plugincode}-predefined[]
 
 == Basic setup
 
-To setup the {pluginname} plugin user-interface in the editor
+To setup the {pluginname} plugin user-interface in the editor:
 
 * add `{plugincode}` to the `plugins` option in the editor configuration;
 

--- a/modules/ROOT/pages/advanced-templates.adoc
+++ b/modules/ROOT/pages/advanced-templates.adoc
@@ -117,7 +117,7 @@ There are two approaches to using the Advanced Template Premium plugin: fixed te
 
 === Fixed template lists
 
-For users who work with a fixed template list that does not require modification, you can provide a list directly through the {productname} init configuration using the xref:advtemplate_templates[`+advtemplate_templates+` option].
+For users who work with a fixed template list that does not require modification, you can provide a list directly through the {productname} init configuration using the xref:advtemplate_templates[`+advtemplate_templates+`] option.
 
 The following interactive predefined list example provides guidance for this approach.
 

--- a/modules/ROOT/pages/advanced-templates.adoc
+++ b/modules/ROOT/pages/advanced-templates.adoc
@@ -17,6 +17,61 @@ They can also be added to a {productname} instance by end-users selecting conten
 
 IMPORTANT: This initial {pluginname} release does not support template editing. To update a particular template; insert the template into an editor; make edits; select the, now edited, content; and then create a new template (using, for example, the *Tools > Save as Template…* menu item).
 
+
+== Using the Advanced Template plugin
+=== Inserting a template
+To insert a template
+
+. Select *Template...* from the *Insert* menu or
+. Select the *Insert template* image:icons/template.svg[Insert template] toolbar button.
+. Select the template to add to the TinyMCE document from the _Templates_ dialog that presents.
+. Click *Insert* or press *Return*.
+
+=== Adding a new template
+To add a new template
+
+. Select the material in the TinyMCE document that is going to be the new template and
+
+. Save the template using one of the following methods:
+     * Select *Save as template…* from the *Tools* menu.
+     * Select *Save as template…* from the context menu.
+     * Select the *Save as template* image:icons/template-add.svg[Save as template] toolbar button.
+
+Then, in the _New template_ dialog that presents
+
+. Enter a name for the new template in the *Template* name field;
+. Select a category for the new template from the *Category* pop-up menu; and
+. Click *Save* or press *Return*.
+
+=== Adding a new category
+To add a new category
+
+. Select *Template...* from the *Insert* menu to open _Templates_ dialog.
+. Click on the *New category* button in the footer. This will pop up the *New category* form.
+. In the *New category* form, enter the name of the new category you want to add.
+. Click the *Save* button to submit the form.
+. After saving, the new category should appear in the Tree component of the _Templates_ dialog.
+
+=== Searching for templates
+To search for a template
+
+. Select *Template...* from the *Insert* menu to open _Templates_ dialog.
+. Enter the name of the template you are searching for in the *Search* field.
+. As you type, the dialog will update and display a list of matching templates in the Tree component of the dialog.
+
+=== Template list management
+To manage the template list
+
+. Select *Template...* from the *Insert* menu to open _Templates_ dialog.
+. Select the template or the category that you want to modify.
+. Click on the three dots menu for the selected item. This will open the actions menu.
+. From the actions menu, choose the appropriate operation based on your needs:
+  * Rename category/template.
+  * Move template to another category.
+  * Move all category items to another category.
+  * Delete template/category.
+
+== Interactive examples
 There are two approaches to using the Advanced Template Premium plugin:
 
 . _Fixed Template List._
@@ -25,7 +80,6 @@ For users who work with a fixed template list that does not require modification
 . _User-Modifiable Template List._
 If the template list is intended to be modified by the user, the plugin should be configured with functional options to enable communication with a remote template storage service. Please refer to this interactive xref:#remote-config-example[example] for guidance on configuring the plugin to support user-modifiable template lists.
 
-== Interactive examples
 [[remote-config-example]]
 === Configuring the Advanced Template plugin to interact with a remote backend service via REST API.
 liveDemo::{plugincode}[]

--- a/modules/ROOT/pages/advanced-templates.adoc
+++ b/modules/ROOT/pages/advanced-templates.adoc
@@ -73,6 +73,44 @@ To manage the template list
   * Move all category items to another category.
   * Delete template/category.
 
+== Basic setup
+
+To setup the {pluginname} plugin user-interface in the editor:
+
+* add `{plugincode}` to the `plugins` option in the editor configuration;
+
+* add `inserttemplate` and `addtemplate` to the `toolbar` option in the editor configuration;
+
+* add each {pluginname} option to the editor configuration;
+
+For example:
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your html
+  plugins: "advtemplate",
+  toolbar: "inserttemplate addtemplate",
+  contextmenu: "advtemplate",
+  // Each of the following options must be defined as
+  // a function that returns a Promise.
+  // Please find the specific details for each option below.
+  advtemplate_list,
+  advtemplate_get_template,
+  advtemplate_create_category,
+  advtemplate_create_template,
+  advtemplate_rename_category,
+  advtemplate_rename_template,
+  advtemplate_delete_template,
+  advtemplate_delete_category,
+  advtemplate_move_template,
+  advtemplate_move_category_items
+});
+----
+
+NOTE: The undefined options in the above example must be defined. See the xref:options[Options] below for specific details on each function.
+
+
 == Interactive examples
 
 There are two approaches to using the Advanced Template Premium plugin: fixed template lists and user-modifiable template lists.
@@ -97,41 +135,7 @@ The following interactive remote storage configuration example provides guidance
 ==== Configuring the Advanced Template plugin to interact with a remote backend service via REST API.
 liveDemo::{plugincode}[]
 
-== Basic setup
-
-To setup the {pluginname} plugin user-interface in the editor:
-
-* add `{plugincode}` to the `plugins` option in the editor configuration;
-
-* add `inserttemplate` and `addtemplate` to the `toolbar` option in the editor configuration;
-
-* add each {pluginname} option to the editor configuration;
-
-For example:
-
-[source,js]
-----
-tinymce.init({
-  selector: 'textarea',  // change this value according to your html
-  plugins: "advtemplate",
-  toolbar: "inserttemplate addtemplate",
-  contextmenu: "advtemplate",
-  // Each of the following options should be defined as
-  // a function that returns a Promise.
-  // Please find the specific details for each option below.
-  advtemplate_list,
-  advtemplate_get_template,
-  advtemplate_create_category,
-  advtemplate_create_template,
-  advtemplate_rename_category,
-  advtemplate_rename_template,
-  advtemplate_delete_template,
-  advtemplate_delete_category,
-  advtemplate_move_template,
-  advtemplate_move_category_items
-});
-----
-
+[[options]]
 == Options
 
 The following configuration options affect the behavior of the {pluginname} plugin.

--- a/modules/ROOT/pages/advanced-templates.adoc
+++ b/modules/ROOT/pages/advanced-templates.adoc
@@ -81,21 +81,21 @@ There are two approaches to using the Advanced Template Premium plugin: fixed te
 
 For users who work with a fixed template list that does not require modification, you can provide a list directly through the {productname} init configuration using the xref:advtemplate_templates[`+advtemplate_templates+` option].
 
-The interactive xref:#predefined-list-config-example[predefined list example] provides guidance for this approach.
+The following interactive predefined list example provides guidance for this approach.
+
+[[predefined-list-config-example]]
+==== Configuring the Advanced Template plugin to use a static list of predefined templates.
+liveDemo::{plugincode}-predefined[]
 
 === User-modifiable template lists
 
 If the intention is for the template list to be end-user modifiable, the {pluginname} plugin should be configured with options to enable communication with a remote Template storage service.
 
-The interactive xref:#remote-config-example[remote storage configuration example] provides guidance on configuring the {pluginname} plugin to support user-modifiable template lists.
+The following interactive remote storage configuration example provides guidance on configuring the {pluginname} plugin to support user-modifiable template lists.
 
 [[remote-config-example]]
-=== Configuring the Advanced Template plugin to interact with a remote backend service via REST API.
+==== Configuring the Advanced Template plugin to interact with a remote backend service via REST API.
 liveDemo::{plugincode}[]
-
-[[predefined-list-config-example]]
-=== Configuring the Advanced Template plugin to use a static list of predefined templates.
-liveDemo::{plugincode}-predefined[]
 
 == Basic setup
 

--- a/modules/ROOT/pages/advanced-templates.adoc
+++ b/modules/ROOT/pages/advanced-templates.adoc
@@ -11,19 +11,28 @@ include::partial$misc/admon-premium-plugin.adoc[]
 
 include::partial$misc/admon-requires-6.4v.adoc[]
 
-NOTE: The documentation for this page is a work in progress. Further details on the {pluginname} plugin will be added to this page soon.
-
 The {pluginname} Premium plugin enables the creation of complex, interactive templates using {productname}.
 
 They can also be added to a {productname} instance by end-users selecting content in a {productname} document and saving the selection as a template via the {productname} user-interface.
 
 IMPORTANT: This initial {pluginname} release does not support template editing. To update a particular template; insert the template into an editor; make edits; select the, now edited, content; and then create a new template (using, for example, the *Tools > Save as Template…* menu item).
 
-////
-== Interactive example
+There are two approaches to using the Advanced Template Premium plugin:
 
+. _Fixed Template List._
+For users who work with a fixed template list that does not require modification, you can provide the list directly through the editor init configuration using the xref:advtemplate_templates[`+advtemplate_templates+` option]. Please refer to this interactive xref:#predifined-list-config-example[example] for guidance on this approach.
+
+. _User-Modifiable Template List._
+If the template list is intended to be modified by the user, the plugin should be configured with functional options to enable communication with a remote template storage service. Please refer to this interactive xref:#remote-config-example[example] for guidance on configuring the plugin to support user-modifiable template lists.
+
+== Interactive examples
+[[remote-config-example]]
+=== Configuring the Advanced Template plugin to interact with a remote backend service via REST API.
 liveDemo::{plugincode}[]
-////
+
+[[predifined-list-config-example]]
+=== Configuring the Advanced Template plugin to use a static list of predefined templates.
+liveDemo::{plugincode}-predefined[]
 
 == Basic setup
 
@@ -43,40 +52,28 @@ tinymce.init({
   selector: 'textarea',  // change this value according to your html
   plugins: "advtemplate",
   toolbar: "inserttemplate addtemplate",
-  advtemplate_list: () => {
-    return Promise.resolve([
-      {
-        id: '1',
-        title: 'Resolving tickets',
-        content: '<p>As we have not heard back from you in over a week, so we have gone ahead and resolved your ticket</p>'
-      },
-      {
-        id: '2',
-        title: 'Quick replies',
-        items: [
-          {
-            id: '3',
-            title: 'Message received',
-            content: '<p>Just a quick note to say we have received your message, and will get back to you within 48 hours.</p>'
-          },
-          {
-            id: '4',
-            title: 'Progress update',
-            content: '</p>Just a quick note to let you know we are still working on your case</p>'
-          }
-        ]
-      }
-    ]);
-  }
+  contextmenu: "advtemplate",
+  // Each of the following options should be defined as
+  // a function that returns a Promise.
+  // Please find the specific details for each option below.
+  advtemplate_list,
+  advtemplate_get_template,
+  advtemplate_create_category,
+  advtemplate_create_template,
+  advtemplate_rename_category,
+  advtemplate_rename_template,
+  advtemplate_delete_template,
+  advtemplate_delete_category,
+  advtemplate_move_template,
+  advtemplate_move_category_items
 });
 ----
-
-NOTE: The above example only demonstrates the {pluginname} user interface. An xref:#advtemplate_list[`advtemplate_list`] option has been added, with an included function returning a promise that contains a basic Template structure. This allows the {pluginname} user interface to load and present in a {productname} editor instance. This basic setup example cannot create, edit, or save new {pluginname} items. Nor can it preview Template items or insert Template items into a {productname} editor instance.
-
 
 == Options
 
 The following configuration options affect the behavior of the {pluginname} plugin.
+
+include::partial$configuration/advtemplate_templates.adoc[]
 
 include::partial$configuration/advtemplate_list.adoc[]
 

--- a/modules/ROOT/pages/template.adoc
+++ b/modules/ROOT/pages/template.adoc
@@ -6,7 +6,7 @@
 :plugincode: template
 
 
-IMPORTANT: The Template plugin has been marked as *deprecated*. As a result, it will be completely removed from the upcoming TinyMCE 7.0 release. As an alternative solution, we highly recommend utilizing the xref:advanced-templates.adoc[Advanced Template] Premium plugin. 
+IMPORTANT: The Template plugin has been marked as *deprecated*. It will be completely removed from the upcoming {productname} 7.0 release. As an alternative solution, we recommend the xref:advanced-templates.adoc[Advanced Template] Premium plugin.
 
 The `+template+` plugin adds support for custom templates. It also adds a menu item `+Insert template+` under the `+Insert+` menu and a toolbar button.
 

--- a/modules/ROOT/pages/template.adoc
+++ b/modules/ROOT/pages/template.adoc
@@ -6,7 +6,7 @@
 :plugincode: template
 
 
-IMPORTANT: The Template plugin, has been marked as *deprecated*. As a result, it will be completely removed from the upcoming TinyMCE 7.0 release. As an alternative solution, we highly recommend utilizing the xref:advanced-templates.adoc[Advanced Template] Premium plugin. 
+IMPORTANT: The Template plugin has been marked as *deprecated*. As a result, it will be completely removed from the upcoming TinyMCE 7.0 release. As an alternative solution, we highly recommend utilizing the xref:advanced-templates.adoc[Advanced Template] Premium plugin. 
 
 The `+template+` plugin adds support for custom templates. It also adds a menu item `+Insert template+` under the `+Insert+` menu and a toolbar button.
 

--- a/modules/ROOT/pages/template.adoc
+++ b/modules/ROOT/pages/template.adoc
@@ -5,6 +5,9 @@
 :pluginname: Template
 :plugincode: template
 
+
+IMPORTANT: The Template plugin, has been marked as *deprecated*. As a result, it will be completely removed from the upcoming TinyMCE 7.0 release. As an alternative solution, we highly recommend utilizing the xref:advanced-templates.adoc[Advanced Template] Premium plugin. 
+
 The `+template+` plugin adds support for custom templates. It also adds a menu item `+Insert template+` under the `+Insert+` menu and a toolbar button.
 
 == Basic setup

--- a/modules/ROOT/partials/configuration/advtemplate_list.adoc
+++ b/modules/ROOT/partials/configuration/advtemplate_list.adoc
@@ -38,7 +38,7 @@ The data returned by `advtemplate_list` must adhere to the following requirement
 
 . Each list item must have a unique `id` value.
 . Each list item must have a non-empty `title` value.
-. Each category item is required to include a `items` sublist, which can be empty.
+. Each category item is required to include an `items` sublist, which can be empty.
 . Category items must not contain nested subcategories.
 . Template item is not required to include a `content` value.
 

--- a/modules/ROOT/partials/configuration/advtemplate_list.adoc
+++ b/modules/ROOT/partials/configuration/advtemplate_list.adoc
@@ -8,8 +8,39 @@ The plugin uses the `advtemplate_list` asynchronous function to retreive the tem
 *Input parameters:*
 None
 
-*Return data:*
-Look in the example below
+*Return data:* `+Array+`
+
+=== Example of `advtemplate_list` response
+
+[source,js]
+----
+[{
+    id: '1',
+    title: 'Resolving tickets',
+  },
+  {
+    id: '2',
+    title: 'Quick replies',
+    items: [{
+        id: '3',
+        title: 'Message received',
+      },
+      {
+        id: '4',
+        title: 'Progress update',
+      }
+    ]
+  }
+]
+----
+
+The data returned by `advtemplate_list` must adhere to the following requirements:
+
+. Each list item must have a unique `id` value.
+. Each list item must have a non-empty `title` value.
+. Each category item is required to include a `items` sublist, which can be empty.
+. Category items must not contain nested subcategories.
+. Template item is not required to include a `content` value.
 
 === Example: using `advtemplate_list`
 
@@ -27,35 +58,3 @@ tinymce.init({
     .catch((error) => console.log('Failed to get template list\n' + error)),
 });
 ----
-
-=== Example of `advtemplate_list` response
-
-[source,js]
-----
-const data = [{
-    id: '1',
-    title: 'Resolving tickets',
-  },
-  {
-    id: '2',
-    title: 'Quick replies',
-    items: [{
-        id: '3',
-        title: 'Message received',
-      },
-      {
-        id: '4',
-        title: 'Progress update',
-      }
-    ]
-  }
-];
-----
-
-The data returned by `advtemplate_list` must match the following requirements:
-
-. Each list item must have a unique `id` value.
-. Each list item must have a non-empty `title` value.
-. Category items in the list must not contain nested categories.
-. Category item may contain an empty `items` list.
-. Template item is not required to include a `content` value.

--- a/modules/ROOT/partials/configuration/advtemplate_templates.adoc
+++ b/modules/ROOT/partials/configuration/advtemplate_templates.adoc
@@ -1,0 +1,43 @@
+[[advtemplate_templates]]
+== `advtemplate_templates`
+
+This option lets you specify a static list of predefined templates that can be inserted using the _Templates_ dialog. It is specifically designed for scenarios where the template list is intended to be unchangeable. In such cases, there is no need to set up a persistent template store and provide a more complex plugin configuration.
+
+*Type:* `+Array+`
+
+The template list assigned to the `advtemplate_templates` option must adhere to the following requirements:
+
+. Each item must have a non-empty `title` value.
+. Each template item is required to include a non-empty `content` value.
+. Each category item is required to include a `items` sublist, which can be empty.
+. Category items must not contain nested subcategories.
+
+=== Example: using `advtemplate_templates`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea#advtemplate',  // change this value according to your html
+  plugins: ["advtemplate"],
+  toolbar: 'inserttemplate',
+  advtemplate_templates: [
+    {
+      title: 'Template 1',
+      content: 'Template 1 content'
+    },
+    {
+      title: 'Category 2',
+      items: [
+        {
+          title: 'Template 2.1',
+          content: 'Template 2.1 content'
+        },
+        {
+          title: 'Template 2.2',
+          content: 'Template 2.2 content'
+        }
+      ]
+    }
+  ],
+});
+----

--- a/modules/ROOT/partials/configuration/advtemplate_templates.adoc
+++ b/modules/ROOT/partials/configuration/advtemplate_templates.adoc
@@ -1,7 +1,7 @@
 [[advtemplate_templates]]
 == `advtemplate_templates`
 
-This option lets you specify a static list of predefined templates that can be inserted using the _Templates_ dialog. It is specifically designed for scenarios where the template list is intended to be unchangeable. In such cases, there is no need to set up a persistent template store and provide a more complex plugin configuration.
+This option lets you specify a static list of predefined templates that can be inserted using the _Templates_ dialog. It is for scenarios where the provided template list is unchangeable. In this use-case, there is no need to set up a persistent template store and provide a more complex plugin configuration.
 
 *Type:* `+Array+`
 
@@ -18,8 +18,8 @@ The template list assigned to the `advtemplate_templates` option must adhere to 
 ----
 tinymce.init({
   selector: 'textarea#advtemplate',  // change this value according to your html
-  plugins: ["advtemplate"],
-  toolbar: 'inserttemplate',
+  plugins: "advtemplate",
+  toolbar: "inserttemplate",
   advtemplate_templates: [
     {
       title: 'Template 1',


### PR DESCRIPTION
Ticket: DOC-1953, Advanced Template Docs update

Changes:
* Added documentation for the  new `advtemplate_templates` option.
* Interactive example of `advtemplate_templates` option usage.
* Interactive example of configuring the plugin for interacting with remote backend service.
* Deprecated the old Template plugin.
* Added plugin usage instructions.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] Files has been included where required (if applicable)
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
