### PR TITLE
DOC-2135: bug fix documentation entry for TINY-10078 in the 6.6.1-release-notes.adoc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+
+### Unreleased
+
+- DOC-2135: documentation of bug fix, _On Safari and Firefox browsers, scroll positions were not always maintained when updating the content of a `streamContent: true` iframe dialog component_, added to **Bug fixes** section of `6.6.1-release-notes.adoc`.
+
 ### 2023-07-21
 
 - DOC-2093: The TinyMCE 6.6 Release notes.

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -122,8 +122,15 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 === On Safari and Firefox browsers, scroll positions were not always maintained when updating the content of a `streamContent: true` iframe dialog component
 //#TINY-10078
 
-// CCFR here.
+On each content update for iframe dialog components with `streamContent: true` set, the iframe is expected to automatically scroll to the bottom if the pre-update scrolled position is already at the end of the scrollable area. It is also expected, however, that the end-user can freely scroll through the iframe as content updates occur.
 
+When Chrome is the host browser, scroll positions are natively maintained after `document.write()`, but this is not the case when either Safari or Firefox are the host browsers. Both these browsers reset the scroll positions to the top.
+
+As a consequence, once the user scrolls up in the iframe as content updates occur, the programmatic scrolling to the bottom no longer occurs. Instead, the native behavior takes over and keeps the scroll at the top, even as content updates continue.
+
+This makes the {productname} dialog feel stuck when Safari or Firefox are the host browsers, which is both against expected behavior and poor UX.
+
+As of {productname} 6.6.1, the extant `scrollTop` value before any content updates happen is stored. After a content update, if the host browser is Firefox or Safari and the previous scroll position was not at the end of the scrollable area, {productname} now programmatically restore the previous scroll position using the stored `scrollTop` value.
 
 === [Safari] iframe not consistently autoscrolling to bottom when streamContent: true
 //#TINY-10109

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -119,7 +119,7 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 {productname} 6.6.1 also includes the following bug fixes:
 
-=== On Safari and Firefox browsers, scroll positions were not always maintained when updating the content of a `streamContent: true` iframe dialog component
+=== On Safari and Firefox, scroll positions were not always maintained when updating the content of a `streamContent: true` iframe dialog component
 //#TINY-10078
 
 On each content update for iframe dialog components with `streamContent: true` set, the iframe is expected to automatically scroll to the bottom if the pre-update scrolled position is already at the end of the scrollable area. It is also expected, however, that the end-user can freely scroll through the iframe as content updates occur.

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -126,7 +126,7 @@ On each content update for iframe dialog components with `streamContent: true` s
 
 When Chrome is the host browser, scroll positions are natively maintained after content updates via `document.write()`, but this is not the case when either Safari or Firefox are the host browsers. Both these browsers reset the scroll positions to the top.
 
-As a consequence, once the user scrolls up in the iframe as content updates occur, the programmatic scrolling to the bottom no longer occurs. Instead, the native behavior takes over and keeps the scroll at the top, even as content updates continue.
+As a consequence, once the user scrolls up in the iframe as content updates occur and the programmatic scrolling to the bottom no longer occurs, the native behavior takes over. On Safari and Firefox, this results in the scroll being kept at the top even as the user attempts to scroll, which is both against expected behavior and poor UX.
 
 This makes the {productname} dialog feel stuck when Safari or Firefox are the host browsers, which is both against expected behavior and poor UX.
 

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -124,7 +124,7 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 On each content update for iframe dialog components with `streamContent: true` set, the iframe is expected to automatically scroll to the bottom if the pre-update scrolled position is already at the end of the scrollable area. It is also expected, however, that the end-user can freely scroll through the iframe as content updates occur.
 
-When Chrome is the host browser, scroll positions are natively maintained after `document.write()`, but this is not the case when either Safari or Firefox are the host browsers. Both these browsers reset the scroll positions to the top.
+When Chrome is the host browser, scroll positions are natively maintained after content updates via `document.write()`, but this is not the case when either Safari or Firefox are the host browsers. Both these browsers reset the scroll positions to the top.
 
 As a consequence, once the user scrolls up in the iframe as content updates occur, the programmatic scrolling to the bottom no longer occurs. Instead, the native behavior takes over and keeps the scroll at the top, even as content updates continue.
 

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -130,7 +130,7 @@ As a consequence, once the user scrolls up in the iframe as content updates occu
 
 This makes the {productname} dialog feel stuck when Safari or Firefox are the host browsers, which is both against expected behavior and poor UX.
 
-As of {productname} 6.6.1, the extant `scrollTop` value before any content updates happen is stored. After a content update, if the host browser is Firefox or Safari and the previous scroll position was not at the end of the scrollable area, {productname} now programmatically restore the previous scroll position using the stored `scrollTop` value.
+As of {productname} 6.6.1, after a content update to a `streamContent: true` iframe dialog component, if the host browser is Firefox or Safari and the previous scroll position was not at the end of the scrollable area, {productname} now programmatically restores the previous scroll position.
 
 === [Safari] iframe not consistently autoscrolling to bottom when streamContent: true
 //#TINY-10109

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -128,7 +128,6 @@ When Chrome is the host browser, scroll positions are natively maintained after 
 
 As a consequence, once the user scrolls up in the iframe as content updates occur and the programmatic scrolling to the bottom no longer occurs, the native behavior takes over. On Safari and Firefox, this results in the scroll being kept at the top even as the user attempts to scroll, which is both against expected behavior and poor UX.
 
-This makes the {productname} dialog feel stuck when Safari or Firefox are the host browsers, which is both against expected behavior and poor UX.
 
 As of {productname} 6.6.1, after a content update to a `streamContent: true` iframe dialog component, if the host browser is Firefox or Safari and the previous scroll position was not at the end of the scrollable area, {productname} now programmatically restores the previous scroll position.
 


### PR DESCRIPTION
Ticket: DOC-2135, bug fix documentation entry for TINY-10078 in the 6.6.1 Release Notes

Changes:
* documentation of bug fix, _On Safari and Firefox browsers, scroll positions were not always maintained when updating the content of a `streamContent: true` iframe dialog component_, added to **Bug fix** section of `6.6.1-release-notes.adoc`.
	* NB: the base branch for this PR is deliberate. Individual Release Note entries are merged back to the general Release Notes branch and the entire Release Notes branch is then merged back to `/staging/docs-6`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
