### PR TITLE
DOC-2133: incorrect ‘For information’ links in `code` and `code sample` sections

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### 2023-07-26
 
-- DOC-2133: Added `:pluginpage:` variables to `code` and `codesample` entries in `available-toolbar-buttons.adoc`.
+- DOC-2133: Added required `:pluginpage:` variables to entries in `available-toolbar-buttons.adoc`.
 
 ### 2023-07-25
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,9 +4,13 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### 2023-07-26
+
+- DOC-2133: Added `:pluginpage:` variables to `code` and `codesample` entries in `available-toolbar-buttons.adoc`.
+
 ### 2023-07-25
 
-- DOC-2108: added links to *AI Assistant* sign-up page to `admon-ai-pricing.adoc` and `ai-proxy.adoc`.
+- DOC-2108: Added links to *AI Assistant* sign-up page to `admon-ai-pricing.adoc` and `ai-proxy.adoc`.
 
 ### 2023-07-21
 

--- a/modules/ROOT/pages/available-toolbar-buttons.adoc
+++ b/modules/ROOT/pages/available-toolbar-buttons.adoc
@@ -87,11 +87,13 @@ include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 :plugincategory: opensource
 :pluginname: Code
 :plugincode: code
+:pluginpage: code.adoc
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Code Sample
 :plugincode: codesample
+:pluginpage: codesample.adoc
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium

--- a/modules/ROOT/pages/available-toolbar-buttons.adoc
+++ b/modules/ROOT/pages/available-toolbar-buttons.adoc
@@ -62,26 +62,31 @@ include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 :plugincategory: opensource
 :pluginname: Anchor
 :plugincode: anchor
+:pluginpage: anchor.adoc
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Autosave
 :plugincode: autosave
+:pluginpage: autosave.adoc
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
 :pluginname: Case Change
 :plugincode: casechange
+:pluginpage: casechange.adoc
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource
 :pluginname: Character Map
 :plugincode: charmap
+:pluginpage: charmap.adoc
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
 :pluginname: Checklist
 :plugincode: checklist
+:pluginpage: checklist.adoc
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: opensource


### PR DESCRIPTION
Ticket: DOC-2133, In **Toolbar Buttons Available for TinyMCE**, the _For information_ links in `code` and `code sample` incorrectly point to Advanced Typography

Changes:
* Added :pluginpage: variables to entries as required.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
