### PR TITLE
DOC-2149: change documentation entry for TINY-10073 in the 6.6.1 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### Unreleased
+
+- DOC-2149: documentation of change, _API comments/documentation: a markup typo and run-on sentences both corrected_, added to **Change** section of `6.6.1-release-notes.adoc`.
+
 ### 2023-07-21
 
 - DOC-2093: The TinyMCE 6.6 Release notes.

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -113,7 +113,7 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 === API comments/documentation: a markup typo and run-on sentences both corrected
 //#TINY-10073
 
-A markup typo in `/tinymce/modules/tinymce/src/core/main/ts/api/WindowManager.ts` resulted in an extraneous html markup tag displaying in the xref:api/tinymce.windowmanager.adoc[tinymce.WindowManager()] documentation.
+A markup typo in `/tinymce/modules/tinymce/src/core/main/ts/api/WindowManager.ts` resulted in an extraneous html markup tag displaying in the xref:/apis/tinymce.windowmanager.adoc[tinymce.WindowManager()] documentation.
 
 As well, two run-on sentences in the same file were corrected.
 

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -110,9 +110,12 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 {productname} 6.6.1 also includes the following change:
 
-=== API comments/documentation corrected: a typo correction and run-on sentences fixed.
+=== API comments/documentation: a markup typo and run-on sentences both corrected
 //#TINY-10073
 
+A markup typo in `/tinymce/modules/tinymce/src/core/main/ts/api/WindowManager.ts` resulted in an extraneous html markup tag displaying in the xref:api/tinymce.windowmanager.adoc[tinymce.WindowManager()] documentation.
+
+As well, two run-on sentences in the same file were corrected.
 
 [[bug-fixes]]
 == Bug fixes


### PR DESCRIPTION
Ticket: DOC-2149, change documentation entry for TINY-10073 in the 6.6.1 Release Notes

Changes:
* documentation of change, _API comments/documentation: a markup typo and run-on sentences both corrected_, added to **Change** section of `6.6.1-release-notes.adoc`.
	* NB: the base branch for this PR is deliberate. Individual Release Note entries are merged back to the general Release Notes branch and the entire Release Notes branch is then merged back to `/staging/docs-6`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed