### PR TITLE
DOC-2098: Typo in include statement in table_merge_content_on_paste.adoc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### 2023-07-06
 
-- DOC-2098: Typo in include statement in `table_merge_content_on_paste.adoc`.
+- DOC-2098: Typo corrected in include statement in `table_merge_content_on_paste.adoc`.
 
 ### 2023-07-05
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### 2023-07-06
+
+- DOC-2098: Typo in include statement in `table_merge_content_on_paste.adoc`.
+
 ### 2023-07-05
 
 - DOC-2094: Typo corrections in `/ie-template-creation/index.js`.

--- a/modules/ROOT/partials/configuration/table_merge_content_on_paste.adoc
+++ b/modules/ROOT/partials/configuration/table_merge_content_on_paste.adoc
@@ -1,7 +1,7 @@
 [[table_merge_content_on_paste]]
 == `+table_merge_content_on_paste+`
 
-include::partials$misc/admon-requires-6.5v.adoc[]
+include::partial$misc/admon-requires-6.5v.adoc[]
 
 This option sets the behavior of the editor when a table is pasted into another table.
 


### PR DESCRIPTION
DOC-2098: Typo in include statement in `table_merge_content_on_paste.adoc`.

Changes:
* Corrected typo in include statement.
	* s/partials/partial/.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
