### PR TITLE
DOC-2150: correct the example URLs used in the Link Checker plugin live-demo

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### Unreleased
+
+- DOC_2150: Re-wrote `/live-demos/linkchecker/index.html`: it is now an actual interactive example, using canonically invalid domain names for the invalid domain-name strings and in-house domain names for the valid domain name strings.
+
 ### 2023-07-21
 
 - DOC-2093: The TinyMCE 6.6 Release notes.

--- a/modules/ROOT/examples/live-demos/linkchecker/index.html
+++ b/modules/ROOT/examples/live-demos/linkchecker/index.html
@@ -19,7 +19,7 @@
 <li>highlighted in red by the <strong>Link Checker</strong> plugin.</li>
 </ol>
 
-<p>Choose <strong>View → Source code</strong>, or click the <strong>Source code</strong> toolbar button to see that each automatically created anchor tag has also had the <code>aria-invalid="true"</code> attribute added by the <strong>Link Checker</strong> plugin.</p>
+<p>Choose <strong>View → Source code</strong>, or click the <strong>Source code</strong> toolbar button, to see that each automatically created anchor tag has also had the <code>aria-invalid="true"</code> attribute added by the <strong>Link Checker</strong> plugin.</p>
 
 <h3>Valid domain-name strings</h3>
 
@@ -40,6 +40,6 @@
 <li><strong>not</strong> highlighted in red by the <strong>Link Checker</strong> plugin.</li>
 </ol>
 
-<p>Choose <strong>View → Source code</strong>, or click the <strong>Source code</strong> toolbar button to see that each automatically created anchor tag does <em>not</em> have the <code>aria-invalid="true"</code> attribute.</p>
+<p>Choose <strong>View → Source code</strong>, or click the <strong>Source code</strong> toolbar button, to see that each automatically created anchor tag does <em>not</em> have the <code>aria-invalid="true"</code> attribute.</p>
 
 </textarea>

--- a/modules/ROOT/examples/live-demos/linkchecker/index.html
+++ b/modules/ROOT/examples/live-demos/linkchecker/index.html
@@ -1,4 +1,45 @@
 <textarea id="linkchecker">
-  <p><a href="http://www.gooogglge.com">www.gooogglge.com</a> &ne; <a href="http://www.google.com">www.google.com</a></p>
-  <p><a href="https://www.tinymce.cloud">https://www.tinymce.cloud</a> &ne; <a href="https://www.tiny.cloud/">https://www.tiny.cloud</a></p>
+
+<h3>Canonically invalid domain-name strings</h3>
+
+<p>The three domain-name strings below are all invalid, as per <a href="https://www.rfc-editor.org/rfc/rfc6761.html">RFC 6761</a> and <a href="https://www.rfc-editor.org/rfc/rfc2606.html">RFC 2606</a>.</p>
+
+<p>Type a space after each string.</p>
+
+<ol>
+<li>www.invalid.com</li>
+<li>www.site.example</li>
+<li>www.site.invalid</li>
+</ol>
+
+<p>Note each of them is:
+
+<ol>
+<li>turned into a clickable link by the <a href="https://tiny.cloud/docs/tinymce/6/autolink">Autolink</a> plugin; and then, after a short delay,
+<li>highlighted in red by the <strong>Link Checker</strong> plugin.</li>
+</ol>
+
+<p>Choose <strong>View → Source code</strong>, or click the <strong>Source code</strong> toolbar button to see that each automatically created anchor tag has also had the <code>aria-invalid="true"</code> attribute added by the <strong>Link Checker</strong> plugin.</p>
+
+<h3>Valid domain-name strings</h3>
+
+<p>The three domain-name strings below are all valid</p>
+
+<p>Type a space after each string.</p>
+
+<ol>
+<li>www.tiny.cloud</li>
+<li>www.plupload.com</li>
+<li>www.ephox.com</li>
+</ol>
+
+<p>Note each of them is:</p>
+
+<ol>
+<li>turned into a clickable link by the <a href="https://tiny.cloud/docs/tinymce/6/autolink">Autolink</a> plugin; and then
+<li><strong>not</strong> highlighted in red by the <strong>Link Checker</strong> plugin.</li>
+</ol>
+
+<p>Choose <strong>View → Source code</strong>, or click the <strong>Source code</strong> toolbar button to see that each automatically created anchor tag does <em>not</em> have the <code>aria-invalid="true"</code> attribute.</p>
+
 </textarea>


### PR DESCRIPTION
Ticket: DOC-2150: correct the example URLs used in the Link Checker plugin live-demo

Changes:
* Re-wrote live-demo html: it is now an actual interactive example.
* Used canonically invalid domain names for the invalid domain-name strings and in-house domain names for the valid domain name strings.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
