### PR TITLE
DOC-2171: fix documentation entry for TINY-9971 to support  `Table of Contents 1.2.0` in the 6.7 Release Notes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: fix documentation entry to support `Table of Contents 1.2.0` in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -204,9 +204,13 @@ The {productname} 6.7.0 release includes an accompanying release of the **Table 
 
 ==== Changes to the ToC title were overwritten using the update button.
 // TINY-9971
+In previous versions of the xref:tableofcontents.adoc[Table of contents], an issue was identified that would see the table of contents title, overwritten when pressing the update "refresh" button.
 
+The cause of the problem was that whenever the "refresh" button was pressed, the entire Table of Contents would be regenerated, which included the title.
 
+As a consequence, any changes made to the Table of Contents prior would not be preserved.
 
+**Table of Contents** 1.2.0, addresses this issue, now, if there is already a title present in the Table of Contents, the plugin will use that existing title instead of re-generating it. As a result of this fix, the refresh button no longer overwrites the title, ensuring that changes to the Table of Contents are retained.
 
 
 === Tiny Drive 2.0.3


### PR DESCRIPTION
Ticket: DOC-2171: fix documentation entry for TINY-9971 to support  `Table of Contents 1.2.0` in the 6.7 Release Notes.

Changes:
* added documentation for `Changes to the ToC title were overwritten using the update button.` in the Table of Contents 1.2.0 subsection.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [ ] Documentation Team Lead has reviewed
