### PR TITLE
DOC-2004: Added docs for init_content_sync option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 - DOC-1953: new file, `/modules/ROOT/partials/configuration/advtemplate_templates.adoc`, added. Documentation of new Advanced Template plugin option, `advtemplate_templates`, added to new file.
 - DOC-2028: Add release-notes template to `staging` for 6.5.
+- DOC-2004: Added docs for `init_content_sync` option.
 
 ### 2023-05-03
 

--- a/modules/ROOT/pages/content-appearance.adoc
+++ b/modules/ROOT/pages/content-appearance.adoc
@@ -25,3 +25,10 @@ include::partial$misc/premium-upgrade-promotion-option.adoc[]
 To enable highlighting on focus for the editor,
 
 include::partial$configuration/highlight_on_focus.adoc[]
+
+== Reducing initialization flicker 
+
+To enable synchronous iframe initialization. 
+
+include::partial$configuration/init_content_sync.adoc[]
+

--- a/modules/ROOT/partials/configuration/init_content_sync.adoc
+++ b/modules/ROOT/partials/configuration/init_content_sync.adoc
@@ -1,0 +1,22 @@
+[[init_content_sync]]
+== `+init_content_sync+`
+
+This option enables you to change the way the iframe is initialized from using srcdoc and being async to using document.write and being sync. Setting
+this to `true` will reduce some initialization flicker. But some flicker like loading the content css in could still occur.
+
+*Type:* `+Boolean+`
+
+*Default value:* `+false+`
+
+=== Example: using `+init_content_sync+`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  init_content_sync: true 
+});
+----
+
+include::partial$configuration/indent_use_margin.adoc[]
+

--- a/modules/ROOT/partials/configuration/init_content_sync.adoc
+++ b/modules/ROOT/partials/configuration/init_content_sync.adoc
@@ -21,5 +21,3 @@ tinymce.init({
 });
 ----
 
-include::partial$configuration/indent_use_margin.adoc[]
-

--- a/modules/ROOT/partials/configuration/init_content_sync.adoc
+++ b/modules/ROOT/partials/configuration/init_content_sync.adoc
@@ -1,11 +1,17 @@
 [[init_content_sync]]
 == `+init_content_sync+`
 
+include::partial$misc/admon-requires-6.5v.adoc[]
+
 This option determines whether the iframe is initialized synchronously or asynchronously.
 
-When disabled, the editor is initialized asynchronously using `srcdoc`, however this can occasionally cause the editor to flicker during initialization.
+When disabled, the editor is initialized asynchronously using `srcdoc`. This can, occasionally, cause the editor to flicker during initialization.
 
-When enabled, the editor will be initialized using `document.write`, which can reduce this flickering, but some flicker could still occur, such as loading the content css.
+When enabled, the editor is initialized synchronously, using `document.write`. This can reduce flickering.
+
+Flickering can still occur during synchronous initialization, however, such as when loading the content css.
+
+NOTE: using the https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#document.write()[`document.write`] method is https://developer.mozilla.org/en-US/docs/Web/API/Document/write[strongly discouraged].
 
 *Type:* `+Boolean+`
 
@@ -17,7 +23,8 @@ When enabled, the editor will be initialized using `document.write`, which can r
 ----
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  init_content_sync: true 
+  init_content_sync: 'true',
 });
 ----
 
+NOTE: When {productname} is running in xref:use-tinymce-inline.adoc[inline mode] (ie, when `+inline: true+` is set), setting `init_content_sync: true` has no effect.

--- a/modules/ROOT/partials/configuration/init_content_sync.adoc
+++ b/modules/ROOT/partials/configuration/init_content_sync.adoc
@@ -1,8 +1,11 @@
 [[init_content_sync]]
 == `+init_content_sync+`
 
-This option enables you to change the way the iframe is initialized from using srcdoc and being async to using document.write and being sync. Setting
-this to `true` will reduce some initialization flicker. But some flicker like loading the content css in could still occur.
+This option determines whether the iframe is initialized synchronously or asynchronously.
+
+When disabled, the editor is initialized asynchronously using `srcdoc`, however this can occasionally cause the editor to flicker during initialization.
+
+When enabled, the editor will be initialized using `document.write`, which can reduce this flickering, but some flicker could still occur, such as loading the content css.
 
 *Type:* `+Boolean+`
 


### PR DESCRIPTION
Ticket: DOC-2004, Document new `init_content_sync` option.

Changes:
* Added docs for the `init_content_sync` option

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
