### PR TITLE
DOC-2171: fix documentation entry for TINY-9975 (x2), TINY-9998 in the 6.7 Release Notes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: fix documentation entry for TINY-9975 (x2), TINY-9998 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -299,7 +299,7 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Applying an ordered or unordered list to a selected checklist incorrectly turned the list into paragraphs
 // TINY-9975
-Previously, when a xref:checklist.adoc[Checklist], particularly a checklist that contained a nested checklist, was selected and converted to a bulleted or numbered list, the selection was, incorrectly, converted into plain paragraphs.
+Previously, when a xref:checklist.adoc[Checklist], particularly a checklist that contained a nested checklist, was selected and converted to a bulleted list  the selection was, incorrectly, converted into plain paragraphs.
 
 {productname} 6.7 address this issue. With this update, nested checklists become nested bulleted lists, or nested numbered lists, when selected and converted, as expected.
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -152,7 +152,7 @@ The {productname} 6.7.0 release includes an accompanying release of the **PowerP
 
 **PowerPaste** 6.2.1 includes the following bug-fixes
 
-==== Stopped pasting comments from word documents.
+==== Stopped pasting comments from Microsoft Word documents.
 // TINY-9975
 Previously, when a copied selection from a Microsoft Word document included comments, these comments were, added to the {productname} document as footnotes when the selection was pasted in to place.
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -156,7 +156,7 @@ The {productname} 6.7.0 release includes an accompanying release of the **PowerP
 // TINY-9975
 Previously, when a copied selection from a Microsoft Word document included comments, these comments were, added to the {productname} document as footnotes when the selection was pasted in to place.
 
-**PowerPaste** 6.2.1 addresses this. Comments are still included in copied selections from Microsoft Word. With this upate, however, they are ignored by the plugin and, consequently, not added to {productname} documents when pasted.
+**PowerPaste** 6.2.1 addresses this. Comments are still included in copied selections from Microsoft Word. With this update, however, they are ignored by the plugin and, consequently, not added to {productname} documents when pasted.
 
 ==== Removed error condition, error message, and error message translations for an error which no longer occurs.
 // TINY-10045

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -158,8 +158,14 @@ Previously, when a copied selection from a Microsoft Word document included comm
 
 **PowerPaste** 6.2.1 addresses this. Comments are still included in copied selections from Microsoft Word. With this upate, however, they are ignored by the plugin and, consequently, not added to {productname} documents when pasted.
 
-==== Removed translations for an error which no longer occurs.
+==== Removed error condition, error message, and error message translations for an error which no longer occurs.
 // TINY-10045
+
+Previously, when **PowerPaste** was running with older versions of Safari as the host browser, an error condition presented, along with an associated error message, when direct image pasting was attempted.
+
+This error condition no longer presents and, for this release, the error catching logic, associated error message, and error message translations, have all been removed.
+
+For information on the **PowerPaste** plugin, see: xref:introduction-to-powerpaste.adoc[PowerPaste].
 
 
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -91,11 +91,11 @@ The {productname} 6.7.0 release includes an accompanying release of the **Checkl
 
 ==== Applying checklist on a list with nested lists turned only the outer list into a checklist
 // TINY-9998
-In previous versions of {productname}, an issue was identified that affected the functionality of the xref:checklist.adoc[Checklist] Plugin when user's would select a checklist that contains a nested checklist and attempted to convert it into a bulleted list or a numbered list.
+Previously, when a xref:checklist.adoc[Checklist] that contained a nested checklist was selected and converted to a bulleted or numbered list, only the outer checklist was converted: the nested checklist remained a checklist.
 
-As a consequence, the outer checklist would be converted into the desired list while the nested checklists retained the previous formatting state.
+**Checklist** 2.0.6 corrects this. With this update, nested checklists become nested bulleted lists, or nested numbered lists, when selected and converted, as expected.
 
-{productname} 6.7 addressed this issue, by ensuring that the whole checklist is now converted into the desired list selected by the user which includes nested checklist.
+For information on the **Checklist** plugin, see: xref:checklist.adoc[Checklist].
 
 
 === Comments 3.3.3

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -293,13 +293,9 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Applying an ordered or unordered list to a selected checklist incorrectly turned the list into paragraphs
 // TINY-9975
-In previous versions of {productname}, an issue was identified that affected the functionality of the xref:checklist.adoc[Checklist] Plugin which would incorrectly convert a list into a paragraph when users attempted to apply an `ordered` or `unordered` list format to a selected checklist, particularly when they selected a bulleted list that included a sublist.
+Previously, when a xref:checklist.adoc[Checklist], particularly a checklist that contained a nested checklist, was selected and converted to a bulleted or numbered list, the selection was, incorrectly, converted into plain paragraphs.
 
-{productname} 6.7 addresses this issue so that when a user selects a bulleted list that contains a sublist and tries to convert it into a checklist, the entire list correctly transforms into a checklist as intended.
-
-As a result of this fix, lists will now longer convert into paragraphs when attempting to apply checklist formatting to them.
-
-For information on the **Checklist** plugin, see: xref:checklist.adoc[Checklist].
+{productname} 6.7 address this issue. With this update, nested checklists become nested bulleted lists, or nested numbered lists, when selected and converted, as expected.
 
 === Returning an empty string in a custom context menu update function resulted in a small white line appearing on right-click and the browser-native context menu would not present
 // TINY-9842

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -299,7 +299,7 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Applying an ordered or unordered list to a selected checklist incorrectly turned the list into paragraphs
 // TINY-9975
-Previously, when a xref:checklist.adoc[Checklist], particularly a checklist that contained a nested checklist, was selected and converted to a bulleted list  the selection was, incorrectly, converted into plain paragraphs.
+Previously, when a xref:checklist.adoc[Checklist], particularly a checklist that contained a nested checklist, was selected and converted to a bulleted list the selection was, incorrectly, converted into plain paragraphs.
 
 {productname} 6.7 address this issue. With this update, nested checklists become nested bulleted lists, or nested numbered lists, when selected and converted, as expected.
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -91,7 +91,11 @@ The {productname} 6.7.0 release includes an accompanying release of the **Checkl
 
 ==== Applying checklist on a list with nested lists turned only the outer list into a checklist
 // TINY-9998
+In previous versions of {productname}, an issue was identified that affected the functionality of the xref:checklist.adoc[Checklist] Plugin when user's would select a checklist that contains a nested checklist and attempted to convert it into a bulleted list or a numbered list.
 
+As a consequence, the outer checklist would be converted into the desired list while the nested checklists retained the previous formatting state.
+
+{productname} 6.7 addressed this issue, by ensuring that the whole checklist is now converted into the desired list selected by the user which includes nested checklist.
 
 
 === Comments 3.3.3
@@ -150,7 +154,13 @@ The {productname} 6.7.0 release includes an accompanying release of the **PowerP
 
 ==== Stopped pasting comments from word documents.
 // TINY-9975
+Previously, pasting content from a word document that contained comments were copied alongside the document's content, resulting in the unintended inclusion of comments when pasting it into a {productname} document.
 
+{productname} 6.7, introduced a solution for xref:introduction-to-powerpaste.adoc[PowerPaste] that now excludes comments when pasting data into a {productname} document.
+
+As a result of this fix, users can now paste content from Word documents without the inconvenience of comments being inadvertently included in the paste operation.
+
+For information on the **PowerPaste** plugin, see: xref:introduction-to-powerpaste.adoc[PowerPaste].
 
 ==== Removed translations for an error which no longer occurs.
 // TINY-10045
@@ -287,6 +297,13 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Applying an ordered or unordered list to a selected checklist incorrectly turned the list into paragraphs
 // TINY-9975
+In previous versions of {productname}, an issue was identified that affected the functionality of the xref:checklist.adoc[Checklist] Plugin which would incorrectly convert a list into a paragraph when users attempted to apply an `ordered` or `unordered` list format to a selected checklist, particularly when they selected a bulleted list that included a sublist.
+
+{productname} 6.7 addresses this issue so that when a user selects a bulleted list that contains a sublist and tries to convert it into a checklist, the entire list correctly transforms into a checklist as intended.
+
+As a result of this fix, lists will now longer convert into paragraphs when attempting to apply checklist formatting to them.
+
+For information on the **Checklist** plugin, see: xref:checklist.adoc[Checklist].
 
 === Returning an empty string in a custom context menu update function resulted in a small white line appearing on right-click and the browser-native context menu would not present
 // TINY-9842

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -154,13 +154,9 @@ The {productname} 6.7.0 release includes an accompanying release of the **PowerP
 
 ==== Stopped pasting comments from word documents.
 // TINY-9975
-Previously, pasting content from a word document that contained comments were copied alongside the document's content, resulting in the unintended inclusion of comments when pasting it into a {productname} document.
+Previously, when a copied selection from a Microsoft Word document included comments, these comments were, added to the {productname} document as footnotes when the selection was pasted in to place.
 
-{productname} 6.7, introduced a solution for xref:introduction-to-powerpaste.adoc[PowerPaste] that now excludes comments when pasting data into a {productname} document.
-
-As a result of this fix, users can now paste content from Word documents without the inconvenience of comments being inadvertently included in the paste operation.
-
-For information on the **PowerPaste** plugin, see: xref:introduction-to-powerpaste.adoc[PowerPaste].
+**PowerPaste** 6.2.1 addresses this. Comments are still included in copied selections from Microsoft Word. With this upate, however, they are ignored by the plugin and, consequently, not added to {productname} documents when pasted.
 
 ==== Removed translations for an error which no longer occurs.
 // TINY-10045

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -301,7 +301,7 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 // TINY-9975
 Previously, when a xref:checklist.adoc[Checklist], particularly a checklist that contained a nested checklist, was selected and converted to a bulleted list the selection was, incorrectly, converted into plain paragraphs.
 
-{productname} 6.7 address this issue. With this update, nested checklists become nested bulleted lists, or nested numbered lists, when selected and converted, as expected.
+{productname} 6.7 address this issue. With this update, nested checklists become nested bulleted lists when selected and converted, as expected.
 
 === Returning an empty string in a custom context menu update function resulted in a small white line appearing on right-click and the browser-native context menu would not present
 // TINY-9842


### PR DESCRIPTION
Ticket: DOC-2171: fix documentation entry for TINY-9975 (x2), TINY-9998 in the 6.7 Release Notes.

Changes:
* added fix documentation for the below
* `Applying checklist on a list with nested lists turned only the outer list into a checklist` to `checklist` subsection.
* `Stopped pasting comments from word documents.` to `powerpaste` subsection.
* `Applying an ordered or unordered list to a selected checklist incorrectly turned the list into paragraphs`
* `Removed error condition, error message, and error message translations for an error which no longer occurs.` into `powerpaste` subsection.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
