### PR TITLE
DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10123 in the 6.7 Release Notes.
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -338,6 +338,11 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Fixed the inability to insert content next to the `<details>` element when it is the first or last content element. Pressing the **Up** or **Down** arrow key now inserts a block element before or after the `<details>` element
 // TINY-9827
+Previously, when a `<details>` element such as an Accordion component was positioned either as the first or last element within the editor, users were unable to move the cursor above or below the element, restricting them from inserting new content to the editor. 
+
+In {productname} 6.7, the `InsertNewBlockBefore` and `InsertNewBlockAfter` commands are now associated with `Up` and `Down` arrow key presses, which triggers when the cursor is in the relevant position.
+
+As a result, when the user presses either `Up` or `Down` keys, the cursor will now move either above or below the `<details>` element when it is at either edges of the editor's content.
 
 === An empty element with a `contenteditable="true"` attribute within a noneditable root was deleted when the Backspace key was pressed
 // TINY-10011

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -338,11 +338,11 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Fixed the inability to insert content next to the `<details>` element when it is the first or last content element. Pressing the **Up** or **Down** arrow key now inserts a block element before or after the `<details>` element
 // TINY-9827
-Previously, when a `<details>` element such as an Accordion component was positioned either as the first or last element within the editor, users were unable to move the cursor above or below the element, restricting them from inserting new content to the editor. 
+Previously, when a `<details>` element, such as is automatically part of an xref:accordion.adoc[Accordion] component, was either the first or last element within a {productname} editor instance, users were unable to move the insertion point above or below the element. This prevented them from adding new content to the editor instance.
 
-In {productname} 6.7, the `InsertNewBlockBefore` and `InsertNewBlockAfter` commands are now associated with `Up` and `Down` arrow key presses, which triggers when the cursor is in the relevant position.
+In {productname} 6.7, the `InsertNewBlockBefore` and `InsertNewBlockAfter` commands have been associated with the *Up Arrow* and *Down Arrow* keys, activating when the insertion point is in the relevant position.
 
-As a result, when the user presses either `Up` or `Down` keys, the cursor will now move either above or below the `<details>` element when it is at either edges of the editor's content.
+As a result, when the insertion point is in the relevant position and the user presses either of the *Up Arrow* or *Down Arrow* keys, the insertion point now moves either above or below the `<details>` element when it is at either the beginning or end of the current editor’s content.
 
 === An empty element with a `contenteditable="true"` attribute within a noneditable root was deleted when the Backspace key was pressed
 // TINY-10011


### PR DESCRIPTION
Ticket: DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes

Changes:
* add fix documentation for `Fixed the inability to insert content next to the `details` element when it is the first or last content element. Pressing the **Up** or **Down** arrow key now inserts a block element before or after the `details` element`

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [ ] Documentation Team Lead has reviewed
