### PR TITLE
DOC-2171: bug-fix documentation entry for TINY-10089 in `6.7-release-notes.adoc`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: Added entry for TINY-10089, *Change event did not fire upon adding a reply*, to Comments section of `6.7-release-notes.adoc`.
 - DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -104,6 +104,10 @@ The {productname} 6.7.0 release includes an accompanying release of the **Commme
 // TINY-10089
 
 
+Previously, when a comment was added to an existing comment thread in a {productname} document, an expected change event was not fired, and the expected *Editor changed* message was not sent to the console.
+
+**Comments** 3.3.3 corrects this. When comments are added to extant threads, the change event is now fired as expected, and the *Editor changed* message is sent to the console, also as expected.
+
 
 === Enhanced Media Embed 3.1.3
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -103,7 +103,6 @@ The {productname} 6.7.0 release includes an accompanying release of the **Commme
 ==== Change event did not fire upon adding a reply
 // TINY-10089
 
-
 Previously, when a comment was added to an existing comment thread in a {productname} document, an expected change event was not fired, and the expected *Editor changed* message was not sent to the console.
 
 **Comments** 3.3.3 corrects this. When comments are added to extant threads, the change event is now fired as expected, and the *Editor changed* message is sent to the console, also as expected.


### PR DESCRIPTION
DOC-2171: bug-fix documentation entry for TINY-10089 in `6.7-release-notes.adoc`.

Changes:
* added entry for TINY-10089, *Change event did not fire upon adding a reply*, to Comments section of `6.7-release-notes.adoc`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
