### PR TITLE
DOC-2156: bug fix documentation entry for TINY-10098 in the 6.6.1 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2156: documentation of bug fix, _The `color_cols` option was not respected when a custom `color_map` was defined_, added to **Bug fixes** section of `6.6.1-release-notes.adoc`.
 - DOC-2147: documentation of bug fix, _On Safari and Firefox, the border around `iframe` dialog components did not highlight when focused_, added to **Bug fixes** section of `6.6.1-release-notes.adoc`.
 - DOC-2144: documentation of bug fix, _A warning message was sometimes printed to the browser console when closing a dialog that contained an iframe component_, added to **Bug fixes** section of `6.6.1-release-notes.adoc`.
 - DOC-2139: documentation of bug fix, _Scrolling behavior was inconsistent when updating a `streamContent: true` iframe dialog component with content lacking an HTML document type declaration_, added to **Bug fixes** section of `6.6.1-release-notes.adoc`.

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -221,7 +221,7 @@ The square root is rounded up and five is the default number of columns a {produ
 
 For example, for a custom xref:user-formatting-options.adoc#color_map[`color_map`] containing 30 colors:
 
-√30 ≅ 5.4772 ≈ 6
+√30 ≅ 5.4772 ≈ 6.
 
 And, since 6 > 5, this custom color selection grid displays six columns.
 

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -217,7 +217,7 @@ The xref:user-formatting-options.adoc#color_cols[`color_cols`] option allows for
 
 If `color_cols` is not set, the number of columns displayed by a custom color swatch is, by default, the greater of the square root of the number of colors in the swatch and five (5).
 
-The square root is rounded up and five is the default number of columns a {productname} color swatch displays.
+The square root is rounded up and five is the default number of columns a {productname} color swatch displays with the default `color_map`.
 
 For example, for a custom xref:user-formatting-options.adoc#color_map[`color_map`] containing 30 colors:
 

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -213,7 +213,31 @@ When either Safari or Firefox were the host browsers, however, the border did no
 === The `color_cols` option was not respected when a custom `color_map` was defined
 // #TINY-10098
 
-// CCFR here
+The xref:user-formatting-options.adoc#color_cols[`color_cols`] option allows for specifying the number of columns for text color selection grids.
+
+If `color_cols` is not set, the number of columns displayed by a custom color swatch is, by default, the greater of the square root of the number of colors in the swatch and five (5).
+
+The square root is rounded up and five is the default number of columns a {productname} color swatch displays.
+
+For example, for a custom xref:user-formatting-options.adoc#color_map[`color_map`] containing 30 colors:
+
+√30 ≅ 5.4772 ≈ 6
+
+And, since 6 > 5, this custom color selection grid displays six columns.
+
+Setting a `color_cols` value over-rides this default behavior.
+
+Previously, however, the `color_cols` option was not respected when a custom xref:user-formatting-options.adoc#color_map[`color_map`] was specified. In this circumstance the default method above still specified the number of columns displayed.
+
+{productname} 6.6.1 addresses this. As of this update, setting a `color_cols` value over-rides the default method of calculating the number of displayed columns, as expected.
+
+[NOTE]
+.Known issue
+====
+Setting `color_cols: 5` still results in the `color_cols` value not being used.
+
+When `color_cols` is set to the default number of columns displayed by a {productname} color selection grid (ie 5), the default method for calculating the number of displayed columns is used.
+====
 
 === The `color_cols` options were were not rounded to the nearest number when set to a decimal number
 //#TINY-9737


### PR DESCRIPTION
Ticket: DOC-2156, bug fix documentation entry for TINY-10098 in the 6.6.1 Release Notes

Changes:
* documentation of bug fix, _The `color_cols` option was not respected when a custom `color_map` was defined_, added to **Bug fixes** section of `6.6.1-release-notes.adoc`.
	* NB: the base branch for this PR is deliberate. Individual Release Note entries are merged back to the general Release Notes branch and the entire Release Notes branch is then merged back to `/staging/docs-6`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
