### PR TITLE
DOC-2171: change documentation entry for TINY-9764 in the 6.7 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: change documentation entry for TINY-9764 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -273,6 +273,9 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Change `UndoLevelType` from `enum` to union type so that it is easier to use
 // TINY-9764
+Previously in {productname} 6.3, a TypeError for `type: "complete"` was triggering when trying to fire a change event, due to it not been assignable to the type 'UndoLevelType'.
+
+{productname} 6.7 addresses this issue, by updating the `UndoLevelType` from a `enum` type to a `union type`, resulting in the TypeError no longer presenting itself within the console, when the fire event is triggered.
 
 === The pattern replacement removed spaces if they were contained within a tag that only contained a space and the text to replace
 // TINY-9744


### PR DESCRIPTION
Ticket: DOC-2171: change documentation entry for TINY-9764 in the 6.7 Release Notes

Changes:
* added change documentation for `Change `UndoLevelType` from `enum` to union type so that it is easier to use`

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [ ] Documentation Team Lead has reviewed
