### PR TITLE
DOC-2171: bug fix entry for TINY-9889 in `6.7-release-notes.adoc`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: added entry for TINY-9889, *The Page Embed toolbar button and menu item are now disabled when the selection is not editable* to the Page Embed section of `6.7-release-notes.adoc`.
 - DOC-2171: fix documentation entry for TINY-9842 in the 6.7 Release Notes.
 - DOC-2171: addition documentation entry for TINY-9379 in the 6.7 Release Notes.
 - DOC-2171: fix documentation for (2) TINY-9463 entries and TINY-10062 in the 6.7 Release Notes.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -218,9 +218,14 @@ The {productname} 6.7.0 release includes an accompanying release of the **Page E
 
 **Page Embed** 2.2.1 includes the following bug-fix:
 
-==== The pageembed toolbar button and menu item was still enabled when the selection was non-editable
+==== The Page Embed toolbar button and menu item are now disabled when the selection is not editable
 // TINY-9889
 
+Previously, the **Page Embed** plugin’s toolbar button and menu item were not disabled when the insertion point was within a read-only (ie, non-editable) section or when the selection was within a read-only section or included a read-only portion.
+
+**Page Embed** 2.2.1 addresses this. If the selection includes or is within a read-only section, or if the insertion point is within a read-only section, the Page Embed UI objects now, correctly, present as disabled.
+
+For information on the **Page Embed** plugin, see: xref:pageembed.adoc[Page Embed].
 
 
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -223,7 +223,7 @@ The {productname} 6.7.0 release includes an accompanying release of the **Page E
 
 Previously, the **Page Embed** plugin’s toolbar button and menu item were not disabled when the insertion point was within a read-only (ie, non-editable) section or when the selection was within a read-only section or included a read-only portion.
 
-**Page Embed** 2.2.1 addresses this. If the selection includes or is within a read-only section, or if the insertion point is within a read-only section, the Page Embed UI objects now, correctly, present as disabled.
+**Page Embed** 2.2.1 addresses this. If the selection includes or is within a read-only section, or if the insertion point is within a read-only section, the Page Embed UI components now, correctly, present as disabled.
 
 For information on the **Page Embed** plugin, see: xref:pageembed.adoc[Page Embed].
 


### PR DESCRIPTION
[DOC-2171](https://ephocks.atlassian.net/browse/DOC-2171), bug fix entry for [TINY-9889](https://ephocks.atlassian.net/browse/TINY-9889) in `6.7-release-notes.adoc`.

Changes:

* Entry for [TINY-9889](https://ephocks.atlassian.net/browse/TINY-9889), *Page Embed toolbar button and menu item are now disabled when the selection is not editable*, added to Page Embed section of 6.7-release-notes.adoc.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed


[DOC-2171]: https://ephocks.atlassian.net/browse/DOC-2171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TINY-9889]: https://ephocks.atlassian.net/browse/TINY-9889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TINY-9889]: https://ephocks.atlassian.net/browse/TINY-9889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ