### PR TITLE
DOC-2147: bug fix documentation entry for TINY-10101 in the 6.6.1 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### Unreleased
+
+- DOC-2147: documentation of bug fix, _On Safari and Firefox, the border around `iframe` dialog components did not highlight when focused_, added to **Bug fixes** section of `6.6.1-release-notes.adoc`.
+
 ### 2023-07-21
 
 - DOC-2093: The TinyMCE 6.6 Release notes.

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -146,8 +146,13 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 // CCFR here.
 
-=== Safari and Firefox `focus` border missing from `iframe`
+=== On Safari and Firefox, the border around `iframe` dialog components did not highlight when focused
 //TINY-10101
-//2023-06-26: sub-head is ticket summary, not changelog entry.
 
-//CCFR here.
+{productname} 6.6, introduced a new dialog configuration property, xref:dialog-configuration.adoc#border[`border`].
+
+When set to `true`, this property adds a border around `iframe` dialog components that highlights when the compoment takes focus. By default, {productname} renders this as a blue border around the component.
+
+When either Safari or Firefox were the host browsers, however, the border did not render as expected when this component had focus.
+
+{productname} 6.6.1 corrects this. When either Safari or Firefox are the host browsers, `iframe` dialog components now highlight when taking focus, as expected.

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -151,7 +151,7 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 {productname} 6.6, introduced a new dialog configuration property, xref:dialog-configuration.adoc#border[`border`].
 
-When set to `true`, this property adds a border around `iframe` dialog components that highlights when the compoment takes focus. By default, {productname} renders this as a blue border around the component.
+When set to `true`, this property adds a border around `iframe` dialog components that highlights when the component takes focus. By default, {productname} renders this as a blue border around the component.
 
 When either Safari or Firefox were the host browsers, however, the border did not render as expected when this component had focus.
 


### PR DESCRIPTION
Ticket: DOC-2147, bug fix documentation entry for TINY-10101 in the 6.6.1 Release Notes

Changes:
* documentation of bug fix, _On Safari and Firefox, the border around `iframe` dialog components did not highlight when focused_, added to **Bug fixes** section of `6.6.1-release-notes.adoc`.
	* NB: the base branch for this PR is deliberate. Individual Release Note entries are merged back to the general Release Notes branch and the entire Release Notes branch is then merged back to `/staging/docs-6`.

Note for reviewers:
* This write-up makes no mention of the work done to deal with the issue of the highlighted border persisting in Safari and Firefox after focus has left the component. This issue presented internally and was fixed before the new code went public. So, effort and work to fix notwithstanding, it isn’t an issue end-users encountered.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed