### PR TITLE
DOC-2171: fix documentation entry for TINY-9860 in the 6.7 Release Notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: fix documentation entry for TINY-9860 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes.
 - DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -377,12 +377,17 @@ pressing Backspace deleted the entire `<details>` element rather than just the c
 
 {productname} 6.7 addresses this. With this release, the Backspace key functions as expected when Safari is the host browser: it deletes only the character immediately before when the insertion point is inside a `<summary>` element, as expected.
 
-=== Removed attribute from being added to `<br>` in empty table cells #TINY-9860.
+=== Removed attribute from being added to `<br>` in empty table cells
 // TINY-9860
-When a table was inserted to the last cell containing a bookmark `span`, moving the selection to the bookmark span would result in its deletion, and an empty table cell is filled with a new <br> tag.
 
-As a consequence during serialization, the `<br>` tag was converted into a character due to a particular line of code in the parsing step.
+By default, {productname} removes `+<br>+` tags at the end of block elements.
 
-{productname} 6.7 addresses this by, preserving of the <br> tag in the last cell of a table.
+Setting the `+xref:content-filtering.adoc#remove_trailing_brs[remove_trailing_brs]+` option to `+false+` turns this default behaviour off.
 
-As a result of this fix, when 'remove_trailing_brs' is set to 'false', all cells in a newly inserted table, including the last cell, will consistently maintain the <br> tag.
+Previously, however, when `+remove_trailing_brs: false+` was set, and a table was added to a {productname} document, the last cell of the newly-created table did not contain a `+<br+` tag, as expected.
+
+During serialization, this last tag was converted into a character by code in the parsing logic.
+
+In {productname} 6.7, the parsing code has been altered and the character conversion during serialization no longer occurs.
+
+As a consequence, when `+remove_trailing_brs: false+` is set and tables are added to a {productname} document, all newly-created and otherwise empty cells contain a `+<br>+` tag, as is expected in this circumstance.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -386,7 +386,7 @@ Setting the `+xref:content-filtering.adoc#remove_trailing_brs[remove_trailing_br
 
 Previously, however, when `+remove_trailing_brs: false+` was set, and a table was added to a {productname} document, the last cell of the newly-created table did not contain a `+<br+` tag, as expected.
 
-During serialization, this last tag was converted into a character by code in the parsing logic.
+During serialization, this last tag was instead converted into a whitespace character.
 
 In {productname} 6.7, this character conversion during serialization no longer occurs in table cells.
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -376,3 +376,13 @@ Previously, when Safari was the host browser, and
 pressing Backspace deleted the entire `<details>` element rather than just the character immediately before the insertion point.
 
 {productname} 6.7 addresses this. With this release, the Backspace key functions as expected when Safari is the host browser: it deletes only the character immediately before when the insertion point is inside a `<summary>` element, as expected.
+
+=== Removed attribute from being added to `<br>` in empty table cells #TINY-9860.
+// TINY-9860
+When a table was inserted to the last cell containing a bookmark `span`, moving the selection to the bookmark span would result in its deletion, and an empty table cell is filled with a new <br> tag.
+
+As a consequence during serialization, the `<br>` tag was converted into a character due to a particular line of code in the parsing step.
+
+{productname} 6.7 addresses this by, preserving of the <br> tag in the last cell of a table.
+
+As a result of this fix, when 'remove_trailing_brs' is set to 'false', all cells in a newly inserted table, including the last cell, will consistently maintain the <br> tag.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -388,6 +388,6 @@ Previously, however, when `+remove_trailing_brs: false+` was set, and a table wa
 
 During serialization, this last tag was converted into a character by code in the parsing logic.
 
-In {productname} 6.7, the parsing code has been altered and the character conversion during serialization no longer occurs.
+In {productname} 6.7, this character conversion during serialization no longer occurs in table cells.
 
 As a consequence, when `+remove_trailing_brs: false+` is set and tables are added to a {productname} document, all newly-created and otherwise empty cells contain a `+<br>+` tag, as is expected in this circumstance.


### PR DESCRIPTION
Ticket: DOC-2171: fix documentation entry for TINY-9860 in the 6.7 Release Notes

Changes:
* added fix documentation for `Removed attribute from being added to `<br>` in empty table cells`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
