### PR TITLE
DOC-2171: bug fix entry for TINY-9894 in `6.7-release-notes.adoc`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: Entry for TINY-9894, *Tiny Drive toolbar button and menu item are now disabled when the selection is not editable*, added to Tiny Drive section of `6.7-release-notes.adoc`.
 - DOC-2171: fix documentation entry for TINY-9842 in the 6.7 Release Notes.
 - DOC-2171: addition documentation entry for TINY-9379 in the 6.7 Release Notes.
 - DOC-2171: fix documentation for (2) TINY-9463 entries and TINY-10062 in the 6.7 Release Notes.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -355,7 +355,7 @@ Previously, the Table of Contents toolbar button and menu item were not disabled
 
 Clicking the enabled button, or choosing the enabled menu item did not generate a Table of Contents. The commands were disabled, as expected. The UI objects did not, however, present as disabled.
 
-**Table of Contents 1.2.0** addresses this. If the selection includes or is within a read-only section, or if the insertion point is within a read-only section, the Table of Contents UI objects now, correctly, present as disabled.
+**Table of Contents** 1.2.0 addresses this. If the selection includes or is within a read-only section, or if the insertion point is within a read-only section, the Table of Contents UI objects now, correctly, present as disabled.
 
 
 ==== Empty headers would be included in table of content
@@ -389,7 +389,17 @@ For information on the **Table of Contents** plugin, see: xref:tableofcontents.a
 
 The {productname} 6.7.0 release includes an accompanying release of the **Tiny Drive** premium plugin.
 
-**Tiny Drive** 2.0.3 includes the following
+**Tiny Drive** 2.0.3 includes the following fix:
+
+=== Tiny Drive toolbar button and menu item are now disabled when the selection is not editable
+// TINY-9894
+
+Previously, the **Tiny Drive** plugin’s `insertfile` toolbar button and menu item were not disabled when the insertion point was within a read-only (ie, non-editable) section or when the selection was within a read-only section or included a read-only portion.
+
+**Tiny Drive** 2.0.3 addresses this. If the selection includes or is within a read-only section, or if the insertion point is within a read-only section, the Tiny Drive UI objects now, correctly, present as disabled.
+
+For information on the **Tiny Drive** plugin, see: xref:tinydrive-introduction.adoc[Tiny Drive Introduction].
+
 
 
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -396,7 +396,7 @@ The {productname} 6.7.0 release includes an accompanying release of the **Tiny D
 
 Previously, the **Tiny Drive** plugin’s `insertfile` toolbar button and menu item were not disabled when the insertion point was within a read-only (ie, non-editable) section or when the selection was within a read-only section or included a read-only portion.
 
-**Tiny Drive** 2.0.3 addresses this. If the selection includes or is within a read-only section, or if the insertion point is within a read-only section, the Tiny Drive UI objects now, correctly, present as disabled.
+**Tiny Drive** 2.0.3 addresses this. If the selection includes or is within a read-only section, or if the insertion point is within a read-only section, the Tiny Drive UI components now, correctly, present as disabled.
 
 For information on the **Tiny Drive** plugin, see: xref:tinydrive-introduction.adoc[Tiny Drive Introduction].
 


### PR DESCRIPTION
DOC-2171, bug fix entry for TINY-9894 in `6.7-release-notes.adoc`.

Changes:
* Entry for TINY-9894, Tiny Drive toolbar button and menu item are now disabled when the selection is not editable, added to Tiny Drive section of `6.7-release-notes.adoc`.
* Also a typo correction.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
