### PR TITLE
DOC-1992: Added TINY-9678 to the release notes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-1992: Added TINY-9678 to `staging`.
 - DOC-2028: Add release-notes template to `staging` for 6.5.
 
 ### 2023-05-03

--- a/modules/ROOT/pages/6.5-release-notes.adoc
+++ b/modules/ROOT/pages/6.5-release-notes.adoc
@@ -76,7 +76,7 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 In previous versions of {productname}, formatting issues caused incorrect application or removal of formats in relation to the closest `contenteditable= "true"` element when the selection was within a `contenteditable= "false"` context.
 
-This issue also affected the formatters API as well, as its `canApply` function failed to return `false` when the selection was in a `contenteditable= "false"` context.
+This issue also affected the formatter API as well, as its `canApply` function failed to return `false` when the selection was in a `contenteditable="false"` context.
 
 In {productname} 6.5, the issue has been resolved. Now, formats are correctly applied or removed only to and from `contenteditable= "true"` elements.
 

--- a/modules/ROOT/pages/6.5-release-notes.adoc
+++ b/modules/ROOT/pages/6.5-release-notes.adoc
@@ -71,14 +71,16 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 {productname} 6.5 also includes the following bug fixes:
 
-=== Resolving formatting issues with `contenteditable= "false"` contexts and the formatter API
+=== Formatting issues with elements with a `contenteditable="false"` attribute set and the formatter API resolved
 //#TINY-9678
 
-In previous versions of {productname}, formatting issues caused incorrect application or removal of formats in relation to the closest `contenteditable= "true"` element when the selection was within a `contenteditable= "false"` context.
+If the selection is in an element with a `contenteditable="false"` attribute set, and spot-formatting is applied to the selection, the spot formatting is not applied to the selected content, as expected.
 
-This issue also affected the formatter API as well, as its `canApply` function failed to return `false` when the selection was in a `contenteditable="false"` context.
+However, In previous versions of {productname}, in such a circumstance, the spot formatting was erroneously applied to the nearest writeable element, if such an element existed.
 
-In {productname} 6.5, the issue has been resolved. Now, formats are correctly applied or removed only to and from `contenteditable= "true"` elements.
+This incorrect application of spot-formatting also presented when the formatter API was used, because the API’s `canApply` function did not return `false` when the selection was in an element with a `contenteditable="false"` attribute set.
+
+In {productname} 6.5, the issue has been resolved. Spot formatting is no longer misapplied to not-selected elements.
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/pages/6.5-release-notes.adoc
+++ b/modules/ROOT/pages/6.5-release-notes.adoc
@@ -71,6 +71,14 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 {productname} 6.5 also includes the following bug fixes:
 
+=== Resolving formatting issues with `contenteditable= "false"` contexts and the formatter API
+//#TINY-9678
+
+In previous versions of {productname}, formatting issues caused incorrect application or removal of formats in relation to the closest `contenteditable= "true"` element when the selection was within a `contenteditable= "false"` context.
+
+This issue also affected the formatters API as well, as its `canApply` function failed to return `false` when the selection was in a `contenteditable= "false"` context.
+
+In {productname} 6.5, the issue has been resolved. Now, formats are correctly applied or removed only to and from `contenteditable= "true"` elements.
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-1992

Changes:
* Added TINY-9678 to the release notes.

This entry covers the below `changelog` entries.

- Formats were incorrectly applied to the closest editable element if the selection was in a noneditable context. #TINY-9678
- Formats were incorrectly removed to the closest editable element if the selection was in a noneditable context. #TINY-9678
- Formatter API `canApply` was not returning `false` when the selection was in a noneditable context. #TINY-9678

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
