### PR TITLE
DOC-2171: bug-fix documentation entry for TINY-10060 in `6.7-release-notes.adoc`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: added entry for TINY-10060, *Automatic media embed would not work as expected if the link was pasted into a `<div>` element*, to Enhanced Media Embed section of `6.7-release-notes.adoc`.
 - DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -111,8 +111,18 @@ The {productname} 6.7.0 release includes an accompanying release of the **Enhanc
 
 **Enhanced Media Embed** 3.1.3 includes the following
 
-==== Automatic media embed would not work as expected if the link was pasted into a div element
+==== Automatic media embed would not work as expected if the link was pasted into a `<div>` element
 // TINY-10060
+
+The **Enhanced Media Embed** did not, previously, accept a `<div>` element as a valid parent. 
+
+As a consequence, if an otherwise supported media URL was pasted inside a `<div>` element, automatic embedding of the referenced media did not occur.
+
+With this update, the `<div>` element has been added to the list of parent elements considered valid by the plugin.
+
+Supported media URLs now embed as expected when pasted inside `<div>` elements.
+
+NOTE: Although this was discovered in a {productname} instance running with the `xref:content-filtering.adoc#forced_root_block[forced_root_block: 'div']` configuration setting, the embed failure occurred in any circumstance where a media URL was pasted directly inside a `<div>` element.
 
 
 === Footnotes 1.0.1


### PR DESCRIPTION
DOC-2171: bug-fix documentation entry for TINY-10060 in `6.7-release-notes.adoc`

Changes:
* added entry for TINY-10060, *Automatic media embed would not work as expected if the link was pasted into a `<div>` element*, to Enhanced Media Embed section of `6.7-release-notes.adoc`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
