### PR TITLE
DOC-2154: Improvement documentation entry for TINY-9385 added to 6.6 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### Unreleased
+
+- documentation of *Improved detection of scrollable containers when the `ui_mode: 'split'` option is set*, added to **Improvement** section of `6.6-release-notes.adoc`.
+
 ### 2023-07-21
 
 - DOC-2093: The TinyMCE 6.6 Release notes.

--- a/modules/ROOT/pages/6.6-release-notes.adoc
+++ b/modules/ROOT/pages/6.6-release-notes.adoc
@@ -192,10 +192,16 @@ For more information about this component, see the xref:dialog-components.adoc#i
 
 For more information about dialogs, see the xref:dialog-configuration.adoc[Dialog configuration] documentation.
 
-=== Improved detection of scrollable containers when the `ui_mode: 'split'` option is set.
+=== Improved detection of scrollable containers when the `ui_mode: 'split'` option is set
 //#TINY-9385
 
-//CCFR
+When a {productname} instance has it’s xref:ui-mode-configuration-options.adoc[UI mode] set to `split`, support for setting the editor inside a scrollable container is enabled and {productname} editor elements — such as pop-ups, menus, and inline dialogs — are rendered in separate containers and inserted as sibling elements to the editor.
+
+Previously, howver, identifying all scrollable parent elements in such a setup was done with only a naive check. As a consequence, when other overflow properties — such as `overflow-x` — were introduced, the {productname} editor and the {productname} toolbar could behave unexpectedly in some circumstance.
+
+In {productname} 6.6.1, the naive check has been replaced with specific edge case coverage and a related test.
+
+As a consequence, the {productname} editor and the {productname} toolbar now behave as expected when overflow properties are introduced.
 
 
 

--- a/modules/ROOT/pages/6.6-release-notes.adoc
+++ b/modules/ROOT/pages/6.6-release-notes.adoc
@@ -192,6 +192,12 @@ For more information about this component, see the xref:dialog-components.adoc#i
 
 For more information about dialogs, see the xref:dialog-configuration.adoc[Dialog configuration] documentation.
 
+=== Improved detection of scrollable containers when the `ui_mode: 'split'` option is set.
+//#TINY-9385
+
+//CCFR
+
+
 
 [[changes]]
 == Changes

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -18,6 +18,7 @@ NOTE: This is the {productname} Community version changelog. For information abo
 === Improved
 * When defining a modal or inline dialog, if the buttons property is an empty array, or is not defined at all, the footer will now no longer be rendered.
 * The `iframe` dialog component now has a minimum height of 200px.
+* Improved detection of scrollable containers when the `ui_mode: 'split'` option is set.
 
 === Changed
 * The icon in an `alertbanner` dialog component is no longer clickable if the _URL_ field is not specified.


### PR DESCRIPTION
Ticket: DOC-2154, Improvement documentation entry for TINY-9385

Changes:
* documentation of _Improved detection of scrollable containers when the `ui_mode: 'split'` option is set_, added to **Improvement** section of `6.6-release-notes.adoc`.
* Added entry for TINY-9385 to Improved section of the 6.6-specific changelog.


Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] (New product features only) Release Note added

Review:
- [ ] Documentation Team Lead has reviewed
