### PR TITLE
DOC-2107: replace mis-leading explanatory text in powerpaste_html_import.adoc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,8 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
-- DOC_2150: Re-wrote `/live-demos/linkchecker/index.html`: it is now an actual interactive example, using canonically invalid domain names for the invalid domain-name strings and in-house domain names for the valid domain name strings.
+- DOC-2107: In `powerpaste_import_types.adoc`: removed misleading sentence from introductory paragraph in; re-structured value behaviour documentation from list to table for greater readability and pars-ability; copy-edited behaviour documentation to further improve readability and pars-ability; added NOTE admonition documenting what is done when pasting from a TinyMCE instance to a TinyMCE instance; edited `powerpaste_import_types.adoc` so the equivalent material in this partial presents in the *powerpaste_googledocs_import* and *powerpaste_word_import* sections equivalently to the presentation in the *powerpaste_html_import* section.
+- DOC-2150: Re-wrote `/live-demos/linkchecker/index.html`: it is now an actual interactive example, using canonically invalid domain names for the invalid domain-name strings and in-house domain names for the valid domain name strings.
 - DOC-2114: file, `pad_empty_with_br.adoc`, added to `/partials/configuration/`; documentation of option, `pad_empty_with_br`, added to file. `pad_empty_with_br.adoc` added to `content-filtering.adoc` with `include` statement. Also, notes re this option’s existence added to table in `6.0-release-notes-summary.adoc` noting the removal of equivalent previous option, `padd_empty_with_br`.
 
 ### 2023-07-21

--- a/modules/ROOT/partials/configuration/powerpaste_html_import.adoc
+++ b/modules/ROOT/partials/configuration/powerpaste_html_import.adoc
@@ -1,3 +1,5 @@
+:powerpaste-import-control-without-function-option: powerpaste-html
+
 [[powerpaste_html_import]]
 == `+powerpaste_html_import+`
 
@@ -7,6 +9,9 @@ This option controls how content pasted from sources other than Microsoft Word a
 
 *Default value:* `+'clean'+`
 
+include::partial$plugins/powerpaste_import_types.adoc[]
+
+////
 *Possible values:* `+'clean'+`, `+merge+`, `+prompt+`
 
 What the supported string-based values do:
@@ -32,6 +37,7 @@ This ensures the HTML is valid while more closely matching the original document
 |`+prompt+`
 |Prompts the user to choose between the `+clean+` and `+merge+` options after attempting to paste HTML content.
 |===
+////
 
 === example: using `+powerpaste_html_import+` to require a prompt when pasting html
 

--- a/modules/ROOT/partials/configuration/powerpaste_html_import.adoc
+++ b/modules/ROOT/partials/configuration/powerpaste_html_import.adoc
@@ -9,7 +9,7 @@ This option controls how content pasted from sources other than Microsoft Word a
 
 *Possible values:* `+'clean'+`, `+merge+`, `+prompt+`
 
-What the possible values do:
+What the supported string-based values do:
 
 [cols="1,1"]
 |===

--- a/modules/ROOT/partials/configuration/powerpaste_html_import.adoc
+++ b/modules/ROOT/partials/configuration/powerpaste_html_import.adoc
@@ -33,6 +33,14 @@ This ensures the HTML is valid while more closely matching the original document
 |Prompts the user to choose between the `+clean+` and `+merge+` options after attempting to paste HTML content.
 |===
 
+[NOTE]
+.Pasting from a {productname} instance to a {productname} instance
+====
+Content copied or cut from a {productname} instance and then pasted into a {productname} instance (eg, copyied or cut from one part of a {productname} document and pasted into another place within the same document) is not processed by `+powerpaste_html_import+`.
+
+In this circumstance, whatever is copied or cut is exactly what is pasted.
+====
+
 === example: using `+powerpaste_html_import+` to require a prompt when pasting html
 
 [source,js]
@@ -43,11 +51,3 @@ tinymce.init({
   powerpaste_html_import: 'prompt',
 });
 ----
-
-[IMPORTANT]
-.Pasting from a {productname} instance to a {productname} instance
-====
-Content copied or cut from a {productname} instance and then pasted into a {productname} instance (eg, copyied or cut from one part of a {productname} document and pasted into another place within the same document) is not processed by `+powerpaste_html_import+`.
-
-In this circumstance, whatever is copied or cut is exactly what is pasted.
-====

--- a/modules/ROOT/partials/configuration/powerpaste_html_import.adoc
+++ b/modules/ROOT/partials/configuration/powerpaste_html_import.adoc
@@ -1,14 +1,42 @@
 [[powerpaste_html_import]]
 == `+powerpaste_html_import+`
 
-This option controls how content pasted from sources other than Microsoft Word and Google Docs are filtered. Note that this includes content copied from {productname} itself.
+This option controls how content pasted from sources other than Microsoft Word and Google Docs are filtered.
 
 *Type:* `+String+`
 
 *Default value:* `+'clean'+`
 
-The supported values are:
+*Possible values:* `+'clean'+`, `+merge+`, `+prompt+`
 
-* `+clean+` - Preserve the structure of the content such as headings, tables, and lists but remove inline styles and classes. This results in simple content that uses the site's CSS stylesheet while retaining the semantic structure from the original document.
-* `+merge+` - Preserve the inline formatting and structure of the original document. Invalid and proprietary styles, tags and attributes are still removed ensuring that the HTML is valid while more closely matching the original document formatting.
-* `+prompt+` - Prompt the user to choose between the clean and merge options after attempting to paste HTML content.
+What the possible values do:
+
+[cols="1,1"]
+|===
+|Value |Behavior
+
+|`+clean+`
+|Preserves the structure of the content such as headings, tables, and lists.
+
+Removes inline styles and classes.
+
+This results in simple content that uses the site’s CSS stylesheet while retaining the semantic structure of the original document.
+
+|`+merge+`
+|Preserves the inline formatting and structure of the original document.
+
+Removes invalid and proprietary styles, tags and attributes.
+
+This ensures the HTML is valid while more closely matching the original document formatting.
+
+|`+prompt+`
+|Prompts the user to choose between the `+clean+` and `+merge+` options after attempting to paste HTML content.
+|===
+
+[IMPORTANT]
+.Pasting from a {productname} instance to a {productname} instance
+====
+Content copied or cut from a {productname} instance and then pasted into a {productname} instance (eg, copyied or cut from one part of a {productname} document and pasted into another place within the same document) is not processed by `+powerpaste_html_import+`.
+
+In this circumstance, whatever is copied or cut is exactly what is pasted.
+====

--- a/modules/ROOT/partials/configuration/powerpaste_html_import.adoc
+++ b/modules/ROOT/partials/configuration/powerpaste_html_import.adoc
@@ -1,5 +1,3 @@
-:powerpaste-import-control-without-function-option: powerpaste-html
-
 [[powerpaste_html_import]]
 == `+powerpaste_html_import+`
 
@@ -9,9 +7,6 @@ This option controls how content pasted from sources other than Microsoft Word a
 
 *Default value:* `+'clean'+`
 
-include::partial$plugins/powerpaste_import_types.adoc[]
-
-////
 *Possible values:* `+'clean'+`, `+merge+`, `+prompt+`
 
 What the supported string-based values do:
@@ -37,7 +32,6 @@ This ensures the HTML is valid while more closely matching the original document
 |`+prompt+`
 |Prompts the user to choose between the `+clean+` and `+merge+` options after attempting to paste HTML content.
 |===
-////
 
 === example: using `+powerpaste_html_import+` to require a prompt when pasting html
 

--- a/modules/ROOT/partials/configuration/powerpaste_html_import.adoc
+++ b/modules/ROOT/partials/configuration/powerpaste_html_import.adoc
@@ -33,6 +33,17 @@ This ensures the HTML is valid while more closely matching the original document
 |Prompts the user to choose between the `+clean+` and `+merge+` options after attempting to paste HTML content.
 |===
 
+=== example: using `+powerpaste_html_import+` to require a prompt when pasting html
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your html
+  plugins: 'powerpaste',
+  powerpaste_html_import: 'prompt',
+});
+----
+
 [IMPORTANT]
 .Pasting from a {productname} instance to a {productname} instance
 ====

--- a/modules/ROOT/partials/plugins/powerpaste_import_types.adoc
+++ b/modules/ROOT/partials/plugins/powerpaste_import_types.adoc
@@ -1,4 +1,4 @@
-*Possible values:* `+'clean'+`, `+merge+`, `+prompt+`
+*Possible values:* `+'clean'+`, `+merge+`, `+prompt+` **or** a `+Function+`
 
 What the supported string-based values do:
 
@@ -24,6 +24,4 @@ This ensures the HTML is valid while more closely matching the original document
 |Prompts the user to choose between the `+clean+` and `+merge+` options after attempting to paste HTML content.
 |===
 
-ifndef::[powerpaste-import-control-without-function-option]
 Alternatively, this option can take an asynchronous function that returns a https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise[Promise] which will resolve with the string `+clean+` or `+merge+`. This allows the paste mode to be dynamically set each time a user pastes relevant content. It can be used, for example, to replicate the `+prompt+` dialog with a custom dialog.
-ifndef::[]

--- a/modules/ROOT/partials/plugins/powerpaste_import_types.adoc
+++ b/modules/ROOT/partials/plugins/powerpaste_import_types.adoc
@@ -1,7 +1,27 @@
-The supported string-based values are:
+*Possible values:* `+'clean'+`, `+merge+`, `+prompt+`
 
-* `+clean+` - Preserve the structure of the content such as headings, tables, and lists but remove inline styles and classes. This results in simple content that uses the site's CSS stylesheet while retaining the semantic structure from the original document.
-* `+merge+` - Preserve the inline formatting and structure of the original document. Invalid and proprietary styles, tags and attributes are still removed ensuring that the HTML is valid while more closely matching the original document formatting.
-* `+prompt+` - Prompt the user to choose between the clean and merge options after attempting to paste HTML content.
+What the supported string-based values do:
+
+[cols="1,1"]
+|===
+|Value |Behavior
+
+|`+clean+`
+|Preserves the structure of the content such as headings, tables, and lists.
+
+Removes inline styles and classes.
+
+This results in simple content that uses the site’s CSS stylesheet while retaining the semantic structure of the original document.
+
+|`+merge+`
+|Preserves the inline formatting and structure of the original document.
+
+Removes invalid and proprietary styles, tags and attributes.
+
+This ensures the HTML is valid while more closely matching the original document formatting.
+
+|`+prompt+`
+|Prompts the user to choose between the `+clean+` and `+merge+` options after attempting to paste HTML content.
+|===
 
 Alternatively, this option can take an asynchronous function that returns a https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise[Promise] which will resolve with the string `+clean+` or `+merge+`. This allows the paste mode to be dynamically set each time a user pastes relevant content. It can be used, for example, to replicate the `+prompt+` dialog with a custom dialog.

--- a/modules/ROOT/partials/plugins/powerpaste_import_types.adoc
+++ b/modules/ROOT/partials/plugins/powerpaste_import_types.adoc
@@ -24,4 +24,6 @@ This ensures the HTML is valid while more closely matching the original document
 |Prompts the user to choose between the `+clean+` and `+merge+` options after attempting to paste HTML content.
 |===
 
+ifndef::[powerpaste-import-control-without-function-option]
 Alternatively, this option can take an asynchronous function that returns a https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise[Promise] which will resolve with the string `+clean+` or `+merge+`. This allows the paste mode to be dynamically set each time a user pastes relevant content. It can be used, for example, to replicate the `+prompt+` dialog with a custom dialog.
+ifndef::[]


### PR DESCRIPTION
Ticket: DOC-2107: replace mis-leading explanatory text in powerpaste_html_import.adoc

Changes:
1. Removed misleading sentence from introductory paragraph.
2. Re-structured value behaviour documentation from list to table for greater readability and pars-ability.
3. Copy-edits to the behaviour documentation to further improve readability and pars-ability.
4. Added NOTE admonition documenting what is done when pasting from a TinyMCE instance to a TinyMCE instance.
5. Edited `powerpaste_import_types.adoc` so the equivalent material in this partial presents in the *powerpaste_googledocs_import* and *powerpaste_word_import* sections equivalently to the presentation in the *powerpaste_html_import* section.


Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
