### PR TITLE
DOC-2134: 6.6.1-release-notes.adoc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### Unreleased
+
+- DOC-2134: documentation of bug fix, _When Safari is the host browser, content updates for iframe dialog components with `streamContent: true` set are now throttled to 500ms intervals_, added to **Improvement** section of `6.6.1-release-notes.adoc`.
+
 ### 2023-07-21
 
 - DOC-2093: The TinyMCE 6.6 Release notes.

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -407,7 +407,7 @@
 **** xref:6.6.1-release-notes.adoc#overview[Overview]
 **** xref:6.6.1-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]
 **** xref:6.6.1-release-notes.adoc#accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]
-**** xref:6.6.1-release-notes.adoc#improvements[Improvements]
+**** xref:6.6.1-release-notes.adoc#improvement[Improvement]
 **** xref:6.6.1-release-notes.adoc#addition[Addition]
 **** xref:6.6.1-release-notes.adoc#change[Change]
 **** xref:6.6.1-release-notes.adoc#bug-fixes[Bug fixes]

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -91,10 +91,18 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 {productname} 6.6.1 also includes the following improvement:
 
-=== Content updates for streamContent: true iframe dialog components on Safari are now throttled to 500ms intervals to reduce the visual impact of flickering when rapidly updating iframe content
+=== When Safari is the host browser, content updates for iframe dialog components with `streamContent: true` set are now throttled to 500ms intervals
 //#TINY-10097
 
-// CCFR here.
+When `iframe` dialog components have xref:dialog-configuration.adoc#dialog_streamContent[`streamContent: true`] set, content is updated using the `document.write()` method rather than by setting the `srcdoc` attribute to prevent the `iframe` from reloading.
+
+This setting stops the content from flickering as it updates when the host browser is Google Chrome or Mozila Firefox.
+
+The flickering still occured when the host browser was Apple Safari, however.
+
+In {productname} 6.6.1, content updates for `iframe` dialog components with `streamContent: true` set are throttled to 500ms intervals when Safari is the host browser. This significantly reduces the apparent flickering.
+
+NOTE: This throttling is specific to Safari. It is not applied when any browser other than Safari is the host browser.
 
 
 [[addition]]

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -102,7 +102,7 @@ The flickering still occurred when the host browser was Apple Safari, however.
 
 In {productname} 6.6.1, content updates for `iframe` dialog components with `streamContent: true` set are throttled to 500ms intervals when Safari is the host browser. This significantly reduces the apparent flickering.
 
-NOTE: This throttling is specific to Safari. It is not applied when any browser other than Safari is the host browser.
+NOTE: This 500ms throttling is specific to Safari. It is not applied when any browser other than Safari is the host browser.
 
 
 [[addition]]

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -98,7 +98,7 @@ When `iframe` dialog components have xref:dialog-configuration.adoc#dialog_strea
 
 This setting stops the content from flickering as it updates when the host browser is Google Chrome or Mozila Firefox.
 
-The flickering still occured when the host browser was Apple Safari, however.
+The flickering still occurred when the host browser was Apple Safari, however.
 
 In {productname} 6.6.1, content updates for `iframe` dialog components with `streamContent: true` set are throttled to 500ms intervals when Safari is the host browser. This significantly reduces the apparent flickering.
 

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -96,7 +96,7 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 When `iframe` dialog components have xref:dialog-configuration.adoc#dialog_streamContent[`streamContent: true`] set, content is updated using the `document.write()` method rather than by setting the `srcdoc` attribute to prevent the `iframe` from reloading.
 
-This setting stops the content from flickering as it updates when the host browser is Google Chrome or Mozila Firefox.
+This setting stops the iframe from flickering as it updates its contents when the host browser is Google Chrome or Mozilla Firefox.
 
 The flickering still occurred when the host browser was Apple Safari, however.
 


### PR DESCRIPTION
Ticket: DOC-2134: Improvement documentation entry for TINY-10097 in the 6.6.1 Release Notes

Changes:
* documentation of improvement, _When Safari is the host browser, content updates for iframe dialog components with `streamContent: true` set are now throttled to 500ms intervals_, added to **Improvement** section of `6.6.1-release-notes.adoc`.
	* NB: the base branch for this PR is deliberate. Individual Release Note entries are merged back to the general Release Notes branch and the entire Release Notes branch is then merged back to `/staging/docs-6`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
