### PR TITLE
DOC-2146: Addition documentation entry for TINY-9861 in the 6.6.1 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### Unreleased
+
+- DOC-2146: documentation of addition, _New filtering option: `pad_empty_with_br`_, added to **Addition** section of `6.6.1-release-notes.adoc`.
+
 ### 2023-07-21
 
 - DOC-2093: The TinyMCE 6.6 Release notes.

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -107,7 +107,7 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 {productname} 6.6.1 includes a further content filtering option, `pad_empty_with_br`.
 
-COontent filtering options change the way {productname} manages input and output.
+Content filtering options change the way {productname} manages input and output.
 
 The `pad_empty_with_br` option, when set to `true`, places a `+<br>+` tag within empty block elements rather than the default non-breaking space entity, `+&nbsp;+`.
 

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -102,10 +102,10 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 {productname} 6.6.1 also includes the following addition:
 
-=== New filtering option: `pad_empty_with_br`
+=== Restored filtering option: `pad_empty_with_br`
 //#TINY-9861
 
-{productname} 6.6.1 includes a further content filtering option, `pad_empty_with_br`.
+{productname} 6.6.1 restores a further content filtering option, `pad_empty_with_br`.
 
 Content filtering options change the way {productname} manages input and output.
 
@@ -118,14 +118,14 @@ That is, when a {productname} instance includes the following setting
 pad_empty_with_br: true,
 ----
  
-this input
+empty block elements within said instance
 
 [source,html]
 ----
-<p>&nbsp;</p>
+<p></p>
 ----
 
-is automatically stored and rendered as
+are automatically stored and rendered as
 
 [source,html]
 ----

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -134,7 +134,7 @@ is automatically stored and rendered as
 
 [NOTE]
 ====
-An equivalent filtering option, `padd_empty_with_br` was xref:migration-from-5x.adoc/#previously-deprecated-items-now-removed[removed from {productname} 6.0.0].
+An equivalent filtering option, `padd_empty_with_br` was xref:migration-from-5x.adoc#previously-deprecated-items-now-removed[removed from {productname} 6.0.0].
 
 This new — and correctly spelled — option behaves in essentially identical fashion to the older option.
 ====

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -102,8 +102,42 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 {productname} 6.6.1 also includes the following addition:
 
-=== New `pad_empty_with_br` option that can be set to `true` to pad empty block elements with `<br>` tag instead of nbsp character
+=== New filtering option: `pad_empty_with_br`
 //#TINY-9861
+
+{productname} 6.6.1 includes a further content filtering option, `pad_empty_with_br`.
+
+COontent filtering options change the way {productname} manages input and output.
+
+The `pad_empty_with_br` option, when set to `true`, places a `+<br>+` tag within empty block elements rather than the default non-breaking space entity, `+&nbsp;+`.
+
+That is, when a {productname} instance includes the following setting
+
+[source,js]
+----
+pad_empty_with_br: true,
+----
+ 
+this input
+
+[source,html]
+----
+<p>&nbsp;</p>
+----
+
+is automatically stored and rendered as
+
+[source,html]
+----
+<p><br></p>
+----
+
+[NOTE]
+====
+An equivalent filtering option, `padd_empty_with_br` was xref:migration-from-5x/#previously-deprecated-items-now-removed[removed from {productname} 6.0.0].
+
+This new — and correctly spelled — option behaves in essentially identical fashion to the older option.
+====
 
 [[change]]
 == Change

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -134,7 +134,7 @@ is automatically stored and rendered as
 
 [NOTE]
 ====
-An equivalent filtering option, `padd_empty_with_br` was xref:migration-from-5x/#previously-deprecated-items-now-removed[removed from {productname} 6.0.0].
+An equivalent filtering option, `padd_empty_with_br` was xref:migration-from-5x.adoc/#previously-deprecated-items-now-removed[removed from {productname} 6.0.0].
 
 This new — and correctly spelled — option behaves in essentially identical fashion to the older option.
 ====


### PR DESCRIPTION
Ticket: DOC-2146, Addition documentation entry for TINY-9861 in the 6.6.1 Release Notes

Changes:
* DOC-2146: documentation of addition, _New filtering option: `pad_empty_with_br`_, added to **Addition** section of `6.6.1-release-notes.adoc`.
	* NB: the base branch for this PR is deliberate. Individual Release Note entries are merged back to the general Release Notes branch and the entire Release Notes branch is then merged back to `/staging/docs-6`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
