### PR TITLE
DOC-2171_TINY-9943_10104_10099_10114: AI Assistant

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 ### Unreleased
 
 
-- DOC-2171: added entry for TINY-9943, *new UI string translations*, to AI Assistant section of `6.7-release-notes.adoc`; added entry for TINY-10104, *the generate button is now disabled when input field is empty, rather than displaying an alert*, to AI Assistant section of `6.7-release-notes.adoc`; added entry for TINY-10099, *the default prompts in the `ai_shortcuts` option have been improved for better results*, to AI Assistant section of `6.7-release-notes.adoc`.
+- DOC-2171: added entry for TINY-9943, *new UI string translations*, to AI Assistant section of `6.7-release-notes.adoc`; added entry for TINY-10104, *the generate button is now disabled when input field is empty, rather than displaying an alert*, to AI Assistant section of `6.7-release-notes.adoc`; added entry for TINY-10099, *the default prompts in the `ai_shortcuts` option have been improved for better results*, to AI Assistant section of `6.7-release-notes.adoc`; added entry for TINY-10114, *the dialog sometimes unblocked and showed the preview component too early when a response is streamed*, to AI Assistant section of `6.7-release-notes.adoc`.
 - DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+
+- DOC-2171: added entry for TINY-9943, *New UI string translations*, to AI Assistant section of `6.7-release-notes.adoc`.
 - DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.

--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 ### Unreleased
 
 
-- DOC-2171: added entry for TINY-9943, *New UI string translations*, to AI Assistant section of `6.7-release-notes.adoc`; added entry for TINY-10104, *The generate button is now disabled when input field is empty, rather than displaying an alert*, to AI Assistant section of `6.7-release-notes.adoc`.
+- DOC-2171: added entry for TINY-9943, *new UI string translations*, to AI Assistant section of `6.7-release-notes.adoc`; added entry for TINY-10104, *the generate button is now disabled when input field is empty, rather than displaying an alert*, to AI Assistant section of `6.7-release-notes.adoc`; added entry for TINY-10099, *the default prompts in the `ai_shortcuts` option have been improved for better results*, to AI Assistant section of `6.7-release-notes.adoc`.
 - DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.

--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 ### Unreleased
 
 
-- DOC-2171: added entry for TINY-9943, *New UI string translations*, to AI Assistant section of `6.7-release-notes.adoc`.
+- DOC-2171: added entry for TINY-9943, *New UI string translations*, to AI Assistant section of `6.7-release-notes.adoc`; added entry for TINY-10104, *The generate button is now disabled when input field is empty, rather than displaying an alert*, to AI Assistant section of `6.7-release-notes.adoc`.
 - DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -87,9 +87,12 @@ In **AI Assistant** 1.1.0, the generate button is now disabled when the prompt i
 Separately, an alert is displayed when the **AI Assistant** encounters an error. This alert still presents in **AI Assistant** 1.1.0. However, the spacing around this alert in the **AI Assistant** dialog has been improved: it is now properly balanced in the space between the dialog’s buttons and the dialog’s text input field.
 
 
-==== The default prompts in the ai_shortcuts option have been improved for better results
+==== The default prompts in the `ai_shortcuts` option have been improved for better results
 // TINY-10099
 
+By default, the `xref:ai.adoc#ai_shortcuts[ai_shortcuts]` option includes a set of queries provided as an array of objects.
+
+For **AI Assistant** 1.1.0, each prompt in this default set has been re-written so as to produce better and more immediately useful responses when sent to an AI API endpoint.
 
 ==== The dialog sometimes unblocked and showed the preview component too early when a response is streamed
 // TINY-10114

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -97,6 +97,13 @@ For **AI Assistant** 1.1.0, each prompt in this default set has been re-written 
 ==== The dialog sometimes unblocked and showed the preview component too early when a response is streamed
 // TINY-10114
 
+Previously, after submitting a prompt, the dialog would unblock early, showing a blank preview component for some time, before rendering the first chunk of visible content.
+
+This was due to the first chunk of documents containing the `<!DOCTYPE html>` declaration returned by OpenAI’s endpoint being the characters `<!`.
+
+These characters are interpreted as comment nodes by the {productname} parser. And comment nodes are considered nonempty by our associated `isEmpty` method. This is unsuitable for previewing purposes, thereby triggering the early unblocking of the dialog.
+
+In {productname} 6.7, comment nodes are now excluded from the `isEmpty` logic, resulting in them being counted as empty nodes. This is more appropriate for the purposes of checking for nodes that are visible when rendered for preview, and prevents the dialog from being unblocked early.
 
 
 === Checklist 2.0.6

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -80,6 +80,12 @@ NOTE: The query prompts included by default with the `xref:ai.adoc#ai_shortcuts[
 ==== The generate button is now disabled when input field is empty, rather than displaying an alert
 // TINY-10104
 
+Previously, when an empty prompt was submitted using the **AI Assistant** dialog, an alert would display. 
+
+In **AI Assistant** 1.1.0, the generate button is now disabled when the prompt input is empty and no alert is displayed when an empty prompt is submitted.
+
+Separately, an alert is displayed when the **AI Assistant** encounters an error. This alert still presents in **AI Assistant** 1.1.0. However, the spacing around this alert in the **AI Assistant** dialog has been improved: it is now properly balanced in the space between the dialog’s buttons and the dialog’s text input field.
+
 
 ==== The default prompts in the ai_shortcuts option have been improved for better results
 // TINY-10099

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -64,10 +64,17 @@ The {productname} 6.7.0 release includes an accompanying release of the **Advanc
 
 The {productname} 6.7.0 release includes an accompanying release of the **AI Assistant** premium plugin.
 
-**AI Assistant** 1.3.0 includes the following addition, improvements, and bug fix:
+**AI Assistant** 1.1.0 includes the following addition, improvements, and bug fix:
 
 ==== New UI string translations
 // TINY-9943
+
+
+The initial release of the **AI Assistant** plugin was an English-language–only release.
+
+**AI Assistant** 1.1.0 includes translations of all UI elements into all of {productname}’s xref:bundling-localization.adoc#supported-languages[supported languages].
+
+NOTE: The query prompts included by default with the `xref:ai.adoc#ai_shortcuts[ai_shortcuts]` option are not currently translated.
 
 
 ==== The generate button is now disabled when input field is empty, rather than displaying an alert


### PR DESCRIPTION
DOC-2171 for TINY-9943, TINY-10104, TINY-10099, and TINY-10114.

Changes:
* added entry for TINY-9943, *new UI string translations*, to AI Assistant section of `6.7-release-notes.adoc`.
* added entry for TINY-10104, *the generate button is now disabled when input field is empty, rather than displaying an alert*, to AI Assistant section of `6.7-release-notes.adoc`.
* added entry for TINY-10099, *the default prompts in the `ai_shortcuts` option have been improved for better results*, to AI Assistant section of `6.7-release-notes.adoc`.
	* NB: documentation of these new prompts is already in `staging/docs-6`.
* added entry for TINY-10114, *the dialog sometimes unblocked and showed the preview component too early when a response is streamed*, to AI Assistant section of `6.7-release-notes.adoc`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
