### PR TITLE
DOC-2171: improvement documentation for TINY-10003 and TINY-10165 in the 6.7 Release Notes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: improvement documentation for TINY-10003 and TINY-10165 in the 6.7 Release Notes. 
 - DOC-2171: new options for TOC for TINY-9970, TINY-9968 and TINY-9969 in the 6.7 Release Notes.
 - DOC-2171: change documentation entry for TINY-9764 in the 6.7 Release Notes.
 - DOC-2171: improvement documentation entry for TINY-10115 in the 6.7 Release Notes.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -55,7 +55,7 @@ In previous versions of {productname}, the toolbar implemented for mobile lacked
 
 Consequently, when switching from the **Advanced Code** view back to the editor, {productname} triggered an unintended refresh operation, leading to a TypeError to display within the console.
 
-**Advanced Code** 3.3.1 addresses this issue, by integrating the refresh API into the mobile toolbar.
+**Advanced Code** 3.3.1 addresses this issue, by integrating an empty refresh API into the mobile toolbar.
 
 With this fix, the refresh API is now invoked, and the console no longer throws the TypeError when transitioning from the **Advanced Code** view back to editor mode on Android tablets.
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -47,7 +47,17 @@ When this alert presents, if the currently set language is one of the xref:bundl
 
 The {productname} 6.7.0 release includes an accompanying release of the **Advanced Code** premium plugin.
 
-**Advanced Code** 3.3.1 includes the following bug fix:
+**Advanced Code** 3.3.1 includes the following improvement and bugfix:
+
+==== Going back from a view to the editor in mobile caused an error.
+// TINY-10003
+In previous versions of {productname}, the toolbar implemented for mobile lacked the essential refresh API.
+
+Consequently, when switching from the **Advanced Code** view back to the editor, {productname} triggered an unintended refresh operation, leading to a TypeError to display within the console.
+
+**Advanced Code** 3.3.1 addresses this issue, by integrating the refresh API into the mobile toolbar.
+
+With this fix, the refresh API is now invoked, and the console no longer throws the TypeError when transitioning from the **Advanced Code** view back to editor mode on Android tablets.
 
 ==== Editing the data before switching theme would mean a loss of edited data
 // TINY-10046
@@ -59,7 +69,6 @@ This resulted in the loss of any entered data.
 In **Advanced Code** 3.3.1, switching between themes now sets the data state to the current state before the theme switch is made.
 
 This ensures any data entered before switching themes is kept.
-
 
 
 === Advanced Templates 1.3.0


### PR DESCRIPTION
Ticket: DOC-2171: improvement documentation for TINY-10003 and TINY-10165 in the 6.7 Release Notes.

Changes:
* added improvement documentation for `Going back from a view to the editor in mobile caused an error.` and `Going back from a view to the editor in mobile visualization on browser caused an error.` for TINY-10165.
* `merged` the two tickets under the same heading.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
