### PR TITLE
DOC-2171: fix documentation entry for TINY-9965 in the 6.7 Release Notes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: fix documentation entry for TINY-9965 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10123 in the 6.7 Release Notes.
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -311,6 +311,13 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === It was possible to delete the sole empty block immediately before a `<details>` element if it was nested within another `<details>` element
 // TINY-9965
+In previous versions of the xref:accordion.adoc[Accordion Plugin], when inserting an accordion component inside the body of another accordion, it was possible to delete the summary block element of the nested accordion.
+
+{productname} 6.7 introduced a fix that now blocks the `delete` and `backspace` keys when pressed within a empty block before an nested accordion.
+
+As a result, using `delete` and `backspace` keys no longer allow the user to delete into the summary element of the accordion, and the caret remains in the empty block before the accordion.
+
+For information on the **Accordion** plugin see xref:accordion.adoc[Accordion]
 
 === Deleting `<li>` elements that only contained `<br>` tags sometimes caused a crash
 // TINY-6888

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -313,11 +313,11 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 // TINY-9965
 In previous versions of the xref:accordion.adoc[Accordion Plugin], when inserting an accordion component inside the body of another accordion, it was possible to delete the summary block element of the nested accordion.
 
-{productname} 6.7 introduced a fix that now blocks the `delete` and `backspace` keys when pressed within a empty block before an nested accordion.
+{productname} 6.7 addresses this by blocking *Delete* and *Backspace* key presses when the insertion point is within an empty block before a nested Accordion component.
 
-As a result, using `delete` and `backspace` keys no longer allow the user to delete into the summary element of the accordion, and the caret remains in the empty block before the accordion.
+As a result, using the *Delete* or *Backspace*` keys no longer allows a user to delete into the summary element of an Accordion component, and the insertion point remains in the empty block before the Accordion.
 
-For information on the **Accordion** plugin see xref:accordion.adoc[Accordion]
+For more information on the **Accordion** plugin see xref:accordion.adoc[Accordion].
 
 === Deleting `<li>` elements that only contained `<br>` tags sometimes caused a crash
 // TINY-6888


### PR DESCRIPTION
Ticket: DOC-2171: fix documentation entry for TINY-9965 in the 6.7 Release Notes.

Changes:
* added bugfix documentation entry for `It was possible to delete the sole empty block immediately before a `details` element if it was nested within another `details` element`

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
