### PR TITLE
DOC-2171: fix documentation entry for TINY-10007 in the 6.7 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: fix documentation entry for TINY-10007 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10123 in the 6.7 Release Notes.
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -326,11 +326,17 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Using the Media plugin unexpectedly changed `<script>` tags in the editor body to `<image>` tags
 // TINY-10007
-A regression was observed in {productname} version 5 that affected the behavior for the media plugin. The issue was identified from code responsible for handling script tags, even though it was no longer actively utilized.
+As part of the {productname} 5.10 release, the `https://tiny.cloud/docs/plugins/opensource/media/#media_scripts)[media_scripts]` option was deprecated. And, as of the {productname} 6.0 release, this option was removed.
 
-As a consequence of the presence of this lingering code, scripts were inadvertently being converted into images, causing unexpected behavior for users.
+When the setting was available, it was used to allow some script tags, with specified source URLs, to have some of their properties edited in the https://tiny.cloud/docs/plugins/opensource/media/[*Media*] plugin’s dialog.
 
-Changes in {productname} 6.7 removed the redundant code entirely. As a result, the non-existing code no longer poses a risk of triggering the conversion of scripts into images.
+And, while the `media_scripts` option was removed, the logic that allowed the plugin to edit properties in some script tags was not.
+
+As a consequence, a regression presented. When the xref:introduction-to-mediaembed.adoc/[*Enhanced Media Embed*] Premium plugin was loaded, the plugin converts all script tags into placeholder images.
+
+For the {productname} 6.7 release the code that handled script tags was removed, which corrects this regression.
+
+In {productname} 6.7, when the *Enhanced Media Embed* is loaded, script tags are treated as script tags, and are no longer converted into placeholder images.
 
 === In some circumstances, pressing the **Enter** key scrolled the entire page
 // TINY-9828

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -326,6 +326,11 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Using the Media plugin unexpectedly changed `<script>` tags in the editor body to `<image>` tags
 // TINY-10007
+A regression was observed in {productname} version 5 that affected the behavior for the media plugin. The issue was identified from code responsible for handling script tags, even though it was no longer actively utilized.
+
+As a consequence of the presence of this lingering code, scripts were inadvertently being converted into images, causing unexpected behavior for users.
+
+Changes in {productname} 6.7 removed the redundant code entirely. As a result, the non-existing code no longer poses a risk of triggering the conversion of scripts into images.
 
 === In some circumstances, pressing the **Enter** key scrolled the entire page
 // TINY-9828


### PR DESCRIPTION
Ticket: DOC-2171: fix documentation entry for TINY-10007 in the 6.7 Release Notes

Changes:
* added bugfix documentation for `Using the Media plugin unexpectedly changed `<script>` tags in the editor body to `<image>` tags`

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
