### PR TITLE
DOC-2171: addition documentation entry for TINY-9379 in the 6.7 Release Notes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: addition documentation entry for TINY-9379 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -259,6 +259,23 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === New `help_accessibility` option displays the keyboard shortcut to open the in-application help in the status bar
 // TINY-9379
+In previous versions of {productname}, keyboard users without screen readers had no indicator of how to access the help menu. However, users that used screen readers would get announcements on accessing the help menu. 
+
+As a consequence, keyboard users could only see the help button, but could not access it unless they were aware of the keyboard shortcuts such as **⌥+0**.
+
+{productname} 6.7 addressed this issue by introducing a new option `help_accessibility`, which defaults to `true`, that adds a shortcut indicator in the status bar to indicate the keyboard shortcut for the help menu. This new option when set, helps identify to keyboard users that the shortcut is available which will help them access the help menu via the editor's statusbar.
+
+[source, js]
+----
+tinymce.init({
+    selector: "textarea",
+    plugins: [
+        "help", 
+    ],
+    toolbar: "help",
+	help_accessibility: true, // default value is set to true.
+});
+----
 
 === Added a new `InsertNewBlockBefore` command which inserts an empty block before the block containing the current selection
 // TINY-10022

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -259,11 +259,13 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === New `help_accessibility` option displays the keyboard shortcut to open the in-application help in the status bar
 // TINY-9379
-In previous versions of {productname}, keyboard users without screen readers had no indicator of how to access the help menu. However, users that used screen readers would get announcements on accessing the help menu. 
+In previous versions of {productname}, keyboard-centric users without screen readers had no indicator of how to access the {productname} **Help → Help** command. (Users with screen readers got and continue to get announcements on accessing the **Help** menu and the **Help → Help** command.)
 
-As a consequence, keyboard users could only see the help button, but could not access it unless they were aware of the keyboard shortcuts such as **⌥+0**.
+By default, the **Help → Help** command is accessible using a keyboard chord. **Alt+0** on Windows or Linux and **⌥+0** on macOS. But this chord is not presented except when the **Help** menu is opened and the **Help → Help** command is displayed.
 
-{productname} 6.7 addressed this issue by introducing a new option `help_accessibility`, which defaults to `true`, that adds a shortcut indicator in the status bar to indicate the keyboard shortcut for the help menu. This new option when set, helps identify to keyboard users that the shortcut is available which will help them access the help menu via the editor's statusbar.
+{productname} 6.7 addresses this issue by introducing a new option `help_accessibility` option, which defaults to `true`
+
+When set to `true`, this option displays the **Help → Help** command keyboard shortcut in the {productname} status bar.
 
 [source, js]
 ----


### PR DESCRIPTION
Ticket: DOC-2171: addition documentation entry for TINY-9379 in the 6.7 Release Notes.

Changes:
* added `additions` documentation entry for `New `help_accessibility` option displays the keyboard shortcut to open the in-application help in the status bar`.
* NB: documentation of this new option has been added to the docs-proper via DOC-2027.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
