### PR TITLE
DOC-2171: fix documentation entry for TINY-10136 in the 6.7 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: fix documentation entry for TINY-10136 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10123 in the 6.7 Release Notes.
 

--- a/modules/ROOT/pages/6.4.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.1-release-notes.adoc
@@ -886,7 +886,7 @@ Fixes were introduced with the release of {productname} 6.4.1, that:
 
 As a result, when a root element is set to `contenteditable="false"`, any `contenteditable="true"` elements inside that root element such as `<p>` tag will no longer try to split the `contenteditable="true"` element. 
 
-=== Creating a list in a table cell when the caret is in front of an anchor element would not properly include the anchor in the list.
+=== Creating a list in a table cell when the caret is in front of an anchor element would not properly include the anchor in the list
 //#TINY-6853
 
 In previous versions of {productname}, when the caret is to the left of an anchor element at the start of a line in a table cell, creating a `<ul>` or `<ol>` list would not include the anchor element. Instead, the line with the anchor element would be unexpectedly pushed below and an empty list would be created above.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -302,13 +302,11 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Creating lists in empty blocks sometimes, and incorrectly, converted adjacent block elements into list items
 // TINY-10136
-A previous fix to lists within table cells was implemented, which included an adjustment to the DOM hierarchy traversal.
+{productname} 6.4.1 included a fix for when xref:6.4.1-release-notes.adoc#_creating_a_list_in_a_table_cell_when_the_caret_is_in_front_of_an_anchor_element_would_not_properly_include_the_anchor_in_the_list[creating a list in a table cell when the insertion point is in front of an anchor element did not properly include the anchor in the list]. This fix included an adjustment to DOM hierarchy traversal.
 
-Previously, when advancing to the next leaf element in the hierarchy, the process didn't take into account whether this leaf element was correctly nested under its parent, occasionally leading to it straying outside its intended parent.
+In the earlier fix’s implementation, when advancing to the next leaf element in the hierarchy, the process did not take into account whether this leaf element was correctly nested under its parent. This occasionally led to it straying outside its intended parent. And, as a consequence, unexpected elements could be (and sometimes were) added to a list when a list was created.
 
-As a consequence, one or more unexpected elements were added to the list.
-
-{productname} 6.7, addresses this fix by setting the expected block parent as the boundary for DOM tree traversal, ensuring that it doesn't extend beyond this defined limit. As a result, any extraneous elements are now effectively excluded from the list.
+{productname} 6.7, addresses this fix by setting the expected block parent as the boundary for DOM tree traversal, ensuring that it does not extend beyond this defined limit. As a result, any extraneous elements are now effectively excluded from the list.
 
 === Creating a list from multiple `<div>` elements only created a partial list
 // TINY-9872

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -302,6 +302,13 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Creating lists in empty blocks sometimes, and incorrectly, converted adjacent block elements into list items
 // TINY-10136
+A previous fix to lists within table cells was implemented, which included an adjustment to the DOM hierarchy traversal.
+
+Previously, when advancing to the next leaf element in the hierarchy, the process didn't take into account whether this leaf element was correctly nested under its parent, occasionally leading to it straying outside its intended parent.
+
+As a consequence, one or more unexpected elements were added to the list.
+
+{productname} 6.7, addresses this fix by setting the expected block parent as the boundary for DOM tree traversal, ensuring that it doesn't extend beyond this defined limit. As a result, any extraneous elements are now effectively excluded from the list.
 
 === Creating a list from multiple `<div>` elements only created a partial list
 // TINY-9872


### PR DESCRIPTION
Ticket: DOC-2171: fix documentation entry for TINY-10136 in the 6.7 Release Notes

Changes:
* added bugfix documentation for `Creating lists in empty blocks sometimes, and incorrectly, converted adjacent block elements into list items`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
