### PR TITLE
DOC-2138: document the only-ten-users-present-to-the-end-user UI.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### 2023-07-27
+
+- DOC-2138: Added admonition to `mentions_fetch.adoc`, documenting the *only ten users present to the end user* UI.
+
 ### 2023-07-26
 
 - DOC-2133: Added required `:pluginpage:` variables to entries in `available-toolbar-buttons.adoc`.

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### 2023-07-27
 
-- DOC-2138: Added admonition to `mentions_fetch.adoc`, documenting the *only ten users present to the end user* UI.
+- DOC-2138: Added admonition to `mentions_fetch.adoc`, documenting the *only ten users present to the end user* UI. Also added paragraph to `examples/live-demos/mentions/index.html` noting the random nature of the photo-and-name pairing possible when using the *Mentions* live demo.
 
 ### 2023-07-26
 

--- a/modules/ROOT/examples/live-demos/mentions/index.html
+++ b/modules/ROOT/examples/live-demos/mentions/index.html
@@ -1,4 +1,7 @@
 <textarea id="mentions">
   <p>Type "<kbd>@</kbd>" followed immediately by one or more characters.</p>
   <p>For example: @a</p>
+  <p>&nbsp;</p>
+  <p><strong>NB:</strong> This demonstration emulates a back-end database store by randomly matching freely-distributable portrait photographs with a semi-arbitrary list of names and titles. Curious-to-cultural-norms pairings of portraits and names are entirely possible.</p>
+  
 </textarea>

--- a/modules/ROOT/partials/configuration/mentions_fetch.adoc
+++ b/modules/ROOT/partials/configuration/mentions_fetch.adoc
@@ -1,7 +1,13 @@
 [[mentions_fetch]]
 == `+mentions_fetch+`
 
-This option lets you request a list of users from your server that match a search query. The callback gets passed two parameters: one is the search query object, the other is the success callback to execute with the results. The query object has a term property that contains what the user has typed after the "@" sign. The success call should contain an array of users. For information on the user properties to pass the success callback for the available mentions item types (`+mentions_item_type+`), see: xref:mentions.adoc#user-properties[User properties].
+This option lets you request a list of users from your server that match a search query. The callback gets passed two parameters: one is the search query object, the other is the success callback to execute with the results. The query object has a term property that contains what the user has typed after the "@" sign.
+
+The success call should contain an array of users.
+
+NOTE: Only the first ten (10) users listed in the array are displayed in the Mentions UI presented to end-users.
+
+For information on the user properties to pass the success callback for the available mentions item types (`+mentions_item_type+`), see: xref:mentions.adoc#user-properties[User properties].
 
 *Type:* `+Function+`
 

--- a/modules/ROOT/partials/configuration/mentions_fetch.adoc
+++ b/modules/ROOT/partials/configuration/mentions_fetch.adoc
@@ -7,7 +7,7 @@ The success call should contain an array of users.
 
 NOTE: Only the first ten (10) users listed in the array are displayed in the Mentions UI presented to end-users.
 
-For information on the user properties to pass the success callback for the available mentions item types (`+mentions_item_type+`), see: xref:mentions.adoc#user-properties[User properties].
+For information on the user properties to pass to the success callback for the available mentions item types (`+mentions_item_type+`), see: xref:mentions.adoc#user-properties[User properties].
 
 *Type:* `+Function+`
 


### PR DESCRIPTION
Ticket: DOC-2138, document the only-ten-users-present-to-the-end-user UI.

Changes:
* Added NOTE admonition to `mentions_fetch.adoc`, documenting the *only ten users present to the end user* UI.
* added paragraph to `examples/live-demos/mentions/index.html` noting the random nature of the photo-and-name pairing possible when using the *Mentions* live demo.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
