### PR TITLE
DOC-2171: fix documentation entry to support Table of Contents 1.2.0 in the 6.7 Release Notes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: fix documentation entry to support Table of Contents 1.2.0 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -200,7 +200,11 @@ The {productname} 6.7.0 release includes an accompanying release of the **Table 
 
 ==== Empty headers would be included in table of content.
 // TINY-9862
+In previous versions of the xref:tableofcontents.adoc[Table of contents], the Table of Contents (TOC) was linked to all headers, regardless of whether they contained meaningful content or were empty.
 
+As a consequence of this oversight, the Table of Contents would display these empty headers, causing confusion to the user.
+
+**Table of Contents** 1.2.0, addresses this issue, which now filter's out empty headers from the Table of Contents. As a result of this action, the Table of Contents now functions as expected, and displays only headers that contain relevant content.
 
 ==== Changes to the ToC title were overwritten using the update button.
 // TINY-9971


### PR DESCRIPTION
Ticket: DOC-2171: fix documentation entry to support Table of Contents 1.2.0 in the 6.7 Release Notes.

Changes:
* added fix documentation for `Empty headers would be included in table of content` to support **Table of Contents** 1.2.0.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [ ] Documentation Team Lead has reviewed
