### PR TITLE
DOC-2171: fix documentation entry for TINY-10017 in the 6.7 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: fix documentation entry for TINY-10017 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10123 in the 6.7 Release Notes.
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -293,11 +293,13 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === For sufficiently long URLs and sufficiently wide windows, URL autocompletion hid middle portions of the URL from view
 // TINY-10017
-Previously, even when using sufficiently wide screens with {productname}, the insert link dialog that uses `overflow: hidden` as part of its default configuration was restrained by the width of the menu when a long URL link was pasted or manually entered into the source form field.
+The **Insert/Edit Link** dialog uses `overflow:hidden` as part of its default configuration. When a sufficiently long URL is pasted in to the *URL* field, a preview window appears to display the entire pasted-in URL.
 
-As a consequence, the typehead preview menu item was not visible for the newly added URL once it was inside the form field.
+Previously, even when sufficiently wide viewports were available, a portion of the pasted-in URL was cut off at top-right of the preview window.
 
-{productname} 6.7, addresses this issue which now restrict's the menu item width to the typehead preview menu popup, which now also adds scrollable functionality if the URL is considered to long to render within the width.
+In {productname} 6.7, this preview window has been constrained to the width of the *URL* field. As well, a scroll bar will present if the pasted-in URL is too long to render in this constrained width.
+
+As a consequence, no part of pasted-in URL is cut off when the preview window now presents.
 
 === Numeric input in toolbar items did not disable when a switching from edit to read-only mode
 // TINY-10129

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -293,6 +293,11 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === For sufficiently long URLs and sufficiently wide windows, URL autocompletion hid middle portions of the URL from view
 // TINY-10017
+Previously, even when using sufficiently wide screens with {productname}, the insert link dialog that uses `overflow: hidden` as part of its default configuration was restrained by the width of the menu when a long URL link was pasted or manually entered into the source form field.
+
+As a consequence, the typehead preview menu item was not visible for the newly added URL once it was inside the form field.
+
+{productname} 6.7, addresses this issue which now restrict's the menu item width to the typehead preview menu popup, which now also adds scrollable functionality if the URL is considered to long to render within the width.
 
 === Numeric input in toolbar items did not disable when a switching from edit to read-only mode
 // TINY-10129


### PR DESCRIPTION
Ticket: DOC-2171: fix documentation entry for TINY-10017 in the 6.7 Release Notes.

Changes:
* added bugfix documentation for `For sufficiently long URLs and sufficiently wide windows, URL autocompletion hid middle portions of the URL from view`

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
