### PR TITLE
DOC-2092: Add xref, pointing to `apis/tinymce.windowmanager.adoc`, to Dialog position section of dialog-configuration.adoc.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### 2023-07-26
 
+- DOC-2092: Added xref, pointing to `apis/tinymce.windowmanager.adoc`, in `dialog-configuration.adoc`.
 - DOC-2133: Added required `:pluginpage:` variables to entries in `available-toolbar-buttons.adoc`.
 
 ### 2023-07-25

--- a/modules/ROOT/pages/dialog-configuration.adoc
+++ b/modules/ROOT/pages/dialog-configuration.adoc
@@ -90,7 +90,7 @@ This presented position can be changed by providing a second argument, with an a
 [[inline]]
 === `+inline+`
 
-The `+inline+` option, passed to `editor.windowManager.open()`, sets the dialog’s presented position to one of two possiblities.
+The `+inline+` option, passed to xref:apis/tinymce.windowmanager.adoc#open[`editor.windowManager.open()`], sets the dialog’s presented position to one of two possiblities.
 
 When added to a configuration with the value, `+toolbar+`, it sets the dialog to appear adjacent to the {productname} toolbar.
 

--- a/modules/ROOT/pages/dialog-configuration.adoc
+++ b/modules/ROOT/pages/dialog-configuration.adoc
@@ -85,12 +85,12 @@ include::partial$configuration/dialog_streamContent.adoc[]
 
 By default a dialog is shown as a modal in the center of the editor viewport.
 
-This presented position can be changed by providing a second argument, with an appropriate value, to `editor.windowManager.open()`.
+This presented position can be changed by providing a second argument, with an appropriate value, to xref:apis/tinymce.windowmanager.adoc#open[`editor.windowManager.open()`].
 
 [[inline]]
 === `+inline+`
 
-The `+inline+` option, passed to xref:apis/tinymce.windowmanager.adoc#open[`editor.windowManager.open()`], sets the dialog’s presented position to one of two possiblities.
+The `+inline+` option, passed to `editor.windowManager.open()`, sets the dialog’s presented position to one of two possiblities.
 
 When added to a configuration with the value, `+toolbar+`, it sets the dialog to appear adjacent to the {productname} toolbar.
 

--- a/modules/ROOT/partials/configuration/mentions_fetch.adoc
+++ b/modules/ROOT/partials/configuration/mentions_fetch.adoc
@@ -1,13 +1,7 @@
 [[mentions_fetch]]
 == `+mentions_fetch+`
 
-This option lets you request a list of users from your server that match a search query. The callback gets passed two parameters: one is the search query object, the other is the success callback to execute with the results. The query object has a term property that contains what the user has typed after the "@" sign.
-
-The success call should contain an array of users.
-
-NOTE: Only the first ten (10) users listed in the array are displayed in the Mentions UI presented to end-users.
-
-For information on the user properties to pass the success callback for the available mentions item types (`+mentions_item_type+`), see: xref:mentions.adoc#user-properties[User properties].
+This option lets you request a list of users from your server that match a search query. The callback gets passed two parameters: one is the search query object, the other is the success callback to execute with the results. The query object has a term property that contains what the user has typed after the "@" sign. The success call should contain an array of users. For information on the user properties to pass the success callback for the available mentions item types (`+mentions_item_type+`), see: xref:mentions.adoc#user-properties[User properties].
 
 *Type:* `+Function+`
 

--- a/modules/ROOT/partials/configuration/mentions_fetch.adoc
+++ b/modules/ROOT/partials/configuration/mentions_fetch.adoc
@@ -1,7 +1,13 @@
 [[mentions_fetch]]
 == `+mentions_fetch+`
 
-This option lets you request a list of users from your server that match a search query. The callback gets passed two parameters: one is the search query object, the other is the success callback to execute with the results. The query object has a term property that contains what the user has typed after the "@" sign. The success call should contain an array of users. For information on the user properties to pass the success callback for the available mentions item types (`+mentions_item_type+`), see: xref:mentions.adoc#user-properties[User properties].
+This option lets you request a list of users from your server that match a search query. The callback gets passed two parameters: one is the search query object, the other is the success callback to execute with the results. The query object has a term property that contains what the user has typed after the "@" sign.
+
+The success call should contain an array of users.
+
+NOTE: Only the first ten (10) users listed in the array are displayed in the Mentions UI presented to end-users.
+
+For information on the user properties to pass the success callback for the available mentions item types (`+mentions_item_type+`), see: xref:mentions.adoc#user-properties[User properties].
 
 *Type:* `+Function+`
 


### PR DESCRIPTION
Ticket:
* DOC-2092: Add xref, pointing to `apis/tinymce.windowmanager.adoc`, to *Dialog position* section of `dialog-configuration.adoc`.

Changes:
* Added xref, pointing to `apis/tinymce.windowmanager.adoc`, to *Dialog position* section of `dialog-configuration.adoc`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
