### PR TITLE
DOC-2148: AI Assistant bug fix documentation entry for TINY-10102 in the 6.6.1 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### Unreleased
+
+- DOC-2148: documentation of bug fix, _when Safari on macOS was the host environment and a returned response was inserted into the {productname} editor, the inserted content did not scroll into view_, added to **AI Assistant** section of `6.6.1-release-notes.adoc`.
+
 ### 2023-07-21
 
 - DOC-2093: The TinyMCE 6.6 Release notes.

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
-- DOC-2148: documentation of bug fix, _when Safari on macOS was the host environment and a returned response was inserted into the {productname} editor, the inserted content did not scroll into view_, added to **AI Assistant** section of `6.6.1-release-notes.adoc`.
+- DOC-2148: documentation of bug fix, _When a response from the AI Assistant dialog was inserted into a selection not in view, the content did not scroll into view_, added to **AI Assistant** section of `6.6.1-release-notes.adoc`.
 
 ### 2023-07-21
 

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -58,7 +58,7 @@ Previously when:
 . the **AI Assistant** dialog was open and contained a returned response; and
 . the *Insert* button was pressed
 
-The **AI Assistant** dialog closed but, if the inserted content was not visible, the {productname} editor instance did not scroll the material into view.
+the **AI Assistant** dialog closed but, if the inserted content was not visible, the {productname} editor instance did not scroll the returned response into view.
 
 **AI Assistant** 1.0.1 fixes this.
 

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -49,7 +49,7 @@ The {productname} 6.6.1 release includes an accompanying release of the **AI Ass
 // CCFR here.
 
 
-==== When Safari on macOS was the host environment and a returned response was inserted into the {productname} editor, the inserted content did not scroll into view
+==== When a response from the AI Assistant dialog was inserted into a selection not in view, the content did not scroll into view
 //#TINY-10102
 
 Previously when inserting a response from the AI Assistant dialog at a selection which is above the current view, the inserted content would not be scrolled into view.

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -49,7 +49,7 @@ The {productname} 6.6.1 release includes an accompanying release of the **AI Ass
 // CCFR here.
 
 
-==== when Safari on macOS was the host environment and a returned response was inserted into the {productname} editor, the inserted content did not scroll into view
+==== When Safari on macOS was the host environment and a returned response was inserted into the {productname} editor, the inserted content did not scroll into view
 //#TINY-10102
 
 Previously when:

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -49,10 +49,20 @@ The {productname} 6.6.1 release includes an accompanying release of the **AI Ass
 // CCFR here.
 
 
-==== Using AI Assistant within OSX Safari, caused the editor to scroll to the bottom of the editor
+==== when Safari on macOS was the host environment and a returned response was inserted into the {productname} editor, the inserted content did not scroll into view
 //#TINY-10102
 
-// CCFR here.
+Previously when:
+
+. Safari running on macOS was the host browser; and
+. the **AI Assistant** dialog was open and contained a returned response; and
+. the *Insert* button was pressed
+
+The **AI Assistant** dialog closed but, if the inserted content was not visible, the {productname} editor instance did not scroll the material into view.
+
+**AI Assistant** 1.0.1 fixes this.
+
+With this release, after the *Insert* button is pressed and the **AI Assistant** dialog closes, if the inserted response is not visible, the {productname} editor scrolls it into view.
 
 For information on the **AI Assistant** plugin, see: xref:ai.adoc[AI Assistant].
 

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -52,17 +52,9 @@ The {productname} 6.6.1 release includes an accompanying release of the **AI Ass
 ==== When Safari on macOS was the host environment and a returned response was inserted into the {productname} editor, the inserted content did not scroll into view
 //#TINY-10102
 
-Previously when:
+Previously when inserting a response from the AI Assistant dialog at a selection which is above the current view, the inserted content would not be scrolled into view.
 
-. Safari running on macOS was the host browser; and
-. the **AI Assistant** dialog was open and contained a returned response; and
-. the *Insert* button was pressed
-
-the **AI Assistant** dialog closed but, if the inserted content was not visible, the {productname} editor instance did not scroll the returned response into view.
-
-**AI Assistant** 1.0.1 fixes this.
-
-With this release, after the *Insert* button is pressed and the **AI Assistant** dialog closes, if the inserted response is not visible, the {productname} editor scrolls it into view.
+In **AI Assistant** 1.0.1, the response is now inserted after the dialog is closed, allowing the content to be scrolled into view correctly.
 
 For information on the **AI Assistant** plugin, see: xref:ai.adoc[AI Assistant].
 


### PR DESCRIPTION
Ticket: DOC-2148: AI Assistant bug fix documentation entry for TINY-10102 in the 6.6.1 Release Notes

Changes:
* documentation of bug fix, _When a response from the AI Assistant dialog was inserted into a selection not in view, the content did not scroll into view_, added to **AI Assistant** section of `6.6.1-release-notes.adoc`.
	* NB: the base branch for this PR is deliberate. Individual Release Note entries are merged back to the general Release Notes branch and the entire Release Notes branch is then merged back to `/staging/docs-6`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
