### PR TITLE
DOC-2171: fix documentation entry for TINY-10123 in the 6.7 Release Notes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### Unreleased
+
+- DOC-2171: fix documentation entry for TINY-10123 in the 6.7 Release Notes.
 
 ### 2023-08-30
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -347,4 +347,6 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === In Safari on macOS, deleting backwards within a `<summary>` element removed the entire `<details>` element if it had no other content
 // TINY-10123
+Previously, when Safari was the host web browser, when pressing the Backspace key while the cursor was inside the `<summary>` element of an Accordion component, and there was no other content within the parent `<details>` element, the entire parent `<details>` element would be deleted, rather than just the character before the cursor within the `<summary>`.
 
+With the release of {productname} version 6.7, we have corrected Safari's backward delete behavior in the `<details>` command. As of this update, the Backspace key now functions as expected, deleting only the character before the cursor within the `<summary>` element.


### PR DESCRIPTION
Ticket: DOC-2171: fix documentation entry for TINY-10123 in the 6.7 Release Notes.

Changes:
* Added Bug Fix documentation entry for TINY-10123 in the 6.7 Release Notes.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [ ] Documentation Team Lead has reviewed
