### PR TITLE
DOC-2139: bug fix documentation entry for TINY-10110 in the 6.6.1 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### Unreleased
+
+- DOC-2139: documentation of bug fix, _Scrolling behavior was inconsistent when updating a `streamContent: true` iframe dialog component with content lacking an HTML document type declaration_, added to **Bug fixes** section of `6.6.1-release-notes.adoc`.
+
 ### 2023-07-21
 
 - DOC-2093: The TinyMCE 6.6 Release notes.

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -129,7 +129,7 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 When an iframe dialog has `streamContent: true` set and the scrolled position is already at the end of the scrollable area, the expected behavior is to maintain this end-of-scrollable-area position by automatically scrolling to the end of the area as content in the scrollable area updates
 
-However, it was found that, when setting content without an HTML document type declaration using `document.write()`, the scrolling element used to determine scrolling conditions is the iframe’s body, not its document element. And, previously, only the latter was handled. As a consequence updating the iframe with content without an HTML doctype declaration did not always maintain scroll positions as expected.
+However, it was found that, when setting content without an HTML document type declaration using `document.write()`, the scrolling element used to determine scrolling conditions is the iframe’s body, not its document element. And, previously, only the latter was handled. As a consequence, updating the iframe with content without an HTML doctype declaration did not always maintain scroll positions as expected.
 
 {productname} 6.6.1 now checks whether the content contains an HTML doctype declaration and, if so, it chooses the iframe’s body as the scrolling element to determine scrolling condition. This allows content updates for `streamContent: true` iframe dialog components to behave as expected for both content with and without an HTML doctype declaration.
 

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -124,10 +124,14 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 // CCFR here.
 
-=== Scrolling behavior was inconsistent when updating a `streamContent: true` iframe dialog component with content lacking an HTML document type declaration.
+=== Scrolling behavior was inconsistent when updating a `streamContent: true` iframe dialog component with content lacking an HTML document type declaration
 //#TINY-10110
 
-// CCFR here.
+When an iframe dialog has `streamContent: true` set and the scrolled position is already at the end of the scrollable area, the expected behavior is to maintain this end-of-scrollable-area position by automatically scrolling to the end of the area as content in the scrollable area updates
+
+However, it was found that, when setting content without an HTML document type declaration using `document.write()`, the scrolling element used to determine scrolling conditions is the iframe’s body, not its document element. And, previously, only the latter was handled. As a consequence updating the iframe with content without an HTML doctype declaration did not always maintain scroll positions as expected.
+
+{productname} 6.6.1 now checks whether the content contains an HTML doctype declaration and, if so, it chooses the iframe’s body as the scrolling element to determine scrolling condition. This allows content updates for `streamContent: true` iframe dialog components to behave as expected for both content with and without an HTML doctype declaration.
 
 === A warning message was sometimes printed to the browser console when closing a dialog that contains an iframe component
 //#TINY-10070

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -131,7 +131,7 @@ When an iframe dialog has `streamContent: true` set and the scrolled position is
 
 However, it was found that, when setting content without an HTML document type declaration using `document.write()`, the scrolling element used to determine scrolling conditions is the iframe’s body, not its document element. And, previously, only the latter was handled. As a consequence, updating the iframe with content without an HTML doctype declaration did not always maintain scroll positions as expected.
 
-{productname} 6.6.1 now checks whether the content contains an HTML doctype declaration and, if so, it chooses the iframe’s body as the scrolling element to determine scrolling condition. This allows content updates for `streamContent: true` iframe dialog components to behave as expected for both content with and without an HTML doctype declaration.
+{productname} 6.6.1 now checks whether the content contains an HTML doctype declaration and, if so, it chooses the iframe’s body as the scrolling element to determine scrolling conditions. This allows content updates for `streamContent: true` iframe dialog components to behave as expected for both content with and without an HTML doctype declaration.
 
 === A warning message was sometimes printed to the browser console when closing a dialog that contains an iframe component
 //#TINY-10070


### PR DESCRIPTION
Ticket: DOC-2139, bug fix documentation entry for TINY-10110 in the 6.6.1 Release Notes

Changes:
* documentation of bug fix, _Scrolling behavior was inconsistent when updating a `streamContent: true` iframe dialog component with content lacking an HTML document type declaration_, added to **Bug fixes** section of `6.6.1-release-notes.adoc`.
	* NB: the base branch for this PR is deliberate. Individual Release Note entries are merged back to the general Release Notes branch and the entire Release Notes branch is then merged back to `/staging/docs-6`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
