### PR TITLE
DOC-2142: AI Assistant bug fix documentation entry for TINY-10077 (№2) in the 6.6.1 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### Unreleased
+
+- DOC-2142: documentation of bug fix, _Error events from streaming requests were included in seperate threads to the corresponding response event_, added to **AI Assistant** section of `6.6.1-release-notes.adoc`.
+
 ### 2023-07-21
 
 - DOC-2093: The TinyMCE 6.6 Release notes.

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -38,10 +38,12 @@ The {productname} 6.6.1 release includes an accompanying release of the **AI Ass
 
 // CCFR here.
 
-==== Error events from streaming requests were included in threads separately to the corresponding response event
+==== Error events from streaming requests were included in seperate threads to the corresponding response event
 //#TINY-10077 #2
 
-// CCFR here.
+Previously, when an error occurred while a streaming response was in progress, both an error and response event were added to the current thread.
+
+**AI Assistant 1.0.1** corrects this. Now, when an error occurs during an in-progress streaming response, a single event — containing both the error and the response — is added to the current thread.
 
 ==== Preview content was removed when an error is encountered part way through a streaming response
 //#TINY-10096

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -38,7 +38,7 @@ The {productname} 6.6.1 release includes an accompanying release of the **AI Ass
 
 // CCFR here.
 
-==== Error events from streaming requests were included in seperate threads to the corresponding response event
+==== Error events from streaming requests were included in separate threads to the corresponding response event
 //#TINY-10077 #2
 
 Previously, when an error occurred while a streaming response was in progress, both an error and response event were added to the current thread.


### PR DESCRIPTION
Ticket: DOC-2142: AI Assistant bug fix documentation entry for TINY-10077 (№2) in the 6.6.1 Release Notes

Changes:
* documentation of bug fix, _Error events from streaming requests were included in seperate threads to the corresponding response event_, added to **AI Assistant** section of `6.6.1-release-notes.adoc`.
	* NB: the base branch for this PR is deliberate. Individual Release Note entries are merged back to the general Release Notes branch and the entire Release Notes branch is then merged back to `/staging/docs-6`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
