### PR TITLE
DOC-2171: improvement documentation entry for TINY-9978 in the Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: improvement documentation entry for TINY-9978 in the Release Notes.
 - DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -239,11 +239,11 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Menus now have a slight margin at the top and bottom to more clearly separate them from the frame edge
 // TINY-9978
-In previous versions of {productname}, an issue was identified were the menu was reaching the edge of the host browser's window.
+Previously, the {productname} menu could reach the edge of the host browser’s window.
 
-As a consequence, it was not apparent to the user if the menu stopped at the edge of the window or continued past its bounds which led to confusion with users, as the were uncertain if the menu was showing everything.
+As a consequence, it was not apparent if the menu stopped at the edge of the window or continued past its bounds. This led to user confusion, since it was unclear if the {productname} menu was showing everything.
 
-{productname} 6.7 addressed this issue, by adding a margin to the bottom and/or top of the menu layout to separate it from the frame edge.
+{productname} 6.7 addresses this issue, by adding a margin to the menu layout to separate it from the frame edge. This margin is placed at the top or bottom of the {productname} menu, depending on where the menu is displayed in a given {productname} instance.
 
 As a result, in {productname} 6.7, the menu is now more noticeably distinct from the frame edge.
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -239,6 +239,13 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Menus now have a slight margin at the top and bottom to more clearly separate them from the frame edge
 // TINY-9978
+In previous versions of {productname}, an issue was identified were the menu was reaching the edge of the host browser's window.
+
+As a consequence, it was not apparent to the user if the menu stopped at the edge of the window or continued past its bounds which led to confusion with users, as the were uncertain if the menu was showing everything.
+
+{productname} 6.7 addressed this issue, by adding a margin to the bottom and/or top of the menu layout to separate it from the frame edge.
+
+As a result, in {productname} 6.7, the menu is now more noticeably distinct from the frame edge.
 
 === Updated **More** toolbar button tooltip text from *More...* to *Reveal or hide additional toolbar items*
 // TINY-9629


### PR DESCRIPTION
Ticket: DOC-2171: improvement documentation entry for TINY-9978 in the Release Notes

Changes:
* added improvement documentation for `Menus now have a slight margin at the top and bottom to more clearly separate them from the frame edge`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
