### PR TITLE
DOC-2083: boilerplate missing from `accordion.adoc`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### 2023-06-23
+
+- DOC-2083: Added back standard sentence inadvertently removed from `accordion.adoc`.
+
 ### 2023-06-21
 
 - DOC-2082: Copy edits to TinyMCE 6.5.1 release-notes.

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### 2023-06-21
 
+- DOC-2082: Copy edits to TinyMCE 6.5.1 release-notes.
 - DOC-2081: Updates to 6.5.1 release-notes accordion.adoc file.
 - DOC-1781: add List Properties menu item & two commands (mceListUpdate & mceListProps) to Lists Plugin documentation.
 - DOC-2072: Corrections and updates for 6.5.1 `staging`

--- a/modules/ROOT/pages/accordion.adoc
+++ b/modules/ROOT/pages/accordion.adoc
@@ -34,6 +34,8 @@ tinymce.init({
 
 == Options
 
+The following configuration options affect the behavior of the {pluginname} plugin.
+
 include::partial$configuration/details_initial_state.adoc[][leveloffset=+1]
 
 include::partial$configuration/details_serialized_state.adoc[][leveloffset=+1]


### PR DESCRIPTION
DOC-2083: boilerplate missing from `accordion.adoc`

Changes:
* Added back standard sentence inadvertently removed from `accordion.adoc`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [ ] Documentation Team Lead has reviewed
