### PR TITLE
DOC-2025: Document new `table_merge_content_on_paste` option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2025: Added new partial`table_merge_content_on_paste.adoc`; documented new option — `table_merge_content_on_paste` — in this new file; added include statement pointing to this file to `table.adoc`.
 - DOC-2049: Added multiple `/partial/misc/admon-requires-6.<x>v.adoc` files for use as required by 6.5-and-later specific docs.
 - DOC-2047: Added TINY-9848 to `staging`.
 - DOC-2048: Added TINY-9812 to `staging`.

--- a/modules/ROOT/pages/table.adoc
+++ b/modules/ROOT/pages/table.adoc
@@ -52,6 +52,8 @@ include::partial$configuration/table_row_advtab.adoc[leveloffset=+1]
 
 include::partial$configuration/table_style_by_css.adoc[leveloffset=+1]
 
+include::partial$configuration/table_merge_content_on_paste.adoc[leveloffset=+1]
+
 NOTE: The advanced tabs of the table, row, and cell properties dialogs use the `+colorpicker+` to allow for border and background colors to be applied. See docs to use and configure a custom xref:user-formatting-options.adoc#text-color-options[colorpicker].
 
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]

--- a/modules/ROOT/pages/table.adoc
+++ b/modules/ROOT/pages/table.adoc
@@ -52,9 +52,9 @@ include::partial$configuration/table_row_advtab.adoc[leveloffset=+1]
 
 include::partial$configuration/table_style_by_css.adoc[leveloffset=+1]
 
-include::partial$configuration/table_merge_content_on_paste.adoc[leveloffset=+1]
-
 NOTE: The advanced tabs of the table, row, and cell properties dialogs use the `+colorpicker+` to allow for border and background colors to be applied. See docs to use and configure a custom xref:user-formatting-options.adoc#text-color-options[colorpicker].
+
+include::partial$configuration/table_merge_content_on_paste.adoc[leveloffset=+1]
 
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 

--- a/modules/ROOT/partials/configuration/table_merge_content_on_paste.adoc
+++ b/modules/ROOT/partials/configuration/table_merge_content_on_paste.adoc
@@ -1,0 +1,50 @@
+[[table_merge_content_on_paste]]
+== `+table_merge_content_on_paste+`
+
+This option sets the behavior of the editor when a table is pasted into another table.
+
+(If the insertion point is within a table or the current selection includes any part of a table, paste events happens into the table.)
+
+When set to `+true+`, pasting a table into another table replaces the extant table with the pasted table. It merges the pasted table into the extant table, replacing the extant table in the process.
+
+When set to `+false+`, pasting a table into another table creates a new table within the selected cell of the extant table.
+
+The specific behavior, when this option is set to `+false+`, depends on the nature of the current selection.
+
+. If there is no selection (ie the insertion point is within a cell), pasting a table in
+  * pastes the table at the insertion point;
+  * places material in the cell before the insertion point above the pasted-in table; and
+  * places material in the cell after the insertion point after the pasted-in table.
+
+. If the selection is the complete contents of a cell, pasting a table in
+  * replaces those contents; and
+  * puts the pasted-in table into the, now otherwise empty, table cell.
+
+. If the selection is the complete contents of more than one cell, pasting a table in
+  * replaces those contents;
+  * puts the pasted-in table into the first selected cell; and
+  * removes the other selected cells from the extant table.
+
+. If the selection is the complete contents of more than one cell and the partial contents of a final cell, pasting a table in
+  * replaces the contents of the completely selected cells;
+  * places the pasted-in table in the first selected cell;
+  * removes the other completely selected cells; and
+  * leaves the partially selected cell unchanged.
+
+This option is set to `+true+` by default.
+
+*Type:* `+Boolean+`
+
+*Default value:* `+true+`
+
+*Possible values:* `+true+`, `+false+`
+
+=== Example: using `+table_merge_content_on_paste+`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  table_merge_content_on_paste: false
+});
+----

--- a/modules/ROOT/partials/configuration/table_merge_content_on_paste.adoc
+++ b/modules/ROOT/partials/configuration/table_merge_content_on_paste.adoc
@@ -14,7 +14,7 @@ The specific behavior, when this option is set to `+false+`, depends on the natu
 . If there is no selection (ie the insertion point is within a cell), pasting a table in
   * pastes the table at the insertion point;
   * places material in the cell before the insertion point above the pasted-in table; and
-  * places material in the cell after the insertion point after the pasted-in table.
+  * places material in the cell after the insertion point below the pasted-in table.
 
 . If the selection is the complete contents of a cell, pasting a table in
   * replaces those contents; and

--- a/modules/ROOT/partials/configuration/table_merge_content_on_paste.adoc
+++ b/modules/ROOT/partials/configuration/table_merge_content_on_paste.adoc
@@ -1,6 +1,8 @@
 [[table_merge_content_on_paste]]
 == `+table_merge_content_on_paste+`
 
+include::partials$misc/admon-requires-6.5v.adoc[]
+
 This option sets the behavior of the editor when a table is pasted into another table.
 
 (If the insertion point is within a table or the current selection includes any part of a table, paste events happens into the table.)


### PR DESCRIPTION
DOC-2025: Document new `table_merge_content_on_paste` option.

Changes:
* Added include statement pointing to new partial: /configuration/table_merge_content_on_paste.adoc.
* Added new partial: /configuration/table_merge_content_on_paste.adoc
* Documented new option, `table_merge_content_on_paste`, in this new file.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] Files has been included where required (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
