### PR TITLE
DOC-2171: fix documentation entry for TINY-10054 in the 6.7 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: fix documentation entry for TINY-10054 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10123 in the 6.7 Release Notes.
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -299,13 +299,13 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === The Quick Toolbars plugin showed text alignment buttons on pagebreaks
 // TINY-10054
-Previously in {productname}, and issue was identified where xref:quickbars.adoc[Quickbars], a feature for changing alignment, did not properly consider page breaks.
+When a {productname} instance includes the open source xref:pagebreak.adoc[Page Break] plugin, and a page break is inserted into a {productname} document, the break is represented in the document by a thin dotted-line rectangle _image_, complete with the expected `<img>` tag.
 
-As a consequence, when a page break was encountered, the context toolbar would display alignment options.
+Previously, the logic for displaying xref:quickbars.adoc[Quickbars] toolbars did not exclude page break images.
 
-{productname} 6.7, addresses this fix which involved adding a check to page breaks for the Quickbars functionality.
+As a consequence, when a page break was encountered, an incorrect context toolbar would display.
 
-As a result of this fix, the context menu no longer display's alignment options when a page break is encountered.
+{productname} 6.7 includes an added check for page breaks in the predicate logic that prevents Quickbars contextual menus from displaying for page breaks.
 
 For information on the **Quickbars** plugin, see: xref:quickbars.adoc[Quickbars].
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -299,6 +299,15 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === The Quick Toolbars plugin showed text alignment buttons on pagebreaks
 // TINY-10054
+Previously in {productname}, and issue was identified where xref:quickbars.adoc[Quickbars], a feature for changing alignment, did not properly consider page breaks.
+
+As a consequence, when a page break was encountered, the context toolbar would display alignment options.
+
+{productname} 6.7, addresses this fix which involved adding a check to page breaks for the Quickbars functionality.
+
+As a result of this fix, the context menu no longer display's alignment options when a page break is encountered.
+
+For information on the **Quickbars** plugin, see: xref:quickbars.adoc[Quickbars].
 
 === Creating lists in empty blocks sometimes, and incorrectly, converted adjacent block elements into list items
 // TINY-10136


### PR DESCRIPTION
Ticket: DOC-2171: fix documentation entry for TINY-10054 in the 6.7 Release Notes

Changes:
* added bugfix documentation for `The Quick Toolbars plugin showed text alignment buttons on pagebreaks`

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
