### PR TITLE
DOC-2114: Document the `pad_empty_with_br` option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### Unreleased
+
+- DOC-2114: file, `pad_empty_with_br.adoc`, added to `/partials/configuration/`; documentation of option, `pad_empty_with_br`, added to file. `pad_empty_with_br.adoc` added to `content-filtering.adoc` with `include` statement. Also, notes re this option’s existence added to table in `6.0-release-notes-summary.adoc` noting the removal of equivalent previous option, `padd_empty_with_br`.
+
 ### 2023-07-21
 
 - DOC-2093: The TinyMCE 6.6 Release notes.

--- a/modules/ROOT/pages/content-filtering.adoc
+++ b/modules/ROOT/pages/content-filtering.adoc
@@ -37,6 +37,8 @@ include::partial$configuration/invalid_elements.adoc[]
 
 include::partial$configuration/invalid_styles.adoc[]
 
+include::partial$configuration/pad_empty_with_br.adoc[]
+
 include::partial$configuration/protect.adoc[]
 
 include::partial$configuration/remove_trailing_brs.adoc[]

--- a/modules/ROOT/partials/configuration/pad_empty_with_br.adoc
+++ b/modules/ROOT/partials/configuration/pad_empty_with_br.adoc
@@ -1,0 +1,31 @@
+[[pad_empty_with_br]]
+== `+pad_empty_with_br+`
+
+include::partial#$misc/admon-requires-6.6.1v.adoc[]
+
+By default, {productname} places non-breaking space entities — `+&nbsp;+` — as placeholders inside empty block elements. For example, inside an otherwise empty `+<p></p>+` pair.
+
+The `+pad_empty_with_br+` option enables {productname} to change this default placeholder to a break tag: `+<br>+`.
+
+*Type:* `+Boolean+`
+
+*Possible values:* `true`, `false`
+
+*Default value:* `false`
+
+=== Example: using `pad_empty_with_br`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your html
+  pad_empty_with_br: true,
+});
+----
+
+[NOTE]
+====
+An equivalent filtering option, `padd_empty_with_br` was xref:migration-from-5x.adoc#previously-deprecated-items-now-removed[removed from {productname} 6.0.0].
+
+This new — and correctly spelled — option behaves in essentially identical fashion to the older option.
+====

--- a/modules/ROOT/partials/configuration/pad_empty_with_br.adoc
+++ b/modules/ROOT/partials/configuration/pad_empty_with_br.adoc
@@ -5,7 +5,7 @@ include::partial$misc/admon-requires-6.6.1v.adoc[]
 
 By default, {productname} places non-breaking space entities — `+&nbsp;+` — as placeholders inside empty block elements. For example,  the empty paragraph will be serialized to `<p>&nbsp;</p>`.
 
-The `+pad_empty_with_br+` option enables {productname} to change this default placeholder to a break tag: `+<br>+`.
+The `+pad_empty_with_br+` option enables {productname} to change this default placeholder to a break tag: `+<br>+`. For example,  the empty paragraph will be serialized to `<p><br></p>`.
 
 *Type:* `+Boolean+`
 

--- a/modules/ROOT/partials/configuration/pad_empty_with_br.adoc
+++ b/modules/ROOT/partials/configuration/pad_empty_with_br.adoc
@@ -3,9 +3,13 @@
 
 include::partial$misc/admon-requires-6.6.1v.adoc[]
 
-By default, {productname} places non-breaking space entities — `+&nbsp;+` — as placeholders inside empty block elements. For example,  the empty paragraph will be serialized to `<p>&nbsp;</p>`.
+By default, {productname} places non-breaking space entities — `+&nbsp;+` — as placeholders inside empty block elements.
 
-The `+pad_empty_with_br+` option enables {productname} to change this default placeholder to a break tag: `+<br>+`. For example,  the empty paragraph will be serialized to `<p><br></p>`.
+For example, the empty paragraph `+<p></p>+` will, by default, be serialized to `+<p>&nbsp;</p>+`.
+
+The `+pad_empty_with_br+` option enables {productname} to change this default placeholder to a break tag: `+<br>+`.
+
+For example, when this option is set to `true`, an empty paragraph, `+<p></p>+`, is serialized to `+<p><br></p>+`.
 
 *Type:* `+Boolean+`
 

--- a/modules/ROOT/partials/configuration/pad_empty_with_br.adoc
+++ b/modules/ROOT/partials/configuration/pad_empty_with_br.adoc
@@ -1,7 +1,7 @@
 [[pad_empty_with_br]]
 == `+pad_empty_with_br+`
 
-include::partial#$misc/admon-requires-6.6.1v.adoc[]
+include::partial$misc/admon-requires-6.6.1v.adoc[]
 
 By default, {productname} places non-breaking space entities — `+&nbsp;+` — as placeholders inside empty block elements. For example, inside an otherwise empty `+<p></p>+` pair.
 

--- a/modules/ROOT/partials/configuration/pad_empty_with_br.adoc
+++ b/modules/ROOT/partials/configuration/pad_empty_with_br.adoc
@@ -3,7 +3,7 @@
 
 include::partial$misc/admon-requires-6.6.1v.adoc[]
 
-By default, {productname} places non-breaking space entities — `+&nbsp;+` — as placeholders inside empty block elements. For example, inside an otherwise empty `+<p></p>+` pair.
+By default, {productname} places non-breaking space entities — `+&nbsp;+` — as placeholders inside empty block elements. For example,  the empty paragraph will be serialized to `<p>&nbsp;</p>`.
 
 The `+pad_empty_with_br+` option enables {productname} to change this default placeholder to a break tag: `+<br>+`.
 

--- a/modules/ROOT/partials/misc/admon-requires-6.6.1v.adoc
+++ b/modules/ROOT/partials/misc/admon-requires-6.6.1v.adoc
@@ -1,0 +1,1 @@
+NOTE: This feature is only available for {productname} 6.6.1 and later.

--- a/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
+++ b/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
@@ -242,7 +242,7 @@ The following elements were previously deprecated and have, with this release, b
 
 | `non_empty_elements`                  | Schema option |
 
-| `padd_empty_with_br`                  | Option        |
+| `padd_empty_with_br`                  | Option        | Replaced, as of {productname} 6.6.1, by xref:content-filtering.adoc#pad_empty_with_br[`pad_empty_with_br`].
 
 | `requestAnimationFrame`               | API           | From `Delay`.
 


### PR DESCRIPTION
Ticket: DOC-2114, document the `pad_empty_with_br` option.

Changes:
* file, `pad_empty_with_br.adoc`, added to `/partials/configuration/`.
* documentation of option, `pad_empty_with_br`, added to file.
* `pad_empty_with_br.adoc` added to `content-filtering.adoc` with `include` statement.
* This option’s existence added to table in `6.0-release-notes-summary.adoc` noting the removal of equivalent previous option, `padd_empty_with_br`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] Files has been included where required (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
