### PR TITLE
DOC-2171: fix documentation entry for TINY-9843 in the 6.7 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: fix documentation entry for TINY-9843 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10123 in the 6.7 Release Notes.
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -348,7 +348,7 @@ style="border: 3px solid red;"
 
 This constitutes un-announced and un-asked-for modification of the table’s underlying HTML within the {productname} editor.
 
-{productname} 6.7 addresses by immediately applying border style changes made using the *Table Properties* dialog using the shorthand format.
+{productname} 6.7 addresses this by immediately applying border style changes made using the *Table Properties* dialog using the shorthand format.
 
 Table HTML is, as a consequence, unaltered when it is reloaded into the {productname} editor.
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -332,6 +332,9 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === The border styles of a table were incorrectly split into a longhand form after table dialog updates
 // TINY-9843
+Previously, when applying border style updates using the table dialog, it would initially break down the border shorthand into individual components such as border-width, border-color, and border-style. However, upon reloading the content, the styles are automatically optimized and condensed into a shorthand format (border: <width> <style> <color>). This process resulted in a modification of the table HTML within the editor.
+
+To resolve this issue, {productname} 6.7, introduced a fix what involves converting the styles into shorthand format immediately after applying the border style updates through the table dialog. As a result of this fix, the table HTML remains unaltered even after it is loaded into the editor.
 
 === Links in **Help → Help → Plugins** and **Help → Help → Version** were not navigable by keyboard
 // TINY-10071

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -332,9 +332,25 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === The border styles of a table were incorrectly split into a longhand form after table dialog updates
 // TINY-9843
-Previously, when applying border style updates using the table dialog, it would initially break down the border shorthand into individual components such as border-width, border-color, and border-style. However, upon reloading the content, the styles are automatically optimized and condensed into a shorthand format (border: <width> <style> <color>). This process resulted in a modification of the table HTML within the editor.
+Previously, when applying border style changes using the {productname} *Table Properties* dialog, changes were applied as individual properties. For example:
 
-To resolve this issue, {productname} 6.7, introduced a fix what involves converting the styles into shorthand format immediately after applying the border style updates through the table dialog. As a result of this fix, the table HTML remains unaltered even after it is loaded into the editor.
+[source,html]
+----
+style="border-width: 3px; border-style: solid; border-color: red;"
+----
+
+When the content was re-loaded, however, the styles were automatically condensed into the shorthand format:
+
+[source,html]
+----
+style="border: 3px solid red;"
+----
+
+This constitutes un-announced and un-asked-for modification of the table’s underlying HTML within the {productname} editor.
+
+{productname} 6.7 addresses by immediately applying border style changes made using the *Table Properties* dialog using the shorthand format.
+
+Table HTML is, as a consequence, unaltered when it is reloaded into the {productname} editor.
 
 === Links in **Help → Help → Plugins** and **Help → Help → Version** were not navigable by keyboard
 // TINY-10071

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -348,7 +348,7 @@ style="border: 3px solid red;"
 
 This constitutes un-announced and un-asked-for modification of the table’s underlying HTML within the {productname} editor.
 
-{productname} 6.7 addresses this by immediately applying border style changes made using the *Table Properties* dialog using the shorthand format.
+{productname} 6.7 addresses this by immediately applying border style changes made using the *Table Properties* dialog in the shorthand format.
 
 Table HTML is, as a consequence, unaltered when it is reloaded into the {productname} editor.
 


### PR DESCRIPTION
Ticket: DOC-2171: fix documentation entry for TINY-9843 in the 6.7 Release Notes

Changes:
* added bugfix documentation for `The border styles of a table were incorrectly split into a longhand form after table dialog updates`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
