### PR TITLE
DOC-2171: fix documentation entry for TINY-9890 to support Table of Contents 1.2.0 in the 6.7 Release Notes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: fix documentation entry for TINY-9890 to support Table of Contents 1.2.0 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -196,7 +196,13 @@ The {productname} 6.7.0 release includes an accompanying release of the **Table 
 
 ==== ToC toolbar button and menu item are now disabled when the selection is not editable
 // TINY-9890
+In previous versions of the xref:tableofcontents.adoc[Table of contents], a UI issue occurred when the Table of Contents plugin was active, and the user's cursor or selection was placed within a section of the editor that was set as `non-editable`.
 
+This lead to an unintended consequence, where the Table of Contents toolbar button remained visible to the user despite the users cursor or selection being within a `non-editable` element.
+
+**Table of Contents** 1.2.0, addresses this issue, which now disables of the Table of Contents toolbar button when the user's selection is within a `non-editable` element or when the editor is set to **readonly** mode.
+
+As a result of this fix, the Table of Contents toolbar button now correctly renders the button as either `enabled` or `disabled` based on the user's cursor position or context selection.
 
 ==== Empty headers would be included in table of content.
 // TINY-9862

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -198,7 +198,7 @@ The {productname} 6.7.0 release includes an accompanying release of the **Table 
 // TINY-9890
 In previous versions of the xref:tableofcontents.adoc[Table of contents], a UI issue occurred when the Table of Contents plugin was active, and the user's cursor or selection was placed within a section of the editor that was set as `non-editable`.
 
-This lead to an unintended consequence, where the Table of Contents toolbar button remained visible to the user despite the users cursor or selection being within a `non-editable` element.
+This lead to an unintended consequence, where the Table of Contents toolbar button remained enabled despite the users cursor or selection being within a `non-editable` element.
 
 **Table of Contents** 1.2.0, addresses this issue, which now disables of the Table of Contents toolbar button when the user's selection is within a `non-editable` element or when the editor is set to **readonly** mode.
 


### PR DESCRIPTION
Ticket: DOC-2171: fix documentation entry for TINY-9890 to support Table of Contents 1.2.0 in the 6.7 Release Notes.

Changes:
* added fix documentation for `ToC toolbar button and menu item are now disabled when the selection is not editable` in the Table of Contents subsection.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [ ] Documentation Team Lead has reviewed
