### PR TITLE
DOC-2144: bug fix documentation entry for TINY-10070 in the 6.6.1 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### Unreleased
+
+- DOC-2144: documentation of bug fix, _A warning message was sometimes printed to the browser console when closing a dialog that contained an iframe component_, added to **Bug fixes** section of `6.6.1-release-notes.adoc`.
+
 ### 2023-07-21
 
 - DOC-2093: The TinyMCE 6.6 Release notes.

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -136,10 +136,20 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 // CCFR here.
 
-=== A warning message was sometimes printed to the browser console when closing a dialog that contains an iframe component
+=== A warning message was sometimes printed to the browser console when closing a dialog that contained an iframe component
 //#TINY-10070
 
-// CCFR here.
+In some circumstances, when a dialog that contained an iframe component was closed, the console warning message, *the component must be in a context to execute*, was generated.
+
+This happened because, while the dialog was closed, the currently focussed element was not within the {productname} instance. This caused the `onAction()` callback function to set the focus back to the (now closed) dialog element.
+
+In {productname} 6.6.1, a check has been implemented:
+
+* to see if the dialog still exists within the DOM; and
+* to ensure the element with focus is within the {productname} instance after a dialog is closed.
+
+As a consequence, the console warning is no longer generated when dialogs with iframe components are closed.
+
 
 === When an editable area was nested inside a non-editable area, creating lists was not possible
 //#TINY-10000


### PR DESCRIPTION
Ticket: DOC-2144, bug fix documentation entry for TINY-10070 in the 6.6.1 Release Notes

Changes:
* documentation of bug fix, _A warning message was sometimes printed to the browser console when closing a dialog that contained an iframe component_, added to **Bug fixes** section of `6.6.1-release-notes.adoc`.
	* NB: the base branch for this PR is deliberate. Individual Release Note entries are merged back to the general Release Notes branch and the entire Release Notes branch is then merged back to `/staging/docs-6`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
