### PR TITLE
DOC-2167: sync the full-featured demo toolbar to the tiny.cloud home page demo toolbar

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,9 +4,13 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### 2023-08-29
+
+- DOC-2167: edited toolbar configurations in both the open-source–only and Premium-plugins–included full-featured demos; also added the Accordion plugin and toolbar items to the open-source–only full-featured demo.
+
 ### 2023-08-24
 
-- DOC_2163: added release and end-of-support dates for TinyMCE versions 6.4, 6.5, and 6.6 to `supported-versions.adoc`; updated value of `productminorversion` variable in `antora.yml`; added annotated version of `antora.yml` to release-notes-template infrastructure; added annotated version of `supported-versions.adoc` to release-notes-template infrastructure; added include statement, pointing to `/modules/ROOT/partials/misc/admon-rtc-eol.adoc`, to `premium-plugin-list.adoc`.
+- DOC-2163: added release and end-of-support dates for TinyMCE versions 6.4, 6.5, and 6.6 to `supported-versions.adoc`; updated value of `productminorversion` variable in `antora.yml`; added annotated version of `antora.yml` to release-notes-template infrastructure; added annotated version of `supported-versions.adoc` to release-notes-template infrastructure; added include statement, pointing to `/modules/ROOT/partials/misc/admon-rtc-eol.adoc`, to `premium-plugin-list.adoc`.
 
 ### 2023-08-21
 

--- a/modules/ROOT/examples/live-demos/full-featured/example.js
+++ b/modules/ROOT/examples/live-demos/full-featured/example.js
@@ -18,7 +18,7 @@ tinymce.init({
     }
   },
   menubar: 'file edit view insert format tools table tc help',
-  toolbar: 'undo redo | bold italic underline strikethrough | typography | fontfamily fontsize blocks | alignleft aligncenter alignright alignjustify | inserttemplate addtemplate | outdent indent | numlist bullist checklist | forecolor backcolor casechange permanentpen formatpainter removeformat | pagebreak | charmap emoticons | fullscreen  preview save print | insertfile image media pageembed link anchor codesample | a11ycheck ltr rtl | showcomments addcomment | footnotes | mergetags',
+  toolbar: "undo redo | aidialog aishortcuts | blocks fontsizeinput | bold italic | align numlist bullist | link image | table media pageembed | lineheight  outdent indent | strikethrough forecolor backcolor formatpainter removeformat | charmap emoticons checklist | code fullscreen preview | save print export | pagebreak anchor codesample footnotes mergetags | addtemplate inserttemplate | addcomment showcomments | ltr rtl casechange | spellcheckdialog a11ycheck," // Note: if a toolbar item requires a plugin, the item will not present in the toolbar if the plugin is not also loaded.
   toolbar_sticky: true,
   toolbar_sticky_offset: isSmallScreen ? 102 : 108,
   autosave_ask_before_unload: true,

--- a/modules/ROOT/examples/live-demos/full-featured/example.js
+++ b/modules/ROOT/examples/live-demos/full-featured/example.js
@@ -18,7 +18,7 @@ tinymce.init({
     }
   },
   menubar: 'file edit view insert format tools table tc help',
-  toolbar: "undo redo | aidialog aishortcuts | blocks fontsizeinput | bold italic | align numlist bullist | link image | table media pageembed | lineheight  outdent indent | strikethrough forecolor backcolor formatpainter removeformat | charmap emoticons checklist | code fullscreen preview | save print export | pagebreak anchor codesample footnotes mergetags | addtemplate inserttemplate | addcomment showcomments | ltr rtl casechange | spellcheckdialog a11ycheck," // Note: if a toolbar item requires a plugin, the item will not present in the toolbar if the plugin is not also loaded.
+  toolbar: "undo redo | aidialog aishortcuts | blocks fontsizeinput | bold italic | align numlist bullist | link image | table media pageembed | lineheight  outdent indent | strikethrough forecolor backcolor formatpainter removeformat | charmap emoticons checklist | code fullscreen preview | save print export | pagebreak anchor codesample footnotes mergetags | addtemplate inserttemplate | addcomment showcomments | ltr rtl casechange | spellcheckdialog a11ycheck", // Note: if a toolbar item requires a plugin, the item will not present in the toolbar if the plugin is not also loaded.
   toolbar_sticky: true,
   toolbar_sticky_offset: isSmallScreen ? 102 : 108,
   autosave_ask_before_unload: true,

--- a/modules/ROOT/examples/live-demos/full-featured/index.js
+++ b/modules/ROOT/examples/live-demos/full-featured/index.js
@@ -161,7 +161,7 @@ tinymce.ScriptLoader.loadScripts(['https://cdn.jsdelivr.net/npm/faker@5/dist/fak
       }
     },
     menubar: 'file edit view insert format tools table tc help',
-    toolbar: 'undo redo | bold italic underline strikethrough | typography | fontfamily fontsize blocks | alignleft aligncenter alignright alignjustify | outdent indent | inserttemplate addtemplate | numlist bullist checklist | forecolor backcolor casechange permanentpen formatpainter removeformat | pagebreak | charmap emoticons | fullscreen  preview save print | insertfile image media pageembed link anchor codesample | a11ycheck ltr rtl | showcomments addcomment | footnotes | mergetags',
+      toolbar: "undo redo | aidialog aishortcuts | blocks fontsizeinput | bold italic | align numlist bullist | link image | table media pageembed | lineheight  outdent indent | strikethrough forecolor backcolor formatpainter removeformat | charmap emoticons checklist | code fullscreen preview | save print export | pagebreak anchor codesample footnotes mergetags | addtemplate inserttemplate | addcomment showcomments | ltr rtl casechange | spellcheckdialog a11ycheck," // Note: if a toolbar item requires a plugin, the item will not present in the toolbar if the plugin is not also loaded.
     toolbar_sticky: true,
     toolbar_sticky_offset: isSmallScreen ? 102 : 108,
     autosave_ask_before_unload: true,

--- a/modules/ROOT/examples/live-demos/full-featured/index.js
+++ b/modules/ROOT/examples/live-demos/full-featured/index.js
@@ -161,7 +161,7 @@ tinymce.ScriptLoader.loadScripts(['https://cdn.jsdelivr.net/npm/faker@5/dist/fak
       }
     },
     menubar: 'file edit view insert format tools table tc help',
-      toolbar: "undo redo | aidialog aishortcuts | blocks fontsizeinput | bold italic | align numlist bullist | link image | table media pageembed | lineheight  outdent indent | strikethrough forecolor backcolor formatpainter removeformat | charmap emoticons checklist | code fullscreen preview | save print export | pagebreak anchor codesample footnotes mergetags | addtemplate inserttemplate | addcomment showcomments | ltr rtl casechange | spellcheckdialog a11ycheck," // Note: if a toolbar item requires a plugin, the item will not present in the toolbar if the plugin is not also loaded.
+      toolbar: "undo redo | aidialog aishortcuts | blocks fontsizeinput | bold italic | align numlist bullist | link image | table media pageembed | lineheight  outdent indent | strikethrough forecolor backcolor formatpainter removeformat | charmap emoticons checklist | code fullscreen preview | save print export | pagebreak anchor codesample footnotes mergetags | addtemplate inserttemplate | addcomment showcomments | ltr rtl casechange | spellcheckdialog a11ycheck", // Note: if a toolbar item requires a plugin, the item will not present in the toolbar if the plugin is not also loaded.
     toolbar_sticky: true,
     toolbar_sticky_offset: isSmallScreen ? 102 : 108,
     autosave_ask_before_unload: true,

--- a/modules/ROOT/examples/live-demos/open-source-plugins/index.js
+++ b/modules/ROOT/examples/live-demos/open-source-plugins/index.js
@@ -3,10 +3,10 @@ const isSmallScreen = window.matchMedia('(max-width: 1023.5px)').matches;
 
 tinymce.init({
   selector: 'textarea#open-source-plugins',
-  plugins: 'preview importcss searchreplace autolink autosave save directionality code visualblocks visualchars fullscreen image link media template codesample table charmap pagebreak nonbreaking anchor insertdatetime advlist lists wordcount help charmap quickbars emoticons',
+  plugins: 'preview importcss searchreplace autolink autosave save directionality code visualblocks visualchars fullscreen image link media template codesample table charmap pagebreak nonbreaking anchor insertdatetime advlist lists wordcount help charmap quickbars emoticons accordion',
   editimage_cors_hosts: ['picsum.photos'],
   menubar: 'file edit view insert format tools table help',
-  toolbar: "undo redo | blocks fontfamily fontsize | bold italic underline strikethrough | align numlist bullist | link image | table media | lineheight outdent indent| forecolor backcolor removeformat | charmap emoticons | code fullscreen preview | save print | pagebreak anchor codesample | ltr rtl",
+  toolbar: "undo redo | accordion accordiontoggle accordionremove | blocks fontfamily fontsize | bold italic underline strikethrough | align numlist bullist | link image | table media | lineheight outdent indent| forecolor backcolor removeformat | charmap emoticons | code fullscreen preview | save print | pagebreak anchor codesample | ltr rtl",
   toolbar_sticky: true,
   toolbar_sticky_offset: isSmallScreen ? 102 : 108,
   autosave_ask_before_unload: true,

--- a/modules/ROOT/examples/live-demos/open-source-plugins/index.js
+++ b/modules/ROOT/examples/live-demos/open-source-plugins/index.js
@@ -6,7 +6,7 @@ tinymce.init({
   plugins: 'preview importcss searchreplace autolink autosave save directionality code visualblocks visualchars fullscreen image link media template codesample table charmap pagebreak nonbreaking anchor insertdatetime advlist lists wordcount help charmap quickbars emoticons accordion',
   editimage_cors_hosts: ['picsum.photos'],
   menubar: 'file edit view insert format tools table help',
-  toolbar: "undo redo | accordion accordiontoggle accordionremove | blocks fontfamily fontsize | bold italic underline strikethrough | align numlist bullist | link image | table media | lineheight outdent indent| forecolor backcolor removeformat | charmap emoticons | code fullscreen preview | save print | pagebreak anchor codesample | ltr rtl",
+  toolbar: "undo redo | accordion accordionremove | blocks fontfamily fontsize | bold italic underline strikethrough | align numlist bullist | link image | table media | lineheight outdent indent| forecolor backcolor removeformat | charmap emoticons | code fullscreen preview | save print | pagebreak anchor codesample | ltr rtl",
   toolbar_sticky: true,
   toolbar_sticky_offset: isSmallScreen ? 102 : 108,
   autosave_ask_before_unload: true,

--- a/modules/ROOT/examples/live-demos/open-source-plugins/index.js
+++ b/modules/ROOT/examples/live-demos/open-source-plugins/index.js
@@ -6,7 +6,7 @@ tinymce.init({
   plugins: 'preview importcss searchreplace autolink autosave save directionality code visualblocks visualchars fullscreen image link media template codesample table charmap pagebreak nonbreaking anchor insertdatetime advlist lists wordcount help charmap quickbars emoticons',
   editimage_cors_hosts: ['picsum.photos'],
   menubar: 'file edit view insert format tools table help',
-  toolbar: 'undo redo | bold italic underline strikethrough | fontfamily fontsize blocks | alignleft aligncenter alignright alignjustify | outdent indent |  numlist bullist | forecolor backcolor removeformat | pagebreak | charmap emoticons | fullscreen  preview save print | insertfile image media template link anchor codesample | ltr rtl',
+  toolbar: "undo redo | blocks fontfamily fontsize | bold italic underline strikethrough | align numlist bullist | link image | table media | lineheight outdent indent| forecolor backcolor removeformat | charmap emoticons | code fullscreen preview | save print | pagebreak anchor codesample | ltr rtl",
   toolbar_sticky: true,
   toolbar_sticky_offset: isSmallScreen ? 102 : 108,
   autosave_ask_before_unload: true,


### PR DESCRIPTION
DOC-2167: sync the full-featured demo toolbar to the tiny.cloud home page demo toolbar

Changes:
1. Brought _Full-featured demo with Premium plugins_ demo toolbar into sync with the TinyMCE instance presented on Tiny home page.
2. Added comment to this configuration noting a toolbar item will not load if it relies on a plugin that is not loaded.
3. Brought _Full-featured demo with open source plugins only_ demo toolbar as into sync with the TinyMCE instance presented on Tiny home page as is possible.


Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
