### PR TITLE
DOC-2171: fix documentation entry for TINY-10129 in the 6.7 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: fix documentation entry for TINY-10129 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10123 in the 6.7 Release Notes.
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -302,7 +302,7 @@ Previously, when a {productname} editor instance was set to *read-only* mode, be
 
 As a consequence, the `fontsizeinput` text-entry field presents as disabled when a {productname} editor instance is set to *read-only* mode, as expected.
 
-NOTE: this was a display error only. Previously, when the editor was set to *read-only* mode, text could be entered into the `fontsizeinput` text-entry field. Setting this field to a new value in this circumstance did not, however, have any effect on selected material in a {productname} document, nor on text added at an insertion point after the {productname} instance was switched away from *read-only* mode.
+NOTE: This was a display error only. Previously, when the editor was set to *read-only* mode, text could be entered into the `fontsizeinput` text-entry field. Setting this field to a new value in this circumstance did not, however, have any effect on selected material in a {productname} document, nor on text added at an insertion point after the {productname} instance was switched away from *read-only* mode.
 
 === The Quick Toolbars plugin showed text alignment buttons on pagebreaks
 // TINY-10054

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -296,6 +296,11 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Numeric input in toolbar items did not disable when a switching from edit to read-only mode
 // TINY-10129
+In previous versions of {productname}, an issue related to the `fontsizeinput` was identified, when the Editor's configuration was set to **readonly** mode.
+
+This issue was due to the `Changenode` event not being fired when switching modes, which prevented the event listener responsible for disabling the `fontsizeinput` button from triggering. Consequently this caused the toolbar button to appear to be interactable even while the editor was set to **readonly** mode.
+
+{productname} 6.7, addresses this fix by listening to the "ChangeMode" event in addition to the previous event, ensuring that the missing event is now properly handled. As a result, the bug no longer exists, and the `fontsizeinput` button is correctly disabled when the Editor's configuration is set to **readonly** mode.
 
 === The Quick Toolbars plugin showed text alignment buttons on pagebreaks
 // TINY-10054

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -296,11 +296,13 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Numeric input in toolbar items did not disable when a switching from edit to read-only mode
 // TINY-10129
-In previous versions of {productname}, an issue related to the `fontsizeinput` was identified, when the Editor's configuration was set to **readonly** mode.
+Previously, when a {productname} editor instance was set to *read-only* mode, because a `Changenode` event was not fired when switching modes, the text-entry field in the `fontsizeinput` toolbar object did not present as disabled and the field’s value could be changed.
 
-This issue was due to the `Changenode` event not being fired when switching modes, which prevented the event listener responsible for disabling the `fontsizeinput` button from triggering. Consequently this caused the toolbar button to appear to be interactable even while the editor was set to **readonly** mode.
+{productname} 6.7, addresses this by listening to the `ChangeMode` event in addition to the previous event. This ensures the missing event is now properly handled.
 
-{productname} 6.7, addresses this fix by listening to the "ChangeMode" event in addition to the previous event, ensuring that the missing event is now properly handled. As a result, the bug no longer exists, and the `fontsizeinput` button is correctly disabled when the Editor's configuration is set to **readonly** mode.
+As a consequence, the `fontsizeinput` text-entry field presents as disabled when a {productname} editor instance is set to *read-only* mode, as expected.
+
+NOTE: this was a display error only. Previously, when the editor was set to *read-only* mode, text could be entered into the `fontsizeinput` text-entry field. Setting this field to a new value in this circumstance did not, however, have any effect on selected material in a {productname} document, nor on text added at an insertion point after the {productname} instance was switched away from *read-only* mode.
 
 === The Quick Toolbars plugin showed text alignment buttons on pagebreaks
 // TINY-10054


### PR DESCRIPTION
Ticket: DOC-2171: fix documentation entry for TINY-10129 in the 6.7 Release Notes.

Changes:
* added bugfix documentation for `Numeric input in toolbar items did not disable when a switching from edit to read-only mode`

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
