### PR TITLE
DOC-2175: Update CODEOWNERS automatic reviewers upon opening new DOC- PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @tinymce/documentation-team @tinymce/editor-platform-team @HAFRMO
+* @tinymce/documentation-team
 
 # Integration docs
 /integrations/ @tinymce/documentation-team @tinymce/editor-platform-team @tinymce/integrations-team

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2175: Update CODEOWNERS automatic reviewers upon opening new DOC-PRs.
 - DOC-2173: updated the default value code sample in `ai_shortcuts.adoc` to match the updated values included in the AI Assistant. Also re-wrote the **Note** admonition to call-out the absence of any translations or alternative language versions of these default values.
 
 


### PR DESCRIPTION
Ticket: DOC-2175: Update CODEOWNERS automatic reviewers upon opening new DOC- PRs

Changes:
* Update CODEOWNERS list to disable automatically adding the entire `editorTeam` and `other` reviewers to every DOCs ticket PR when they are created.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
