### PR TITLE
DOC-2152: bug fix documentation entry for TINY-10109 in the 6.6.1 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### Unreleased
+
+- DOC-2152: documentation of bug fix, _On Safari, iframe dialog components did not consistently autoscroll to the end of the scrollable area when `streamContent: true` was set_, added to **Bug fix** section of `6.6.1-release-notes.adoc`.
+
 ### 2023-07-21
 
 - DOC-2093: The TinyMCE 6.6 Release notes.

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -130,7 +130,7 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 {productname} 6.6.0 added support for a `streamContent` setting for iframe dialog components. One of the features of this setting allows the iframe to automatically scroll to the end of the scrollable area on each content update if the scrolled position is already at the end of this area before content updates begin.
 
-However, when Safari was the host browser, when attempting to scroll an ifram component with `streamContent: true` set before the load event has fired, the scroll unexpectedly jumped back to the top after the iframe loaded.
+However, when Safari was the host browser, when attempting to scroll an iframe component with `streamContent: true` set before its `load` event has fired, the scroll unexpectedly jumped back to the top after the iframe loaded.
 
 This made the autoscrolling feature inconsistent on Safari, as it depended on how quickly the iframe loaded after the content update.
 

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -134,7 +134,7 @@ However, when Safari was the host browser, when attempting to scroll an iframe c
 
 This made the autoscrolling feature inconsistent on Safari, as it depended on how quickly the iframe loaded after the content update.
 
-In {productname} 6.6.1, when Safari is the host browser, the autoscrolling behavior is attached to a one-time event listener that responds to the iframe’s load event on each content update.
+In {productname} 6.6.1, when Safari is the host browser, the autoscrolling behavior is attached to a one-time event listener that responds to the iframe’s `load` event on each content update.
 
 This allows iframe dialog components with `streamContent: true` set to consistently autoscroll to the end of the scrollable area when Safari is the host browser.
 

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -125,10 +125,18 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 // CCFR here.
 
 
-=== [Safari] iframe not consistently autoscrolling to bottom when streamContent: true
+=== On Safari, iframe dialog components did not consistently autoscroll to the end of the scrollable area when `streamContent: true` was set
 //#TINY-10109
 
-// CCFR here.
+{productname} 6.6.0 added support for a `streamContent` setting for iframe dialog components. One of the features of this setting allows the iframe to automatically scroll to the end of the scrollable area on each content update if the scrolled position is already at the end of this area before content updates begin.
+
+However, when Safari was the host browser, when attempting to scroll an ifram component with `streamContent: true` set before the load event has fired, the scroll unexpectedly jumped back to the top after the iframe loaded.
+
+This made the autoscrolling feature inconsistent on Safari, as it depended on how quickly the iframe loaded after the content update.
+
+In {productname} 6.6.1, when Safari is the host browser, the autoscrolling behavior is attached to a one-time event listener that responds to the iframe’s load event on each content update.
+
+This allows iframe dialog components with `streamContent: true` set to consistently autoscroll to the end of the scrollable area when Safari is the host browser.
 
 
 === Scrolling behavior was inconsistent when updating a `streamContent: true` iframe dialog component with content lacking an HTML document type declaration.


### PR DESCRIPTION
Ticket: DOC-2152, bug fix documentation entry for TINY-10109 in the 6.6.1 Release Notes

Changes:
* documentation of bug fix, _On Safari, iframe dialog components did not consistently autoscroll to the end of the scrollable area when `streamContent: true` was set_, added to **Bug fixes** section of `6.6.1-release-notes.adoc`.
	* NB: the base branch for this PR is deliberate. Individual Release Note entries are merged back to the general Release Notes branch and the entire Release Notes branch is then merged back to `/staging/docs-6`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
