### PR TITLE
DOC-2171: fix documentation for (2) TINY-9463 entries and TINY-10062 in the 6.7 Release Notes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: fix documentation for (2) TINY-9463 entries and TINY-10062 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -161,20 +161,39 @@ The {productname} 6.7.0 release includes an accompanying release of the **PowerP
 
 The {productname} 6.7.0 release includes an accompanying release of the **Spell Checker Pro** premium plugin.
 
-**Spell Checker Pro** 3.3.3 includes the following bug-fixes:
+**Spell Checker Pro** 3.3.1 includes the following bug-fixes:
 
 ==== Switching to readonly mode would not hide spelling mistakes.
 // TINY-9463
+In previous versions of **Spell Checker Pro**, an issue was identified when switching to readonly mode within a {productname} document.
 
+As a consequence of this, the plugin failed to hide spelling mistakes as expected, even when users toggle to **readonly** mode, the presence of spelling errors remained visible.
+
+**Spell Checker Pro** 3.3.1 addresses this issue, users can expect that when switching between these modes, the visibility of spelling mistakes will correctly align with their chosen editing state.
+
+For information on the **Spell Checker Pro plugin** plugin, see: xref:introduction-to-tiny-spellchecker.adoc[Spell Checker Pro plugin].
 
 ==== Switching the editable root state to false would not hide spelling mistakes in non-editable content.
 // TINY-9463
+In previous versions of **Spell Checker Pro**, an issue was identified that affected the spellchecker's behavior when the users cursor or content selection was within a `non-editable` block element.
 
+As a consequence of the bug, the **Spell Checker Pro** would check for spelling mistakes within `non-editable` element. As a result, the spellchecker would incorrectly highlight these errors.
+
+**Spell Checker Pro** 3.3.1 addresses this issue, as it now checks if the users content selection or cursor position is an `editable` block element before proceeding to highlight any potential spelling mistakes. As of {productname} 6.7, spelling mistakes will no longer be highlighted within `non-editable` block element, even in cases when the {productname} editor's mode is set to either **readonly** or as a `non-editable` root.
+
+For information on the **Spell Checker Pro plugin** plugin, see: xref:introduction-to-tiny-spellchecker.adoc[Spell Checker Pro plugin].
 
 ==== Text content with Unicode characters was causing the spellchecker to modify and duplicate the text.
 // TINY-10062
+In previous versions of **Spell Checker Pro**, an issue was identified that, arose when the spellchecker attempted to annotate invalid characters within Dutch language text. During this process, text containing Unicode characters led to the generation of duplicated indices.
 
+As a consequence, this duplication had adverse consequences, primarily affecting the search functionality. When attempting to regenerate the text element using these indices, it resulted in unintended alterations and duplications within the text itself.
 
+**Spell Checker Pro** 3.3.1 addresses this issue, by removing and filtering out the duplicated indices during the annotation of invalid characters.
+
+As a result, pasting text content with Unicode characters no longer triggers the alteration and duplication of the text.
+
+For information on the **Spell Checker Pro plugin** plugin, see: xref:introduction-to-tiny-spellchecker.adoc[Spell Checker Pro plugin].
 
 === Table of Contents 1.2.0
 


### PR DESCRIPTION
Ticket: DOC-2171: fix documentation for (2) TINY-9463 entries and TINY-10062 in the 6.7 Release Notes.

Changes:
* added bugfix documentation for the below:
* `Switching to readonly mode would not hide spelling mistakes.
* `Switching the editable root state to false would not hide spelling mistakes in non-editable content.`
* Text content with Unicode characters was causing the spellchecker to modify and duplicate the text.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [ ] Documentation Team Lead has reviewed
