### PR TITLE
DOC-2171: change documentation entry for TINY-9744 in the 6.7 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: change documentation entry for TINY-9744 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -276,6 +276,11 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === The pattern replacement removed spaces if they were contained within a tag that only contained a space and the text to replace
 // TINY-9744
+An issue that affected {productname} 6.3.1, identified an problem that affected the `cleanEmptyNodes` function, that is responsible for removing nodes that contain whitespaces within it.
+
+As a consequence, in some specific cases, the pattern would remove the whitespace, if they were within a tag that contained only whitespace.
+
+{productname} 6.7, addresses this issue by updating the `cleanEmptyNodes` function that now preserves cases of nodes in which that contain whitespace.
 
 === If loading content CSS takes more than 500ms, the editor will be set to an *in progress* state until the CSS is ready
 // TINY-10008


### PR DESCRIPTION
Ticket: DOC-2171: change documentation entry for TINY-9744 in the 6.7 Release Notes

Changes:
* added change documentation for `The pattern replacement removed spaces if they were contained within a tag that only contained a space and the text to replace`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [ ] Documentation Team Lead has reviewed
