### PR TITLE
DOC-2095: Correct table mark-up in release-notes.adoc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-### Unreleased
+### 2023-07-05
 
 - DOC-2094: Typo corrections in `/ie-template-creation/index.js`.
 - DOC-2095: Typo correction in `release-notes.adoc`.

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 ### Unreleased
 
 - DOC-2094: Typo corrections in `/ie-template-creation/index.js`.
+- DOC-2095: Typo correction in `release-notes.adoc`.
 
 ### 2023-07-04
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -81,7 +81,7 @@ Release notes for {productname} 6.0
 //    odd.
 // 2. Prepend the inline comment markup to this element
 //    when the number of cells in the table is even.
-//a|
+a|
 
 |===
 


### PR DESCRIPTION
DOC-2095: Correct table mark-up in release-notes.adoc

Changes:
* Markup for an empty cell, required when the number of content-carrying cells is odd, was incorrectly commented out.
	* It is now not so.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
