### PR TITLE
DOC-2171: fix documentation entry for TINY-10071 in the 6.7 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: fix documentation entry for TINY-10071 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10123 in the 6.7 Release Notes.
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -335,6 +335,11 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Links in **Help → Help → Plugins** and **Help → Help → Version** were not navigable by keyboard
 // TINY-10071
+Accessibility of links within the Plugins Tab of the Help Dialog could not be navigable to the user as these links lacked the essential attribute, `data-alloy-tabstop="true"` rendering them inaccessible via keyboard navigation.
+
+Consequently, users were unable to navigate through these links using the tab key.
+
+{productname} 6.7, implemented a fix which involved adding the missing `data-alloy-tabstop="true"` attribute to these links. As a result of this, users can now efficiently navigate through the links within the Plugins Tab of the Help Dialog using their keyboards.
 
 === Fixed the inability to insert content next to the `<details>` element when it is the first or last content element. Pressing the **Up** or **Down** arrow key now inserts a block element before or after the `<details>` element
 // TINY-9827

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -335,11 +335,30 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Links in **Help → Help → Plugins** and **Help → Help → Version** were not navigable by keyboard
 // TINY-10071
-Accessibility of links within the Plugins Tab of the Help Dialog could not be navigable to the user as these links lacked the essential attribute, `data-alloy-tabstop="true"` rendering them inaccessible via keyboard navigation.
+The Help dialog built-in to {productname} includes four tabs:
+* *Handy Shortcuts*;
+* *Keyboard Navigation*;
+* *Plugins*; and
+* *Version*.
 
-Consequently, users were unable to navigate through these links using the tab key.
+Previously, keyboard navigation was supported across these four tabs, and into each tab’s contents. (When a tab’s contents have focus, the content can be scrolled through using Arrow keys.)
 
-{productname} 6.7, implemented a fix which involved adding the missing `data-alloy-tabstop="true"` attribute to these links. As a result of this, users can now efficiently navigate through the links within the Plugins Tab of the Help Dialog using their keyboards.
+However, keyboard-based navigation of links in the focussed content was not supported.
+
+{productname} 6.7 corrects this. The `data-alloy-tabstop="true"` attribute, which was previously not applied to these links, has been added.
+
+Users of {productname} 6.7 can navigate to and activate links in Help dialog contents entirely with keyboard navigation.
+
+[NOTE]
+====
+As of this release, only the *Plugins*, and *Version* tabs include links.
+
+Also, there is no visual feedback when a given tab’s contents pane takes focus.
+
+Consequently, the UX is such that it appears to take two presses of the *Tab* key to go from a tab label having the focus and the first link within a tab’s content pane having focus.
+
+Likewise, going from the first link within a tab’s content pane having focus to a tab label having focus appears to take two presses of the *Shift-Tab* keyboard chord.
+====
 
 === Fixed the inability to insert content next to the `<details>` element when it is the first or last content element. Pressing the **Up** or **Down** arrow key now inserts a block element before or after the `<details>` element
 // TINY-9827


### PR DESCRIPTION
Ticket: DOC-2171: fix documentation entry for TINY-10071 in the 6.7 Release Notes

Changes:
* added bugfix documentation for `Links in **Help → Help → Plugins** and **Help → Help → Version** were not navigable by keyboard`

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
