### PR TITLE
DOC-2143: Enhanced Image Editor bug fix documentation entry for TINY-10016 in the 6.6.1 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### Unreleased
+
+- DOC-2143: documentation of bug fix, _Context menu and context toolbar no longer show when the selected image is in a non-editable context_ added to **Enhanced Image Editing** section of `6.6.1-release-notes.adoc`..
+
 ### 2023-07-21
 
 - DOC-2093: The TinyMCE 6.6 Release notes.

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
-- DOC-2143: documentation of bug fix, _Context menu and context toolbar no longer show when the selected image is in a non-editable context_ added to **Enhanced Image Editing** section of `6.6.1-release-notes.adoc`..
+- DOC-2143: documentation of bug fix, _Context menu and context toolbar no longer show when the selected image is in a non-editable context_ added to **Enhanced Image Editing** section of `6.6.1-release-notes.adoc`.
 
 ### 2023-07-21
 

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -66,15 +66,17 @@ The {productname} 6.6.1 release includes an accompanying release of the **Enhanc
 ==== Context menu and context toolbar no longer show when the selected image is in a non-editable context
 //#TINY-10016
 
-When a {productname} instance is setup with `editable_root: false` set, the entire instance is, by default, a read-only instance. To allow editing of any portion, that portion must have a `contenteditable="true"` attribute set.
+When a {productname} instance is setup with `editable_root: false` set, the entire instance is, by default, a read-only instance.
 
-Previously, however, if an image was in a {productname} instance with an `editable_root: false` set, bringing up the {productname} context menu (eg by right-clicking on the image in a desktop setting or by long-pressing on the image in a mobile setting) allowed the {productname} context toolbar to be further presented, which allowed for image manipulation.
+To allow editing of any portion, that portion must be specifically set as writable (for example, by being within an element that has a `contenteditable="true"` attribute set).
 
-**Enhanced Image Editing** 1.1.1 addresses this. With this update, right-clicking on an image, or long-pressing on an image in a mobile setting, no longer brings up the {productname} context menu, obviating the path to, further, bringing up the {productname} toolbar.
+Previously, however, if an image was in a {productname} instance with both an `editable_root: false` set and the xref:editimage.adoc[Enhanced Image Editing] Premium plugin loaded, bringing up a {productname} context menu (eg by right-clicking on the image in a desktop setting or by long-pressing on the image in a mobile setting) allowed the Enhanced Image Editing plugin’s context toolbar to present, which allowed for image manipulation.
+
+**Enhanced Image Editing** 1.1.1 addresses this. With this update, invoking a context menu in non-editable area no longer brings up the plugin’s context toolbar.
 
 As a consequence, images presented within a {productname} instance setup with a `editable_root: false` set are properly read-only, as expected.
 
-NOTE: right-clicking on an image, or long-pressing on an image in a mobile instance, still invokes the host browser’s context menu in such a setup.
+NOTE: right-clicking on an image, or long-pressing on an image in a mobile instance, still invokes the host browser’s context menu in such a circumstance.
 
 For information on the **Enhanced Image Editing** plugin, see: xref:editimage.adoc[Enhanced Image Editing].
 

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -66,7 +66,15 @@ The {productname} 6.6.1 release includes an accompanying release of the **Enhanc
 ==== Context menu and context toolbar no longer show when the selected image is in a non-editable context
 //#TINY-10016
 
-// CCFR here.
+When a {productname} instance is setup with `editable_root: false` set, the entire instance is, by default, a read-only instance. To allow editing of any portion, that portion must have a `contenteditable="true"` attribute set.
+
+Previously, however, if an image was in a {productname} instance with an `editable_root: false` set, bringing up the {productname} context menu (eg by right-clicking on the image in a desktop setting or by long-pressing on the image in a mobile setting) allowed the {productname} context toolbar to be further presented, which allowed for image manipulation.
+
+**Enhanced Image Editing** 1.1.1 addresses this. With this update, right-clicking on an image, or long-pressing on an image in a mobile setting, no longer brings up the {productname} context menu, obviating the path to, further, bringing up the {productname} toolbar.
+
+As a consequence, images presented within a {productname} instance setup with a `editable_root: false` set are properly read-only, as expected.
+
+NOTE: right-clicking on an image, or long-pressing on an image in a mobile instance, still invokes the host browser’s context menu in such a setup.
 
 For information on the **Enhanced Image Editing** plugin, see: xref:editimage.adoc[Enhanced Image Editing].
 


### PR DESCRIPTION
Ticket: DOC-2143: Enhanced Image Editor bug fix documentation entry for TINY-10016 in the 6.6.1 Release Notes

Changes:
* documentation of bug fix, _Context menu and context toolbar no longer show when the selected image is in a non-editable context_ added to **Enhanced Image Editing** section of `6.6.1-release-notes.adoc`.
	* NB: the base branch for this PR is deliberate. Individual Release Note entries are merged back to the general Release Notes branch and the entire Release Notes branch is then merged back to `/staging/docs-6`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
