### PR TITLE
DOC-2027: document `help_accessibility` option and related updates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2027: added `/modules/ROOT/partials/configuration/help_accessibility.adoc`, documenting the `help_accessibility` option; edits, re-writes and re-structuring of `help.adoc`; plus copy-edits to `keyboard-shortcuts.adoc`, `tinymce-and-screenreaders.adoc` & `accessibility.adoc`.
 - DOC-2175: Update CODEOWNERS automatic reviewers upon opening new DOC-PRs.
 - DOC-2173: updated the default value code sample in `ai_shortcuts.adoc` to match the updated values included in the AI Assistant. Also re-wrote the **Note** admonition to call-out the absence of any translations or alternative language versions of these default values.
 

--- a/modules/ROOT/pages/accessibility.adoc
+++ b/modules/ROOT/pages/accessibility.adoc
@@ -10,3 +10,5 @@ include::partial$configuration/highlight_on_focus.adoc[]
 include::partial$configuration/iframe_aria_text.adoc[]
 
 include::partial$configuration/taborder.adoc[]
+
+include::partial$configuration/help_accessibility.adoc[]

--- a/modules/ROOT/pages/help.adoc
+++ b/modules/ROOT/pages/help.adoc
@@ -12,7 +12,9 @@ The help plugin adds a button and/or menu item that opens a dialog showing four 
 |Tab display name |Tab configuration name |Purpose
 |Handy shortcuts |`shortcuts` |Presents keyboard shortcuts available in the {productname} editor.
 |Keyboard Navigation |`keyboardnav` |Documents the keyboard-based options for navigating and controlling the entire {productname} editor.
-|Plugins |`plugins` |Lists the installed plugins for the {productname} instance, with links to the relevant {productname} documentation. Also presents a list of available {productname} Premium plugins.
+|Plugins |`plugins` |Lists the installed plugins for the {productname} instance, with links to the relevant {productname} documentation.
+
+ Also presents a list of available {productname} Premium plugins.
 |Version |`versions` |Displays the {productname} version.
 |===
 

--- a/modules/ROOT/pages/help.adoc
+++ b/modules/ROOT/pages/help.adoc
@@ -5,14 +5,26 @@
 :pluginname: Help
 :plugincode: help
 
-The help plugin adds a button and/or menu item that opens a dialog showing two tabs:
+The help plugin adds a button and/or menu item that opens a dialog showing four tabs:
 
-* Handy shortcuts that explains some nice-to-know keyboard shortcuts
-* Plugin list that shows which plugins that have been installed, with links to the relevant documentation pages if available, and a list of available premium plugins.
+[cols=",,",options="header"]
+|===
+|Tab display name |Tab configuration name |Purpose
+|Handy shortcuts |`shortcuts` |Presents keyboard shortcuts available in the {productname} editor.
+|Keyboard Navigation |`keyboardnav` |Documents the keyboard-based options for navigating and controlling the entire {productname} editor.
+|Plugins |`plugins` |Lists the installed plugins for the {productname} instance, with links to the relevant {productname} documentation. Also presents a list of available {productname} Premium plugins.
+|Version |`versions` |Displays the {productname} version.
+|===
 
-In the footer of the dialog you can also see which version of {productname} you are using.
+The {productname} Help dialog can also be shown by pressing a keyboard shortcut.
 
-The help dialog can also be shown by pressing the keyboard shortcut `+Alt + 0+`.
+[cols=",,",options="header"]
+|===
+|Action |Windows or Linux |macOS
+|Open the {productname} Help dialog |Alt+0 |⌥+0
+|===
+
+As of {productname} 6.7, the keyboard shortcut that opens the {productname} Help dialog displays, by default, in the {productname} status bar.
 
 == Basic setup
 
@@ -26,6 +38,8 @@ tinymce.init({
 ----
 
 == Options
+
+include::partial$configuration/help_accessibility.adoc[leveloffset=+1]
 
 include::partial$configuration/help_tabs.adoc[leveloffset=+1]
 

--- a/modules/ROOT/pages/keyboard-shortcuts.adoc
+++ b/modules/ROOT/pages/keyboard-shortcuts.adoc
@@ -11,32 +11,32 @@ This is a list of available keyboard shortcuts within the editor body.
 
 [cols=",,,",options="header"]
 |===
-|Action |PC |Mac |Core/Plugin
-|Bold |Ctrl+B |Command+B |core
-|Italic |Ctrl+I |Command+I |core
-|Underline |Ctrl+U |Command+U |core
-|Select All |Ctrl+A |Command+A |core
-|Redo |Ctrl+Y / Ctrl+Shift+Z |Command+Y / Command+Shift+Z |core
-|Undo |Ctrl+Z |Command+Z |core
-|Header 1 |Alt+Shift+1 |Ctrl+Option+1 |core
-|Header 2 |Alt+Shift+2 |Ctrl+Option+2 |core
-|Header 3 |Alt+Shift+3 |Ctrl+Option+3 |core
-|Header 4 |Alt+Shift+4 |Ctrl+Option+4 |core
-|Header 5 |Alt+Shift+5 |Ctrl+Option+5 |core
-|Header 6 |Alt+Shift+6 |Ctrl+Option+6 |core
-|Paragraph |Alt+Shift+7 |Ctrl+Option+7 |core
-|Div |Alt+Shift+8 |Ctrl+Option+8 |core
-|Address |Alt+Shift+9 |Ctrl+Option+9 |core
-|Focus to menu bar |Alt+F9 |Option+F9 |core
-|Focus to toolbar |Alt+F10 |Option+F10 |core
-|Focus to element path |Alt+F11 |Option+F11 |core
+|Action |Windows or Linux |macOS |Core/Plugin
+|Bold |Ctrl+B |⌘+B |core
+|Italic |Ctrl+I |⌘+I |core
+|Underline |Ctrl+U |⌘+U |core
+|Select All |Ctrl+A |⌘+A |core
+|Redo |Ctrl+Y / Ctrl+Shift+Z |⌘+Y / ⌘+Shift+Z |core
+|Undo |Ctrl+Z |⌘+Z |core
+|Header 1 |Alt+Shift+1 |Ctrl+⌥+1 |core
+|Header 2 |Alt+Shift+2 |Ctrl+⌥+2 |core
+|Header 3 |Alt+Shift+3 |Ctrl+⌥+3 |core
+|Header 4 |Alt+Shift+4 |Ctrl+⌥+4 |core
+|Header 5 |Alt+Shift+5 |Ctrl+⌥+5 |core
+|Header 6 |Alt+Shift+6 |Ctrl+⌥+6 |core
+|Paragraph |Alt+Shift+7 |Ctrl+⌥+7 |core
+|Div |Alt+Shift+8 |Ctrl+⌥+8 |core
+|Address |Alt+Shift+9 |Ctrl+⌥+9 |core
+|Focus to menu bar |Alt+F9 |⌥+F9 |core
+|Focus to toolbar |Alt+F10 |⌥+F10 |core
+|Focus to element path |Alt+F11 |⌥+F11 |core
 |Focus to contextual toolbar |Ctrl+F9 |Ctrl+F9 |core
-|Print |Ctrl+P |Command+P |core
-|Open the help dialog |Alt+0 |Option+0 |xref:help.adoc[help]
-|Insert link |Ctrl+K |Command+K |xref:link.adoc[link]
-|Toggle Fullscreen |Ctrl+Shift+F |Command+Shift+F |xref:fullscreen.adoc[fullscreen]
-|Save |Ctrl+S |Command+S |xref:save.adoc[save]
-|Find |Ctrl+F |Command+F |xref:searchreplace.adoc[searchreplace]
+|Print |Ctrl+P |⌘+P |core
+|Open the {productname} Help dialog |Alt+0 |⌥+0 |xref:help.adoc[help]
+|Insert link |Ctrl+K |⌘+K |xref:link.adoc[link]
+|Toggle Fullscreen |Ctrl+Shift+F |⌘+Shift+F |xref:fullscreen.adoc[fullscreen]
+|Save |Ctrl+S |⌘+S |xref:save.adoc[save]
+|Find |Ctrl+F |⌘+F |xref:searchreplace.adoc[searchreplace]
 |===
 
 == Accessibility keyboard shortcuts
@@ -45,7 +45,7 @@ This is a list of available keyboard shortcuts within the editor user interface.
 
 [cols=",,",options="header"]
 |===
-|Action |PC |Mac
+|Action |Windows or Linux |macOS
 |Execute command |Enter / Spacebar |Enter / Spacebar
 |Focus on next UI Element(such as: Menu bar, Toolbar, Toolbar Group, Status Bar Item) |Tab |Tab
 |Focus on previous UI Element(such as: Menu bar, Toolbar, Toolbar Group, Status Bar Item) |Shift+Tab |Shift+Tab

--- a/modules/ROOT/pages/tinymce-and-screenreaders.adoc
+++ b/modules/ROOT/pages/tinymce-and-screenreaders.adoc
@@ -12,30 +12,31 @@ The following *Alt+key* and *Option+key* shortcuts can only be used when the con
 
 [cols=",,",options="header"]
 |===
-|Task |PC (Non-macOS users) |macOS
-|Focus/jump to menu bar |Alt+F9 |Option+F9
-|Focus/jump to toolbar |Alt+F10 |Option+F10
-|Focus/jump to element path |Alt+F11 |Option+F11
+|Task |Windows or Linux |macOS
+|Focus/jump to menu bar |Alt+F9 |⌥+F9
+|Focus/jump to toolbar |Alt+F10 |⌥+F10
+|Focus/jump to element path |Alt+F11 |⌥+F11
 |Close menu/submenu/dialog |Esc |Esc
 |Return to the editor content area |Esc |Esc
 |Navigate left/right through menu/toolbar |Tab and the Arrow Keys |Tab and the Arrow Keys
+|Open the {productname} Help dialog |Alt+0 |⌥+0
 |===
 
 For additional navigation keyboard shortcuts and shortcuts for applying some commonly-used formats, see: xref:keyboard-shortcuts.adoc[Keyboard shortcuts].
 
 == How to work with the editor
 
-When navigating to a TinyMCE editor, the keyboard focus (caret) will be in the content area. The up and down arrow keys navigate between the lines of the editor, such as within and between paragraphs, headings and other items such as links.
+When navigating to a {productname} editor, the keyboard focus (caret) will be in the content area. The up and down arrow keys navigate between the lines of the editor, such as within and between paragraphs, headings and other items such as links.
 
 === Navigating the menu bar
 
-To focus on the editor menu bar, press *Alt+F9*. The *Left Arrow* and *Right Arrow* keys navigate through the top menu items. The *Enter*, *Return*, *Spacebar*, or *Down Arrow* keys open the highlighted menu and moves focus to the first menu item. To activate or select the highlighted menu item, use the *Enter*, *Return*, or *Spacebar* keys. Press the *Esc* key to collapse the menu. The *Right Arrow* key opens submenus and the *Esc* key collapses submenus. To return focus to the content area from the menu bar, use the *Esc* key.
+To focus on the editor menu bar, press *Alt+F9* (or *⌥+F9*). The *Left Arrow* and *Right Arrow* keys navigate through the top menu items. The *Enter*, *Return*, *Spacebar*, or *Down Arrow* keys open the highlighted menu and moves focus to the first menu item. To activate or select the highlighted menu item, use the *Enter*, *Return*, or *Spacebar* keys. Press the *Esc* key to collapse the menu. The *Right Arrow* key opens submenus and the *Esc* key collapses submenus. To return focus to the content area from the menu bar, use the *Esc* key.
 
 === Navigating the toolbar
 
 ==== General toolbar navigation
 
-To focus on the editor toolbars, press *Alt+F10*; which moves the keyboard focus to the first toolbar button on the first toolbar. To move between toolbar buttons _within_ toolbar groups (visual groups of toolbar buttons), use the *Left Arrow* and *Right Arrow* keys. To move the focus _between_ toolbar groups, use the *Tab* or *Shift+Tab* keys. When you reach the end of a toolbar group the *Right Arrow* key will return the focus to the start of the toolbar group. To activate or select the highlighted toolbar button, use the *Enter*, *Return*, or *Spacebar* keys. To return focus to the content area from the toolbar, use the *Esc* key.
+To focus on the editor toolbars, press *Alt+F10* (or *⌥+F10*); which moves the keyboard focus to the first toolbar button on the first toolbar. To move between toolbar buttons _within_ toolbar groups (visual groups of toolbar buttons), use the *Left Arrow* and *Right Arrow* keys. To move the focus _between_ toolbar groups, use the *Tab* or *Shift+Tab* keys. When you reach the end of a toolbar group the *Right Arrow* key will return the focus to the start of the toolbar group. To activate or select the highlighted toolbar button, use the *Enter*, *Return*, or *Spacebar* keys. To return focus to the content area from the toolbar, use the *Esc* key.
 
 ==== Navigating toolbar buttons that contain menus or grids
 

--- a/modules/ROOT/partials/configuration/help_accessibility.adoc
+++ b/modules/ROOT/partials/configuration/help_accessibility.adoc
@@ -3,7 +3,7 @@
 
 include::partial$misc/admon-requires-6.7v.adoc
 
-When the *Help* plugin is loaded, the {productname} editor displays the keyboard shortcut for accessing the Help dialog in the {productname} status bar by default.
+When the xref:help.adoc[Help] plugin is loaded, the {productname} editor displays the keyboard shortcut for accessing the Help dialog in the {productname} status bar by default.
 
 The `help_accessibility` option allows for this display to be turned off.
 

--- a/modules/ROOT/partials/configuration/help_accessibility.adoc
+++ b/modules/ROOT/partials/configuration/help_accessibility.adoc
@@ -1,0 +1,40 @@
+[[help_accessibility]]
+== `help_accessibility`
+
+include::partial$misc/admon-requires-6.7v.adoc
+
+When the *Help* plugin is loaded, the {productname} editor displays the keyboard shortcut for accessing the Help dialog in the {productname} status bar by default.
+
+The `help_accessibility` option allows for this display to be turned off.
+
+*Type:* `+Boolean+`
+
+*Possible values:* `true`, `false`
+
+*Default value:* `true`
+
+=== Example: turning `help_accessibility` off
+
+[source,js]
+----
+tinymce.init({
+  selector: "textarea",  // change this value according to your html
+  plugins: "help",
+  help_accessibility: false,
+});
+----
+
+=== Example: explicitly turning `help_accessibility` on
+
+The `help_accessibility` option is set to true by default when the *Help* plugin is loaded.
+
+It is not necessary, but may be useful, to explicitly set the option to `true`.
+
+[source,js]
+----
+tinymce.init({
+  selector: "textarea",  // change this value according to your html
+  plugins: "help",
+  help_accessibility: true,
+});
+----

--- a/modules/ROOT/partials/configuration/help_accessibility.adoc
+++ b/modules/ROOT/partials/configuration/help_accessibility.adoc
@@ -1,7 +1,7 @@
 [[help_accessibility]]
 == `help_accessibility`
 
-include::partial$misc/admon-requires-6.7v.adoc
+include::partial$misc/admon-requires-6.7v.adoc[]
 
 When the xref:help.adoc[Help] plugin is loaded, the {productname} editor displays the keyboard shortcut for accessing the Help dialog in the {productname} status bar by default.
 


### PR DESCRIPTION
DOC-2027: document `help_accessibility` option and related updates

Changes:
* `keyboard-shortcuts.adoc` copy-edits:
	1. s/Option/⌥/
	2. s/Command/⌘/
	3. s/Mac/macOS
	4. s/PC/Windows or Linux/
	5. s/TinyMCE/{productname}/
* `tinymce-and-screenreaders.adoc` copy-edits:
	1. s/Option/⌥/
	2. s/Mac/macOS
	3. s/PC/Windows or Linux/
	4. s/TinyMCE/{productname}/
	5. added help-dialog keyboard shortcut to the keyboard shortcuts table.
	6. added ‘(or *⌥+Fx*)’ to sections that only had the Windows/Linux shortcut listed.
* `help_accessibility.adoc`
	1. Added `help_accessibility.adoc` to `/modules/ROOT/partials/configuration/`.
	2. Added documentation of the `help_accessibility` option to `help_accessibility.adoc`.
* `help.adoc`
	1. re-structured introductory text from bulleted list to table.
	2. added documentation of two tabs heretefore not documented: Keyboard shortcuts & Version.
	3. re-structured text concerning opening the help dialog from prose to a table.
	4. added note re the keyboard shortcut displaying by default in the TinyMCE status bar as of version 6.7.
	5. added `include::` statement pointing to new configuration option doc: `help_accessibility.adoc`.
* `accessibility.adoc`
	1. Added include statement pointing to `/modules/ROOT/partials/configuration/help_accessibility.adoc`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] Files has been included where required (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
