### PR TITLE
DOC-2171: fix documentation entry for TINY-9828 in the 6.7 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: fix documentation entry for TINY-9828 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10123 in the 6.7 Release Notes.
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -329,6 +329,11 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === In some circumstances, pressing the **Enter** key scrolled the entire page
 // TINY-9828
+Previously, in {productname} 6.4.2, a bugfix was implemented to address a specific issue related to scrolling. The issue originated from the `scrollToMarker` function, which determined vertical scrolling while also calculating horizontal scrolling based on the marker's left position.
+
+Subsequently, in {productname} 6.7, further refinements were introduced to improve the previous logic applied. This update was prompted by the need to address a specific issue, where scrolling didn't reach the correct position in certain situations. The original `scrollToMarker` function had been altered to use `scrollIntoView`, affecting not only the content but also the editor container. This unintentionally caused pressing the "Enter" key to trigger scrolling of both the content and the container. To correct this, {productname} reverted to the previous logic and adjusted the calculation of the scroll left.
+
+This fix, now corrects the previous and new issues with the release of {productname} 6.7.
 
 === The border styles of a table were incorrectly split into a longhand form after table dialog updates
 // TINY-9843

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -329,11 +329,15 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === In some circumstances, pressing the **Enter** key scrolled the entire page
 // TINY-9828
-Previously, in {productname} 6.4.2, a bugfix was implemented to address a specific issue related to scrolling. The issue originated from the `scrollToMarker` function, which determined vertical scrolling while also calculating horizontal scrolling based on the marker's left position.
+{productname} 6.4.2 addressed an issue in which xref:6.4.2-release-notes.adoc#_selection_was_not_correctly_scrolled_horizontally_into_view_when_using_the_selection.scrollIntoView_API[a selection was not correctly scrolled horizontally into view].
 
-Subsequently, in {productname} 6.7, further refinements were introduced to improve the previous logic applied. This update was prompted by the need to address a specific issue, where scrolling didn't reach the correct position in certain situations. The original `scrollToMarker` function had been altered to use `scrollIntoView`, affecting not only the content but also the editor container. This unintentionally caused pressing the "Enter" key to trigger scrolling of both the content and the container. To correct this, {productname} reverted to the previous logic and adjusted the calculation of the scroll left.
+{productname} 6.7 includes changes to the previously applied logic to address a further issue, in which scrolling did not reach the correct position in some circumstances.
 
-This fix, now corrects the previous and new issues with the release of {productname} 6.7.
+The fix applied in {productname} 6.4.2 altered the `scrollToMarker` function, affecting not only editor content, but also the editor container itself. This, unintentionally, caused an *Enter* key-press to trigger scrolling of both the content and the container.
+
+{productname} 6.7 makes two changes to address this. It reverts the logic applied in {productname} 6.4.2. And it adjusts the scroll left calculation.
+
+These changes correct both issues. Pressing the *Enter* key no longer triggers scrolling and the selection is (still) correctly scrolled into horizontal view.
 
 === The border styles of a table were incorrectly split into a longhand form after table dialog updates
 // TINY-9843


### PR DESCRIPTION
…tes.

Ticket: DOC-2171: fix documentation entry for TINY-9828 in the 6.7 Release Notes

Changes:
* added bugfix documentation for `In some circumstances, pressing the **Enter** key scrolled the entire page`

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
