### PR TITLE
DOC-2052: Correct default value of `language` option to `en`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 ### Unreleased
 
 - DOC-1980: Converted all mentions of Transifex to Crowdin as TinyMCE's community translations platform.
+- DOC-2052: Correct default value of `language` option to `en`.
 
 ### 2023-05-03
 

--- a/modules/ROOT/partials/configuration/language.adoc
+++ b/modules/ROOT/partials/configuration/language.adoc
@@ -15,7 +15,7 @@ For information on:
 
 *Type:* `+String+`
 
-*Default value:* `+'en_US'+`
+*Default value:* `+'en'+`
 
 === Example: using `+language+`
 


### PR DESCRIPTION
Ticket: DOC-2052, Incorrect default for language option.

Changes:
* Correct default value of `language` option to `en`

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
