### PR TITLE
DOC-2140: AI Assistant bug fix documentation entry for TINY-10096 in the 6.6.1 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### Unreleased
+
+- DOC-2140: documentation of bug fix, _Preview content was removed when an error is encountered part way through a streaming response_, added to **AI Assistant** section of `6.6.1-release-notes.adoc`.
+
 ### 2023-07-21
 
 - DOC-2093: The TinyMCE 6.6 Release notes.

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -46,8 +46,11 @@ The {productname} 6.6.1 release includes an accompanying release of the **AI Ass
 ==== Preview content was removed when an error is encountered part way through a streaming response
 //#TINY-10096
 
-// CCFR here.
+Previously, when an error was encountered while a streaming response was in progress, the **AI Assistant** dialog removed the partial response when displaying the error.
 
+With the release of **AI Assistant 1.0.1**, the partial response is left in place, displayed as a finished response.
+
+And the error message is displayed below this, left-in-place, response.
 
 ==== Using AI Assistant within OSX Safari, caused the editor to scroll to the bottom of the editor
 //#TINY-10102


### PR DESCRIPTION
Ticket: DOC-2140: AI Assistant bug fix documentation entry for TINY-10096 in the 6.6.1 Release Notes

Changes:
* documentation of bug fix, _review content was removed when an error is encountered part way through a streaming response_, added to **AI Assistant** section of `6.6.1-release-notes.adoc`.
	* NB: the base branch for this PR is deliberate. Individual Release Note entries are merged back to the general Release Notes branch and the entire Release Notes branch is then merged back to `/staging/docs-6`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
