### PR TITLE
DOC-2170: correct link pointing to official TinyMCE 5.x jQuery component in TinyMCE 5.x jQuery component docs

### DIFF
--- a/integrations/jquery.md
+++ b/integrations/jquery.md
@@ -8,7 +8,7 @@ keywords: integration integrate jquery javascript
 
 ## TinyMCE jQuery integration quick start guide
 
-The [Official {{site.productname}} jQuery component](https://github.com/tinymce/tinymce/blob/master/modules/tinymce/src/core/main/js/JqueryIntegration.js) integrates TinyMCE into jQuery projects.
+The [Official {{site.productname}} jQuery component](https://github.com/tinymce/tinymce/blob/release/5.10/modules/tinymce/src/core/main/js/JqueryIntegration.js) integrates TinyMCE into jQuery projects.
 This procedure creates a basic jQuery integration containing a {{site.productname}} editor based on our [Basic example]({{site.baseurl}}/demo/basic-example/).
 
 ### Procedure


### PR DESCRIPTION
DOC-2170: correct link pointing to official TinyMCE 5.x jQuery component in TinyMCE 5.x jQuery component docs

Changes:
* URL pointing to Official jQuery component changed. It now points to the file in the `/release/5.10` branch of TinyMCE, where the 5.x-specific jQuery component still exists. It no longer points to the `master` branch, which does not have this file in that spot at all.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`

Review:
- [x] Documentation Team Lead has reviewed
