### PR TITLE
DOC-2171 bug fix entries for TINY-9891 in `6.7-release-notes.adoc`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: Entry for TINY-9891, *The Footnotes toolbar button and menu item are now disabled when the selection is not editable*, and TINY-9891, *Calling the `mceInsertFootnote` command now does nothing when the selection is non-editable*, added to Footnotes section of `6.7-release-notes.adoc`.
 - DOC-2171: Entry for TINY-9894, *Tiny Drive toolbar button and menu item are now disabled when the selection is not editable*, added to Tiny Drive section of `6.7-release-notes.adoc`.
 - DOC-2171: fix documentation entry for TINY-9842 in the 6.7 Release Notes.
 - DOC-2171: addition documentation entry for TINY-9379 in the 6.7 Release Notes.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -203,12 +203,22 @@ The {productname} 6.7.0 release includes an accompanying release of the **Footno
 
 **Footnotes** 1.0.1 includes the following bug-fixes:
 
-==== The footnotes toolbar button and menu item is now disabled when the selection is non-editable
+==== The Footnotes toolbar button and menu item are now disabled when the selection is not editable
 //TINY-9891
 
+Previously, the **Footnotes** plugin’s toolbar button and menu item were not disabled when the insertion point was within a read-only (ie, non-editable) section or when the selection was within a read-only section or included a read-only portion.
 
-==== Calling the mceInsertFootnote command does nothing when the selection is non-editable
+**Footnotes** 1.0.1 addresses this. If the selection includes or is within a read-only section, or if the insertion point is within a read-only section, the Footnote UI components now, correctly, present as disabled.
+
+
+==== Calling the `mceInsertFootnote` command now does nothing when the selection is non-editable
 // TINY-9891
+
+Previously, the `mceInsertFootnote` command attempted to set a footnote when the insertion point was within a read-only (ie, non-editable) section or when the selection was within a read-only section or included a read-only portion.
+
+**Footnotes** 1.0.1 addresses this. If the selection includes or is within a read-only section, or if the insertion point is within a read-only section, the `mceInsertFootnote` command, correctly, does nothing.
+
+For information on the **Footnotes** plugin, see: xref:footnotes.adoc[Footnotes].
 
 
 


### PR DESCRIPTION
DOC-2171 bug fix entries for TINY-9891 in `6.7-release-notes.adoc`

Changes:
* Entry for TINY-9891, *The Footnotes toolbar button and menu item are now disabled when the selection is not editable*
* Entry for TINY-9891, *Calling the `mceInsertFootnote` command now does nothing when the selection is non-editable*
* both added to `6.7-release-notes.adoc`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
