### PR TITLE
DOC-2171: bug fix documentation entry for TINY-9776 in `6.7-release-notes.adoc`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2171: Entry for TINY-9776, *PowerPaste prevented uploaded images from using their original file-name*, added to PowerPaste section of `6.7-release-notes.adoc`.
 - DOC-2171: Entry for TINY-9891, *The Footnotes toolbar button and menu item are now disabled when the selection is not editable*, and TINY-9891, *Calling the `mceInsertFootnote` command now does nothing when the selection is non-editable*, added to Footnotes section of `6.7-release-notes.adoc`.
 - DOC-2171: added entry for TINY-9889, *The Page Embed toolbar button and menu item are now disabled when the selection is not editable* to the Page Embed section of `6.7-release-notes.adoc`.
 - DOC-2171: Entry for TINY-9894, *Tiny Drive toolbar button and menu item are now disabled when the selection is not editable*, added to Tiny Drive section of `6.7-release-notes.adoc`.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -258,6 +258,17 @@ Previously, when **PowerPaste** was running with older versions of Safari as the
 
 This error condition no longer presents and, for this release, the error catching logic, associated error message, and error message translations, have all been removed.
 
+==== PowerPaste prevented uploaded images from using their original file-name
+// TINY-9776
+
+Previously **PowerPaste** used an internal image management mechanism.
+
+This mechanism ignored `images_reuse_filename`, which prevented uploaded images from keeping and using their original filenames.
+
+With **PowerPaste** 6.2.1, the plugin has been switched to use core {productname} image management logic, which takes proper note of `images_reuse_filename`.
+
+Image filenames are now managed correctly, and as expected, when images are uploaded.
+
 For information on the **PowerPaste** plugin, see: xref:introduction-to-powerpaste.adoc[PowerPaste].
 
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -267,7 +267,7 @@ This mechanism ignored `images_reuse_filename`, which is used to retain original
 
 With **PowerPaste** 6.2.2, the plugin has been switched to use core {productname} image management logic, which takes proper note of `images_reuse_filename`.
 
-Image filenames are now managed correctly, and as expected, when images are uploaded.
+Image filenames are now managed correctly, and as expected, when they are uploaded.
 
 For information on the **PowerPaste** plugin, see: xref:introduction-to-powerpaste.adoc[PowerPaste].
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -263,7 +263,7 @@ This error condition no longer presents and, for this release, the error catchin
 
 Previously **PowerPaste** used an internal image management mechanism.
 
-This mechanism ignored `images_reuse_filename`, which prevented uploaded images from keeping and using their original filenames.
+This mechanism ignored `images_reuse_filename`, which is used to retain original image filenames when they are uploaded.
 
 With **PowerPaste** 6.2.2, the plugin has been switched to use core {productname} image management logic, which takes proper note of `images_reuse_filename`.
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -265,7 +265,7 @@ Previously **PowerPaste** used an internal image management mechanism.
 
 This mechanism ignored `images_reuse_filename`, which prevented uploaded images from keeping and using their original filenames.
 
-With **PowerPaste** 6.2.1, the plugin has been switched to use core {productname} image management logic, which takes proper note of `images_reuse_filename`.
+With **PowerPaste** 6.2.2, the plugin has been switched to use core {productname} image management logic, which takes proper note of `images_reuse_filename`.
 
 Image filenames are now managed correctly, and as expected, when images are uploaded.
 


### PR DESCRIPTION
DOC-2171: bug fix documentation entry for TINY-9776 in `6.7-release-notes.adoc`.

Changes:
* Entry for TINY-9776, *PowerPaste prevented uploaded images from using their original file-name*, added to PowerPaste section of `6.7-release-notes.adoc`.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
