### PR TITLE
DOC-2171: change documentation entry for TINY-10008 in the 6.7 Release Notes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: change documentation entry for TINY-10008 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -279,7 +279,13 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === If loading content CSS takes more than 500ms, the editor will be set to an *in progress* state until the CSS is ready
 // TINY-10008
+Previously, an issue was identified that was reproducible during the {productname} initialization process.
 
+If the `contentEditable: 'true'` property was set within the editors configuration, and the user host browser was affected by a slow internet connection such as "3G", and the `contentCss` was still loading, the user could interact with the editor before the `ContentCss` had finished its loading phase.
+
+As a consequence, after the `ContentCss` had completed its initial load, any content inserted into the editor before the `ContentCss` had completed loading was removed from the editor.
+
+{productname} 6.7 addresses this issues, which now blocks any interaction with the editor while the `contentCss` is loading. As a result of this fix, it is no longer possible to insert any text into the editor during the `contentCss` loading phase.
 
 
 [[bug-fixes]]

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -279,13 +279,13 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === If loading content CSS takes more than 500ms, the editor will be set to an *in progress* state until the CSS is ready
 // TINY-10008
-Previously, an issue was identified that was reproducible during the {productname} initialization process.
+If a {productname} configuration included a `contentEditable: 'true'` setting (or had no explicit global setting for `contentEditable`, and therefore defaulted this option to `'true'`) and the host browser was operating over a relatively slow connection, it was possible to add content to the editor before `ContentCss` finished loading.
 
-If the `contentEditable: 'true'` property was set within the editors configuration, and the user host browser was affected by a slow internet connection such as "3G", and the `contentCss` was still loading, the user could interact with the editor before the `ContentCss` had finished its loading phase.
+This could lead to data loss. After `ContentCSS` completed its initial load, any content added to the editor before the load had completed was removed from the editor.
 
-As a consequence, after the `ContentCss` had completed its initial load, any content inserted into the editor before the `ContentCss` had completed loading was removed from the editor.
+{productname} 6.7 addresses this by blocking interaction with the editor until `ContentCss` has completed loading, disallowing content insertion until initialisation is complete.
 
-{productname} 6.7 addresses this issues, which now blocks any interaction with the editor while the `contentCss` is loading. As a result of this fix, it is no longer possible to insert any text into the editor during the `contentCss` loading phase.
+A relatively slow network connection for this purpose is an ≅ 400 kb/sec connection with an ≅ 2000 ms latency; equivalent to a Slow 3G wireless connection. The potential UX change caused by this change will, therefore, be experienced by very few users.
 
 
 [[bug-fixes]]


### PR DESCRIPTION
Ticket: DOC-2171: change documentation entry for TINY-10008 in the 6.7 Release Notes.

Changes:
* added change documentation for `If loading content CSS takes more than 500ms, the editor will be set to an *in progress* state until the CSS is ready`

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
