### PR TITLE
DOC-2171: fix documentation entry for TINY-9815 in the 6.7 Release Notes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: fix documentation entry for TINY-9815 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10123 in the 6.7 Release Notes.
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -308,11 +308,19 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Tab navigation incorrectly stopped around `iframe` dialog components
 // TINY-9815
-In previous implementations of iframe dialog components was to wrap the component into two tab stop `div` elements which are required for the tabbing cycle to remain within the dialog itself.  These fake tab stop `divs` should by default, immediately forward the focus to the next component, However, while one of the `div's` correctly achieved this functionality, the other one failed in the initial implementation. 
+The previous implementation of the `iframe`-based dialog component wrapped the component inside two `<div>` elements.
 
-As a consequence, It meant that it took one additional redundant tab stop to navigate over the iframe dialog component.
+This was (and is) required for *Tab* key-based navigation through the dialog’s UI objects to remain within the dialog itself.
 
-{productname} 6.7, introduced a fix that now ensures that the Tab navigation now forwards the focus to the next component which now excludes redundant tab stops after the iframe dialog component.
+The intended result was for the two `<div>` elements, by default, to switch focus to the next UI object of the `iframe` component for each press of the *Tab* key.
+
+As initially implemented, however, only one of the wrapping `<div>` elements produced this functionality.
+
+As a consequence, an additional, and redundant, pressing of the *Tab* key (or *Shift+Tab* keyboard chord if navigating backwards through the dialog) was required to navigate every addressable object within an `iframe`-based dialog component.
+
+{productname} 6.7 includes a fix that addresses this. When navigating through an `iframe`-based dialog component using the *Tab* key, {productname} now skips over the elements that keep Tab-key–based navigation within the dialog but which do not present as focussable UI elements.
+
+Navigating through an `iframe`-based dialog with the *Tab* key no longer requires a redundant key-press to exit an otherwise invisible component.
 
 === It was possible to delete the sole empty block immediately before a `<details>` element if it was nested within another `<details>` element
 // TINY-9965

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -308,6 +308,11 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Tab navigation incorrectly stopped around `iframe` dialog components
 // TINY-9815
+In previous implementations of iframe dialog components was to wrap the component into two tab stop `div` elements which are required for the tabbing cycle to remain within the dialog itself.  These fake tab stop `divs` should by default, immediately forward the focus to the next component, However, while one of the `div's` correctly achieved this functionality, the other one failed in the initial implementation. 
+
+As a consequence, It meant that it took one additional redundant tab stop to navigate over the iframe dialog component.
+
+{productname} 6.7, introduced a fix that now ensures that the Tab navigation now forwards the focus to the next component which now excludes redundant tab stops after the iframe dialog component.
 
 === It was possible to delete the sole empty block immediately before a `<details>` element if it was nested within another `<details>` element
 // TINY-9965


### PR DESCRIPTION
Ticket: DOC-2171: fix documentation entry for TINY-9815 in the 6.7 Release Notes.

Changes:
* added bugfix documentation for `Tab navigation incorrectly stopped around iframe dialog components`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
