### PR TITLE
DOC-2073: Added TINY-9947 to the release notes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2073: Add TINY-9947 to `staging`.
 - DOC-2049: Added multiple `/partial/misc/admon-requires-6.<x>v.adoc` files for use as required by 6.5-and-later specific docs.
 - DOC-2047: Added TINY-9848 to `staging`.
 - DOC-2048: Added TINY-9812 to `staging`.

--- a/modules/ROOT/pages/6.5-release-notes.adoc
+++ b/modules/ROOT/pages/6.5-release-notes.adoc
@@ -90,12 +90,14 @@ In particular, the keyboard navigation text in the help dialog is now readable i
 
 {productname} 6.5 also incorporates the following changes:
 
-=== Help dialog was restored to `medium` width for better readability.
+=== The {productname} *Help* dialog was restored to medium width for better readability.
 //#TINY-9947
 
-A change was made in {productname} 6.4 that unintentionally caused the help dialog to become narrower.
+A change was made in {productname} 6.4 that caused the help dialog to become narrower.
 
-As a result, users experienced difficulty in reading the content, especially in languages other than English. To address this issue, the width of the help dialog has now been restored to its previous size, ensuring better readability for all users.
+As a result, users experienced difficulty in reading the content, especially in languages other than English.
+
+To address this issue, the width of the help dialog has been restored to its previous size, ensuring better readability for all users.
 
 [[bug-fixes]]
 == Bug fixes

--- a/modules/ROOT/pages/6.5-release-notes.adoc
+++ b/modules/ROOT/pages/6.5-release-notes.adoc
@@ -78,12 +78,24 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 == Additions
 {productname} 6.5 also includes the following additions:
 
+=== Dialog `tabpanel` tab labels are now allowed to word wrap for better readability with long labels.
+//#TINY-9947
+
+In {productname} 6.5, improvements were made to the `tabpanel` dialogs, which now allows labels on the tabs to wrap to multiple lines if necessary. This improves the readability of the tab labels, particularly with languages that contain longer labels.
+
+As a result, the recently translated keyboard navigation text on the help dialog is now easily readable in all languages, without compromising the width of the dialog tab buttons.
 
 [[changes]]
 == Changes
 
 {productname} 6.5 also incorporates the following changes:
 
+=== Help dialog was restored to `medium` width for better readability.
+//#TINY-9947
+
+A change was made in {productname} 6.4 that unintentionally caused the help dialog to become narrower.
+
+As a result, users experienced difficulty in reading the content, especially in languages other than English. To address this issue, the width of the help dialog has now been restored to its previous size, ensuring better readability for all users.
 
 [[bug-fixes]]
 == Bug fixes

--- a/modules/ROOT/pages/6.5-release-notes.adoc
+++ b/modules/ROOT/pages/6.5-release-notes.adoc
@@ -78,12 +78,12 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 == Additions
 {productname} 6.5 also includes the following additions:
 
-=== Dialog `tabpanel` tab labels are now allowed to word wrap for better readability with long labels.
+=== `tabpanel` labels in {productname} dialogs can now word wrap for better readability with long labels.
 //#TINY-9947
 
-In {productname} 6.5, improvements were made to the `tabpanel` dialogs, which now allows labels on the tabs to wrap to multiple lines if necessary. This improves the readability of the tab labels, particularly with languages that contain longer labels.
+For {productname} 6.5, improvements were made to the `tabpanel` dialogs: labels on the tabs can now wrap to multiple lines. This improves the readability of the tab labels, particularly when longer labels are displayed.
 
-As a result, the recently translated keyboard navigation text on the help dialog is now easily readable in all languages, without compromising the width of the dialog tab buttons.
+In particular, the keyboard navigation text in the help dialog is now readable in all languages, without compromising the width of the dialog tab buttons.
 
 [[changes]]
 == Changes


### PR DESCRIPTION
Ticket: DOC-2073

Changes:
* Added TINY-9947 to the release notes.
* Entry for `=== Dialog `tabpanel` tab labels are now allowed to word wrap for better readability with long labels.
TINY-9947` & `=== Help dialog was restored to `medium` width for better readability.
TINY-9947`

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
