### PR TITLE
DOC-2029: Document new editable root APIs and options

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 - DOC-1953: new file, `/modules/ROOT/partials/configuration/advtemplate_templates.adoc`, added. Documentation of new Advanced Template plugin option, `advtemplate_templates`, added to new file.
 - DOC-2028: Add release-notes template to `staging` for 6.5.
-- DOC-2029: Added new options `editable_root` and `newdocument_content`.
+- DOC-2029: Added new partials, `editable_root.adoc` and `newdocument_content.adoc`, to `/configuration/`. Also added includes for both to `content-behavior-options.adoc`.
 
 ### 2023-05-03
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 - DOC-1953: new file, `/modules/ROOT/partials/configuration/advtemplate_templates.adoc`, added. Documentation of new Advanced Template plugin option, `advtemplate_templates`, added to new file.
 - DOC-2028: Add release-notes template to `staging` for 6.5.
+- DOC-2029: Added new options `editable_root` and `newdocument_content`.
 
 ### 2023-05-03
 

--- a/modules/ROOT/pages/content-behavior-options.adoc
+++ b/modules/ROOT/pages/content-behavior-options.adoc
@@ -4,6 +4,8 @@
 
 include::partial$configuration/custom_undo_redo_levels.adoc[]
 
+include::partial$configuration/editable_root.adoc[]
+
 include::partial$configuration/end_container_on_empty_block.adoc[]
 
 include::partial$configuration/draggable_modal.adoc[]
@@ -11,6 +13,8 @@ include::partial$configuration/draggable_modal.adoc[]
 include::partial$configuration/keep_styles.adoc[]
 
 include::partial$configuration/editable_class.adoc[]
+
+include::partial$configuration/newdocument_content.adoc[]
 
 include::partial$configuration/newline_behavior.adoc[]
 

--- a/modules/ROOT/partials/configuration/editable_root.adoc
+++ b/modules/ROOT/partials/configuration/editable_root.adoc
@@ -1,0 +1,20 @@
+[[editable_root]]
+== `+editable_root+`
+
+This option enables you to specify that the initial editable state of the root of {productname}. The root could still contain child elements with `contenteditable="true"` and those
+would remain editable even if you set this option to `false`.
+
+*Type:* `+Boolean+`
+
+*Default value:* `+'true'+`
+
+=== Example: using `+editable_root+`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  editable_root: false 
+});
+----
+

--- a/modules/ROOT/partials/configuration/editable_root.adoc
+++ b/modules/ROOT/partials/configuration/editable_root.adoc
@@ -1,12 +1,15 @@
 [[editable_root]]
 == `+editable_root+`
 
-This option enables you to specify that the initial editable state of the root of {productname}. The root could still contain child elements with `contenteditable="true"` and those
-would remain editable even if you set this option to `false`.
+This option sets the initial editable state of a {productname} instance’s root.
+
+Setting `editable_root` to `false` sets the {productname} root to non-editable (in effect, read-only).
+
+NOTE: a {productname} root set as not-editable can contain child elements with the `contenteditable="true"` attribute set. And these child elements remain editable even when `editable_root: false` is set.
 
 *Type:* `+Boolean+`
 
-*Default value:* `+'true'+`
+*Default value:* `+true+`
 
 === Example: using `+editable_root+`
 

--- a/modules/ROOT/partials/configuration/newdocument_content.adoc
+++ b/modules/ROOT/partials/configuration/newdocument_content.adoc
@@ -1,0 +1,21 @@
+[[newdocument_content]]
+== `+newdocument_content+`
+
+This option enables you to set the content that the editor will contain if you use the New document menu item. This can
+be used together with xref:content-behavior-options.adoc#editable_root[editable_root] to make sure there is always a editable field within the non-editable root.
+
+*Type:* `+String+`
+
+*Default value:* `+''+`
+
+=== Example: using `+newdocument_content+`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  newdocument_content: '<p contenteditable="true">Editable content</p>' 
+});
+----
+
+

--- a/modules/ROOT/partials/configuration/newdocument_content.adoc
+++ b/modules/ROOT/partials/configuration/newdocument_content.adoc
@@ -1,8 +1,7 @@
 [[newdocument_content]]
 == `+newdocument_content+`
 
-This option enables you to set the content that the editor will contain if you use the New document menu item. This can
-be used together with xref:content-behavior-options.adoc#editable_root[editable_root] to make sure there is always a editable field within the non-editable root.
+This option sets the content a new editor contains when the xref:available-menu-items.adoc#the-core-menu-items[File -> New document] menu item is invoked.
 
 *Type:* `+String+`
 
@@ -10,12 +9,13 @@ be used together with xref:content-behavior-options.adoc#editable_root[editable_
 
 === Example: using `+newdocument_content+`
 
+This example shows `+newdocument_content+` being used with the xref:content-behavior-options.adoc#editable_root[`+editable_root+`] option to set an editable element within a non-editable root.
+
 [source,js]
 ----
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  newdocument_content: '<p contenteditable="true">Editable content</p>' 
+  editable_root: false,
+  newdocument_content: '<div contenteditable="true">Editable content</div>' 
 });
 ----
-
-


### PR DESCRIPTION
Ticket: DOC-2029, Document new editable root APIs and options.

Changes:
* Added docs for the new `editable_root` and `newdocument_content` options unsure where to stick them none of the categories seems right to me. So I put both under `content-behavior-options.adoc`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
~- [ ] `modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] Files has been included where required (if applicable)
~- [ ] Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
