### PR TITLE
DOC-2165: add notes re selection state and switching from rich-text to code-view

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### 2023-08-21
+
+- DOC-2165: `code-dialog-and-selection-state.adoc`, documentation of selection state behaviour when switching from rich-text to code-view dialog, added to `/partials/misc/`; include statements, pointing to `/partials/misc/code-dialog-and-selection-state.adoc`, added to `code.adoc` & `advcode.adoc`.
+
 ### 2023-08-18
 
 - DOC-2266: updated paths in `package.json` (& path documentation in `api-reference-local.sh` and `README.md`) to new script path: s/_scripts/-scripts/.

--- a/modules/ROOT/pages/advcode.adoc
+++ b/modules/ROOT/pages/advcode.adoc
@@ -53,6 +53,7 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/code-dialog-and-selection-state.adoc[]
 
 include::partial$configuration/advcode.adoc[]
 

--- a/modules/ROOT/pages/code.adoc
+++ b/modules/ROOT/pages/code.adoc
@@ -18,6 +18,8 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/code-dialog-and-selection-state.adoc[]
+
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]

--- a/modules/ROOT/partials/misc/code-dialog-and-selection-state.adoc
+++ b/modules/ROOT/partials/misc/code-dialog-and-selection-state.adoc
@@ -1,6 +1,6 @@
 == Selection state when opening and closing the code editor
 
-The safest assumption is that selection state is not preserved when switching between the rich-text editor (ie the default {productname} editor instance) to the code editor dialog view of a {productname} document.
+The safest assumption is that selection state is not preserved when switching between the rich-text editor (ie, the default {productname} editor instance) to the code editor dialog view of a {productname} document.
 
 === Switching from the rich-text editor view to the code editor
 

--- a/modules/ROOT/partials/misc/code-dialog-and-selection-state.adoc
+++ b/modules/ROOT/partials/misc/code-dialog-and-selection-state.adoc
@@ -1,0 +1,27 @@
+== Selection state when opening and closing the code editor
+
+The safest assumption is that selection state is not preserved when switching between the rich-text editor (ie the default {productname} editor instance) to the code editor dialog view of a {productname} document.
+
+=== Switching from the rich-text editor view to the code editor
+
+If the current selection in the {productname} instance is collapsed (ie, is a flashing insertion point), the insertion point will be in the equivalent place when the code editor is opened.
+
+If the current selection in the rich-text editor is an actual selection, that state is not preserved when switching to the code editor.
+
+Instead, the insertion point in the code editor is placed at the beginning of what was the selection in the rich-text editor.
+
+=== Switching from the code editor back to the rich-text editor view
+
+When switching back from the code-view dialog to the rich-text editor, selection state is almost never preserved.
+
+If you have a selection or a collapsed selection in the rich-text editor and
+
+. open the code view dialog;
+. make no changes; and
+. exit the code view dialog by clicking **Cancel** (or pressing the **Esc** key);
+
+the selection or collapsed selection will likely be preserved in the rich-text editor.
+
+Otherwise, the selection state is not preserved on round-tripping from rich-text to code-view and back.
+
+Instead, the insertion point is placed at the beginning of the editable block closest to the beginning of the {productname} document.


### PR DESCRIPTION
DOC-2165: add notes re selection state and switching from rich-text to code-view

Changes:
1. Added file, `code-dialog-and-selection-state.adoc`, to `/partials/misc/`.
2. Added documentation of selection state behaviour when switching from rich-text to code-view dialog.
3. *include::* statements, pointing to `/partials/misc/code-dialog-and-selection-state.adoc`, added to `code.adoc` & `advcode.adoc`.


Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] Files has been included where required (if applicable)

Review:
- [x] Documentation Team Lead has reviewed
