### PR TITLE
DOC-2076: typo correction in changelog.adoc

### DIFF
--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -4,7 +4,7 @@
 
 NOTE: This is the {productname} Community version changelog. For information about the latest {cloudname} or {enterpriseversion} Release, see: xref:release-notes.adoc[{productname} Release Notes].
 
-== 6.5 - 2023-06-13
+== 6.5.0 - 2023-06-13
 
 === Added
 * Support for the `h` hash parameter in Vimeo video URLs in the Media plugin.


### PR DESCRIPTION
DOC-2076: typo correction in changelog.adoc

Changes:
* s/6.5/6.5.0/

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`

Review:
- [x] Documentation Team Lead has reviewed
