### PR TITLE
DOC-2155: bug fix documentation entry for TINY-10016 in the 6.6.1 Release Notes №2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2155: documentation of bug fix, _Right-clicking on an image that was in a non-editable area would open the Image plugin’s context menu_, added to **Bug fixes** section of `6.6.1-release-notes.adoc`.
 - DOC-2147: documentation of bug fix, _On Safari and Firefox, the border around `iframe` dialog components did not highlight when focused_, added to **Bug fixes** section of `6.6.1-release-notes.adoc`.
 - DOC-2144: documentation of bug fix, _A warning message was sometimes printed to the browser console when closing a dialog that contained an iframe component_, added to **Bug fixes** section of `6.6.1-release-notes.adoc`.
 - DOC-2139: documentation of bug fix, _Scrolling behavior was inconsistent when updating a `streamContent: true` iframe dialog component with content lacking an HTML document type declaration_, added to **Bug fixes** section of `6.6.1-release-notes.adoc`.

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -208,7 +208,17 @@ When either Safari or Firefox were the host browsers, however, the border did no
 === Right-clicking on an image that was in a non-editable area would open the Image plugin’s context menu
 //#TINY-10016
 
-// CCFR here
+When a {productname} instance is setup with `editable_root: false` set, the entire instance is, by default, a read-only instance.
+
+To allow editing of any portion, that portion must be specifically set as writable (for example, by being within an element that has a `contenteditable="true"` attribute set).
+
+Previously, however, if an image was in a {productname} instance with both an `editable_root: false` set and the xref:image.adoc[Image open source plugin] loaded, bringing up a {productname} context menu (eg by right-clicking on the image in a desktop setting or by long-pressing on the image in a mobile setting) allowed the Image plugin’s context menu to present, which allowed for image manipulation.
+
+{productname} 6.6.1 addresses this. With this update, invoking a context menu in non-editable area no longer brings up any {productname}-related context menus.
+
+As a consequence, images presented within a {productname} instance setup with a `editable_root: false` set are properly read-only, as expected.
+
+NOTE: right-clicking on an image, or long-pressing on an image in a mobile instance, still invokes the host browser’s context menu in such a circumstance.
 
 === The `color_cols` option was not respected when a custom `color_map` was defined
 // #TINY-10098


### PR DESCRIPTION
Ticket: DOC-2155, bug fix documentation entry for TINY-10016 in the 6.6.1 Release Notes №2

Changes:
* documentation of bug fix, _Right-clicking on an image that was in a non-editable area would open the Image plugin’s context menu_, added to **Bug fixes** section of `6.6.1-release-notes.adoc`.
	* NB: the base branch for this PR is deliberate. Individual Release Note entries are merged back to the general Release Notes branch and the entire Release Notes branch is then merged back to `/staging/docs-6`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
