### PR TITLE
DOC-2049: create `/partial/misc/admon-requires-6.xv.adoc` for use as required by 6.5-and-later specific docs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,8 +6,9 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2049: Added multiple `/partial/misc/admon-requires-6.<x>v.adoc` files for use as required by 6.5-and-later specific docs.
 - DOC-2047: Added TINY-9848 to `staging`.
-- DOC-2048 Added TINY-9812 to `staging`.
+- DOC-2048: Added TINY-9812 to `staging`.
 - DOC-2044: Added TINY-9849 to `staging`.
 - DOC-1953: new file, `/modules/ROOT/partials/configuration/advtemplate_templates.adoc`, added. Documentation of new Advanced Template plugin option, `advtemplate_templates`, added to new file.
 - DOC-2028: Add release-notes template to `staging` for 6.5.

--- a/modules/ROOT/partials/misc/admon-requires-6.5v.adoc
+++ b/modules/ROOT/partials/misc/admon-requires-6.5v.adoc
@@ -1,0 +1,1 @@
+NOTE: This feature is only available for {productname} 6.5 and later.

--- a/modules/ROOT/partials/misc/admon-requires-6.6v.adoc
+++ b/modules/ROOT/partials/misc/admon-requires-6.6v.adoc
@@ -1,0 +1,1 @@
+NOTE: This feature is only available for {productname} 6.6 and later.

--- a/modules/ROOT/partials/misc/admon-requires-6.7v.adoc
+++ b/modules/ROOT/partials/misc/admon-requires-6.7v.adoc
@@ -1,0 +1,1 @@
+NOTE: This feature is only available for {productname} 6.7 and later.

--- a/modules/ROOT/partials/misc/admon-requires-6.8v.adoc
+++ b/modules/ROOT/partials/misc/admon-requires-6.8v.adoc
@@ -1,0 +1,1 @@
+NOTE: This feature is only available for {productname} 6.8 and later.


### PR DESCRIPTION
Ticket: DOC-2049 create `/partial/misc/admon-requires-6.<x>v.adoc` for use as required by 6.5-and-later specific docs

Changes:
* Added multiple admon-requires files to /partials/misc/:
	* admon-requires-6.5v.adoc
	* admon-requires-6.6v.adoc
	* admon-requires-6.7v.adoc
	* admon-requires-6.8v.adoc


Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] Files has been included where required (if applicable)

Review:
- [x] Documentation Team Lead has reviewed
