### PR TITLE
DOC-2171: fix documentation (3) entries for TINY-9960 in the 6.7 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: fix documentation (3) entries for TINY-9960 in the 6.7 Release Notes. 
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10123 in the 6.7 Release Notes.
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -325,34 +325,40 @@ In {productname} 6.7, when the user drags a `<summary>` element’s  contents ou
 
 === It was possible to break `<summary>` elements if content containing block elements was dragged-and-dropped inside them
 // TINY-9960
-In previous versions of the Accordion Plugin, dragging and dropping block elements within the `<summary>` element of an accordion component could unintentionally cause the `<summary>` element to break.
+In previous versions of the xref:accordion.adoc[Accordion] plugin, dragging and dropping block elements within the `<summary>` element of an Accordion component could break the `<summary>` element.
 
-As a consequence, the editor would duplicate the `<summary>` element.
+As a consequence, {productname} would duplicate the `<summary>` element.
 
-Example initial content:
+For example, if the initial state was as follows:
+
 [source, html]
-——
+----
 <details class="mce-accordion" open="open">
 <summary>Accordion summary...</summary>
 <p>Accordion body...</p>
 </details>
 <h1>block_element</h1>
-——
+----
 
-Example of duplicated content after the drag and drop.
+After a drag-and-drop event, the Accordion component would be thus:
+
 [source, html]
-——
+----
 <details class="mce-accordion" open="open">
 <summary>Accordion</summary>
 <h1>block_element</h1>
-<summary class="mce-accordion-summary">&nbsp;summary...</summary> // duplicated summary class
+<summary class="mce-accordion-summary">&nbsp;summary...</summary>
+<!-- Note the duplicated <summary> class. -->
+<!-- Also note, this comment was manually added to this example. -->
 <p>Accordion body...</p>
 </details>
-——
+----
 
-{productname} 6.7, introduced a fix that now unwraps block elements after they are dragged from a block element.
+Note the duplicated `<summary>` class in the post-drag Accordion component.
 
-In {productname} 6.7, dragging and dropping content from within a block element can no longer produce duplicate summary elements by dragging in blocks into the summary element.
+To address this, {productname} 6.7 now unwraps block elements after they are dragged from within another block element.
+
+As a consequence, dragging and dropping content from within a block element no longer produces duplicate summary elements.
 
 === Contents were not removed from the drag start source if dragging and dropping internally into a transparent block element
 // TINY-9960

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -317,12 +317,71 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === It was possible to remove the `<summary>` element from a `<details>` element by dragging and dropping
 // TINY-9960
+Previously, dragging and dropping the `<summary>` element contained within the `<details>` parent container for the Accordion element, would inadvertently cause the element to be removed from the parent container.
+
+As a consequence, this would render the accordion element unusable as the `<details>` element requires the `<summary>` element for the title/heading for the specific accordion component.
+
+In {productname} 6.7, when the user attempts to drag the `<summary>` element out of the accordion, the editor will add a empty summary element back in order to normalize the `<details>` element back after a deletion occurs by the dragging event.
 
 === It was possible to break `<summary>` elements if content containing block elements was dragged-and-dropped inside them
 // TINY-9960
+In previous versions of the Accordion Plugin, dragging and dropping block elements within the `<summary>` element of an accordion component could unintentionally cause the `<summary>` element to break.
+
+As a consequence, the editor would duplicate the `<summary>` element.
+
+Example initial content:
+[source, html]
+——
+<details class="mce-accordion" open="open">
+<summary>Accordion summary...</summary>
+<p>Accordion body...</p>
+</details>
+<h1>block_element</h1>
+——
+
+Example of duplicated content after the drag and drop.
+[source, html]
+——
+<details class="mce-accordion" open="open">
+<summary>Accordion</summary>
+<h1>block_element</h1>
+<summary class="mce-accordion-summary">&nbsp;summary...</summary> // duplicated summary class
+<p>Accordion body...</p>
+</details>
+——
+
+{productname} 6.7, introduced a fix that now unwraps block elements after they are dragged from a block element.
+
+In {productname} 6.7, dragging and dropping content from within a block element can no longer produce duplicate summary elements by dragging in blocks into the summary element.
 
 === Contents were not removed from the drag start source if dragging and dropping internally into a transparent block element
 // TINY-9960
+Previously, when dragging and dropping a context selection from a transparent element into another transparent block element, the drag start source content would not properly be deleted after the drop event.
+
+Example: of the drag event before the drop
+[source,html]
+----
+<a href="../../undefined/">
+  <p>Transparent element</p>
+</a>
+<a href="../../undefined/">
+  <p>Transparent element</p>
+</a>
+----
+
+Example: of the drop source content remaining after the drop event
+[source,html]
+----
+<a href="../../undefined/">
+  <p>Transparent element</p> // original source not removed.
+</a>
+<a href="../../undefined/">
+  <p>Transparent element</p>
+  <p>Transparent element</p> // after the drop event.
+</a>
+----
+
+{productname} 6.7, introduced a fix that overrides this unintended behavior. Now, when dragging a content selection from one transparent element into another, removes the original source element as expected.
 
 === Using the Media plugin unexpectedly changed `<script>` tags in the editor body to `<image>` tags
 // TINY-10007

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -317,11 +317,11 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === It was possible to remove the `<summary>` element from a `<details>` element by dragging and dropping
 // TINY-9960
-Previously, dragging and dropping the `<summary>` element contained within the `<details>` parent container for the Accordion element, would inadvertently cause the element to be removed from the parent container.
+Previously, dragging and dropping the contents of a `<summary>` element contained within the `<details>` parent container of an xref:accordion.adoc[Accordion] component, caused the `<summary>` element to be removed from the parent container.
 
-As a consequence, this would render the accordion element unusable as the `<details>` element requires the `<summary>` element for the title/heading for the specific accordion component.
+As a consequence, the Accordion element was rendered unusable: the `<details>` element requires a `<summary>` element to act as the title or heading of a specific Accordion component.
 
-In {productname} 6.7, when the user attempts to drag the `<summary>` element out of the accordion, the editor will add a empty summary element back in order to normalize the `<details>` element back after a deletion occurs by the dragging event.
+In {productname} 6.7, when the user drags a `<summary>` element’s  contents out of an Accordion component, the editor puts an empty `<summary>` element back in place after the deletion consequent to the dragging event. This restores the Accordion component to its required form.
 
 === It was possible to break `<summary>` elements if content containing block elements was dragged-and-dropped inside them
 // TINY-9960

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -362,32 +362,39 @@ As a consequence, dragging and dropping content from within a block element no l
 
 === Contents were not removed from the drag start source if dragging and dropping internally into a transparent block element
 // TINY-9960
-Previously, when dragging and dropping a context selection from a transparent element into another transparent block element, the drag start source content would not properly be deleted after the drop event.
+Previously, when dragging and dropping a context selection from a transparent element into another transparent block element, the source content (ie the content selected for dragging) was not properly deleted after the drop event.
 
-Example: of the drag event before the drop
+For example, if the initial selection for dragging was as follows:
+
 [source,html]
 ----
 <a href="../../undefined/">
-  <p>Transparent element</p>
+  <p>Selected content in transparent element to be dragged.</p>
 </a>
 <a href="../../undefined/">
-  <p>Transparent element</p>
+  <p>Content in another transparent element</p>
 </a>
 ----
 
-Example: of the drop source content remaining after the drop event
+After the drop event, the editor state was thus:
+
 [source,html]
 ----
 <a href="../../undefined/">
-  <p>Transparent element</p> // original source not removed.
+  <p>Selected content in transparent element to be dragged.</p>
+  <!-- Note the dragged content has remained in place. -->
 </a>
 <a href="../../undefined/">
-  <p>Transparent element</p>
-  <p>Transparent element</p> // after the drop event.
+  <p>Content in another transparent element</p>
+  <p>Selected content in transparent element to be dragged.</p>
+  <!-- Causing, in effect, the dragged content to be duplicated rather than moved. -->
+  <!-- Also note, these comments were manually added to this example. -->
 </a>
 ----
 
-{productname} 6.7, introduced a fix that overrides this unintended behavior. Now, when dragging a content selection from one transparent element into another, removes the original source element as expected.
+Note the duplicated material in the post-drag editor state example.
+
+{productname} 6.7 includes a fix that over-rides this unintended behavior. Now, when dragging a content selection from one transparent element into another, the drag’s source selection is moved rather than duplicated, as expected.
 
 === Using the Media plugin unexpectedly changed `<script>` tags in the editor body to `<image>` tags
 // TINY-10007


### PR DESCRIPTION
Ticket: DOC-2171: fix documentation (3) entries for TINY-9960 in the 6.7 Release Notes.

Changes:
* added bugfix documentation for `It was possible to remove the `summary` element from a `details` element by dragging and dropping`.
* added bugfix documentation for `It was possible to break `summary` elements if content containing block elements was dragged-and-dropped inside them`.
* added bugfix documentation for `Contents were not removed from the drag start source if dragging and dropping internally into a transparent block element`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
