### PR TITLE
DOC-2171: fix documentation entry for TINY-6888 in the Release Notes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: fix documentation entry for TINY-6888 in the Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10123 in the 6.7 Release Notes.
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -314,11 +314,11 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Deleting `<li>` elements that only contained `<br>` tags sometimes caused a crash
 // TINY-6888
-In previous version of {productname}, "Uncaught TypeError: Cannot read property 'nextSibling' of null" would be thrown in some specific use cases such as after the removal of a `<li>` element.
+In previous  {productname} versions, "Uncaught TypeError: Cannot read property 'nextSibling' of null" were thrown in some specific use cases. For example, after the removal of any `<li>` element.
 
-Previously, `<li>` elements used the same caret position as the parent of the new caret container, but after removal of the `<li>` element, the editor would try to use `ToggleList.mergeWithAdjacentLists` which is used on the `otherLi.parentNode`, which triggered the TypeError, as the editor had already removed the `otherLi`.
+Previously, `<li>` elements used the same caret position as the parent of the new caret container. After removal of the `<li>` element, however, the editor tred to use `ToggleList.mergeWithAdjacentLists` which is used on the `otherLi.parentNode`. This triggered the TypeError, as the editor had already removed the other `otherLi` element.
 
-To solve this, {productname} 6.7 now uses the `otherLi.parentNode` reference is stored in a `const` before the removal.
+{productname} 6.7 addresses this by using, for caret position, the `otherLi.parentNode` reference stored in a `const` before the removal.
 
 === It was possible to remove the `<summary>` element from a `<details>` element by dragging and dropping
 // TINY-9960

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -314,6 +314,11 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Deleting `<li>` elements that only contained `<br>` tags sometimes caused a crash
 // TINY-6888
+In previous version of {productname}, "Uncaught TypeError: Cannot read property 'nextSibling' of null" would be thrown in some specific use cases such as after the removal of a `<li>` element.
+
+Previously, `<li>` elements used the same caret position as the parent of the new caret container, but after removal of the `<li>` element, the editor would try to use `ToggleList.mergeWithAdjacentLists` which is used on the `otherLi.parentNode`, which triggered the TypeError, as the editor had already removed the `otherLi`.
+
+To solve this, {productname} 6.7 now uses the `otherLi.parentNode` reference is stored in a `const` before the removal.
 
 === It was possible to remove the `<summary>` element from a `<details>` element by dragging and dropping
 // TINY-9960


### PR DESCRIPTION
Ticket: DOC-2171: fix documentation entry for TINY-6888 in the Release Notes.

Changes:
* added bugfix documentation for `Deleting <li> elements that only contained <br> tags sometimes caused a crash`

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
