### PR TITLE
DOC-2171: new options for TINY-9970, TINY-9968 and TINY-9969 for TOC in the 6.7 Release Notes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
-- DOC-2171: new option tableofcontents_orderedlist_type for TOC in the 6.7 Release Notes.
+- DOC-2171: new options for TOC for TINY-9970, TINY-9968 and TINY-9969 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: new option tableofcontents_orderedlist_type for TOC in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -182,94 +182,98 @@ The {productname} 6.7.0 release includes an accompanying release of the **Table 
 
 **Table of Contents** 1.2.0 includes the following improvements and bug-fixes:
 
-==== Added new boolean option tableofcontents_includeheader to control whether a header is included in the table of contents. Defaults to true.
+
+==== Added new boolean option, `tableofcontents_includeheader`, to control whether a header is included
 // TINY-9970
 
-{productname} 6.7, added a new option `tableofcontents_includeheader`, to **Table of Contents 1.2.0**, that when set to `false`, removes the Table of Content header from the TOC.
+**Table of Contents** 1.2.0 includes a new option, `tableofcontents_includeheader`.
 
-.Basic configuration setup for new option `tableofcontents_includeheader: false`
-[source, js]
-----
-tinymce.init({
-    selector: "textarea",
-    plugins: [
-        "tableofcontents", "code",
-    ],
-    toolbar: "tableofcontents",
-	tableofcontents_includeheader: false, // default is set to true
-});
-----
+This option is set to `true` by default.
 
-For information on the **Table of Contents** plugin, see: xref:tableofcontents.adoc[Table of Contents].
+When set to `false`, this option removes the header string, **Table of Content**, from the rendered Table of Contents.
 
-==== Added new boolean option tableofcontents_orderedlist to use ordered lists instead of unordered lists in the table of contents.
+
+==== Added new boolean option, `tableofcontents_orderedlist`, to use ordered lists instead of unordered lists
 // TINY-9968
-{productname} 6.7, added a new option to the register for **Table of Contents 1.2.0**, that supports the additional new option `tableofcontents_orderedlist_type: 'true'.
 
-[NOTE]
-The `tableofcontents_orderedlist_type: 'true' option must be present in the same {productname} configuration, to support the secondary option `tableofcontents_orderedlist_type` , which takes one of five `string` values currently to modify the specific type for the ordered list.
+**Table of Contents 1.2.0** includes a new option, `tableofcontents_orderedlist`.
 
-.Basic configuration setup for `tableofcontents_orderedlist`
-[source, js]
-----
-tinymce.init({
-    selector: "textarea",
-    plugins: [
-        "tableofcontents", "code",
-    ],
-    toolbar: "tableofcontents",
-    tableofcontents_orderedlist: true, // option required to configure tableofcontents_orderedlist_type
-	tableofcontents_orderedlist_type: 'I', // optional values are '1', 'A', 'a', 'I', 'i'
-});
-----
+This option is set to `false` by default.
 
-For information on the **Table of Contents** plugin, see: xref:tableofcontents.adoc[Table of Contents].
+When set to `true`, this option renders a Table of Contents as an ordered list instead of the default unordered list.
 
-==== Added new option tableofcontents_orderedlist_type to set a specific type of ordered list, defaulting to a numeric ordered list.
+
+==== Added new option, `tableofcontents_orderedlist_type` to set a specific type of ordered list
 // TINY-9969
-{productname} 6.7, introduced a new option in **Table of Contents 1.2.0**.
 
-This new option allows the user to change the visual appearance for the ordered list within the Table of Contents.
+**Table of Contents 1.2.0** includes a new option, `tableofcontents_orderedlist_type`.
 
-.Basic configuration setup for `tableofcontents_orderedlist_type: 'I'`
-[source, js]
-----
-tinymce.init({
-    selector: "textarea",
-    plugins: [
-        "tableofcontents", "code",
-    ],
-    toolbar: "tableofcontents",
-    tableofcontents_orderedlist: true, // option required to configure tableofcontents_orderedlist_type
-	tableofcontents_orderedlist_type: 'I', // optional values are '1', 'A', 'a', 'I', 'i'
-});
-----
+When set to one of its available values, this option renders the table of contents as the specified type of ordered list rather than the default unordered list.
+
+This option takes one of the following values to set the type attribute of the ordered list, `<ol>`:
+
+[cols="10%,90%"]
+|===
+|Value | Ordered list type
+
+|`+'1'+`
+|A list sorted by Arabic/Hindu numerals.
+
+This is the default.
+
+|`+'A'+`
+|A list sorted alphabetically by capital letter.
+
+|`+'a'+`
+|A list sorted alphabetically by lowercase letter.
+
+|`+'I'+`
+|A list sorted by uppercase Roman numerals.
+
+|`+'i'+`
+|A list sorted by lowercase Roman numerals.
+|===
 
 [IMPORTANT]
-`tableofcontents_orderedlist_type` is dependant on `tableofcontents_orderedlist: true` to be within the same {productname} editor configuration in order to modify the visual appearance for the ordered list.
+====
+The `tableofcontents_orderedlist: true` option must be present in a {productname} configuration for whatever `tableofcontents_orderedlist_type` setting to come into effect.
+====
 
-Optional values to change the type attribute for the ordered list `<ol>`as per the below standards referenced from https://www.w3schools.com/html/html_lists_ordered.asp#:~:text=Ordered%20HTML%20List%20%2D%20The%20Type%20Attribute[Ordered_HTML_List-The_Type_Attribute]
 
-* **1**: The list items will be numbered with numbers (default).
-* **A**: The list items will be numbered with uppercase letters.
-* **a**: The list items will be numbered with lowercase letters.
-* **I**: The list items will be numbered with uppercase roman numbers.
-* **i**: The list items will be numbered with lowercase roman numbers.
-
-For information on the **Table of Contents** plugin, see: xref:tableofcontents.adoc[Table of Contents].
-
-==== ToC toolbar button and menu item are now disabled when the selection is not editable
+==== Table of Contents toolbar button and menu item are now disabled when the selection is not editable
 // TINY-9890
 
+Previously, the Table of Contents toolbar button and menu item were not disabled when the insertion point was within a read-only (ie, non-editable) section or when the selection was within a read-only section or included a read-only portion.
 
-==== Empty headers would be included in table of content.
+Clicking the enabled button, or choosing the enabled menu item did not generate a Table of Contents. The commands were disabled, as expected. The UI objects did not, however, present as disabled.
+
+**Table of Contents 1.2.0** addresses this. If the selection includes or is within a read-only section, or if the insertion point is within a read-only section, the Table of Contents UI objects now, correctly, present as disabled.
+
+
+==== Empty headers would be included in table of content
 // TINY-9862
 
+Previously, the **Table of Contents** plugin included all header blocks in a generated Table of Contents, including empty header blocks.
 
-==== Changes to the ToC title were overwritten using the update button.
+These empty header blocks were presented, in the generated Table of Contents, as an underline character.
+
+**Table of Contents 1.2.0** addresses this by filtering out empty header blocks when it generates a Table of Contents section.
+
+[IMPORTANT]
+====
+For filtering purposes, the plugin treats a header block which contains non-printing characters, such as spaces, as **not** empty.
+====
+
+==== Changes to the Table of Contents title were overwritten by the update button.
 // TINY-9971
 
+By default, a generated Table of Contents includes a title, **Table of Contents**. This title can be edited.
 
+Previously, however, if a particular Table of Contents was re-generated using the update button, the default title was restored and the edited title was lost.
+
+In **Table of Contents** 1.2.0, edits to the Table of Contents title are respected. When a given Table of Contents, which includes an edited title, is re-generated, the edited title is preserved.
+
+For information on the **Table of Contents** plugin, see: xref:tableofcontents.adoc[Table of Contents].
 
 
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -185,17 +185,9 @@ The {productname} 6.7.0 release includes an accompanying release of the **Table 
 ==== Added new boolean option tableofcontents_includeheader to control whether a header is included in the table of contents. Defaults to true.
 // TINY-9970
 
+{productname} 6.7, added a new option `tableofcontents_includeheader`, to **Table of Contents 1.2.0**, that when set to `false`, removes the Table of Content header from the TOC.
 
-==== Added new boolean option tableofcontents_orderedlist to use ordered lists instead of unordered lists in the table of contents.
-// TINY-9968
-
-==== Added new option tableofcontents_orderedlist_type to set a specific type of ordered list, defaulting to a numeric ordered list.
-// TINY-9969
-{productname} 6.7, introduced a new option in **Table of Contents 1.2.0**.
-
-This new option allows the user to change the visual appearance for the ordered list within the Table of Contents.
-
-.Example
+.Basic configuration setup for new option `tableofcontents_includeheader: false`
 [source, js]
 ----
 tinymce.init({
@@ -204,9 +196,57 @@ tinymce.init({
         "tableofcontents", "code",
     ],
     toolbar: "tableofcontents",
+	tableofcontents_includeheader: false, // default is set to true
+});
+----
+
+For information on the **Table of Contents** plugin, see: xref:tableofcontents.adoc[Table of Contents].
+
+==== Added new boolean option tableofcontents_orderedlist to use ordered lists instead of unordered lists in the table of contents.
+// TINY-9968
+{productname} 6.7, added a new option to the register for **Table of Contents 1.2.0**, that supports the additional new option `tableofcontents_orderedlist_type: 'true'.
+
+[NOTE]
+The `tableofcontents_orderedlist_type: 'true' option must be present in the same {productname} configuration, to support the secondary option `tableofcontents_orderedlist_type` , which takes one of five `string` values currently to modify the specific type for the ordered list.
+
+.Basic configuration setup for `tableofcontents_orderedlist`
+[source, js]
+----
+tinymce.init({
+    selector: "textarea",
+    plugins: [
+        "tableofcontents", "code",
+    ],
+    toolbar: "tableofcontents",
+    tableofcontents_orderedlist: true, // option required to configure tableofcontents_orderedlist_type
 	tableofcontents_orderedlist_type: 'I', // optional values are '1', 'A', 'a', 'I', 'i'
 });
 ----
+
+For information on the **Table of Contents** plugin, see: xref:tableofcontents.adoc[Table of Contents].
+
+==== Added new option tableofcontents_orderedlist_type to set a specific type of ordered list, defaulting to a numeric ordered list.
+// TINY-9969
+{productname} 6.7, introduced a new option in **Table of Contents 1.2.0**.
+
+This new option allows the user to change the visual appearance for the ordered list within the Table of Contents.
+
+.Basic configuration setup for `tableofcontents_orderedlist_type: 'I'`
+[source, js]
+----
+tinymce.init({
+    selector: "textarea",
+    plugins: [
+        "tableofcontents", "code",
+    ],
+    toolbar: "tableofcontents",
+    tableofcontents_orderedlist: true, // option required to configure tableofcontents_orderedlist_type
+	tableofcontents_orderedlist_type: 'I', // optional values are '1', 'A', 'a', 'I', 'i'
+});
+----
+
+[IMPORTANT]
+`tableofcontents_orderedlist_type` is dependant on `tableofcontents_orderedlist: true` to be within the same {productname} editor configuration in order to modify the visual appearance for the ordered list.
 
 Optional values to change the type attribute for the ordered list `<ol>`as per the below standards referenced from https://www.w3schools.com/html/html_lists_ordered.asp#:~:text=Ordered%20HTML%20List%20%2D%20The%20Type%20Attribute[Ordered_HTML_List-The_Type_Attribute]
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -189,10 +189,34 @@ The {productname} 6.7.0 release includes an accompanying release of the **Table 
 ==== Added new boolean option tableofcontents_orderedlist to use ordered lists instead of unordered lists in the table of contents.
 // TINY-9968
 
-
 ==== Added new option tableofcontents_orderedlist_type to set a specific type of ordered list, defaulting to a numeric ordered list.
 // TINY-9969
+{productname} 6.7, introduced a new option in **Table of Contents 1.2.0**.
 
+This new option allows the user to change the visual appearance for the ordered list within the Table of Contents.
+
+.Example
+[source, js]
+----
+tinymce.init({
+    selector: "textarea",
+    plugins: [
+        "tableofcontents", "code",
+    ],
+    toolbar: "tableofcontents",
+	tableofcontents_orderedlist_type: 'I', // optional values are '1', 'A', 'a', 'I', 'i'
+});
+----
+
+Optional values to change the type attribute for the ordered list `<ol>`as per the below standards referenced from https://www.w3schools.com/html/html_lists_ordered.asp#:~:text=Ordered%20HTML%20List%20%2D%20The%20Type%20Attribute[Ordered_HTML_List-The_Type_Attribute]
+
+* **1**: The list items will be numbered with numbers (default).
+* **A**: The list items will be numbered with uppercase letters.
+* **a**: The list items will be numbered with lowercase letters.
+* **I**: The list items will be numbered with uppercase roman numbers.
+* **i**: The list items will be numbered with lowercase roman numbers.
+
+For information on the **Table of Contents** plugin, see: xref:tableofcontents.adoc[Table of Contents].
 
 ==== ToC toolbar button and menu item are now disabled when the selection is not editable
 // TINY-9890

--- a/modules/ROOT/pages/tableofcontents.adoc
+++ b/modules/ROOT/pages/tableofcontents.adoc
@@ -31,7 +31,7 @@ tinymce.init({
 
 The _Table of Contents_ will have a simple HTML structure - a wrapper `+div+` element, a header with _editable_ title and unordered nested list with navigation links. Nesting depth is customizable.
 
-Internally plugin doesn't apply any inline styles. Basic formatting can be added via xref:editor-content-css.adoc[Boilerplate Content CSS], that can be customized to your needs.
+Internally plugin does not apply inline styles. Basic formatting can be added via xref:editor-content-css.adoc[Boilerplate Content CSS], that can be customized to your needs.
 
 [source,css]
 ----
@@ -45,6 +45,12 @@ include::partial$configuration/tableofcontents_depth.adoc[leveloffset=+1]
 include::partial$configuration/tableofcontents_header.adoc[leveloffset=+1]
 
 include::partial$configuration/tableofcontents_class.adoc[leveloffset=+1]
+
+include::partial$configuration/tableofcontents_includeheader.adoc[leveloffset=+1]
+
+include::partial$configuration/tableofcontents_orderedlist.adoc[leveloffset=+1]
+
+include::partial$configuration/tableofcontents_orderedlist_type.adoc[leveloffset=+1]
 
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 

--- a/modules/ROOT/partials/configuration/tableofcontents_header.adoc
+++ b/modules/ROOT/partials/configuration/tableofcontents_header.adoc
@@ -12,7 +12,7 @@ Table of contents has a header and by default it will be marked up with `+H2+` t
 [source,js]
 ----
 tinymce.init({
-  selector: 'textarea',
+  selector: 'textarea', // change this value according to your HTML
   plugins: 'tableofcontents',
   toolbar: 'tableofcontents',
   tableofcontents_header: 'div' // case doesn't matter

--- a/modules/ROOT/partials/configuration/tableofcontents_includeheader.adoc
+++ b/modules/ROOT/partials/configuration/tableofcontents_includeheader.adoc
@@ -1,0 +1,23 @@
+[[tableofcontents_includeheader]]
+== `+tableofcontents_includeheader+`
+
+By default, Tables of Contents include a header string, *Table of Contents*.
+
+The `+tableofcontents_includeheader+` option allows this header to be turned off.
+
+*Type:* `+Boolean+`
+
+*Default value:* `+'true'+`
+
+*Possible values:* `+'true'+`, `+'false'+`
+
+=== Example: using `tableofcontents_includeheader` to turn the Table of Contents header string off
+[source, js]
+----
+tinymce.init({
+  selector: "textarea", // change this value according to your HTML
+  plugins: "tableofcontents",
+  toolbar: "tableofcontents",
+	tableofcontents_includeheader: false,
+});
+----

--- a/modules/ROOT/partials/configuration/tableofcontents_orderedlist.adoc
+++ b/modules/ROOT/partials/configuration/tableofcontents_orderedlist.adoc
@@ -1,0 +1,35 @@
+[[tableofcontents_orderedlist]]
+== `+tableofcontents_orderedlist+`
+
+By default, Tables of Contents are rendered as unordered lists.
+
+The `+tableofcontents_orderedlist+` option allows Tables of Contents to be rendered as an ordered list.
+
+When the `+tableofcontents_orderedlist+` option is set to `+true+`, Tables of Contents are rendered as numeric ordered lists.
+
+To customise the type of ordered list, add the `+xref:tableofcontents_orderedlist_type[tableofcontents_orderedlist_type]+` option to the configuration.
+
+*Type:* `+Boolean+`
+
+*Default value:* `+'false'+`
+
+*Possible values:* `+'true'+`, `+'false'+`
+
+=== Example: using `+tableofcontents_orderedlist+` to switch from an unordered to an ordered list
+
+[source, js]
+----
+tinymce.init({
+  selector: "textarea", // change this value according to your HTML
+  plugins: "tableofcontents",
+  toolbar: "tableofcontents",
+  tableofcontents_orderedlist: true,
+});
+----
+
+[NOTE]
+====
+If the `tableofcontents_orderedlist: true` option is set and no `tableofcontents_orderedlist_type` option is set, the **Table of Contents** plugin defaults to using a numeric ordered list.
+
+This is equivalent to setting `tableofcontents_orderedlist_type: '1'`.
+====

--- a/modules/ROOT/partials/configuration/tableofcontents_orderedlist_type.adoc
+++ b/modules/ROOT/partials/configuration/tableofcontents_orderedlist_type.adoc
@@ -1,0 +1,57 @@
+[[tableofcontents_orderedlist_type]]
+== `+tableofcontents_orderedlist_type+`
+
+By default, Tables of Contents are rendered as unordered lists.
+
+Setting the option `+tableofcontents_orderedlist: true+`, switches this to a numeric ordered list.
+
+And setting the `+tableofcontents_orderedlist_type+` to one of its available values switches the rendered Table of Contents to the specified https://html.spec.whatwg.org/dev/grouping-content.html#the-ol-element[ordered list type].
+
+
+
+*Type:* `+String+`
+
+*Possible values:* `+'1'+`, `+'A'+`, `+'a'+`, `+'I'+`, `+'i'+`
+
+*Default value:* `+'1'+`
+
+The possible values set the type attribute of the ordered list, `<ol>` as follows:
+
+[cols="10%,90%"]
+|===
+|Value | Ordered list type
+
+|`+'1'+`
+|A list sorted by Arabic/Hindu numerals.
+
+This is the default.
+
+|`+'A'+`
+|A list sorted alphabetically by capital letter.
+
+|`+'a'+`
+|A list sorted alphabetically by lowercase letter.
+
+|`+'I'+`
+|A list sorted by uppercase Roman numerals.
+
+|`+'i'+`
+|A list sorted by lowercase Roman numerals.
+|===
+
+=== Example: using `tableofcontents_orderedlist` to render a Table of Contents as uppercase Roman numerals
+[source, js]
+----
+tinymce.init({
+  selector: "textarea", // change this value according to your HTML
+  plugins: "tableofcontents",
+  toolbar: "tableofcontents",
+  tableofcontents_orderedlist: true, // required to enable tableofcontents_orderedlist_type configuration.
+	tableofcontents_orderedlist_type: 'I',
+});
+----
+
+[IMPORTANT]
+====
+The `tableofcontents_orderedlist: true` option must be present in a {productname} configuration for whatever `tableofcontents_orderedlist_type` setting to come into effect.
+====


### PR DESCRIPTION
Ticket: DOC-2171: new options for TINY-9970, TINY-9968 and TINY-9969 in the 6.7 Release Notes.

Changes:
* added new option documentation for `Added new option tableofcontents_orderedlist_type to set a specific type of ordered list, defaulting to a numeric ordered list.`
* added new option documenation for `Added new boolean option tableofcontents_orderedlist to use ordered lists instead of unordered lists in the table of contents.`
* added new improvement documentation for `Added new boolean option tableofcontents_includeheader to control whether a header is included in the table of contents. Defaults to true.`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] Files has been included where required (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
