### PR TITLE
DOC-2028: Adding release notes template to  staging/doc-6  for 6.5

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2028: Add release-notes template to `staging` for 6.5.
+
 ### 2023-05-03
 
 - DOC-1972: Updated `changelog.md` to be in sync with the release-notes 6.4.2.

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -398,6 +398,17 @@
 ** xref:tinymce-and-cors.adoc[Cross-Origin Resource Sharing (CORS)]
 * Release information
 ** xref:release-notes.adoc[Release notes for TinyMCE 6]
+*** TinyMCE 6.5
+**** xref:6.5-release-notes.adoc#overview[Overview]
+**** xref:6.5-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]
+**** xref:6.5-release-notes.adoc#accompanying-premium-plugin-end-of-life-announcement[Accompanying Premium Plugin end-of-life announcement]
+**** xref:6.5-release-notes.adoc#accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]
+**** xref:6.5-release-notes.adoc#improvements[Improvements]
+**** xref:6.5-release-notes.adoc#additions[Additions]
+**** xref:6.5-release-notes.adoc#changes[Changes]
+**** xref:6.5-release-notes.adoc#bug-fixes[Bug fixes]
+**** xref:6.5-release-notes.adoc#security-fixes[Security fixes]
+**** xref:6.5-release-notes.adoc#known-issues[Known issues]
 *** TinyMCE 6.4.2
 **** xref:6.4.2-release-notes.adoc#overview[Overview]
 **** xref:6.4.2-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]

--- a/modules/ROOT/pages/6.5-release-notes.adoc
+++ b/modules/ROOT/pages/6.5-release-notes.adoc
@@ -1,0 +1,86 @@
+= TinyMCE 6.5
+:navtitle: TinyMCE 6.5
+:description: Release notes for TinyMCE 6.5
+:keywords: releasenotes, new, changes, bugfixes
+:page-toclevels: 1
+
+//include::partial$misc/admon-releasenotes-for-stable.adoc[]
+
+[[overview]]
+== Overview
+
+{productname} 6.5 was released for {enterpriseversion} and {cloudname} on Wednesday, June 14^th^, 2023. These release notes provide an overview of the changes for {productname} 6.5:
+
+* xref:new-premium-plugin[New Premium Plugin]
+* xref:accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]
+* xref:accompanying-premium-plugin-end-of-life-announcement[Accompanying Premium Plugin end-of-life announcement]
+* xref:accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]
+* xref:improvements[Improvements]
+* xref:additions[Additions]
+* xref:changes[Changes]
+* xref:bug-fixes[Bug fixes]
+* xref:security-fixes[Security fixes]
+* xref:known-issues[Known issues]
+
+[[new-premium-plugin]]
+== New Premium Plugin
+
+[[accompanying-premium-plugin-changes]]
+== Accompanying Premium Plugin changes
+
+The following premium plugin updates were released alongside {productname} 6.5.
+
+[[accompanying-premium-plugin-end-of-life-announcement]]
+== Accompanying Premium Plugin end-of-life announcement
+
+The following premium plugin has been announced as reaching its end-of-life:
+
+[[accompanying-premium-skins-and-icon-packs-changes]]
+== Accompanying Premium Skins and Icon Packs changes
+
+The {productname} 6.5 release includes an accompanying release of the **Premium Skins and Icon Packs**.
+
+=== Premium Skins and Icon Packs
+
+The **Premium Skins and Icon Packs** release includes the following updates:
+
+The **Premium Skins and Icon Packs** were rebuilt to pull in the changes also incorporated into the default {productname} 6.5 skin, Oxide.
+
+For information on using premium skins and icon packs, see: xref:premium-skins-and-icons.adoc[Premium Skins and Icon Packs].
+
+
+[[improvements]]
+== Improvements
+
+{productname} 6.5 also includes the following improvements:
+
+
+[[additions]]
+== Additions
+{productname} 6.5 also includes the following additions:
+
+
+[[changes]]
+== Changes
+
+{productname} 6.5 also incorporates the following changes:
+
+
+[[bug-fixes]]
+== Bug fixes
+
+{productname} 6.5 also includes the following bug fixes:
+
+
+[[security-fixes]]
+== Security fixes
+
+{productname} 6.5 includes a fix for the following security issue:
+
+
+[[known-issues]]
+== Known issues
+
+This section describes issues that users of {productname} 6.5 may encounter and possible workarounds for these issues.
+
+There are several known issues in {productname} 6.5.

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -11,6 +11,12 @@ This section lists the releases for {productname} 6 and the changes made in each
 
 a|
 [.lead]
+xref:6.5-release-notes.adoc#overview[{productname} 6.5]
+
+Release notes for {productname} 6.5
+
+a|
+[.lead]
 xref:6.4.2-release-notes.adoc#overview[{productname} 6.4.2]
 
 Release notes for {productname} 6.4.2


### PR DESCRIPTION
Ticket: DOC-2028: Adding release notes template to  for 6.5

Changes:
* Added release notes template to `staging` for 6.5

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
