### PR TITLE
DOC-1980: Convert all mentions of Transifex to Crowdin

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1980: Converted all mentions of Transifex to Crowdin as TinyMCE's community translations platform.
+
 ### 2023-05-03
 
 - DOC-1972: Updated `changelog.md` to be in sync with the release-notes 6.4.2.

--- a/modules/ROOT/partials/configuration/language.adoc
+++ b/modules/ROOT/partials/configuration/language.adoc
@@ -6,7 +6,7 @@ This option specifies the language used for the {productname} user interface, su
 Before changing the language option, ensure that the language pack is available to the {productname} instance. {companyname} provides two collections of language packs:
 
 * _Premium_ language packs — Professionally localized language packs provided on {cloudname} and bundled with premium self-hosted bundles.
-* _Community_ language packs - Localizations provided by {productname} users through Crowdin, which need to be downloaded prior to use, from link:{gettiny}/language-packages/[the {companyname} Downloads Page - Language Packages].
+* _Community_ language packs — Localizations provided by {productname} users through Crowdin. Community languages packs can be downloaded from link:{gettiny}/language-packages/[the {companyname} Community Language Packs downloads page].
 
 For information on:
 

--- a/modules/ROOT/partials/configuration/language.adoc
+++ b/modules/ROOT/partials/configuration/language.adoc
@@ -5,7 +5,7 @@ This option specifies the language used for the {productname} user interface, su
 
 Before changing the language option, ensure that the language pack is available to the {productname} instance. {companyname} provides two collections of language packs:
 
-* _Premium_ language packs - Professionally localized language packs provided on {cloudname} and bundled with premium self-hosted bundles.
+* _Premium_ language packs — Professionally localized language packs provided on {cloudname} and bundled with premium self-hosted bundles.
 * _Community_ language packs - Localizations provided by {productname} users through Crowdin, which need to be downloaded prior to use, from link:{gettiny}/language-packages/[the {companyname} Downloads Page - Language Packages].
 
 For information on:

--- a/modules/ROOT/partials/configuration/language.adoc
+++ b/modules/ROOT/partials/configuration/language.adoc
@@ -6,7 +6,7 @@ This option specifies the language used for the {productname} user interface, su
 Before changing the language option, ensure that the language pack is available to the {productname} instance. {companyname} provides two collections of language packs:
 
 * _Premium_ language packs - Professionally localized language packs provided on {cloudname} and bundled with premium self-hosted bundles.
-* _Community_ language packs - Localizations provided by {productname} users through Transifex, which need to be downloaded prior to use, from link:{gettiny}/language-packages/[the {companyname} Downloads Page - Language Packages].
+* _Community_ language packs - Localizations provided by {productname} users through Crowdin, which need to be downloaded prior to use, from link:{gettiny}/language-packages/[the {companyname} Downloads Page - Language Packages].
 
 For information on:
 

--- a/modules/ROOT/partials/misc/using-community-lang-packs.adoc
+++ b/modules/ROOT/partials/misc/using-community-lang-packs.adoc
@@ -19,4 +19,4 @@ endif::[]
 
 NOTE: The language code set in the {productname} configuration must match the filename of the language file. If the language file is not found, {productname} will not load.
 
-If a language you need is not available, you may wish to translate it yourself. To contribute to translating {productname}, go to our https://www.transifex.com/projects/p/tinymce/[Transifex translation] page and sign up, then request to join a team or create a new team if your language are not listed.
+If a language you need is not available, you may wish to translate it yourself. To contribute to translating {productname}, go to our https://crowdin.com/project/tinymce[Crowdin translation] page and sign up, then request to join a team or create a new team if your language are not listed.

--- a/modules/ROOT/partials/misc/using-community-lang-packs.adoc
+++ b/modules/ROOT/partials/misc/using-community-lang-packs.adoc
@@ -19,4 +19,4 @@ endif::[]
 
 NOTE: The language code set in the {productname} configuration must match the filename of the language file. If the language file is not found, {productname} will not load.
 
-If a language you need is not available, you may wish to translate it yourself. To contribute to translating {productname}, go to our https://crowdin.com/project/tinymce[Crowdin translation] page and sign up, then request to join a team or create a new team if your language are not listed.
+If a language you need is not available, you may wish to translate {productname} yourself. To contribute to translating {productname}, go to our https://crowdin.com/project/tinymce[Crowdin translation page] and sign up. Then request to join an existing team, or create a new team if your language are not listed.


### PR DESCRIPTION
Ticket: DOC-1980, Convert all mentions of Transifex to Crowdin for community translations.

Changes:
* Moved away from Transifex to Crowdin so converted mentions and URLs of Transifex to Crowdin

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed