### PR TITLE
DOC-2108: add link to AI Assistant sign-up page to admon-ai-pricing.adoc and `ai-proxy.adoc`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### 2023-07-25
+
+- DOC-2108: added links to *AI Assistant* sign-up page to `admon-ai-pricing.adoc` and `ai-proxy.adoc`.
+
 ### 2023-07-21
 
 - DOC-2093: The TinyMCE 6.6 Release notes.

--- a/modules/ROOT/pages/ai-proxy.adoc
+++ b/modules/ROOT/pages/ai-proxy.adoc
@@ -37,7 +37,9 @@ The proxy adds a layer of flexibility by allowing extra processing before the re
 .Sign up for the {productname} {pluginname}
 [%collapsible]
 ====
-The {productname} {pluginname} provides the end user Ui interaction components and workflows. This enables end users to make AI requests, modify, fine tune results and insert enhanced content back into the editor. The plugin also provides the server request component that sends user requests to the AI LLM service.
+The TinyMCE {pluginname} provides the end user Ui interaction components and workflows. This enables end users to make AI requests, modify, fine tune results and insert enhanced content back into the editor. The plugin also provides the server request component that sends user requests to the AI LLM service.
+
+Sign-up details are available link:{aipricingurl}[here].
 ====
 .Select a proxy server of your choice
 [%collapsible]

--- a/modules/ROOT/partials/misc/admon-ai-pricing.adoc
+++ b/modules/ROOT/partials/misc/admon-ai-pricing.adoc
@@ -1,1 +1,1 @@
-NOTE: This plugin is only available as a paid add-on to link:{pricingpage}/[a TinyMCE subscription].
+Note: This plugin is only available as a link:{aipricingurl}/[paid add-on] to link:{pricingpage}/[a TinyMCE subscription].

--- a/modules/ROOT/partials/misc/admon-ai-pricing.adoc
+++ b/modules/ROOT/partials/misc/admon-ai-pricing.adoc
@@ -1,1 +1,1 @@
-Note: This plugin is only available as a link:{aipricingurl}/[paid add-on] to link:{pricingpage}/[a TinyMCE subscription].
+NOTE: This plugin is only available as a link:{aipricingurl}/[paid add-on] to link:{pricingpage}/[a TinyMCE subscription].


### PR DESCRIPTION
Changes:
* added link out to AI Assistant sign-up page on tiny.cloud to:
	* `admon-ai-pricing.adoc`; and
	* `ai-proxy.adoc`
* **NB:** the URL — https://www.tiny.cloud/tinymce/features/ai-integration/ — will not go live until ≅2023-07-25 20:00 AEST (2023-07-25 12:00 CEST).

Ticket: DOC-2108: add link to AI Assistant sign up page to admon-ai-pricing.adoc and `ai-proxy.adoc`

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added


Review:
- [x] Documentation Team Lead has reviewed
