### PR TITLE
DOC-2131: bug fix documentation entry for TINY-10000 in the 6.6.1 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### Unreleased
+
+- DOC-2131: documentation of bug fix, _Lists could not be created within editable areas nested inside non-editable areas_, added to **Bug fixes** section of `6.6.1-release-notes.adoc`.
+
 ### 2023-07-21
 
 - DOC-2093: The TinyMCE 6.6 Release notes.

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -141,10 +141,17 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 // CCFR here.
 
-=== When an editable area was nested inside a non-editable area, creating lists was not possible
+=== Lists could not be created within editable areas nested inside non-editable areas
 //#TINY-10000
 
-// CCFR here.
+{productname} 6.5 introduced a check to establish if the current node was within a non-editable context.
+
+As a consequence of this check, if an editable element was nested in a non-editable element, adding a list within the editable element did not work as expected.
+
+Other expected edits — such as changing the selected material’s block element type from paragraph to a heading — worked as expected. It was only adding a list, or making existing material into a list, that did not work as expected.
+
+In {productname} 6.6.1, this check has been removed. Adding or making lists within editable elements now works in all expected contexts, including when the editable element is within a non-editable element.
+
 
 === Safari and Firefox `focus` border missing from `iframe`
 //TINY-10101


### PR DESCRIPTION
Ticket: DOC-2131, bug fix documentation entry for TINY-10000 in the 6.6.1 Release Notes

Changes:
* documentation of bug fix, _Lists could not be created within editable areas nested inside non-editable areas_, added to **Bug fix** section of `6.6.1-release-notes.adoc`.
	* NB: the base branch for this PR is deliberate. Individual Release Note entries are merged back to the general Release Notes branch and the entire Release Notes branch is then merged back to `/staging/docs-6`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
