### PR TITLE
DOC-2171: improvement documentation entry for TINY-9863 in the 6.7 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: improvement documentation entry for TINY-9863 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -236,13 +236,13 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Adding a newline after a table would, in some specific cases, not work
 // TINY-9863
-Previously, when pressing `Enter` after placing the cursor between a table, and a `contenteditable="false"` element, that is also wrapped within a `div` would in some cases, not add a new line to the {productname} document.
+Previously, when the insertion point was between a table and an element with a `contenteditable="false"` attribute that was, itself, wrapped in a `<div>`, pressing the **Enter** or **Return** key did not add a new line to the document.
 
-As a consequence, when a `contenteditable="false"` element was situated within the {productname} document, and after a table element, it was considered to be invalid to add a newline at that position, hence, one was not added.
+{productname}, incorrectly, treated the insertion point’s location in this circumstance as not a valid place for adding a new line.
 
-{productname} 6.7 addresses this issues, which now, consider's the position valid, and adds the expected root blocks.
+{productname} 6.7 corrects this and treats such a location as the valid place for adding a new line that it is.
 
-As a result, newlines are added to the {productname} document, as expected when the cursor is between a table, and a `contenteditable="false"` element wrapped in a `div`.
+As a result, new lines are added to {productname} documents, as expected, when the insertion point is between a table, and an `<div>`-wrapped element with a `contenteditable="false"` attribute.
 
 === Menus now have a slight margin at the top and bottom to more clearly separate them from the frame edge
 // TINY-9978

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -236,6 +236,13 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === Adding a newline after a table would, in some specific cases, not work
 // TINY-9863
+Previously, when pressing `Enter` after placing the cursor between a table, and a `contenteditable="false"` element, that is also wrapped within a `div` would in some cases, not add a new line to the {productname} document.
+
+As a consequence, when a `contenteditable="false"` element was situated within the {productname} document, and after a table element, it was considered to be invalid to add a newline at that position, hence, one was not added.
+
+{productname} 6.7 addresses this issues, which now, consider's the position valid, and adds the expected root blocks.
+
+As a result, newlines are added to the {productname} document, as expected when the cursor is between a table, and a `contenteditable="false"` element wrapped in a `div`.
 
 === Menus now have a slight margin at the top and bottom to more clearly separate them from the frame edge
 // TINY-9978


### PR DESCRIPTION
Ticket: DOC-2171: improvement documentation entry for TINY-9863 in the 6.7 Release Notes

Changes:
* added improvement documentation for `Adding a newline after a table would, in some specific cases, not work`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
