### PR TITLE
WSRF-1310: SEO: Add canonical links as experiment

### DIFF
--- a/_includes/template/head.html
+++ b/_includes/template/head.html
@@ -15,6 +15,15 @@
     <link href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" rel="stylesheet" media="print" onload="this.media='all'; this.onload=null;"/>
     <link href="{{ site.shared_baseurl }}{{ site.baseurl }}/css/common.min.css" rel="stylesheet">
 
+    <!-- Temporary test: https://ephocks.atlassian.net/browse/WSRF-1310 -->
+    {% if page.url == "/plugins/premium/linkchecker/" %}
+      <link rel="canonical" href="https://www.tiny.cloud/docs/tinymce/6/linkchecker/"/>
+    {% endif %}
+
+    {% if page.url == "/plugins/opensource/toc/" %}
+      <link rel="canonical" href="https://www.tiny.cloud/docs/tinymce/6/tableofcontents/"/>
+    {% endif %}
+
     {% include_remote {{ site.origin }}/_docs/head.html %}
 
     {% assign tinymce_script_tag_included = false %}


### PR DESCRIPTION
Ticket: [WSRF-1310](https://ephocks.atlassian.net/browse/WSRF-1310)

Changes:
* Added canonical links for 2 plugin pages as experiment

Pre-checks:
- [ ] Branch prefixed with `feature/6/` or `hotfix/6/`
- [ ] Changelog entry added
- [ ] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [ ] Files has been included where required (if applicable)
- [ ] Files removed have been deleted, not just excluded from the build (if applicable)
- [ ] (New product features only) Release Note added

Review:
- [ ] Documentation Team Lead has reviewed


[WSRF-1310]: https://ephocks.atlassian.net/browse/WSRF-1310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ