### PR TITLE
DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,9 @@ Changes to the TinyMCE documentation are documented in this file.
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+### Unreleased
+
+- DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes.
 ### 2023-08-30
 
 - DOC-2169: added 6.7-specific entries to `changelog.adoc`.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -341,11 +341,15 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === An empty element with a `contenteditable="true"` attribute within a noneditable root was deleted when the Backspace key was pressed
 // TINY-10011
-Previously, when an empty `contenteditable="true"` element was set within a `contenteditable="false"` root, the element was deleted after pressing the `Backspace` key.
+Previously, when an empty element with a `contenteditable="true"` attribute was set within a read-only root (ie a root with a `contenteditable="false"` attribute), the empty element was deleted when the *Backspace* key was pressed.
 
-As a consequence, upon pressing the Backspace key the editor would prune any redundant formatting elements without text. This resulted in call to `dom.isEmpty(body)` that returned a `true` value, even if the body has an empty `contenteditable="true"` element. {productname} introduced a solution in version `6.7` to preserve such empty `contenteditable="true"` elements from being treated as redundant content.
+When the Backspace key was pressed in this circumstance, the {productname} editor removed elements that contained no content.
 
-As a result, empty `contenteditable="true"` elements are not deleted on Backspace key pressing.
+In doing so the `dom.isEmpty(body)` call returned a value, `true`, even if the called `body` included an element that was empty but had a `contenteditable="true"` attribute set.
+
+As of {productname} 6.7, elements with a `contenteditable="true"` attribute set are no longer treated as empty and the `dom.isEmpty(body)` call no longer returns the value `true` with regards such elements.
+
+As a consequence, these elements are no longer deleted when they are immediately before the insertion point and the Backspace key is pressed.
 
 === The `color_cols` option was not respected when set to the value 5 with a custom `color_map` specified
 // TINY-10126

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -341,6 +341,11 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === An empty element with a `contenteditable="true"` attribute within a noneditable root was deleted when the Backspace key was pressed
 // TINY-10011
+Previously, when an empty `contenteditable="true"` element was set within a `contenteditable="false"` root, the element was deleted after pressing the `Backspace` key.
+
+As a consequence, upon pressing the Backspace key the editor would prune any redundant formatting elements without text. This resulted in call to `dom.isEmpty(body)` that returned a `true` value, even if the body has an empty `contenteditable="true"` element. {productname} introduced a solution in version `6.7` to preserve such empty `contenteditable="true"` elements from being treated as redundant content.
+
+As a result, empty `contenteditable="true"` elements are not deleted on Backspace key pressing.
 
 === The `color_cols` option was not respected when set to the value 5 with a custom `color_map` specified
 // TINY-10126


### PR DESCRIPTION
Ticket: DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes

Changes:
* added documentation bugfix for `An empty element with a `contenteditable="true"` attribute within a noneditable root was deleted when the Backspace key was pressed`

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
