### PR TITLE
DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,9 @@ Changes to the TinyMCE documentation are documented in this file.
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+### Unreleased
+
+- DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.
 ### 2023-08-30
 
 - DOC-2169: added 6.7-specific entries to `changelog.adoc`.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -344,6 +344,9 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === The `color_cols` option was not respected when set to the value 5 with a custom `color_map` specified
 // TINY-10126
+In {productname} 6.6.2, the `color_cols` option was not respected when the value was set to 5 while a custom color_map was also present in the same editor configuration.
+
+With the release of {productname} 6.7, when using a custom `color_map`, the `color_cols` option is now respected when set to 5.
 
 === In Safari on macOS, deleting backwards within a `<summary>` element removed the entire `<details>` element if it had no other content
 // TINY-10123

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -344,9 +344,13 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === The `color_cols` option was not respected when set to the value 5 with a custom `color_map` specified
 // TINY-10126
-In {productname} 6.6.2, the `color_cols` option was not respected when the value was set to 5 while a custom color_map was also present in the same editor configuration.
+Previously, when `color_cols: 5` was set, the assigned value was not used.
 
-With the release of {productname} 6.7, when using a custom `color_map`, the `color_cols` option is now respected when set to 5.
+Instead, when `color_cols` was set to the default number of columns displayed by a {productname} color selection grid (ie 5), the default method for calculating the number of displayed columns is used.
+
+For {productname} 6.7, the logic for calculating the default `color_cols` values was re-written. As of this release, {productname} now uses either the `color_cols` option, with its default calculated on the base color map, or the value calculated by custom color maps.
+
+This ensures a set `color_cols` value is always used, even when that value matches the default value.
 
 === In Safari on macOS, deleting backwards within a `<summary>` element removed the entire `<details>` element if it had no other content
 // TINY-10123


### PR DESCRIPTION
Ticket: DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes

Changes:
* Documentation entry for `The `color_cols` option was not respected when set to the value 5 with a custom `color_map` specified`

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
