### PR TITLE
DOC-2067: Added Accordion plugin to the release-notes.adoc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2067: Added TINY-9730 to `staging`.
 - DOC-2049: Added multiple `/partial/misc/admon-requires-6.<x>v.adoc` files for use as required by 6.5-and-later specific docs.
 - DOC-2047: Added TINY-9848 to `staging`.
 - DOC-2048: Added TINY-9812 to `staging`.

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -400,6 +400,7 @@
 ** xref:release-notes.adoc[Release notes for TinyMCE 6]
 *** TinyMCE 6.5
 **** xref:6.5-release-notes.adoc#overview[Overview]
+**** xref:6.5-release-notes.adoc#new-open-source-plugin[New Open Source Plugin]
 **** xref:6.5-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]
 **** xref:6.5-release-notes.adoc#accompanying-premium-plugin-end-of-life-announcement[Accompanying Premium Plugin end-of-life announcement]
 **** xref:6.5-release-notes.adoc#accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]

--- a/modules/ROOT/pages/6.5-release-notes.adoc
+++ b/modules/ROOT/pages/6.5-release-notes.adoc
@@ -31,8 +31,19 @@ The following new Open Source Plugin was released alongside {productname} 6.5.
 === Accordion 1.0.0
 //#TINY-9730
 
+The new Open Source plugin, **Accordion** allows for the creation of sections in a document that can be expanded or collapsed to show or hide additional content.
 
-// a few paragraphs of basic info about the plugin here.
+The Accordion plugin also provides integrators with four commands:
+
+* `InsertAccordion`;
+* `ToggleAccordion`;
+* ToggleAllAccordions`;
+* `RemoveAccordion`;
+
+and two initialization options
+
+* `details_initial_state`;
+* `details_serialized_state`.
 
 For information on the **Accordion** plugin see xref:accordion.adoc[Accordion].
 

--- a/modules/ROOT/pages/6.5-release-notes.adoc
+++ b/modules/ROOT/pages/6.5-release-notes.adoc
@@ -11,6 +11,7 @@
 
 {productname} 6.5 was released for {enterpriseversion} and {cloudname} on Wednesday, June 14^th^, 2023. These release notes provide an overview of the changes for {productname} 6.5:
 
+* xref:new-open-source-plugin[New Open Source Plugin]
 * xref:new-premium-plugin[New Premium Plugin]
 * xref:accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]
 * xref:accompanying-premium-plugin-end-of-life-announcement[Accompanying Premium Plugin end-of-life announcement]
@@ -22,8 +23,18 @@
 * xref:security-fixes[Security fixes]
 * xref:known-issues[Known issues]
 
-[[new-premium-plugin]]
-== New Premium Plugin
+[[new-open-source-plugin]]
+== New Open Source Plugin
+
+The following new Open Source Plugin was released alongside {productname} 6.5.
+
+=== Accordion 1.0.0
+//#TINY-9730
+
+
+// a few paragraphs of basic info about the plugin here.
+
+For information on the **Accordion** plugin see xref:accordion.adoc[Accordion].
 
 [[accompanying-premium-plugin-changes]]
 == Accompanying Premium Plugin changes


### PR DESCRIPTION
Ticket: DOC-2067

Changes:
* Added TINY-9730 Accordion plugin to the release-notes.adoc

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
