### PR TITLE
DOC-2157: TINY-9737 write-up for the 6.6.1 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2157: documentation of buf fix, _the `color_cols` options were were not rounded to the nearest number when set to a decimal number_ added to the **Bug fixes** section of `6.6.1-release-notes.adoc`.
 - DOC-2156: documentation of bug fix, _The `color_cols` option was not respected when a custom `color_map` was defined_, added to **Bug fixes** section of `6.6.1-release-notes.adoc`.
 - DOC-2147: documentation of bug fix, _On Safari and Firefox, the border around `iframe` dialog components did not highlight when focused_, added to **Bug fixes** section of `6.6.1-release-notes.adoc`.
 - DOC-2144: documentation of bug fix, _A warning message was sometimes printed to the browser console when closing a dialog that contained an iframe component_, added to **Bug fixes** section of `6.6.1-release-notes.adoc`.

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -252,4 +252,4 @@ Values **x.1–x.4** are rounded to **x**.
 
 Values **x.5–x.9** are rounded to **x+1**.
 
-NOTE: if `color_cols` is set to a decimal value that would, after rounding, be an invalid value (for example, **0.1**), {productname} continues to act as it did previously. For invalid values, the `color_cols` option is treated as if it has not been set and reverts to displaying the color selection grid with the default five columns.
+NOTE: If `color_cols` is set to a decimal value that would, after rounding, be an invalid value (for example, **0.1**), {productname} continues to act as it did previously. For invalid values, the `color_cols` option is treated as if it has not been set and reverts to displaying the color selection grid with the default five columns.

--- a/modules/ROOT/pages/6.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.6.1-release-notes.adoc
@@ -242,4 +242,14 @@ When `color_cols` is set to the default number of columns displayed by a {produc
 === The `color_cols` options were were not rounded to the nearest number when set to a decimal number
 //#TINY-9737
 
-// CCFR here
+Previously, if `color_cols` was set to a value which included a decimal, the resultant text color selection grid displayed incorrectly.
+
+{productname} 6.6.1 addresses this. As of this update, if `color_cols` is set to a decimal value, {productname} rounds the set value to the nearest integer and displays the color selection grid with that many columns.
+
+In this case, {productname} rounds using the *rounding half up* method.
+
+Values **x.1–x.4** are rounded to **x**.
+
+Values **x.5–x.9** are rounded to **x+1**.
+
+NOTE: if `color_cols` is set to a decimal value that would, after rounding, be an invalid value (for example, **0.1**), {productname} continues to act as it did previously. For invalid values, the `color_cols` option is treated as if it has not been set and reverts to displaying the color selection grid with the default five columns.


### PR DESCRIPTION
* documentation of bug fix, _the `color_cols` options were were not rounded to the nearest number when set to a decimal number_, added to **Bug fixes** section of `6.6.1-release-notes.adoc`.
	* NB: the base branch for this PR is deliberate. Individual Release Note entries are merged back to the general Release Notes branch and the entire Release Notes branch is then merged back to `/staging/docs-6`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
