### PR TITLE
DOC-2171: bug-fix documentation entry for TINY-10053 in `6.7-release-notes.adoc`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: bugfix documentation entry for TINY-10053, *Translation was missing for paragraph used as heading text*, added to `6.7-release-notes.adoc`.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10123 in the 6.7 Release Notes.
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -33,6 +33,14 @@ The {productname} 6.7.0 release includes an accompanying release of the **Access
 ==== Translation was missing for paragraph used as heading text
 // TINY-10053
 
+The alert presented when the **Accessibility Checker** considers a string to likely be a heading includes an explanatory sentence to this effect.
+
+Previously, because of an inadvertent punctuation ommission, this string was not translated and presented in English regardless of {productname}’s `language` setting.
+
+For this update, the punctuation was restored, and the string — _This paragraph looks like a heading. If it is a heading, please select a heading level._ — has been translated.
+
+When this alert presents, if the currently set language is one of the xref:bundling-localization.adoc#supported-languages[supported languages], the entire alert now presents in the currently set language, as expected.
+
 
 
 === Advanced Code 3.3.1


### PR DESCRIPTION
DOC-2171: bug-fix documentation entry for TINY-10053 in `6.7-release-notes.adoc`

Changes:
* Added bugfix documentation for TINY-10053, *Translation was missing for paragraph used as heading text*.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
