### PR TITLE
DOC-2176: Remove references to what plans Premium plugins are available with

### DIFF
--- a/-new-material-templates/plugin-documentation-templates/ROOT/pages/pluginpage.adoc
+++ b/-new-material-templates/plugin-documentation-templates/ROOT/pages/pluginpage.adoc
@@ -28,7 +28,13 @@ liveDemo::{plugincode}[]
 
 // Logic for customising what presents from this included file relies on
 // the :pluginminimumplan: attribute value above.
-include::partial$misc/purchase-premium-plugins.adoc[]
+//
+// 2023-09-06 addendum: the logic in purchase-premium-plugins.adoc needs
+// updating to match the available commercial plans.
+// 
+// Do not include this statement in new documentation until
+// this logic has been updated.
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Basic setup
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2176: Removed references to which commercial plans Premium plugins are or are not available with.
 - DOC-2175: Update CODEOWNERS automatic reviewers upon opening new DOC-PRs.
 - DOC-2173: updated the default value code sample in `ai_shortcuts.adoc` to match the updated values included in the AI Assistant. Also re-wrote the **Note** admonition to call-out the absence of any translations or alternative language versions of these default values.
 

--- a/modules/ROOT/pages/a11ychecker.adoc
+++ b/modules/ROOT/pages/a11ychecker.adoc
@@ -16,7 +16,7 @@ The `+a11ychecker+` premium plugin allows you to check the HTML in the editor fo
 
 liveDemo::a11ychecker[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Basic setup
 

--- a/modules/ROOT/pages/advcode.adoc
+++ b/modules/ROOT/pages/advcode.adoc
@@ -26,7 +26,7 @@ NOTE: For the {pluginname} to offer a full-screen mode requires the xref:fullscr
 
 liveDemo::advcode[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Example: basic setup
 

--- a/modules/ROOT/pages/advtable.adoc
+++ b/modules/ROOT/pages/advtable.adoc
@@ -18,7 +18,7 @@ The `+advtable+` plugin is a premium plugin that extends the core xref:table.ado
 
 liveDemo::advtable[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Enabling the Advanced Tables plugin
 

--- a/modules/ROOT/pages/autocorrect.adoc
+++ b/modules/ROOT/pages/autocorrect.adoc
@@ -17,7 +17,7 @@ The {pluginname} plugin allows {productname} to autocorrect a specified set of s
 
 liveDemo::autocorrect[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Basic setup
 

--- a/modules/ROOT/pages/casechange.adoc
+++ b/modules/ROOT/pages/casechange.adoc
@@ -14,7 +14,7 @@ The *Case Change* plugin is a time saving and handy extension that allows changi
 
 liveDemo::casechange[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Changing the case of selected text
 

--- a/modules/ROOT/pages/checklist.adoc
+++ b/modules/ROOT/pages/checklist.adoc
@@ -16,7 +16,7 @@ In the {productname} editor, checklists are presented as lists with small checkb
 
 liveDemo::checklist[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Creating a Checklist
 

--- a/modules/ROOT/pages/editimage.adoc
+++ b/modules/ROOT/pages/editimage.adoc
@@ -20,7 +20,7 @@ liveDemo::edit-image[]
 
 include::partial$misc/admon-svg-not-supported.adoc[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Cloud Installation
 

--- a/modules/ROOT/pages/export.adoc
+++ b/modules/ROOT/pages/export.adoc
@@ -19,7 +19,7 @@ To export the editor content, either:
 
 liveDemo::export[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Cloud Installation
 

--- a/modules/ROOT/pages/footnotes.adoc
+++ b/modules/ROOT/pages/footnotes.adoc
@@ -20,7 +20,7 @@ The plugin then adds a new line to the footnotes section located at the bottom o
 
 liveDemo::footnotes[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Basic setup
 

--- a/modules/ROOT/pages/formatpainter.adoc
+++ b/modules/ROOT/pages/formatpainter.adoc
@@ -17,7 +17,7 @@ The format painter retains the formatting after application making it possible t
 
 liveDemo::format-painter[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Basic setup
 

--- a/modules/ROOT/pages/introduction-to-mediaembed.adoc
+++ b/modules/ROOT/pages/introduction-to-mediaembed.adoc
@@ -14,7 +14,7 @@ The *Enhanced Media Embed* plugin is a link:{pricingpage}/[premium {productname}
 
 liveDemo::mediaembed[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Installation
 

--- a/modules/ROOT/pages/introduction-to-powerpaste.adoc
+++ b/modules/ROOT/pages/introduction-to-powerpaste.adoc
@@ -16,7 +16,7 @@ NOTE: Due to limitations in Microsoft Excel online (part of Office Live) PowerPa
 
 liveDemo::paste-from-word[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Usage
 

--- a/modules/ROOT/pages/introduction-to-tiny-comments.adoc
+++ b/modules/ROOT/pages/introduction-to-tiny-comments.adoc
@@ -45,7 +45,7 @@ The following example shows how to configure the Comments plugin in *embedded* m
 
 liveDemo::comments-embedded[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 [[getting-started-with-the-comments-plugin-selecting-a-mode]]
 == Getting started with the Comments plugin - Selecting a mode

--- a/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
+++ b/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
@@ -14,7 +14,7 @@ include::partial$misc/admon-premium-plugin.adoc[]
 
 liveDemo::spellcheckerpro[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Cloud Installation
 

--- a/modules/ROOT/pages/linkchecker.adoc
+++ b/modules/ROOT/pages/linkchecker.adoc
@@ -16,7 +16,7 @@ The Link Checker plugin relies on HTTP response status codes to determine if a l
 
 liveDemo::linkchecker[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Cloud Instructions
 

--- a/modules/ROOT/pages/mentions.adoc
+++ b/modules/ROOT/pages/mentions.adoc
@@ -14,7 +14,7 @@ The mentions plugin will present a list of users when a user types the "@" symbo
 
 liveDemo::mentions[height="400"]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Options
 

--- a/modules/ROOT/pages/mergetags.adoc
+++ b/modules/ROOT/pages/mergetags.adoc
@@ -20,7 +20,7 @@ Once a merge tag is inserted, the plugin leaves a non-editable variable wrapped 
 
 liveDemo::merge-tag[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Basic setup
 

--- a/modules/ROOT/pages/pageembed.adoc
+++ b/modules/ROOT/pages/pageembed.adoc
@@ -19,7 +19,7 @@ The *Page Embed* plugin embeds a page in the content using an iframe (Inline fra
 
 liveDemo::page-embed[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Creating a Page Embed toolbar button
 

--- a/modules/ROOT/pages/permanentpen.adoc
+++ b/modules/ROOT/pages/permanentpen.adoc
@@ -34,7 +34,7 @@ For more information on {productname} formats, refer to the xref:content-formatt
 
 liveDemo::permanent-pen[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Using a Permanent Pen
 

--- a/modules/ROOT/pages/premium-skins-and-icons.adoc
+++ b/modules/ROOT/pages/premium-skins-and-icons.adoc
@@ -7,6 +7,8 @@ The {prem_skins_icons} lets you quickly give {productname} a new look. Just choo
 
 == How to use a premium skin
 
+NOTE: premium skins are only available with a link:{pricingpage}/[paid TinyMCE subscriptions].
+
 Use the xref:editor-skin.adoc#skin[skin] option, in combination with the xref:add-css-options.adoc#content_css[content_css] option and the values listed below.
 
 Available values for xref:editor-skin.adoc#skin[skins]:
@@ -101,6 +103,7 @@ Below are some recommended combinations of skins and icon packs:
 * xref:outside-demo.adoc[Outside editor]
 * xref:snow-demo.adoc[Snow editor]
 
+////
 :pluginname: Tiny Skins and Icon
 :pluginminimumplan: tiertwo
 :extensionType: Packs
@@ -108,3 +111,4 @@ Below are some recommended combinations of skins and icon packs:
 include::partial$misc/purchase-premium-plugins.adoc[]
 :!extensionType:
 :!pluralExtensionType:
+////

--- a/modules/ROOT/pages/tableofcontents.adoc
+++ b/modules/ROOT/pages/tableofcontents.adoc
@@ -16,7 +16,7 @@ NOTE: In previous versions of {productname} the {pluginname} plugin was provided
 
 liveDemo::tableofcontents[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Basic setup
 

--- a/modules/ROOT/pages/tinydrive-introduction.adoc
+++ b/modules/ROOT/pages/tinydrive-introduction.adoc
@@ -34,7 +34,7 @@ The storage and bandwidth quota varies based upon your link:{pricingpage}/[{clou
 
 liveDemo::drive[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Upload files URL
 

--- a/modules/ROOT/partials/misc/purchase-premium-plugins.adoc
+++ b/modules/ROOT/partials/misc/purchase-premium-plugins.adoc
@@ -1,3 +1,7 @@
+// 2023-09-06: the logic herein must be updated to cater to
+// extant commercial plan structures before this file can, once again
+// be added to Premium plugin pages via an `include::` statement.
+
 ifeval::["{extensionType}" != "Packs"]
 :extensionType: plugin
 endif::[]


### PR DESCRIPTION
Ticket: DOC-2176: Remove references to what plans Premium plugins are available with

Changes:
1. Commented out include statement adding `misc/purchase-premium-plugins.adoc` to almost every Premium plugin page.
2. Added notes to `pluginpage.adoc` in `-new-material-templates/plugin-documentation-templates/ROOT/pages/` regarding the need to update the logic in purchase-premium-plugins.adoc.
3. Added a NOTE to `premium-skins-and-icons.adoc` about premium skins only being available with a TinyMCE subscription.
4. Placed include statement pointing to `misc/purchase-premium-plugins.adoc`, and surrounding variables, in a comment block.
5. Added comment to head of `misc/purchase-premium-plugins.adoc` regarding the need to update the logic therein.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
