### PR TITLE
DOC-2153: add note re pad_empty_with_br to 5.x docs note re removal of padd_empty_with_br

### DIFF
--- a/release-notes/6.0-upcoming-changes.md
+++ b/release-notes/6.0-upcoming-changes.md
@@ -157,6 +157,7 @@ non_empty_elements
 
 padd_empty_with_br
 : The `padd_empty_with_br` option would replace non-breaking spaces (`&nbsp;`) with `<br>` elements. This option however was misspelled, provided no functional difference to a non-breaking space and is incompatible with Real-time Collaboration.
+: **Note**: {{site.productname}} 6.6.1 includes a new option, [`pad_empty_with_br`](https://tiny.cloud/docs/tinymce/6/content-filtering#pad_empty_with_br) that provides equivalent functionality.
 
 self_closing_elements
 : The `self_closing_elements` option allowed developers to override the built-in HTML schema to specify which elements should be closed if a new element is started without a similar closing tag. Using this option can break the editor and requires the default to be repeated with any desired changes. Additionally, browsers can't be changed to parse the customizations, so this option was not useful for customization.

--- a/release-notes/6.0-upcoming-changes.md
+++ b/release-notes/6.0-upcoming-changes.md
@@ -157,7 +157,7 @@ non_empty_elements
 
 padd_empty_with_br
 : The `padd_empty_with_br` option would replace non-breaking spaces (`&nbsp;`) with `<br>` elements. This option however was misspelled, provided no functional difference to a non-breaking space and is incompatible with Real-time Collaboration.
-: **Note**: {{site.productname}} 6.6.1 includes a new option, [`pad_empty_with_br`](https://tiny.cloud/docs/tinymce/6/content-filtering#pad_empty_with_br) that provides equivalent functionality.
+: **Note**: {{site.productname}} 6.6.2 includes a new option, [`pad_empty_with_br`](https://tiny.cloud/docs/tinymce/6/content-filtering#pad_empty_with_br) that provides equivalent functionality.
 
 self_closing_elements
 : The `self_closing_elements` option allowed developers to override the built-in HTML schema to specify which elements should be closed if a new element is started without a similar closing tag. Using this option can break the editor and requires the default to be repeated with any desired changes. Additionally, browsers can't be changed to parse the customizations, so this option was not useful for customization.


### PR DESCRIPTION
DOC-2153: add note re pad_empty_with_br to 5.x docs note re removal of padd_empty_with_br.

Changes:
Added **Note** re `pad_empty_with_br` being:
	1. available as part of TinyMCE 6.6.2; and
	2. providing equivalent functionality to the deprecated `padd_empty_with_br` option.
to `6.0-upcoming-changes.md`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
