### PR TITLE
DOC-2068: typos and copy-edits found in docs: 2023-06-21 – 2023-06-30

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### 2023-07-02
+
+- DOC-2068: Copy-edits and corrections to two files, `6.5.1-release-notes.adoc` and `opensource-plugins.adoc`.
+
 ### 2023-06-23
 
 - DOC-2083: Added back standard sentence inadvertently removed from `accordion.adoc`.

--- a/modules/ROOT/pages/6.5.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.5.1-release-notes.adoc
@@ -4,7 +4,7 @@
 :keywords: releasenotes, new, changes, bugfixes
 :page-toclevels: 1
 
-//include::partial$misc/admon-releasenotes-for-stable.adoc[]
+include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 [[overview]]
 == Overview

--- a/modules/ROOT/partials/index-pages/opensource-plugins.adoc
+++ b/modules/ROOT/partials/index-pages/opensource-plugins.adoc
@@ -5,6 +5,12 @@ This section lists the open source plugins provided with {productname}.
 
 a|
 [.lead]
+xref:accordion.adoc[Accordion]
+
+Create expandable and collapsible sections.
+
+a|
+[.lead]
 xref:advlist.adoc[Advanced List]
 
 Create styled number and bulleted lists.
@@ -43,7 +49,7 @@ a|
 [.lead]
 xref:code.adoc[Code]
 
-Edit your content's HTML source.
+Edit your content’s HTML source.
 
 a|
 [.lead]
@@ -183,7 +189,7 @@ Show a word count in the {productname} status bar.
 //    odd.
 // 2. Prepend the inline comment markup to this element
 //    when the number of cells in the table is even.
-a|
+//a|
 
 |===
 


### PR DESCRIPTION
Ticket: DOC-2068: typos and copy-edits found in docs: 2023-06-21 – 2023-06-30

Changes:
1. `opensource-plugins.adoc`
	* Added accordions entry to open source plugins index page.
	* Also commented out the empty cell since this addition makes the number of cells even.
	* And applied a seen-in-passing copy-edit.
2. `6.5.1-release-notes.adoc`
	* Removed comment from include adding `admon-releasenotes-for-stable.adoc` to the release notes.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
