### PR TITLE
DOC-2171: bug-fix documentation entry for TINY-10046 in `6.7-release-notes.adoc`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: bug-fix documentation entry for TINY-10046, _Editing the data before switching theme would mean a loss of edited data_.
 - DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -44,6 +44,14 @@ The {productname} 6.7.0 release includes an accompanying release of the **Advanc
 ==== Editing the data before switching theme would mean a loss of edited data
 // TINY-10046
 
+Previously, If the **Advanced Code** dialog was opened, and data was added to the dialog’s text entry, and then the *Dark/light mode* button was pressed, The plugin switched to the new theme using the data present when the dialog was opened.
+
+This resulted in the loss of any entered data.
+
+In **Advanced Code** 3.3.1, switching between themes now sets the data state to the current state before the theme switch is made.
+
+This ensures any data entered before switching themes is kept.
+
 
 
 === Advanced Templates 1.3.0


### PR DESCRIPTION
DOC-2171: bug-fix documentation entry for TINY-10046 in `6.7-release-notes.adoc`

Changes:
* Added bug-fix documentation entry for TINY-10046, _Editing the data before switching theme would mean a loss of edited data_.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
