### PR TITLE
DOC-2141: AI Assistant bug fix documentation entry for TINY-10077 (№1) in the 6.6.1 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### Unreleased
+
+- DOC-2141: documentation of bug fix, _Toolbar buttons and menu items were enabled while the dialog was waiting for a final response_, added to **AI Assistant** section of `6.6.1-release-notes.adoc`.
+
 ### 2023-07-21
 
 - DOC-2093: The TinyMCE 6.6 Release notes.

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -36,7 +36,9 @@ The {productname} 6.6.1 release includes an accompanying release of the **AI Ass
 ==== Toolbar buttons and menu items were enabled while the dialog was waiting for a final response
 //#TINY-10077 #1
 
-// CCFR here.
+The **AI Assistant** toolbar buttons and menu items provide no functionality while a response is being generated in the AI Assistant dialog. Previously, however, these buttons and items continued to present as enabled during response generation.
+
+With the release of **AI Assistant** 1.0.1, this has been corrected. The plugin’s toolbar buttons and menu items are now disabled while a response is being generated.
 
 ==== Error events from streaming requests were included in threads separately to the corresponding response event
 //#TINY-10077 #2


### PR DESCRIPTION
Ticket: DOC-2141: AI Assistant bug fix documentation entry for TINY-10077 (№1) in the 6.6.1 Release Notes

Changes:
* documentation of bug fix, _Toolbar buttons and menu items were enabled while the dialog was waiting for a final response_, added to **AI Assistant** section of `6.6.1-release-notes.adoc`.
	* NB: the base branch for this PR is deliberate. Individual Release Note entries are merged back to the general Release Notes branch and the entire Release Notes branch is then merged back to `/staging/docs-6`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
