### PR TITLE
DOC-2171: fix documentation entry for TINY-9872 in the 6.7 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: fix documentation entry for TINY-9872 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10123 in the 6.7 Release Notes.
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -305,6 +305,13 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Creating a list from multiple `<div>` elements only created a partial list
 // TINY-9872
+Previously, when selecting more than one div contained in a {productname} configuration with `forced_root_block: 'div'` set, and trying to convert the selected content into a list item, the first element was also mistakenly considered as the `root` of the list.
+
+As a consequence, only the first div is entered into the list, and the remaining `<div>` elements were not converted.
+
+{productname} 6.7, addresses this issue, which now looks higher in the DOM tree for a parent when looking for the parent for the list element.
+
+For more information on **forced_root_block: 'div'** options see xref:forced_root_block.adoc[forced_root_block].
 
 === Tab navigation incorrectly stopped around `iframe` dialog components
 // TINY-9815

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -305,13 +305,33 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Creating a list from multiple `<div>` elements only created a partial list
 // TINY-9872
-Previously, when selecting more than one div contained in a {productname} configuration with `forced_root_block: 'div'` set, and trying to convert the selected content into a list item, the first element was also mistakenly considered as the `root` of the list.
+{productname} includes a content filtering option, `xref:content-filtering.adoc#forced_root_block[forced_root_block]`, which can change the default block element used to wrap inline elements and text nodes. The default value for this option is `'p'`.
 
-As a consequence, only the first div is entered into the list, and the remaining `<div>` elements were not converted.
+Previously, if the `forced_root_block` option was set to `'div'`:
 
-{productname} 6.7, addresses this issue, which now looks higher in the DOM tree for a parent when looking for the parent for the list element.
+[source,js]
+----
+forced_root_block: 'div',
+----
 
-For more information on **forced_root_block: 'div'** options see xref:forced_root_block.adoc[forced_root_block].
+multiple lines of text
+
+[source,html]
+----
+<div>Text line one.</div>
+<div>Text line two.</div>
+<div>Text line three.</div>
+----
+
+were selected, and a list was applied to the text (for example, the *Bulleted List* toolbar icon was chosen), only the first selected item became a list. (That is, the line, *Text line one.*, in the example above.)
+
+This occured because the first selected `<div>` was mistakenly treated as the list element’s root.
+
+{productname} 6.7 addresses this by looking higher in the DOM tree when looking for the list element’s parent.
+
+In {productname} 6.7, when selections equivalent to the above example have a list option applied to them, the entire selection becomes a list, as expected.
+
+For more information on the **forced_root_block** option see xref:forced_root_block.adoc[forced_root_block].
 
 === Tab navigation incorrectly stopped around `iframe` dialog components
 // TINY-9815


### PR DESCRIPTION
Ticket: DOC-2171: fix documentation entry for TINY-9872 in the 6.7 Release Notes.

Changes:
* added bugfix documentation for `Creating a list from multiple `<div>` elements only created a partial list`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
