### PR TITLE
DOC-2042: TinyMCE 6.7 Enterprise docs release

### DIFF
--- a/-new-material-templates/plugin-documentation-templates/ROOT/pages/pluginpage.adoc
+++ b/-new-material-templates/plugin-documentation-templates/ROOT/pages/pluginpage.adoc
@@ -28,7 +28,13 @@ liveDemo::{plugincode}[]
 
 // Logic for customising what presents from this included file relies on
 // the :pluginminimumplan: attribute value above.
-include::partial$misc/purchase-premium-plugins.adoc[]
+//
+// 2023-09-06 addendum: the logic in purchase-premium-plugins.adoc needs
+// updating to match the available commercial plans.
+// 
+// Do not include this statement in new documentation until
+// this logic has been updated.
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Basic setup
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @tinymce/documentation-team @tinymce/editor-platform-team @HAFRMO
+* @tinymce/documentation-team
 
 # Integration docs
 /integrations/ @tinymce/documentation-team @tinymce/editor-platform-team @tinymce/integrations-team

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2176: Removed references to which commercial plans Premium plugins are or are not available with.
 - DOC-2175: Update CODEOWNERS automatic reviewers upon opening new DOC-PRs.
 - DOC-2173: updated the default value code sample in `ai_shortcuts.adoc` to match the updated values included in the AI Assistant. Also re-wrote the **Note** admonition to call-out the absence of any translations or alternative language versions of these default values.
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2027: added `/modules/ROOT/partials/configuration/help_accessibility.adoc`, documenting the `help_accessibility` option; edits, re-writes and re-structuring of `help.adoc`; plus copy-edits to `keyboard-shortcuts.adoc`, `tinymce-and-screenreaders.adoc` & `accessibility.adoc`.
 - DOC-2176: Removed references to which commercial plans Premium plugins are or are not available with.
 - DOC-2175: Update CODEOWNERS automatic reviewers upon opening new DOC-PRs.
 - DOC-2173: updated the default value code sample in `ai_shortcuts.adoc` to match the updated values included in the AI Assistant. Also re-wrote the **Note** admonition to call-out the absence of any translations or alternative language versions of these default values.

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,53 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 - DOC-2167: edited toolbar configurations in both the open-source–only and Premium-plugins–included full-featured demos; also added the Accordion plugin and toolbar items to the open-source–only full-featured demo.
 
+### Unreleased
+
+- DOC-2171: fix documentation entry for TINY-9860 in the 6.7 Release Notes.
+- DOC-2171: Entry for TINY-9776, *PowerPaste prevented uploaded images from using their original file-name*, added to PowerPaste section of `6.7-release-notes.adoc`.
+- DOC-2171: Entry for TINY-9891, *The Footnotes toolbar button and menu item are now disabled when the selection is not editable*, and TINY-9891, *Calling the `mceInsertFootnote` command now does nothing when the selection is non-editable*, added to Footnotes section of `6.7-release-notes.adoc`.
+- DOC-2171: added entry for TINY-9889, *The Page Embed toolbar button and menu item are now disabled when the selection is not editable* to the Page Embed section of `6.7-release-notes.adoc`.
+- DOC-2171: Entry for TINY-9894, *Tiny Drive toolbar button and menu item are now disabled when the selection is not editable*, added to Tiny Drive section of `6.7-release-notes.adoc`.
+- DOC-2171: fix documentation entry for TINY-9842 in the 6.7 Release Notes.
+- DOC-2171: addition documentation entry for TINY-9379 in the 6.7 Release Notes.
+- DOC-2171: fix documentation for (2) TINY-9463 entries and TINY-10062 in the 6.7 Release Notes.
+- DOC-2171: added entry for TINY-10060, *Automatic media embed would not work as expected if the link was pasted into a `<div>` element*, to Enhanced Media Embed section of `6.7-release-notes.adoc`.
+- DOC-2171: added entry for TINY-9943, *new UI string translations*, to AI Assistant section of `6.7-release-notes.adoc`; added entry for TINY-10104, *the generate button is now disabled when input field is empty, rather than displaying an alert*, to AI Assistant section of `6.7-release-notes.adoc`; added entry for TINY-10099, *the default prompts in the `ai_shortcuts` option have been improved for better results*, to AI Assistant section of `6.7-release-notes.adoc`; added entry for TINY-10114, *the dialog sometimes unblocked and showed the preview component too early when a response is streamed*, to AI Assistant section of `6.7-release-notes.adoc`.
+- DOC-2171: improvement documentation entry for TINY-9863 in the 6.7 Release Notes.
+- DOC-2171: improvement documentation entry for TINY-9978 in the Release Notes.
+- DOC-2171: fix documentation entry for TINY-9872 in the 6.7 Release Notes.
+- DOC-2171: fix documentation entry for TINY-10017 in the 6.7 Release Notes.
+- DOC-2171: improvement documentation for TINY-10003 and TINY-10165 in the 6.7 Release Notes. 
+- DOC-2171: improvement documentation for TINY-10140 in the 6.7 Release Notes.
+- DOC-2171: fix documentation (3) entries for TINY-9960 in the 6.7 Release Notes. 
+- DOC-2171: change documentation entry for TINY-10008 in the 6.7 Release Notes.
+- DOC-2171: new options for TOC for TINY-9970, TINY-9968 and TINY-9969 in the 6.7 Release Notes.
+- DOC-2171: change documentation entry for TINY-9764 in the 6.7 Release Notes.
+- DOC-2171: improvement documentation entry for TINY-10115 in the 6.7 Release Notes.
+- DOC-2171: change documentation entry for TINY-9744 in the 6.7 Release Notes.
+- DOC-2171: improvement documentation entry for TINY-10124 in the 6.7 Release Notes.
+- DOC-2171: improvement documentation entry for TINY-9629 in the Release Notes.
+- DOC-2171: fix documentation entry for TINY-9975 (x2), TINY-9998 in the 6.7 Release Notes.
+- DOC-2171: fix documentation entry for TINY-10007 in the 6.7 Release Notes.
+- DOC-2171: fix documentation entry for TINY-10136 in the 6.7 Release Notes.
+- DOC-2171: Added entry for TINY-10089, *Change event did not fire upon adding a reply*, to Comments section of `6.7-release-notes.adoc`.
+- DOC-2171: added entry for TINY-9976, *New AdvTemplateInsertTemplateById command to insert the template specified by its id property value*, to Advanced Templates section of `6.7-release-notes.adoc`; added entry for TINY-9973, *New `{{mce-cursor}}` marker to indicate the cursor position after the template is inserted*, to Advanced Templates section of `6.7-release-notes.adoc`; added `AdvTemplateInsertTemplateById` command, description, and example to `advtemplate-cmds.adoc`; added files and directories required for additional live demo, `advtempalte-insertionpoint`, added sample code and configuration and explanatory text to new files; new section, *The insertion point marker*, added to `advanced-templates.adoc`; and new section, *Merge Tags and the Insertion Point Marker* added to `mergetags.adoc`.
+- DOC-2171: fix documentation entry for TINY-10129 in the 6.7 Release Notes.
+- DOC-2171: bugfix documentation entry for TINY-10053, *Translation was missing for paragraph used as heading text*, added to `6.7-release-notes.adoc`.
+- DOC-2171: fix documentation entry for TINY-9843 in the 6.7 Release Notes.
+- DOC-2171: fix documentation entry for TINY-10054 in the 6.7 Release Notes.
+- DOC-2171: fix documentation entry for TINY-9815 in the 6.7 Release Notes.
+- DOC-2171: bug-fix documentation entry for TINY-10046, _Editing the data before switching theme would mean a loss of edited data_.
+- DOC-2171: fix documentation entry for TINY-9828 in the 6.7 Release Notes.
+- DOC-2171: addition documentation entry for TINY-10022 in the 6.7 Release Notes; added entries for two new commands, InsertNewBlockBefore and InsertNewBlockAfter to `editor-command-identifiers.adoc`; and organised Miscellaneous Core command and example tables into alphabetical order.
+- DOC-2171: fix documentation entry for TINY-6888 in the Release Notes.
+- DOC-2171: fix documentation entry for TINY-9965 in the 6.7 Release Notes.
+- DOC-2171: fix documentation entry for TINY-10071 in the 6.7 Release Notes.
+- DOC-2171: fix documentation entry for TINY-10011 in the 6.7 Release Notes.
+- DOC-2171: fix documentation entry for TINY-9827 in the 6.7 Release Notes.
+- DOC-2171: fix documentation entry for TINY-10126 in the 6.7 Release Notes.
+- DOC-2171: fix documentation entry for TINY-10123 in the 6.7 Release Notes.
+
 ### 2023-08-30
 
 - DOC-2169: added 6.7-specific entries to `changelog.adoc`.

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ Changes to the TinyMCE documentation are documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### Unreleased
+
+- DOC-2173: updated the default value code sample in `ai_shortcuts.adoc` to match the updated values included in the AI Assistant. Also re-wrote the **Note** admonition to call-out the absence of any translations or alternative language versions of these default values.
+
 
 ### 2023-08-30
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2175: Update CODEOWNERS automatic reviewers upon opening new DOC-PRs.
 - DOC-2173: updated the default value code sample in `ai_shortcuts.adoc` to match the updated values included in the AI Assistant. Also re-wrote the **Note** admonition to call-out the absence of any translations or alternative language versions of these default values.
 
 

--- a/modules/ROOT/examples/live-demos/advtemplate-insertionpoint/index.html
+++ b/modules/ROOT/examples/live-demos/advtemplate-insertionpoint/index.html
@@ -1,0 +1,46 @@
+<textarea id="advanced-template-insertionpoint">
+<h3>Using the Insertion Point Marker with Advanced Templates (and Merge Tags)<h3>
+
+<h4>To insert a template</h4>
+ <ol>
+  <li>
+    Select <strong>Template…</strong> from the <strong>Insert</strong> menu or<br />
+    select the <strong>Insert template</strong> toolbar button.
+  </li>
+  <li>
+  Select the template to add to the TinyMCE document from the <strong>Templates</strong> dialog that presents.
+    <ol>
+      <li>
+      Click the <strong>Without an insertion point marker</strong> category to see and select a template that does not use the <code>{{mce-cursor}}</code> insertion point marker.
+      </li>
+      <li>
+      Click the <strong>With an insertion point marker</strong> category to see and select a template that does use the <code>{{mce-cursor}}</code> insertion point marker.
+      </li>
+    </ol>
+  </li>
+<li>click <strong>Insert</strong> or press <strong>Return</strong>.</li>
+</ol>
+
+<h4>Noting the difference</h4>
+
+<p>The <em>Name entry prompt</em> template without the <code>{{mce-cursor}}</code> insertion point marker, places the insertion point at the end of the template text.</p>
+
+<p>By contrast, the <em>Name entry prompt</em> template with the <code>{{mce-cursor}}</code> insertion point marker places the insertion point at the right spot for someone to enter their name, as requested.</p>
+
+<p>Similarly, the <em>Letter outline</em> template without the <code>{{mce-cursor}}</code> insertion point marker, places the insertion point at the end of the template text.</p>
+
+<p>And, by equivalent contrast, the <em>Letter outline</em> template with the <code>{{mce-cursor}}</code> insertion point marker places the insertion point at the right spot for someone to start writing a letter.</p>
+
+<h4>Working with Merge Tags</h4>
+
+<p>The second pre-defined template in this demonstration — the <em>Letter outline</em> template — shows the <code>{{mce-cursor}}</code> string working in conjunction with the <a href="https://tiny.cloud/docs/tinymce/6/mergetags/">Merge Tags</a> Premium plugin.</p>
+
+<p>The fixed string that is the Insertion Point Marker uses the same delimiting characters as are used by default by the Merge Tags plugin.</p>
+
+<p>The <strong>Merge Tags</strong> plugin knows nothing about the <code>{{mce-cursor}}</code> being a marker string for the <strong>Advanced Templates</strong> plugin. And, if this particular string was used in a Merge Tags configuration, the <strong>Merge Tags</strong> plugin would recognise it and substitute it with whatever contents it was set to substitute, as expected.
+
+<p>The <strong>Advanced Templates</strong> plugin removes the Insertion Point Marker before inserting a template containing the string in to a TinyMCE instance, however.</p>
+
+<p>Consequently the <strong>Advanced Templates</strong> insertion point marker string is never seen by the <strong>Merge Tags</strong> plugin.</p>
+
+</textarea>

--- a/modules/ROOT/examples/live-demos/advtemplate-insertionpoint/index.js
+++ b/modules/ROOT/examples/live-demos/advtemplate-insertionpoint/index.js
@@ -1,0 +1,81 @@
+tinymce.init({
+  selector: "textarea#advanced-template-insertionpoint",
+  plugins: [ "advtemplate", "mergetags", ],
+  toolbar: "inserttemplate | mergetags",
+  advtemplate_templates: [
+    {
+      title: 'Without an insertion point marker',
+      items: [
+        {
+          title: 'Name entry prompt',
+          content: '<p><strong>Enter your name:</strong></p><p><em>Include both your given and family names, in your preferred order.</em></p>'
+        },
+        {
+          title: 'Letter outline',
+          content: '<p>{{Current.Date}}</p><p>{{Honorific}} {{Person.Name.Last}},</p><p></p><p>&nbsp;</p><p>Regards,</p><p>{{staff.digital.signature}}</p><p>{{Staff.Name}}</p><p>{{Staff.Email}}</p>'
+        },
+      ],
+    },
+    {
+      title: 'With an insertion point marker',
+      items: [
+        {
+          title: 'Name entry prompt',
+          content: '<p><strong>Enter your name:</strong>{{mce-cursor}}</p><p><em>Include both your given and family names, in your preferred order.</em></p>'
+        },
+        {
+          title: 'Letter outline',
+          content: '<p>{{Current.Date}}</p><p>{{Honorific}} {{Person.Name.Last}},</p><p>{{mce-cursor}}&nbsp;</p><p>Regards,</p><p>{{staff.digital.signature}}</p><p>{{Staff.Name}}</p><p>{{Staff.Email}}</p>'
+        },
+      ],
+    },
+  ],
+  mergetags_list: [
+    {
+      value: 'Current.Date',
+      title: 'Current date in DD/MM/YYYY format'
+    },
+    {
+      value: 'Current.Time',
+    },
+    {
+      value: 'Honorific',
+    },
+    {
+      title: 'Person',
+      menu: [
+        {
+          value: 'Customer.Name.Given',
+          title: 'customer first name'
+        },
+        {
+          value: 'Customer.Name.Family',
+          title: 'customer family name'
+        },
+        {
+          value: 'Customer.Name.Full',
+          title: 'customer full name'
+        },
+        {
+          value: 'Staff.Name.Full',
+          title: 'staff full name'
+        },
+        {
+          value: 'Staff.Digital.Signature',
+          title: 'staff digital signaure'
+        },
+        {
+          title: 'Email',
+          menu: [
+            {
+              value: 'Customer.Email'
+            },
+            {
+              value: 'Staff.Email'
+            }
+          ]
+        }
+      ]
+    }
+  ]
+});

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -403,6 +403,14 @@
 ** xref:tinymce-and-cors.adoc[Cross-Origin Resource Sharing (CORS)]
 * Release information
 ** xref:release-notes.adoc[Release notes for TinyMCE 6]
+*** TinyMCE 6.7
+**** xref:6.7-release-notes.adoc#overview[Overview]
+**** xref:6.7-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
+**** xref:6.7-release-notes.adoc#accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]
+**** xref:6.7-release-notes.adoc#improvements[Improvements]
+**** xref:6.7-release-notes.adoc#additions[Additions]
+**** xref:6.7-release-notes.adoc#changes[Changes]
+**** xref:6.7-release-notes.adoc#bug-fixes[Bug fixes]
 *** TinyMCE 6.6.2
 **** xref:6.6.2-release-notes.adoc#overview[Overview]
 **** xref:6.6.2-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]

--- a/modules/ROOT/pages/6.4.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.1-release-notes.adoc
@@ -886,7 +886,8 @@ Fixes were introduced with the release of {productname} 6.4.1, that:
 
 As a result, when a root element is set to `contenteditable="false"`, any `contenteditable="true"` elements inside that root element such as `<p>` tag will no longer try to split the `contenteditable="true"` element. 
 
-=== Creating a list in a table cell when the caret is in front of an anchor element would not properly include the anchor in the list.
+[[creating-a-list-in-a-table-cell-when-the-caret-is-in-front-of-an-anchor-element-would-not-properly-include-the-anchor-in-the-list]]
+=== Creating a list in a table cell when the caret is in front of an anchor element would not properly include the anchor in the list
 //#TINY-6853
 
 In previous versions of {productname}, when the caret is to the left of an anchor element at the start of a line in a table cell, creating a `<ul>` or `<ol>` list would not include the anchor element. Instead, the line with the anchor element would be unexpectedly pushed below and an empty list would be created above.

--- a/modules/ROOT/pages/6.4.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.2-release-notes.adoc
@@ -107,6 +107,7 @@ To fix this issue, the code for the `urlinput` component that is responsible for
 
 As a result, the URL suggestions dropdown list now expands even on the empty _Source_ field. As well, the host browser’s console no longer returns errors.
 
+[[selection-was-not-correctly-scrolled-horizontally-into-view-when-using-the-selection.scrollIntoView-API]]
 === Selection was not correctly scrolled horizontally into view when using the `selection.scrollIntoView` API
 
 In previous versions of {productname}, the `scrollToMarker` function manually calculated how much should be scrolled vertically. The horizontal scroll amount, however, was set to a specific value: left of the marker.

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -1,0 +1,951 @@
+= TinyMCE 6.7.0
+:navtitle: TinyMCE 6.7.0
+:description: Release notes for TinyMCE 6.7.0
+:keywords: releasenotes, new, changes, bugfixes
+:page-toclevels: 1
+
+include::partial$misc/admon-releasenotes-for-stable.adoc[]
+
+[[overview]]
+== Overview
+
+{productname} 6.7.0 was released for {enterpriseversion} and {cloudname} on Wednesday, September 13^th^, 2023. These release notes provide an overview of the changes for {productname} 6.7.0, including:
+
+* xref:accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
+* xref:accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]
+* xref:improvements[Improvements]
+* xref:additions[Additions]
+* xref:changes[Changes]
+* xref:bug-fixes[Bug fixes]
+
+[[accompanying-premium-plugin-changes]]
+== Accompanying Premium plugin changes
+
+The following premium plugin updates were released alongside {productname} 6.7.0.
+
+
+=== Accessibility Checker 3.2.1
+
+The {productname} 6.7.0 release includes an accompanying release of the **Accessibility Checker** premium plugin.
+
+**Accessibility Checker** 3.2.1 includes the following bug fix:
+
+==== Translation was missing for paragraph used as heading text
+// TINY-10053
+
+The alert presented when the **Accessibility Checker** considers a string to likely be a heading includes an explanatory sentence to this effect.
+
+Previously, because of an inadvertent punctuation omission, this string was not translated and presented in English regardless of {productname}’s `language` setting.
+
+For this update, the punctuation was restored, and the string — _This paragraph looks like a heading. If it is a heading, please select a heading level._ — has been translated.
+
+When this alert presents, if the currently set language is one of the xref:bundling-localization.adoc#supported-languages[supported languages], the entire alert now presents in the currently set language, as expected.
+
+
+=== Advanced Code 3.3.1
+
+The {productname} 6.7.0 release includes an accompanying release of the **Advanced Code** premium plugin.
+
+**Advanced Code** 3.3.1 includes the following bugfixes:
+
+==== Going back from a view to the editor in mobile caused an error
+// TINY-10003
+In previous versions of {productname}, the toolbar implemented for mobile lacked the essential refresh API.
+
+Consequently, when switching from the **Advanced Code** view back to the editor, {productname} triggered an unintended refresh operation, resulting in a TypeError displaying in the console.
+
+**Advanced Code** 3.3.1 addresses this issue, by integrating an empty refresh API into the mobile toolbar.
+
+With this fix, the refresh API is now invoked, and the console no longer throws the TypeError when transitioning from the **Advanced Code** view back to editor mode on mobile devices running the Android operating system.
+
+==== Editing the data before switching theme would mean a loss of edited data
+// TINY-10046
+
+Previously, If the **Advanced Code** dialog was opened, and data was added to the dialog's text entry, and then the *Dark/light mode* button was pressed, the plugin switched to the new theme using the data present when the dialog was opened.
+
+This resulted in the loss of any entered data.
+
+In **Advanced Code** 3.3.1, switching between themes now sets the data state to the current state before the theme switch is made.
+
+This ensures any data entered before switching themes is kept.
+
+
+=== Advanced Templates 1.3.0
+
+The {productname} 6.7.0 release includes an accompanying release of the **Advanced Templates** premium plugin.
+
+**Advanced Templates** 1.3.0 includes the following additions:
+
+==== New AdvTemplateInsertTemplateById command to insert the template specified by its id property value
+// TINY-9976
+
+**Advanced Templates** 1.3.0 includes a new command, `AdvTemplateInsertTemplateById`.
+
+This command enables the adding of a new template, specified by its ID, to a {productname} document.
+
+See the xref:advanced-templates.adoc#commands[Commands] section of the xref:advanced-templates.adoc[Advanced Templates] documentation for an example of the command in use.
+
+==== New {{mce-cursor}} marker to indicate the cursor position after the template is inserted
+// TINY-9973
+
+The new insertion point marker is a fixed string for adding to any template.
+
+The string to add is as follows: `+{{mce-cursor}}+`.
+
+Wherever this string is within a template is where the insertion point appears when that template is added to a {productname} document.
+
+For more information, and an interactive demonstration, see the xref:advanced-templates.adoc#the-insertion-point-marker[The Insertion Point Marker] section of the xref:advanced-templates.adoc[Advanced Templates] documentation.
+
+
+=== AI Assistant 1.1.0
+
+The {productname} 6.7.0 release includes an accompanying release of the **AI Assistant** premium plugin.
+
+**AI Assistant** 1.1.0 includes the following addition, improvements, and bug fix:
+
+==== New UI string translations
+// TINY-9943
+
+The initial release of the **AI Assistant** plugin was an English-language–only release.
+
+**AI Assistant** 1.1.0 includes translations of all UI elements into all of {productname}’s xref:bundling-localization.adoc#supported-languages[supported languages].
+
+NOTE: The query prompts included by default with the `xref:ai.adoc#ai_shortcuts[ai_shortcuts]` option are not currently translated.
+
+==== The generate button is now disabled when input field is empty, rather than displaying an alert
+// TINY-10104
+
+Previously, when an empty prompt was submitted using the **AI Assistant** dialog, an alert would display. 
+
+In **AI Assistant** 1.1.0, the generate button is now disabled when the prompt input is empty and no alert is displayed when an empty prompt is submitted.
+
+Separately, an alert is displayed when the **AI Assistant** encounters an error. This alert still presents in **AI Assistant** 1.1.0. However, the spacing around this alert in the **AI Assistant** dialog has been improved: it is now properly balanced in the space between the dialog’s buttons and the dialog’s text input field.
+
+==== The default prompts in the `ai_shortcuts` option have been improved for better results
+// TINY-10099
+
+By default, the `xref:ai.adoc#ai_shortcuts[ai_shortcuts]` option includes a set of queries provided as an array of objects.
+
+For **AI Assistant** 1.1.0, each prompt in this default set has been re-written so as to produce better and more immediately useful responses when sent to an AI API endpoint.
+
+==== The dialog sometimes unblocked and showed the preview component too early when a response is streamed
+// TINY-10114
+
+Previously, after submitting a prompt, the dialog would unblock early, showing a blank preview component for some time, before rendering the first chunk of visible content.
+
+This was due to the first chunk of documents containing the `<!DOCTYPE html>` declaration returned by OpenAI’s endpoint being the characters `<!`.
+
+These characters are interpreted as comment nodes by the {productname} parser. And comment nodes are considered nonempty by our associated `isEmpty` method. This is unsuitable for previewing purposes, thereby triggering the early unblocking of the dialog.
+
+In {productname} 6.7, comment nodes are now excluded from the `isEmpty` logic, resulting in them being counted as empty nodes. This is more appropriate for the purposes of checking for nodes that are visible when rendered for preview, and prevents the dialog from being unblocked early.
+
+For information on the **AI Assistant** plugin, see: xref:ai.adoc[AI Assistant].
+
+
+=== Checklist 2.0.6
+
+The {productname} 6.7.0 release includes an accompanying release of the **Checklist** premium plugin.
+
+**Checklist** 2.0.6 includes the following bug fix:
+
+==== Applying checklist on a list with nested lists turned only the outer list into a checklist
+// TINY-9998
+
+Previously, when a xref:checklist.adoc[Checklist] that contained a nested checklist was selected and converted to a bulleted or numbered list, only the outer checklist was converted: the nested checklist remained a checklist.
+
+**Checklist** 2.0.6 corrects this. With this update, nested checklists become nested bulleted lists, or nested numbered lists, when selected and converted, as expected.
+
+For information on the **Checklist** plugin, see: xref:checklist.adoc[Checklist].
+
+
+=== Comments 3.3.3
+
+The {productname} 6.7.0 release includes an accompanying release of the **Comments** premium plugin.
+
+**Comments** 3.3.3 includes the following bug fix:
+
+==== Change event did not fire upon adding a reply
+// TINY-10089
+
+Previously, when a comment was added to an existing comment thread in a {productname} document, an expected change event was not fired, and the expected *Editor changed* message was not sent to the console.
+
+**Comments** 3.3.3 corrects this. When comments are added to extant threads, the change event is now fired as expected, and the *Editor changed* message is sent to the console, also as expected.
+
+For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to Tiny Comments].
+
+
+=== Enhanced Media Embed 3.1.3
+
+The {productname} 6.7.0 release includes an accompanying release of the **Enhanced Media Embed** premium plugin.
+
+**Enhanced Media Embed** 3.1.3 includes the following bug fix:
+
+==== Automatic media embed would not work as expected if the link was pasted into a `<div>` element
+// TINY-10060
+
+The **Enhanced Media Embed** did not, previously, accept a `<div>` element as a valid parent. 
+
+As a consequence, if an otherwise supported media URL was pasted inside a `<div>` element, automatic embedding of the referenced media did not occur.
+
+With this update, the `<div>` element has been added to the list of parent elements considered valid by the plugin.
+
+Supported media URLs now embed as expected when pasted inside `<div>` elements.
+
+NOTE: Although this was discovered in a {productname} instance running with the `xref:content-filtering.adoc#forced_root_block[forced_root_block: 'div']` configuration setting, the embed failure occurred in any circumstance where a media URL was pasted directly inside a `<div>` element.
+
+For information on the **Enhanced Media Embed** plugin, see: xref:introduction-to-mediaembed.adoc[Introduction to Enhanced Media Embed].
+
+
+=== Footnotes 1.0.1
+
+The {productname} 6.7.0 release includes an accompanying release of the **Footnotes** premium plugin.
+
+**Footnotes** 1.0.1 includes the following bug-fixes:
+
+==== The Footnotes toolbar button and menu item are now disabled when the selection is not editable
+//TINY-9891
+
+Previously, the **Footnotes** plugin’s toolbar button and menu item were not disabled when the insertion point was within a read-only (ie, non-editable) section or when the selection was within a read-only section or included a read-only portion.
+
+**Footnotes** 1.0.1 addresses this. If the selection includes or is within a read-only section, or if the insertion point is within a read-only section, the Footnote UI components now, correctly, present as disabled.
+
+
+==== Calling the `mceInsertFootnote` command now does nothing when the selection is non-editable
+// TINY-9891
+
+Previously, the `mceInsertFootnote` command attempted to set a footnote when the insertion point was within a read-only (ie, non-editable) section or when the selection was within a read-only section or included a read-only portion.
+
+**Footnotes** 1.0.1 addresses this. If the selection includes or is within a read-only section, or if the insertion point is within a read-only section, the `mceInsertFootnote` command, correctly, does nothing.
+
+For information on the **Footnotes** plugin, see: xref:footnotes.adoc[Footnotes].
+
+
+=== Page Embed 2.2.1
+
+The {productname} 6.7.0 release includes an accompanying release of the **Page Embed** premium plugin.
+
+**Page Embed** 2.2.1 includes the following bug-fix:
+
+==== The Page Embed toolbar button and menu item are now disabled when the selection is not editable
+// TINY-9889
+
+Previously, the **Page Embed** plugin’s toolbar button and menu item were not disabled when the insertion point was within a read-only (ie, non-editable) section or when the selection was within a read-only section or included a read-only portion.
+
+**Page Embed** 2.2.1 addresses this. If the selection includes or is within a read-only section, or if the insertion point is within a read-only section, the Page Embed UI components now, correctly, present as disabled.
+
+For information on the **Page Embed** plugin, see: xref:pageembed.adoc[Page Embed].
+
+
+=== PowerPaste 6.2.2
+
+The {productname} 6.7.0 release includes an accompanying release of the **PowerPaste** premium plugin.
+
+**PowerPaste** 6.2.2 includes the following bug-fixes
+
+==== Stopped pasting comments from Microsoft Word documents
+// TINY-9975
+Previously, when a copied selection from a Microsoft Word document included comments, these comments were added to the {productname} document as footnotes when the selection was pasted in to place.
+
+**PowerPaste** 6.2.2 addresses this. Comments are still included in copied selections from Microsoft Word. With this update, however, they are ignored by the plugin and, consequently, not added to {productname} documents when pasted.
+
+[NOTE]
+.Known issue
+====
+Microsoft Word comments are still set as footnotes when pasted into a {productname} instance if the host browser is Safari.
+
+When Safari is the host browser, and a copied selection from a Microsoft Word document includes comments, when that selection is pasted (⌘-V) into a {productname} instance, the included comment or comments are still set as footnotes in the {productname} document.
+
+Such footnotes can be manually deleted but there is currently no other workaround.
+====
+
+==== Removed error condition, error message, and error message translations for an error which no longer occurs
+// TINY-10045
+
+Previously, when **PowerPaste** was running with older versions of Safari as the host browser, an error condition presented, along with an associated error message, when direct image pasting was attempted.
+
+This error condition no longer presents and, for this release, the error catching logic, associated error message, and error message translations, have all been removed.
+
+==== PowerPaste prevented uploaded images from using their original file-name
+// TINY-9776
+
+Previously **PowerPaste** used an internal image management mechanism.
+
+This mechanism ignored `images_reuse_filename`, which is used to retain original image filenames when they are uploaded.
+
+With **PowerPaste** 6.2.2, the plugin has been switched to use core {productname} image management logic, which takes proper note of `images_reuse_filename`.
+
+Image filenames are now managed correctly, and as expected, when they are uploaded.
+
+For information on the **PowerPaste** plugin, see: xref:introduction-to-powerpaste.adoc[PowerPaste].
+
+
+=== Spell Checker Pro 3.3.1
+
+The {productname} 6.7.0 release includes an accompanying release of the **Spell Checker Pro** premium plugin.
+
+**Spell Checker Pro** 3.3.1 includes the following bug-fixes:
+
+==== Switching to readonly mode would not hide spelling mistakes
+// TINY-9463
+In previous versions of **Spell Checker Pro**, when switching to read-only mode within a {productname} document, the plugin failed to hide spelling mistakes as expected.
+
+When in **read-only** mode, the plugin still marked words with the red underline denoting mis-spellings.
+
+**Spell Checker Pro** 3.3.1 addresses this. When switching between edit and read-only modes, spelling error visibility now correctly aligns with the current editor state.
+
+
+==== Switching the editable root state to false would not hide spelling mistakes in non-editable content
+// TINY-9463
+In previous versions of **Spell Checker Pro**, an issue was identified that affected the plugin’s behavior when the insertion point or content selection was within a block element with the `contenteditable="false"` attribute set.
+
+In this circumstance, the **Spell Checker Pro** plugin checked for spelling mistakes within read-only elements (that is, within elements with the `contenteditable="false"` attribute set). As a result, the plugin incorrectly highlighted any errors found in these elements.
+
+**Spell Checker Pro** 3.3.1 addresses this issue. It now checks if the content is in an editable block element before highlighting potential spelling errors.
+
+Spelling mistakes are, as a consequence, no longer highlighted within read-only block elements, even in cases where the {productname} editor’s mode is set to **read-only** or has a root with the `contenteditable="false"` attribute set.
+
+==== Text content with Unicode characters was causing the spellchecker to modify and duplicate the text
+// TINY-10062
+In previous versions of **Spell Checker Pro**, an issue was identified that arose when the spellchecker attempted to annotate invalid characters within Dutch language text. During this process, text containing Unicode characters led to the generation of duplicated indices.
+
+This duplication had adverse consequences, primarily affecting the search functionality. When attempting to regenerate the text element using these indices, it resulted in unintended alterations and duplications within the text itself.
+
+**Spell Checker Pro** 3.3.1 addresses this issue. It removes and filters out the duplicated indices during the annotation of invalid characters.
+
+As a result, pasting text content with Unicode characters no longer triggers the alteration and duplication of the text.
+
+For information on the **Spell Checker Pro plugin** plugin, see: xref:introduction-to-tiny-spellchecker.adoc[Spell Checker Pro plugin].
+
+=== Table of Contents 1.2.0
+
+The {productname} 6.7.0 release includes an accompanying release of the **Table of Contents** premium plugin.
+
+**Table of Contents** 1.2.0 includes the following improvements and bug-fixes:
+
+
+==== Added new boolean option, `tableofcontents_includeheader`, to control whether a header is included
+// TINY-9970
+
+**Table of Contents** 1.2.0 includes a new option, `tableofcontents_includeheader`.
+
+This option is set to `true` by default.
+
+When set to `false`, this option removes the header string, **Table of Content**, from the rendered Table of Contents.
+
+
+==== Added new boolean option, `tableofcontents_orderedlist`, to use ordered lists instead of unordered lists
+// TINY-9968
+
+**Table of Contents 1.2.0** includes a new option, `tableofcontents_orderedlist`.
+
+This option is set to `false` by default.
+
+When set to `true`, this option renders a Table of Contents as an ordered list instead of the default unordered list.
+
+
+==== Added new option, `tableofcontents_orderedlist_type` to set a specific type of ordered list
+// TINY-9969
+
+**Table of Contents 1.2.0** includes a new option, `tableofcontents_orderedlist_type`.
+
+When set to one of its available values, this option renders the table of contents as the specified type of ordered list rather than the default unordered list.
+
+This option takes one of the following values to set the type attribute of the ordered list, `<ol>`:
+
+[cols="10%,90%"]
+|===
+|Value | Ordered list type
+
+|`+'1'+`
+|A list sorted by Arabic/Hindu numerals.
+
+This is the default.
+
+|`+'A'+`
+|A list sorted alphabetically by capital letter.
+
+|`+'a'+`
+|A list sorted alphabetically by lowercase letter.
+
+|`+'I'+`
+|A list sorted by uppercase Roman numerals.
+
+|`+'i'+`
+|A list sorted by lowercase Roman numerals.
+|===
+
+[IMPORTANT]
+====
+The `tableofcontents_orderedlist: true` option must be present in a {productname} configuration for whatever `tableofcontents_orderedlist_type` setting to come into effect.
+====
+
+
+==== Table of Contents toolbar button and menu item are now disabled when the selection is not editable
+// TINY-9890
+
+Previously, the Table of Contents toolbar button and menu item were not disabled when the insertion point was within a read-only (ie, non-editable) section or when the selection was within a read-only section or included a read-only portion.
+
+Clicking the enabled button, or choosing the enabled menu item did not generate a Table of Contents. The commands were disabled, as expected. The UI components did not, however, present as disabled.
+
+**Table of Contents** 1.2.0 addresses this. If the selection includes or is within a read-only section, or if the insertion point is within a read-only section, the Table of Contents UI objects now, correctly, present as disabled.
+
+
+==== Empty headers would be included in table of content
+// TINY-9862
+
+Previously, the **Table of Contents** plugin included all header blocks in a generated Table of Contents, including empty header blocks.
+
+These empty header blocks were presented, in the generated Table of Contents, as an underline character.
+
+**Table of Contents 1.2.0** addresses this by filtering out empty header blocks when it generates a Table of Contents section.
+
+[IMPORTANT]
+====
+For filtering purposes, the plugin treats a header block which contains non-printing characters, such as spaces, as **not** empty.
+====
+
+==== Changes to the Table of Contents title were overwritten by the update button
+// TINY-9971
+
+By default, a generated Table of Contents includes a title, **Table of Contents**. This title can be edited.
+
+Previously, however, if a particular Table of Contents was re-generated using the update button, the default title was restored and the edited title was lost.
+
+In **Table of Contents** 1.2.0, edits to the Table of Contents title are respected. When a given Table of Contents, which includes an edited title, is re-generated, the edited title is preserved.
+
+For information on the **Table of Contents** plugin, see: xref:tableofcontents.adoc[Table of Contents].
+
+
+
+=== Tiny Drive 2.0.3
+
+The {productname} 6.7.0 release includes an accompanying release of the **Tiny Drive** premium plugin.
+
+**Tiny Drive** 2.0.3 includes the following fix:
+
+=== Tiny Drive toolbar button and menu item are now disabled when the selection is not editable
+// TINY-9894
+
+Previously, the **Tiny Drive** plugin’s `insertfile` toolbar button and menu item were not disabled when the insertion point was within a read-only (ie, non-editable) section or when the selection was within a read-only section or included a read-only portion.
+
+**Tiny Drive** 2.0.3 addresses this. If the selection includes or is within a read-only section, or if the insertion point is within a read-only section, the Tiny Drive UI components now, correctly, present as disabled.
+
+For information on the **Tiny Drive** plugin, see: xref:tinydrive-introduction.adoc[Tiny Drive Introduction].
+
+
+[[accompanying-premium-skins-and-icon-packs-changes]]
+== Accompanying Premium Skins and Icon Packs changes
+
+The {productname} 6.7.0 release includes an accompanying release of the **Premium Skins and Icon Packs**.
+
+=== Premium Skins and Icon Packs
+
+The **Premium Skins and Icon Packs** release includes the following updates:
+
+The **Premium Skins and Icon Packs** were rebuilt to pull in the changes also incorporated into the default {productname} 6.7.0 skin, Oxide.
+
+For information on using premium skins and icon packs, see: xref:premium-skins-and-icons.adoc[Premium Skins and Icon Packs].
+
+
+[[improvements]]
+== Improvements
+
+=== Adding a newline after a table would, in some specific cases, not work
+// TINY-9863
+
+Previously, when the insertion point was between a table and an element with a `contenteditable="false"` attribute that was, itself, wrapped in a `<div>`, pressing the **Enter** or **Return** key did not add a new line to the document.
+
+{productname}, incorrectly, treated the insertion point’s location in this circumstance as not a valid place for adding a new line.
+
+{productname} 6.7 corrects this and treats such a location as the valid place for adding a new line that it is.
+
+As a result, new lines are added to {productname} documents, as expected, when the insertion point is between a table, and an `<div>`-wrapped element with a `contenteditable="false"` attribute.
+
+=== Menus now have a slight margin at the top and bottom to more clearly separate them from the frame edge
+// TINY-9978
+
+Previously, the {productname} menu could reach the edge of the host browser’s window.
+
+As a consequence, it was not apparent if the menu stopped at the edge of the window or continued past its bounds. This led to user confusion, since it was unclear if the {productname} menu was showing everything.
+
+{productname} 6.7 addresses this issue, by adding a margin to the menu layout to separate it from the frame edge. This margin is placed at the top or bottom of the {productname} menu, depending on where the menu is displayed in a given {productname} instance.
+
+As a result, in {productname} 6.7, the menu is now more noticeably distinct from the frame edge.
+
+=== Updated **More** toolbar button tooltip text from *More...* to *Reveal or hide additional toolbar items*
+// TINY-9629
+
+In previous versions of {productname}, a bug was discovered when using screen readers, but in particular the https://www.freedomscientific.com/products/software/jaws[JAWS] screen reader, within {productname}. The ellipsis icon representing the **More** option in the {productname} toolbar did not have a meaningful explanation for screen readers.
+
+As a consequence, screen readers would announce *More ellipsis* instead of providing a meaningful description that can be understood.
+
+To fix this, {productname} 6.7 updated the text label for the *More* option to *Reveal or hide more toolbar items*; a clear description for users who rely on this feature.
+
+=== Where multiple case sensitive variants of a translation key are provided, they will now all be preserved in the translation object instead of just the lowercase variant
+// TINY-10115
+
+The {productname} editor is designed to support case-insensitive translations. It converts all translation keys to lowercase when adding them to the internal translations object, and then checks in the object for the lowercase version of whichever string is passed into the translations module.
+
+However, when provided multiple case-sensitive variants of a translation key, only one of the key-value pairs was kept in the internal object.
+
+As a consequence, case-sensitive translations were not supported: the two strings, *test* and *Test* could not have different translation values.
+
+In {productname} 6.7, and with regards case-sensitive variants of a translation key, the following scenarios now apply:
+
+* when a lowercase variant is specified, all case-sensitive variants persist in the internal object; and
+* when a lowercase variant is not specified, a lowercase translation key is created using the value of whichever variant is encountered last when the user-defined translations object is checked.
+
+This approach means a lowercase translation key always exists.
+
+Consequently, this adds support for case-sensitive translations while ensuring case insensitivity is not affected.
+
+=== Improved screen reader announcements of the column and row selection in the grid presented by the **Table** menu and toolbar item
+// TINY-10140
+
+Previously, when using a screen reader, the table grid menu item announced the currently highlighted cell grid with only the numbers. Reading out, for example, *4 x 7*.
+
+In {productname} 6.7 the screen reader now notes which number is the number of columns, and which is the number of rows. In the circumstance noted above, for example, the screen reader now announces, *4 columns, 7 rows*.
+
+=== Improved the keyboard focus visibility for links inside dialogs
+// TINY-10124
+
+Previously, when a link was rendered inside the body content of a {productname} dialog, such as the **Help** dialog, it was difficult for a user to identify the visual difference between the *normal*, *hovered* or *focused* states.
+
+As well, when a link’s state was changed via keyboard navigation, making a distinction between the states was difficult.
+
+{productname} 6.7 addresses this by
+
+. adding an underline to all links to increase the contrast between links and non-links by default; and 
+. adding an outline around the link when the link is given focus using keyboard navigation.
+
+When using {productname} 6.7, users now get greater visual distinction between link and non-links, and immediate feedback as to a link’s change of state when using keyboard navigation.
+
+
+[[additions]]
+== Additions
+
+=== New `help_accessibility` option displays the keyboard shortcut to open the in-application help in the status bar
+// TINY-9379
+
+In previous versions of {productname}, keyboard-centric users without screen readers had no indicator of how to access the {productname} **Help → Help** command. (Users with screen readers got and continue to get announcements on accessing the **Help** menu and the **Help → Help** command.)
+
+By default, the **Help → Help** command is accessible using a keyboard chord. **Alt+0** on Windows or Linux and **⌥+0** on macOS. But this chord is not presented except when the **Help** menu is opened and the **Help → Help** command is displayed.
+
+{productname} 6.7 addresses this issue by introducing a new `help_accessibility` option, which defaults to `true`.
+
+When set to `true`, this option displays the **Help → Help** command keyboard shortcut in the {productname} status bar.
+
+[source, js]
+----
+tinymce.init({
+  selector: "textarea",
+  plugins: [ "help", ],
+  toolbar: "help",
+  help_accessibility: true, // default value is set to true.
+});
+----
+
+=== Added new `InsertNewBlockBefore` and `InsertNewBlockAfter` commands which insert an empty block before or after the block containing the current selection
+// TINY-10022
+
+{productname} 6.7 includes two new commands: `InsertNewBlockBefore` and `InsertNewBlockAfter`.
+
+These commands address scenarios where navigation encounters spatial constraints; most specifically when the constraint is at a {productname} document’s edges.
+
+For example, if a user inserts a `<details>` element (as part of an **xref:accordion.adoc[Accordion]** component) at the beginning of a {productname} document, the `InsertNewBlockBefore` command now provides a way to set the insertion point above this element. 
+
+[IMPORTANT]
+====
+Blocks added by either command are placed at the root level of the {productname} document, immediately before or after the top parent block encompassing the current selection.
+====
+
+[[changes]]
+== Changes
+
+=== Change `UndoLevelType` from `enum` to union type so that it is easier to use
+// TINY-9764
+
+In {productname} 6.3, a TypeError for `type: "complete"` triggered when attempting to fire a change event. The TypeError was triggered due to it not being assignable to the `UndoLevelType` type.
+
+{productname} 6.7 has addressed this issue by updating the `UndoLevelType` from a `enum` type to a union type.
+
+As a consequence, when the change event is fired, the TypeError is no longer triggered.
+
+=== The pattern replacement removed spaces if they were contained within a tag that only contained a space and the text to replace
+// TINY-9744
+
+Previously, a problem was identified with the `cleanEmptyNodes` function. This function is responsible for removing nodes that contain white space.
+
+An inadvertent consequence of an earlier fix to this problem was that, in some specific cases, the function would remove white space contained within tags that, themselves, only contained white space. This was white space it was not expected to remove.
+
+{productname} 6.7 address this and the `cleanEmptyNodes` function now preserves these nodes, as expected.
+
+=== If loading content CSS takes more than 500ms, the editor will be set to an in-progress state until the CSS is ready
+// TINY-10008
+
+If a {productname} configuration included a `contentEditable: 'true'` setting (or had no explicit global setting for `contentEditable`, and therefore defaulted this option to `'true'`) and the host browser was operating over a relatively slow connection, it was possible to add content to the editor before `ContentCss` finished loading.
+
+This could lead to data loss. After `ContentCSS` completed its initial load, any content added to the editor before the load had completed was removed from the editor.
+
+{productname} 6.7 addresses this by blocking interaction with the editor until `ContentCss` has completed loading, disallowing content insertion until initialization is complete.
+
+A relatively slow network connection for this purpose is an ≅{nbsp}400{nbsp}kb/sec connection with an ≅{nbsp}2000{nbsp}ms latency; equivalent to a Slow 3G wireless connection. The potential UX change caused by this change will, therefore, be experienced by very few users.
+
+
+[[bug-fixes]]
+== Bug fixes
+
+=== Applying an ordered or unordered list to a selected checklist incorrectly turned the list into paragraphs
+// TINY-9975
+
+Previously, when a xref:checklist.adoc[Checklist], particularly a checklist that contained a nested checklist, was selected and converted to a bulleted list the selection was, incorrectly, converted into plain paragraphs.
+
+{productname} 6.7 address this issue. With this update, nested checklists become nested bulleted lists when selected and converted, as expected.
+
+=== Returning an empty string in a custom context menu update function resulted in a small white line appearing on right-click and the browser-native context menu not presenting
+// TINY-9842
+
+Adding `browser_spellcheck: true` to a configuration tells {productname} to use the host browser’s native context menu for spell-checking.
+
+When this was set at the same time as multiple custom plugins were added to the `contextmenu` configuration, the browser-native context menu did not present as expected when invoked.
+
+Instead a short white line appeared.
+
+{productname} 6.7 addresses this by improving the handling of multiple empty strings in its context menu logic.
+
+Consequent to this improved handling, the browser-native context menu now presents as expected when invoked.
+
+=== For sufficiently long URLs and sufficiently wide windows, URL autocompletion hid middle portions of the URL from view
+// TINY-10017
+
+The **Insert/Edit Link** dialog uses `overflow:hidden` as part of its default configuration. When a sufficiently long URL is pasted in to the *URL* field, a preview window appears to display the entire pasted-in URL.
+
+Previously, even when sufficiently wide viewports were available, a portion of the pasted-in URL was cut off at top-right of the preview window.
+
+In {productname} 6.7, this preview window has been constrained to the width of the *URL* field. As well, a scroll bar will present if the pasted-in URL is too long to render in this constrained width.
+
+As a consequence, no part of pasted-in URL is cut off when the preview window now presents.
+
+=== Numeric input in toolbar items did not disable when a switching from edit to read-only mode
+// TINY-10129
+
+Previously, when a {productname} editor instance was set to *read-only* mode, because a `Changenode` event was not fired when switching modes, the text-entry field in the `fontsizeinput` toolbar object did not present as disabled and the field’s value could be changed.
+
+{productname} 6.7, addresses this by listening to the `ChangeMode` event in addition to the previous event. This ensures the missing event is now properly handled.
+
+As a consequence, the `fontsizeinput` text-entry field presents as disabled when a {productname} editor instance is set to *read-only* mode, as expected.
+
+NOTE: This was a display error only. Previously, when the editor was set to *read-only* mode, text could be entered into the `fontsizeinput` text-entry field. Setting this field to a new value in this circumstance did not, however, have any effect on selected material in a {productname} document, nor on text added at an insertion point after the {productname} instance was switched away from *read-only* mode.
+
+=== The Quick Toolbars plugin showed text alignment buttons on pagebreaks
+// TINY-10054
+
+When a {productname} instance includes the open source xref:pagebreak.adoc[Page Break] plugin, and a page break is inserted into a {productname} document, the break is represented in the document by a thin dotted-line rectangle _image_, complete with the expected `<img>` tag.
+
+Previously, the logic for displaying xref:quickbars.adoc[Quickbars] toolbars did not exclude page break images.
+
+As a consequence, when a page break was encountered, an incorrect context toolbar would display.
+
+{productname} 6.7 includes an added check for page breaks in the predicate logic that prevents Quickbars contextual menus from displaying for page breaks.
+
+For information on the **Quickbars** plugin, see: xref:quickbars.adoc[Quickbars].
+
+=== Creating lists in empty blocks sometimes, and incorrectly, converted adjacent block elements into list items
+// TINY-10136
+
+{productname} 6.4.1 included a fix for when xref:6.4.1-release-notes.adoc#creating-a-list-in-a-table-cell-when-the-caret-is-in-front-of-an-anchor-element-would-not-properly-include-the-anchor-in-the-list[creating a list in a table cell when the insertion point is in front of an anchor element did not properly include the anchor in the list]. This fix included an adjustment to DOM hierarchy traversal.
+
+In the earlier fix’s implementation, when advancing to the next leaf element in the hierarchy, the process did not take into account whether this leaf element was correctly nested under its parent. This occasionally led to it straying outside its intended parent. And, as a consequence, unexpected elements could be (and sometimes were) added to a list when a list was created.
+
+{productname} 6.7 addresses this by setting the expected block parent as the boundary for DOM tree traversal, ensuring that it does not extend beyond this defined limit. As a result, any extraneous elements are now effectively excluded from the list.
+
+=== Creating a list from multiple `<div>` elements only created a partial list
+// TINY-9872
+
+{productname} includes a content filtering option, `xref:content-filtering.adoc#forced_root_block[forced_root_block]`, which can change the default block element used to wrap inline elements and text nodes. The default value for this option is `'p'`.
+
+Previously, if the `forced_root_block` option was set to `'div'`:
+
+[source,js]
+----
+forced_root_block: 'div',
+----
+
+and multiple lines of text
+
+[source,html]
+----
+<div>Text line one.</div>
+<div>Text line two.</div>
+<div>Text line three.</div>
+----
+
+were selected, and a list was applied to the text (for example, the *Bulleted List* toolbar icon was chosen), only the first selected item became a list. (That is, the line *Text line one.*, in the example above.)
+
+This occurred because the first selected `<div>` was mistakenly treated as the list element’s root.
+
+{productname} 6.7 addresses this by looking higher in the DOM tree when looking for the list element’s parent.
+
+In {productname} 6.7, when selections equivalent to the above example have a list option applied to them, the entire selection becomes a list, as expected.
+
+For more information on the **forced_root_block** option see xref:content-filtering.adoc#forced_root_block[forced_root_block].
+
+=== Tab navigation incorrectly stopped around `iframe` dialog components
+// TINY-9815
+
+The previous implementation of the `iframe`-based dialog component wrapped the component inside two `<div>` elements.
+
+This was (and is) required for *Tab* key based navigation through the dialog’s UI components to remain within the dialog itself.
+
+The intended result was for the two `<div>` elements, by default, to switch focus to the next UI object of the `iframe` component for each press of the *Tab* key.
+
+As initially implemented, however, only one of the wrapping `<div>` elements provided this functionality.
+
+As a consequence, an additional, and redundant, *Tab* key press (or *Shift+Tab* keyboard chord press, if navigating backwards through the dialog) was required to navigate every addressable component within an `iframe`-based dialog component.
+
+{productname} 6.7 includes a fix that addresses this. When navigating through an `iframe`-based dialog component using the *Tab* key, {productname} now skips over the elements that keep Tab-key–based navigation within the dialog but which do not present as focusable UI elements.
+
+Navigating through an `iframe`-based dialog with the *Tab* key no longer requires a redundant key-press to exit an otherwise invisible component.
+
+=== It was possible to delete the sole empty block immediately before a `<details>` element if it was nested within another `<details>` element
+// TINY-9965
+
+In previous versions of the xref:accordion.adoc[Accordion Plugin], when inserting an accordion component inside the body of another accordion, it was possible to delete the summary block element of the nested accordion.
+
+{productname} 6.7 addresses this by blocking *Delete* and *Backspace* key presses when the insertion point is within an empty block before a nested Accordion component.
+
+As a result, using the *Delete* or *Backspace* keys no longer allows a user to delete into the summary element of an Accordion component, and the insertion point remains in the empty block before the Accordion.
+
+For more information on the **Accordion** plugin see xref:accordion.adoc[Accordion].
+
+=== Deleting `<li>` elements that only contained `<br>` tags sometimes caused a crash
+// TINY-6888
+
+In previous  {productname} versions, `"Uncaught TypeError: Cannot read property 'nextSibling' of null"` errors were thrown in some specific use cases. For example, after the removal of any `<li>` element.
+
+Previously, `<li>` elements used the same caret position as the parent of the new caret container. After removal of the `<li>` element, however, the editor tried to use `ToggleList.mergeWithAdjacentLists` which is used on the `otherLi.parentNode`. This triggered the TypeError, as the editor had already removed the other `otherLi` element.
+
+{productname} 6.7 addresses this by using, for caret position, the `otherLi.parentNode` reference stored in a `const` before the removal.
+
+=== It was possible to remove the `<summary>` element from a `<details>` element by dragging and dropping
+// TINY-9960
+Previously, dragging and dropping the contents of a `<summary>` element contained within the `<details>` parent container of an xref:accordion.adoc[Accordion] component, caused the `<summary>` element to be removed from the parent container.
+
+As a consequence, the Accordion element was rendered unusable: the `<details>` element requires a `<summary>` element to act as the title or heading of a specific Accordion component.
+
+In {productname} 6.7, when the user drags a `<summary>` element’s  contents out of an Accordion component, the editor puts an empty `<summary>` element back in place after the deletion consequent to the dragging event. This restores the Accordion component to its required form.
+
+=== It was possible to break `<summary>` elements if content containing block elements was dragged-and-dropped inside them
+// TINY-9960
+In previous versions of the xref:accordion.adoc[Accordion] plugin, dragging and dropping block elements within the `<summary>` element of an Accordion component could break the `<summary>` element.
+
+As a consequence, {productname} would duplicate the `<summary>` element.
+
+For example, if the initial state was as follows:
+
+[source, html]
+----
+<details class="mce-accordion" open="open">
+<summary>Accordion summary...</summary>
+<p>Accordion body...</p>
+</details>
+<h1>block_element</h1>
+----
+
+After a drag-and-drop event, the Accordion component would be thus:
+
+[source, html]
+----
+<details class="mce-accordion" open="open">
+<summary>Accordion</summary>
+<h1>block_element</h1>
+<summary class="mce-accordion-summary">&nbsp;summary...</summary>
+<!-- Note the duplicated <summary>. -->
+<!-- Also note, this comment was manually added to this example. -->
+<p>Accordion body...</p>
+</details>
+----
+
+Note the duplicated `<summary>` in the post-drag Accordion component.
+
+To address this, {productname} 6.7 now unwraps block elements after they are dragged from within another block element.
+
+As a consequence, dragging and dropping content from within a block element no longer produces duplicate summary elements.
+
+=== Contents were not removed from the drag start source if dragging and dropping internally into a transparent block element
+// TINY-9960
+
+Previously, when dragging and dropping a context selection from a transparent element into another transparent block element, the source content (ie the content selected for dragging) was not properly deleted after the drop event.
+
+For example, if the initial selection for dragging was as follows:
+
+[source,html]
+----
+<a href="../../undefined/">
+  <p>Selected content in transparent element to be dragged.</p>
+</a>
+<a href="../../undefined/">
+  <p>Content in another transparent element</p>
+</a>
+----
+
+After the drop event, the editor state was thus:
+
+[source,html]
+----
+<a href="../../undefined/">
+  <p>Selected content in transparent element to be dragged.</p>
+  <!-- Note the dragged content has remained in place. -->
+</a>
+<a href="../../undefined/">
+  <p>Content in another transparent element</p>
+  <p>Selected content in transparent element to be dragged.</p>
+  <!-- Causing, in effect, the dragged content to be duplicated rather than moved. -->
+  <!-- Also note, these comments were manually added to this example. -->
+</a>
+----
+
+Note the duplicated material in the post-drag editor state example.
+
+{productname} 6.7 includes a fix that over-rides this unintended behavior. Now, when dragging a content selection from one transparent element into another, the drag’s source selection is moved rather than duplicated, as expected.
+
+=== Using the Media plugin unexpectedly changed `<script>` tags in the editor body to `<image>` tags
+// TINY-10007
+
+As part of the {productname} 5.10 release, the `https://tiny.cloud/docs/plugins/opensource/media/#media_scripts)[media_scripts]` option was deprecated. And, as of the {productname} 6.0 release, this option was removed.
+
+When the setting was available, it was used to allow some script tags, with specified source URLs, to have some of their properties edited in the https://tiny.cloud/docs/plugins/opensource/media/[*Media*] plugin’s dialog.
+
+And, while the `media_scripts` option was removed, the logic that allowed the plugin to edit properties in some script tags was not.
+
+As a consequence, a regression presented. When the xref:introduction-to-mediaembed.adoc/[*Enhanced Media Embed*] Premium plugin was loaded, the plugin converts all script tags into placeholder images.
+
+For the {productname} 6.7 release the code that handled script tags was removed, which corrects this regression.
+
+In {productname} 6.7, when the *Enhanced Media Embed* is loaded, script tags are treated as script tags, and are no longer converted into placeholder images.
+
+=== In some circumstances, pressing the **Enter** key scrolled the entire page
+// TINY-9828
+
+{productname} 6.4.2 addressed an issue in which xref:6.4.2-release-notes.adoc#selection-was-not-correctly-scrolled-horizontally-into-view-when-using-the-selection.scrollIntoView-API[a selection was not correctly scrolled horizontally into view].
+
+{productname} 6.7 includes changes to the previously applied logic to address a further issue, in which scrolling did not reach the correct position in some circumstances.
+
+The fix applied in {productname} 6.4.2 altered the `scrollToMarker` function, affecting not only editor content, but also the editor container itself. This, unintentionally, caused an *Enter* key-press to trigger scrolling of both the content and the container.
+
+{productname} 6.7 makes two changes to address this. It reverts the logic applied in {productname} 6.4.2. And it adjusts the scroll left calculation.
+
+These changes correct both issues. Pressing the *Enter* key no longer triggers scrolling and the selection is (still) correctly scrolled into horizontal view.
+
+=== The border styles of a table were incorrectly split into a longhand form after table dialog updates
+// TINY-9843
+
+Previously, when applying border style changes using the {productname} *Table Properties* dialog, changes were applied as individual properties. For example:
+
+[source,html]
+----
+style="border-width: 3px; border-style: solid; border-color: red;"
+----
+
+When the content was re-loaded, however, the styles were automatically condensed into the shorthand format:
+
+[source,html]
+----
+style="border: 3px solid red;"
+----
+
+This constitutes un-announced and un-asked-for modification of the table’s underlying HTML within the {productname} editor.
+
+{productname} 6.7 addresses this by immediately applying border style changes made using the *Table Properties* dialog in the shorthand format.
+
+Table HTML is, as a consequence, unaltered when it is reloaded into the {productname} editor.
+
+=== Links in **Help → Help → Plugins** and **Help → Help → Version** were not navigable by keyboard
+// TINY-10071
+
+The Help dialog built-in to {productname} includes four tabs:
+
+* *Handy Shortcuts*;
+* *Keyboard Navigation*;
+* *Plugins*; and
+* *Version*.
+
+Previously, keyboard navigation was supported across these four tabs, and into each tab’s contents. (When a tab’s contents have focus, the content can be scrolled through using Arrow keys.)
+
+However, keyboard-based navigation of links in the focussed content was not supported.
+
+{productname} 6.7 corrects this. The `data-alloy-tabstop="true"` attribute, which was previously not applied to these links, has been added.
+
+Users of {productname} 6.7 can navigate to and activate links in Help dialog contents entirely with keyboard navigation.
+
+[NOTE]
+====
+As of this release, only the *Plugins*, and *Version* tabs include links.
+
+Also, there is no visual feedback when a given tab’s contents pane takes focus.
+
+Consequently, the UX is such that it appears to take two presses of the *Tab* key to go from a tab label having the focus and the first link within a tab’s content pane having focus.
+
+Likewise, going from the first link within a tab’s content pane having focus to a tab label having focus appears to take two presses of the *Shift-Tab* keyboard chord.
+====
+
+=== Fixed the inability to insert content next to the `<details>` element when it is the first or last content element. Pressing the **Up** or **Down** arrow key now inserts a block element before or after the `<details>` element
+// TINY-9827
+
+Previously, when a `<details>` element, such as is automatically part of an xref:accordion.adoc[Accordion] component, was either the first or last element within a {productname} editor instance, users were unable to move the insertion point above or below the element. This prevented them from adding new content to the editor instance.
+
+In {productname} 6.7, the `InsertNewBlockBefore` and `InsertNewBlockAfter` commands have been associated with the *Up Arrow* and *Down Arrow* keys, activating when the insertion point is in the relevant position.
+
+As a result, when the insertion point is in the relevant position and the user presses either of the *Up Arrow* or *Down Arrow* keys, the insertion point now moves either above or below the `<details>` element when it is at either the beginning or end of the current editor’s content.
+
+=== An empty element with a `contenteditable="true"` attribute within a noneditable root was deleted when the Backspace key was pressed
+// TINY-10011
+
+Previously, when an empty element with a `contenteditable="true"` attribute was set within a read-only root (ie a root with a `contenteditable="false"` attribute), the empty element was deleted when the *Backspace* key was pressed.
+
+When the Backspace key was pressed in this circumstance, the {productname} editor removed elements that contained no content.
+
+In doing so the `dom.isEmpty(body)` call returned a value, `true`, even if the called `body` included an element that was empty but had a `contenteditable="true"` attribute set.
+
+As of {productname} 6.7, elements with a `contenteditable="true"` attribute set are no longer treated as empty and the `dom.isEmpty(body)` call no longer returns the value `true` with regards such elements.
+
+As a consequence, these elements are no longer deleted when they are immediately before the insertion point and the Backspace key is pressed.
+
+=== The `color_cols` option was not respected when set to the value 5 with a custom `color_map` specified
+// TINY-10126
+
+Previously, when `color_cols: 5` was set, the assigned value was not used.
+
+Instead, when `color_cols` was set to the default number of columns displayed by a {productname} color selection grid (ie 5), the default method for calculating the number of displayed columns is used.
+
+For {productname} 6.7, the logic for calculating the default `color_cols` values was re-written. As of this release, {productname} now uses either the `color_cols` option, with its default calculated on the base color map, or the value calculated by custom color maps.
+
+This ensures a set `color_cols` value is always used, even when that value matches the default value.
+
+=== In Safari on macOS, deleting backwards within a `<summary>` element removed the entire `<details>` element if it had no other content
+// TINY-10123
+
+Previously, when Safari was the host browser, and
+
+* the insertion point was inside the `<summary>` element of an Accordion component; and
+* there was no other content within the parent `<details>` element;
+
+pressing Backspace deleted the entire `<details>` element rather than just the character immediately before the insertion point.
+
+{productname} 6.7 addresses this. With this release, the Backspace key functions as expected when Safari is the host browser: it deletes only the character immediately before when the insertion point is inside a `<summary>` element, as expected.
+
+=== Removed attribute from being added to `<br>` in empty table cells
+// TINY-9860
+
+By default, {productname} removes `+<br>+` tags at the end of block elements.
+
+Setting the `+xref:content-filtering.adoc#remove_trailing_brs[remove_trailing_brs]+` option to `+false+` turns this default behaviour off.
+
+Previously, however, when `+remove_trailing_brs: false+` was set, and a table was added to a {productname} document, the last cell of the newly-created table did not contain a `+<br+` tag, as expected.
+
+During serialization, this last tag was instead converted into a whitespace character.
+
+In {productname} 6.7, this character conversion during serialization no longer occurs in table cells.
+
+As a consequence, when `+remove_trailing_brs: false+` is set and tables are added to a {productname} document, all newly-created and otherwise empty cells contain a `+<br>+` tag, as is expected in this circumstance.
+{productname} 6.7 addresses this. With this release, the Backspace key functions as expected when Safari is the host browser: it deletes only the character immediately before when the insertion point is inside a `<summary>` element, as expected.

--- a/modules/ROOT/pages/a11ychecker.adoc
+++ b/modules/ROOT/pages/a11ychecker.adoc
@@ -16,7 +16,7 @@ The `+a11ychecker+` premium plugin allows you to check the HTML in the editor fo
 
 liveDemo::a11ychecker[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Basic setup
 

--- a/modules/ROOT/pages/accessibility.adoc
+++ b/modules/ROOT/pages/accessibility.adoc
@@ -10,3 +10,5 @@ include::partial$configuration/highlight_on_focus.adoc[]
 include::partial$configuration/iframe_aria_text.adoc[]
 
 include::partial$configuration/taborder.adoc[]
+
+include::partial$configuration/help_accessibility.adoc[]

--- a/modules/ROOT/pages/advanced-templates.adoc
+++ b/modules/ROOT/pages/advanced-templates.adoc
@@ -135,6 +135,22 @@ The following interactive remote storage configuration example provides guidance
 ==== Configuring the Advanced Template plugin to interact with a remote backend service via REST API.
 liveDemo::{plugincode}[]
 
+[[the-insertion-point-marker]]
+==== The insertion point marker
+
+include::partial$misc/admon-requires-6.7v.adoc[]
+
+The insertion point marker is a fixed string for adding to any template.
+
+The string to add is as follows: `+{{mce-cursor}}+`.
+
+Wherever this string is within a template is where the insertion point appears when that template is added to a {productname} document.
+
+Also, and as shown in the interactive demonstration below, the xref:mergetags.adoc[Merge Tags] plugin knows to ignore this fixed string, making it possible to use the insertion point marker in conjunction with both plugins.
+
+liveDemo::{plugincode}-insertionpoint[]
+
+
 [[options]]
 == Options
 
@@ -167,6 +183,7 @@ include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
+[[commands]]
 == Commands
 
 The {pluginname} plugin provides the following {productname} commands.

--- a/modules/ROOT/pages/advanced-templates.adoc
+++ b/modules/ROOT/pages/advanced-templates.adoc
@@ -136,7 +136,7 @@ The following interactive remote storage configuration example provides guidance
 liveDemo::{plugincode}[]
 
 [[the-insertion-point-marker]]
-==== The insertion point marker
+=== The insertion point marker
 
 include::partial$misc/admon-requires-6.7v.adoc[]
 

--- a/modules/ROOT/pages/advcode.adoc
+++ b/modules/ROOT/pages/advcode.adoc
@@ -26,7 +26,7 @@ NOTE: For the {pluginname} to offer a full-screen mode requires the xref:fullscr
 
 liveDemo::advcode[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Example: basic setup
 

--- a/modules/ROOT/pages/advtable.adoc
+++ b/modules/ROOT/pages/advtable.adoc
@@ -18,7 +18,7 @@ The `+advtable+` plugin is a premium plugin that extends the core xref:table.ado
 
 liveDemo::advtable[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Enabling the Advanced Tables plugin
 

--- a/modules/ROOT/pages/autocorrect.adoc
+++ b/modules/ROOT/pages/autocorrect.adoc
@@ -17,7 +17,7 @@ The {pluginname} plugin allows {productname} to autocorrect a specified set of s
 
 liveDemo::autocorrect[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Basic setup
 

--- a/modules/ROOT/pages/casechange.adoc
+++ b/modules/ROOT/pages/casechange.adoc
@@ -14,7 +14,7 @@ The *Case Change* plugin is a time saving and handy extension that allows changi
 
 liveDemo::casechange[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Changing the case of selected text
 

--- a/modules/ROOT/pages/checklist.adoc
+++ b/modules/ROOT/pages/checklist.adoc
@@ -16,7 +16,7 @@ In the {productname} editor, checklists are presented as lists with small checkb
 
 liveDemo::checklist[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Creating a Checklist
 

--- a/modules/ROOT/pages/editimage.adoc
+++ b/modules/ROOT/pages/editimage.adoc
@@ -20,7 +20,7 @@ liveDemo::edit-image[]
 
 include::partial$misc/admon-svg-not-supported.adoc[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Cloud Installation
 

--- a/modules/ROOT/pages/editor-command-identifiers.adoc
+++ b/modules/ROOT/pages/editor-command-identifiers.adoc
@@ -2,7 +2,7 @@
 :navtitle: Available Commands
 :description_short: Complete list of editor commands.
 :description: The complete list of exposed editor commands.
-:keywords: editorcommands, editorcommand, execcommand, Bold, Italic, Underline, Strikethrough, Superscript, Subscript, Cut, Copy, Paste, Unlink, JustifyLeft, JustifyCenter, JustifyRight, JustifyFull, JustifyNone, InsertUnorderedList, InsertOrderedList, ForeColor, HiliteColor, FontName, FontSize, RemoveFormat, mceBlockQuote, FormatBlock, mceInsertContent, mceToggleFormat, mceSetContent, Indent, Outdent, InsertHorizontalRule, mceToggleVisualAid, mceInsertLink, selectAll, delete, mceNewDocument, Undo, Redo, mceAutoResize, mceShowCharmap, mceCodeEditor, mceDirectionLTR, mceDirectionRTL, mceFullscreen, mceImage, mceInsertDate, mceInsertTime, mceInsertDefinitionList, mceNonBreaking, mcePageBreak, mcePreview, mcePrint, mceSave, SearchReplace, mceInsertTemplate, mceVisualBlocks, mceVisualChars, mceMedia, mceAnchor, mceTableSplitCells, mceTableMergeCells, mceTableInsertRowBefore, mceTableInsertRowAfter, mceTableInsertColBefore, mceTableInsertColAfter, mceTableDeleteCol, mceTableDeleteRow, mceTableCutRow, mceTableCopyRow, mceTablePasteRowBefore, mceTablePasteRowAfter, mceTableDelete, mceInsertTable, mceTableRowProps, mceTableCellProps, mceEditImage, mceAddEditor, mceRemoveEditor, mceToggleEditor, mceAutocompleterClose, mceAutocompleterReload
+:keywords: editorcommands, editorcommand, execcommand, Bold, Italic, Underline, Strikethrough, Superscript, Subscript, Cut, Copy, Paste, Unlink, JustifyLeft, JustifyCenter, JustifyRight, JustifyFull, JustifyNone, InsertUnorderedList, InsertOrderedList, ForeColor, HiliteColor, FontName, FontSize, InsertNewBlockBefore, InsertNewBlockAfter, RemoveFormat, mceBlockQuote, FormatBlock, mceInsertContent, mceToggleFormat, mceSetContent, Indent, Outdent, InsertHorizontalRule, mceToggleVisualAid, mceInsertLink, selectAll, delete, mceNewDocument, Undo, Redo, mceAutoResize, mceShowCharmap, mceCodeEditor, mceDirectionLTR, mceDirectionRTL, mceFullscreen, mceImage, mceInsertDate, mceInsertTime, mceInsertDefinitionList, mceNonBreaking, mcePageBreak, mcePreview, mcePrint, mceSave, SearchReplace, mceInsertTemplate, mceVisualBlocks, mceVisualChars, mceMedia, mceAnchor, mceTableSplitCells, mceTableMergeCells, mceTableInsertRowBefore, mceTableInsertRowAfter, mceTableInsertColBefore, mceTableInsertColAfter, mceTableDeleteCol, mceTableDeleteRow, mceTableCutRow, mceTableCopyRow, mceTablePasteRowBefore, mceTablePasteRowAfter, mceTableDelete, mceInsertTable, mceTableRowProps, mceTableCellProps, mceEditImage, mceAddEditor, mceRemoveEditor, mceToggleEditor, mceAutocompleterClose, mceAutocompleterReload
 
 == Overview
 
@@ -124,78 +124,82 @@ The commands in the following table are provided by the {productname} editor and
 [cols="1,3",options="header"]
 |===
 |Command |Description
-|Lang |Sets the language of the current selection. The value passed in should be a language spec described in xref:content-localization.adoc#content_langs[Content appearance options - `+content_langs+`].
-|mceInsertLink |Inserts a link at the current selection. The value is the URL to add to the link(s). NOTE: This is an alias for the `CreateLink` command.
-|JustifyNone |Removes any alignment to the selected text.
 |HiliteColor |Changes the background color of the text. The value passed in should be the color. NOTE: This is an alias for the `BackColor` command.
-|LineHeight |Sets the line height of the text. The value passed in should be a valid CSS line height.
-|mceApplyTextcolor |Applies text color or background color to the current selection. Requires an argument of either `+'hilitecolor'+` or `+'forecolor'+`, and the value of the color.
-|mceRemoveTextcolor |Removes the text color or background color from the current selection. Requires an argument of either `+'hilitecolor'+` or `+'forecolor'+`.
-|mceBlockQuote |Wraps the selected text blocks into a block quote.
-|mceInsertContent |Inserts contents at the current selection. The value passed in should be the contents to be inserted.
-|mceReplaceContent |Replaces the current selection. The value passed in should be the new content.
-|mceSetContent |Sets the contents of the editor. The value is the contents to set as the editor contents.
-|mceToggleFormat |Toggles a specified format by name. The value is the name of the format to toggle. For a list of options, see: xref:content-formatting.adoc#built-in-formats[Content formatting options - Built-in formats].
-|ToggleSidebar |Closes the current sidebar, or toggles the sidebar if the sidebar name is provided as a value (`_<sidebar-name>_`).
-|ToggleToolbarDrawer |Toggles the Toolbar Drawer. For information on toolbars, see: xref:toolbar-configuration-options.adoc#toolbar[User interface options - Toolbar].
 |InsertLineBreak |Adds a line break `+<br>+` at the current cursor or selection.
-|mceInsertNewLine |Adds a new line at the current cursor or selection, such as splitting the current paragraph element. The behavior of this setting can be controlled with the xref:content-behavior-options.adoc#newline_behavior[newline_behavior] option.
-|mceToggleVisualAid |Toggles the visual aids for: tables without borders and anchors.
-|mceNewDocument |Removes all contents of the editor.
+|InsertNewBlockAfter |inserts an empty block at the root level of the current {productname} document immediately after the block containing the current selection.
+|InsertNewBlockBefore |inserts an empty block at the root level of the current {productname} document immediately before the block containing the current selection.
+|JustifyNone |Removes any alignment to the selected text.
+|Lang |Sets the language of the current selection. The value passed in should be a language spec described in xref:content-localization.adoc#content_langs[Content appearance options - `+content_langs+`].
+|LineHeight |Sets the line height of the text. The value passed in should be a valid CSS line height.
 |mceAddUndoLevel |Adds an undo level.
-|mceEndUndoLevel |Adds an undo level.
-|mceCleanup |Copies the current editor content and sets the content using the copy.
-|mceSelectNode |Selects a node in the editor. The target node is passed as the value (`_<DOM_node>_`).
-|mceSelectNodeDepth |Selects the parent DOM node 'n' levels above the current node.
-|mceRemoveNode |Removes the current node or the target node passed as the value (`_<DOM_node>_`).
-|mceFocus |Focuses and activates the editor. Places DOM focus inside the editor and also sets the editor as the active editor instance on the page.
-|mcePrint |Opens the browser's print dialog for the current page.
-|mceInsertClipboardContent |Triggers a paste event at the cursor location or over the current selection. The command requires an object with: `+html+` containing the HTML content, or `+text+` containing plain text.
-|mceTogglePlainTextPaste |Toggles paste as plain text.
+|mceApplyTextcolor |Applies text color or background color to the current selection. Requires an argument of either `+'hilitecolor'+` or `+'forecolor'+`, and the value of the color.
 |mceAutocompleterClose |Closes any active autocompleter menu.
 |mceAutocompleterReload |Reloads the autocompleter menu with new items. For the data to provide, see the xref:autocompleter.adoc#api[Autocompleter reload API].
+|mceBlockQuote |Wraps the selected text blocks into a block quote.
+|mceCleanup |Copies the current editor content and sets the content using the copy.
+|mceEndUndoLevel |Adds an undo level.
+|mceFocus |Focuses and activates the editor. Places DOM focus inside the editor and also sets the editor as the active editor instance on the page.
+|mceInsertClipboardContent |Triggers a paste event at the cursor location or over the current selection. The command requires an object with: `+html+` containing the HTML content, or `+text+` containing plain text.
+|mceInsertContent |Inserts contents at the current selection. The value passed in should be the contents to be inserted.
+|mceInsertLink |Inserts a link at the current selection. The value is the URL to add to the link(s). NOTE: This is an alias for the `CreateLink` command.
+|mceInsertNewLine |Adds a new line at the current cursor or selection, such as splitting the current paragraph element. The behavior of this setting can be controlled with the xref:content-behavior-options.adoc#newline_behavior[newline_behavior] option.
+|mceNewDocument |Removes all contents of the editor.
+|mcePrint |Opens the browser's print dialog for the current page.
+|mceRemoveNode |Removes the current node or the target node passed as the value (`_<DOM_node>_`).
+|mceRemoveTextcolor |Removes the text color or background color from the current selection. Requires an argument of either `+'hilitecolor'+` or `+'forecolor'+`.
+|mceReplaceContent |Replaces the current selection. The value passed in should be the new content.
+|mceSelectNode |Selects a node in the editor. The target node is passed as the value (`_<DOM_node>_`).
+|mceSelectNodeDepth |Selects the parent DOM node 'n' levels above the current node.
+|mceSetContent |Sets the contents of the editor. The value is the contents to set as the editor contents.
+|mceToggleFormat |Toggles a specified format by name. The value is the name of the format to toggle. For a list of options, see: xref:content-formatting.adoc#built-in-formats[Content formatting options - Built-in formats].
+|mceTogglePlainTextPaste |Toggles paste as plain text.
+|mceToggleVisualAid |Toggles the visual aids for: tables without borders and anchors.
+|ToggleSidebar |Closes the current sidebar, or toggles the sidebar if the sidebar name is provided as a value (`_<sidebar-name>_`).
+|ToggleToolbarDrawer |Toggles the Toolbar Drawer. For information on toolbars, see: xref:toolbar-configuration-options.adoc#toolbar[User interface options - Toolbar].
 |===
 
 .Examples
 [source,js]
 ----
+tinymce.activeEditor.execCommand('HiliteColor', false, '#FF0000');
+tinymce.activeEditor.execCommand('InsertLineBreak');
+tinymce.activeEditor.execCommand('InsertNewBlockAfter')
+tinymce.activeEditor.execCommand('InsertNewBlockBefore')
+tinymce.activeEditor.execCommand('JustifyNone');
 tinymce.activeEditor.execCommand('Lang', false, { code: 'en_US' });  /* OR */
 tinymce.activeEditor.execCommand('Lang', false, { code: 'en_US', customCode: 'en-us-medical' });
-tinymce.activeEditor.execCommand('mceInsertLink', false, 'https://www.tiny.cloud');
-tinymce.activeEditor.execCommand('JustifyNone');
-tinymce.activeEditor.execCommand('HiliteColor', false, '#FF0000');
 tinymce.activeEditor.execCommand('LineHeight', false, '1.4');
-tinymce.activeEditor.execCommand('mceApplyTextcolor', 'hilitecolor', '#FF0000');
-tinymce.activeEditor.execCommand('mceRemoveTextcolor', 'hilitecolor');
-tinymce.activeEditor.execCommand('mceBlockQuote');
-tinymce.activeEditor.execCommand('mceInsertContent', false, 'My new content');
-tinymce.activeEditor.execCommand('mceReplaceContent', false, 'My replacement content');
-tinymce.activeEditor.execCommand('mceSetContent', false, 'My content');
-tinymce.activeEditor.execCommand('mceToggleFormat', false, 'bold');
-tinymce.activeEditor.execCommand('ToggleSidebar');  /* OR */
-tinymce.activeEditor.execCommand('ToggleSidebar', false, '<sidebar-name>');
-tinymce.activeEditor.execCommand('ToggleToolbarDrawer');
-tinymce.activeEditor.execCommand('InsertLineBreak');
-tinymce.activeEditor.execCommand('mceInsertNewLine');
-tinymce.activeEditor.execCommand('mceToggleVisualAid');
-tinymce.activeEditor.execCommand('mceNewDocument');
 tinymce.activeEditor.execCommand('mceAddUndoLevel');
-tinymce.activeEditor.execCommand('mceEndUndoLevel');
-tinymce.activeEditor.execCommand('mceCleanup');
-tinymce.activeEditor.execCommand('mceSelectNode', false, '<DOM_node>');
-tinymce.activeEditor.execCommand('mceSelectNodeDepth', false, 2); // For two nodes up.
-tinymce.activeEditor.execCommand('mceRemoveNode'); /* OR */
-tinymce.activeEditor.execCommand('mceRemoveNode', false, '<DOM_node>');
-tinymce.activeEditor.execCommand('mceFocus');
-tinymce.activeEditor.execCommand('mcePrint');
-tinymce.activeEditor.execCommand('mceInsertClipboardContent', false, {
-  html: '<p>Hello, World!</p>'
-});
-tinymce.activeEditor.execCommand('mceTogglePlainTextPaste');
+tinymce.activeEditor.execCommand('mceApplyTextcolor', 'hilitecolor', '#FF0000');
 tinymce.activeEditor.execCommand('mceAutocompleterClose');
 tinymce.activeEditor.execCommand('mceAutocompleterReload', false, {
   fetchOptions: {}
 });
+tinymce.activeEditor.execCommand('mceBlockQuote');
+tinymce.activeEditor.execCommand('mceCleanup');
+tinymce.activeEditor.execCommand('mceEndUndoLevel');
+tinymce.activeEditor.execCommand('mceFocus');
+tinymce.activeEditor.execCommand('mceInsertClipboardContent', false, {
+  html: '<p>Hello, World!</p>'
+});
+tinymce.activeEditor.execCommand('mceInsertContent', false, 'My new content');
+tinymce.activeEditor.execCommand('mceInsertLink', false, 'https://www.tiny.cloud');
+tinymce.activeEditor.execCommand('mceInsertNewLine');
+tinymce.activeEditor.execCommand('mceNewDocument');
+tinymce.activeEditor.execCommand('mcePrint');
+tinymce.activeEditor.execCommand('mceRemoveNode'); /* OR */
+tinymce.activeEditor.execCommand('mceRemoveNode', false, '<DOM_node>');
+tinymce.activeEditor.execCommand('mceSelectNode', false, '<DOM_node>');
+tinymce.activeEditor.execCommand('mceSelectNodeDepth', false, 2); // For two nodes up.
+tinymce.activeEditor.execCommand('mceSetContent', false, 'My content');
+tinymce.activeEditor.execCommand('mceRemoveTextcolor', 'hilitecolor');
+tinymce.activeEditor.execCommand('mceReplaceContent', false, 'My replacement content');
+tinymce.activeEditor.execCommand('mceToggleFormat', false, 'bold');
+tinymce.activeEditor.execCommand('mceTogglePlainTextPaste');
+tinymce.activeEditor.execCommand('mceToggleVisualAid');
+tinymce.activeEditor.execCommand('ToggleSidebar');  /* OR */
+tinymce.activeEditor.execCommand('ToggleSidebar', false, '<sidebar-name>');
+tinymce.activeEditor.execCommand('ToggleToolbarDrawer');
 ----
 
 [[core-table-commands]]

--- a/modules/ROOT/pages/export.adoc
+++ b/modules/ROOT/pages/export.adoc
@@ -19,7 +19,7 @@ To export the editor content, either:
 
 liveDemo::export[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Cloud Installation
 

--- a/modules/ROOT/pages/footnotes.adoc
+++ b/modules/ROOT/pages/footnotes.adoc
@@ -20,7 +20,7 @@ The plugin then adds a new line to the footnotes section located at the bottom o
 
 liveDemo::footnotes[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Basic setup
 

--- a/modules/ROOT/pages/formatpainter.adoc
+++ b/modules/ROOT/pages/formatpainter.adoc
@@ -17,7 +17,7 @@ The format painter retains the formatting after application making it possible t
 
 liveDemo::format-painter[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Basic setup
 

--- a/modules/ROOT/pages/help.adoc
+++ b/modules/ROOT/pages/help.adoc
@@ -5,14 +5,28 @@
 :pluginname: Help
 :plugincode: help
 
-The help plugin adds a button and/or menu item that opens a dialog showing two tabs:
+The help plugin adds a button and/or menu item that opens a dialog showing four tabs:
 
-* Handy shortcuts that explains some nice-to-know keyboard shortcuts
-* Plugin list that shows which plugins that have been installed, with links to the relevant documentation pages if available, and a list of available premium plugins.
+[cols=",,",options="header"]
+|===
+|Tab display name |Tab configuration name |Purpose
+|Handy shortcuts |`shortcuts` |Presents keyboard shortcuts available in the {productname} editor.
+|Keyboard Navigation |`keyboardnav` |Documents the keyboard-based options for navigating and controlling the entire {productname} editor.
+|Plugins |`plugins` |Lists the installed plugins for the {productname} instance, with links to the relevant {productname} documentation.
 
-In the footer of the dialog you can also see which version of {productname} you are using.
+ Also presents a list of available {productname} Premium plugins.
+|Version |`versions` |Displays the {productname} version.
+|===
 
-The help dialog can also be shown by pressing the keyboard shortcut `+Alt + 0+`.
+The {productname} Help dialog can also be shown by pressing a keyboard shortcut.
+
+[cols=",,",options="header"]
+|===
+|Action |Windows or Linux |macOS
+|Open the {productname} Help dialog |Alt+0 |⌥+0
+|===
+
+As of {productname} 6.7, the keyboard shortcut that opens the {productname} Help dialog displays, by default, in the {productname} status bar.
 
 == Basic setup
 
@@ -26,6 +40,8 @@ tinymce.init({
 ----
 
 == Options
+
+include::partial$configuration/help_accessibility.adoc[leveloffset=+1]
 
 include::partial$configuration/help_tabs.adoc[leveloffset=+1]
 

--- a/modules/ROOT/pages/introduction-to-mediaembed.adoc
+++ b/modules/ROOT/pages/introduction-to-mediaembed.adoc
@@ -14,7 +14,7 @@ The *Enhanced Media Embed* plugin is a link:{pricingpage}/[premium {productname}
 
 liveDemo::mediaembed[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Installation
 

--- a/modules/ROOT/pages/introduction-to-powerpaste.adoc
+++ b/modules/ROOT/pages/introduction-to-powerpaste.adoc
@@ -16,7 +16,7 @@ NOTE: Due to limitations in Microsoft Excel online (part of Office Live) PowerPa
 
 liveDemo::paste-from-word[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Usage
 

--- a/modules/ROOT/pages/introduction-to-tiny-comments.adoc
+++ b/modules/ROOT/pages/introduction-to-tiny-comments.adoc
@@ -45,7 +45,7 @@ The following example shows how to configure the Comments plugin in *embedded* m
 
 liveDemo::comments-embedded[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 [[getting-started-with-the-comments-plugin-selecting-a-mode]]
 == Getting started with the Comments plugin - Selecting a mode

--- a/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
+++ b/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
@@ -14,7 +14,7 @@ include::partial$misc/admon-premium-plugin.adoc[]
 
 liveDemo::spellcheckerpro[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Cloud Installation
 

--- a/modules/ROOT/pages/keyboard-shortcuts.adoc
+++ b/modules/ROOT/pages/keyboard-shortcuts.adoc
@@ -11,32 +11,32 @@ This is a list of available keyboard shortcuts within the editor body.
 
 [cols=",,,",options="header"]
 |===
-|Action |PC |Mac |Core/Plugin
-|Bold |Ctrl+B |Command+B |core
-|Italic |Ctrl+I |Command+I |core
-|Underline |Ctrl+U |Command+U |core
-|Select All |Ctrl+A |Command+A |core
-|Redo |Ctrl+Y / Ctrl+Shift+Z |Command+Y / Command+Shift+Z |core
-|Undo |Ctrl+Z |Command+Z |core
-|Header 1 |Alt+Shift+1 |Ctrl+Option+1 |core
-|Header 2 |Alt+Shift+2 |Ctrl+Option+2 |core
-|Header 3 |Alt+Shift+3 |Ctrl+Option+3 |core
-|Header 4 |Alt+Shift+4 |Ctrl+Option+4 |core
-|Header 5 |Alt+Shift+5 |Ctrl+Option+5 |core
-|Header 6 |Alt+Shift+6 |Ctrl+Option+6 |core
-|Paragraph |Alt+Shift+7 |Ctrl+Option+7 |core
-|Div |Alt+Shift+8 |Ctrl+Option+8 |core
-|Address |Alt+Shift+9 |Ctrl+Option+9 |core
-|Focus to menu bar |Alt+F9 |Option+F9 |core
-|Focus to toolbar |Alt+F10 |Option+F10 |core
-|Focus to element path |Alt+F11 |Option+F11 |core
+|Action |Windows or Linux |macOS |Core/Plugin
+|Bold |Ctrl+B |⌘+B |core
+|Italic |Ctrl+I |⌘+I |core
+|Underline |Ctrl+U |⌘+U |core
+|Select All |Ctrl+A |⌘+A |core
+|Redo |Ctrl+Y / Ctrl+Shift+Z |⌘+Y / ⌘+Shift+Z |core
+|Undo |Ctrl+Z |⌘+Z |core
+|Header 1 |Alt+Shift+1 |Ctrl+⌥+1 |core
+|Header 2 |Alt+Shift+2 |Ctrl+⌥+2 |core
+|Header 3 |Alt+Shift+3 |Ctrl+⌥+3 |core
+|Header 4 |Alt+Shift+4 |Ctrl+⌥+4 |core
+|Header 5 |Alt+Shift+5 |Ctrl+⌥+5 |core
+|Header 6 |Alt+Shift+6 |Ctrl+⌥+6 |core
+|Paragraph |Alt+Shift+7 |Ctrl+⌥+7 |core
+|Div |Alt+Shift+8 |Ctrl+⌥+8 |core
+|Address |Alt+Shift+9 |Ctrl+⌥+9 |core
+|Focus to menu bar |Alt+F9 |⌥+F9 |core
+|Focus to toolbar |Alt+F10 |⌥+F10 |core
+|Focus to element path |Alt+F11 |⌥+F11 |core
 |Focus to contextual toolbar |Ctrl+F9 |Ctrl+F9 |core
-|Print |Ctrl+P |Command+P |core
-|Open the help dialog |Alt+0 |Option+0 |xref:help.adoc[help]
-|Insert link |Ctrl+K |Command+K |xref:link.adoc[link]
-|Toggle Fullscreen |Ctrl+Shift+F |Command+Shift+F |xref:fullscreen.adoc[fullscreen]
-|Save |Ctrl+S |Command+S |xref:save.adoc[save]
-|Find |Ctrl+F |Command+F |xref:searchreplace.adoc[searchreplace]
+|Print |Ctrl+P |⌘+P |core
+|Open the {productname} Help dialog |Alt+0 |⌥+0 |xref:help.adoc[help]
+|Insert link |Ctrl+K |⌘+K |xref:link.adoc[link]
+|Toggle Fullscreen |Ctrl+Shift+F |⌘+Shift+F |xref:fullscreen.adoc[fullscreen]
+|Save |Ctrl+S |⌘+S |xref:save.adoc[save]
+|Find |Ctrl+F |⌘+F |xref:searchreplace.adoc[searchreplace]
 |===
 
 == Accessibility keyboard shortcuts
@@ -45,7 +45,7 @@ This is a list of available keyboard shortcuts within the editor user interface.
 
 [cols=",,",options="header"]
 |===
-|Action |PC |Mac
+|Action |Windows or Linux |macOS
 |Execute command |Enter / Spacebar |Enter / Spacebar
 |Focus on next UI Element(such as: Menu bar, Toolbar, Toolbar Group, Status Bar Item) |Tab |Tab
 |Focus on previous UI Element(such as: Menu bar, Toolbar, Toolbar Group, Status Bar Item) |Shift+Tab |Shift+Tab

--- a/modules/ROOT/pages/linkchecker.adoc
+++ b/modules/ROOT/pages/linkchecker.adoc
@@ -16,7 +16,7 @@ The Link Checker plugin relies on HTTP response status codes to determine if a l
 
 liveDemo::linkchecker[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Cloud Instructions
 

--- a/modules/ROOT/pages/mentions.adoc
+++ b/modules/ROOT/pages/mentions.adoc
@@ -14,7 +14,7 @@ The mentions plugin will present a list of users when a user types the "@" symbo
 
 liveDemo::mentions[height="400"]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Options
 

--- a/modules/ROOT/pages/mergetags.adoc
+++ b/modules/ROOT/pages/mergetags.adoc
@@ -101,6 +101,21 @@ Here is an example of the {pluginname} HTML structure.
 </span>
 ----
 
+== Merge Tags and the Advanced Templates Insertion Point Marker
+
+include::partial$misc/admon-requires-6.7v.adoc[]
+
+The xref:advanced-templates.adoc[Advanced Templates] Premium plugin can use a fixed string — `+{{mce-cursor}}+` — to xref:advanced-templates.adoc#the-insertion-point-marker[set the insertion point] within a template as the template is added to a {productname} document.
+
+This fixed string uses the same default delimiting characters as individual merge tags use by default. It does not, however, interfere or otherwise interact with any {pluginname} configuration.
+
+The Advanced Templates plugin removes the Insertion Point Marker string before inserting a template containing the string in to a {productname} instance.
+
+Consequently, the Advanced Templates Insertion Point Marker string is never seen by the {pluginname} plugin.
+
+It is, therefore, possible to use the Insertion Point Marker string — `+{{mce-cursor}}+` — as a merge tag. It is not recommended, however. Aside from being an unlikely merge tag string, the potential for confusion is reason enough to avoid duplication across purposes.
+
+
 == Options
 
 include::partial$configuration/mergetags_prefix.adoc[leveloffset=+1]

--- a/modules/ROOT/pages/mergetags.adoc
+++ b/modules/ROOT/pages/mergetags.adoc
@@ -20,7 +20,7 @@ Once a merge tag is inserted, the plugin leaves a non-editable variable wrapped 
 
 liveDemo::merge-tag[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Basic setup
 

--- a/modules/ROOT/pages/pageembed.adoc
+++ b/modules/ROOT/pages/pageembed.adoc
@@ -19,7 +19,7 @@ The *Page Embed* plugin embeds a page in the content using an iframe (Inline fra
 
 liveDemo::page-embed[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Creating a Page Embed toolbar button
 

--- a/modules/ROOT/pages/permanentpen.adoc
+++ b/modules/ROOT/pages/permanentpen.adoc
@@ -34,7 +34,7 @@ For more information on {productname} formats, refer to the xref:content-formatt
 
 liveDemo::permanent-pen[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Using a Permanent Pen
 

--- a/modules/ROOT/pages/premium-skins-and-icons.adoc
+++ b/modules/ROOT/pages/premium-skins-and-icons.adoc
@@ -7,6 +7,8 @@ The {prem_skins_icons} lets you quickly give {productname} a new look. Just choo
 
 == How to use a premium skin
 
+NOTE: premium skins are only available with a link:{pricingpage}/[paid TinyMCE subscriptions].
+
 Use the xref:editor-skin.adoc#skin[skin] option, in combination with the xref:add-css-options.adoc#content_css[content_css] option and the values listed below.
 
 Available values for xref:editor-skin.adoc#skin[skins]:
@@ -101,6 +103,7 @@ Below are some recommended combinations of skins and icon packs:
 * xref:outside-demo.adoc[Outside editor]
 * xref:snow-demo.adoc[Snow editor]
 
+////
 :pluginname: Tiny Skins and Icon
 :pluginminimumplan: tiertwo
 :extensionType: Packs
@@ -108,3 +111,4 @@ Below are some recommended combinations of skins and icon packs:
 include::partial$misc/purchase-premium-plugins.adoc[]
 :!extensionType:
 :!pluralExtensionType:
+////

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -11,6 +11,12 @@ This section lists the releases for {productname} 6 and the changes made in each
 
 a|
 [.lead]
+xref:6.7-release-notes.adoc#overview[{productname} 6.7]
+
+Release notes for {productname} 6.7
+
+a|
+[.lead]
 xref:6.6.2-release-notes.adoc#overview[{productname} 6.6.2]
 
 Release notes for {productname} 6.6.2
@@ -95,7 +101,7 @@ Release notes for {productname} 6.0
 // 2. When the number of cells in the table is even:
 //    * prepend the inline comment markup to this
 //      element.
-a|
+//a|
 
 |===
 

--- a/modules/ROOT/pages/tableofcontents.adoc
+++ b/modules/ROOT/pages/tableofcontents.adoc
@@ -31,7 +31,7 @@ tinymce.init({
 
 The _Table of Contents_ will have a simple HTML structure - a wrapper `+div+` element, a header with _editable_ title and unordered nested list with navigation links. Nesting depth is customizable.
 
-Internally plugin doesn't apply any inline styles. Basic formatting can be added via xref:editor-content-css.adoc[Boilerplate Content CSS], that can be customized to your needs.
+Internally plugin does not apply inline styles. Basic formatting can be added via xref:editor-content-css.adoc[Boilerplate Content CSS], that can be customized to your needs.
 
 [source,css]
 ----
@@ -45,6 +45,12 @@ include::partial$configuration/tableofcontents_depth.adoc[leveloffset=+1]
 include::partial$configuration/tableofcontents_header.adoc[leveloffset=+1]
 
 include::partial$configuration/tableofcontents_class.adoc[leveloffset=+1]
+
+include::partial$configuration/tableofcontents_includeheader.adoc[leveloffset=+1]
+
+include::partial$configuration/tableofcontents_orderedlist.adoc[leveloffset=+1]
+
+include::partial$configuration/tableofcontents_orderedlist_type.adoc[leveloffset=+1]
 
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 

--- a/modules/ROOT/pages/tableofcontents.adoc
+++ b/modules/ROOT/pages/tableofcontents.adoc
@@ -16,7 +16,7 @@ NOTE: In previous versions of {productname} the {pluginname} plugin was provided
 
 liveDemo::tableofcontents[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Basic setup
 

--- a/modules/ROOT/pages/tinydrive-introduction.adoc
+++ b/modules/ROOT/pages/tinydrive-introduction.adoc
@@ -34,7 +34,7 @@ The storage and bandwidth quota varies based upon your link:{pricingpage}/[{clou
 
 liveDemo::drive[]
 
-include::partial$misc/purchase-premium-plugins.adoc[]
+// include::partial$misc/purchase-premium-plugins.adoc[]
 
 == Upload files URL
 

--- a/modules/ROOT/pages/tinymce-and-screenreaders.adoc
+++ b/modules/ROOT/pages/tinymce-and-screenreaders.adoc
@@ -12,30 +12,31 @@ The following *Alt+key* and *Option+key* shortcuts can only be used when the con
 
 [cols=",,",options="header"]
 |===
-|Task |PC (Non-macOS users) |macOS
-|Focus/jump to menu bar |Alt+F9 |Option+F9
-|Focus/jump to toolbar |Alt+F10 |Option+F10
-|Focus/jump to element path |Alt+F11 |Option+F11
+|Task |Windows or Linux |macOS
+|Focus/jump to menu bar |Alt+F9 |⌥+F9
+|Focus/jump to toolbar |Alt+F10 |⌥+F10
+|Focus/jump to element path |Alt+F11 |⌥+F11
 |Close menu/submenu/dialog |Esc |Esc
 |Return to the editor content area |Esc |Esc
 |Navigate left/right through menu/toolbar |Tab and the Arrow Keys |Tab and the Arrow Keys
+|Open the {productname} Help dialog |Alt+0 |⌥+0
 |===
 
 For additional navigation keyboard shortcuts and shortcuts for applying some commonly-used formats, see: xref:keyboard-shortcuts.adoc[Keyboard shortcuts].
 
 == How to work with the editor
 
-When navigating to a TinyMCE editor, the keyboard focus (caret) will be in the content area. The up and down arrow keys navigate between the lines of the editor, such as within and between paragraphs, headings and other items such as links.
+When navigating to a {productname} editor, the keyboard focus (caret) will be in the content area. The up and down arrow keys navigate between the lines of the editor, such as within and between paragraphs, headings and other items such as links.
 
 === Navigating the menu bar
 
-To focus on the editor menu bar, press *Alt+F9*. The *Left Arrow* and *Right Arrow* keys navigate through the top menu items. The *Enter*, *Return*, *Spacebar*, or *Down Arrow* keys open the highlighted menu and moves focus to the first menu item. To activate or select the highlighted menu item, use the *Enter*, *Return*, or *Spacebar* keys. Press the *Esc* key to collapse the menu. The *Right Arrow* key opens submenus and the *Esc* key collapses submenus. To return focus to the content area from the menu bar, use the *Esc* key.
+To focus on the editor menu bar, press *Alt+F9* (or *⌥+F9*). The *Left Arrow* and *Right Arrow* keys navigate through the top menu items. The *Enter*, *Return*, *Spacebar*, or *Down Arrow* keys open the highlighted menu and moves focus to the first menu item. To activate or select the highlighted menu item, use the *Enter*, *Return*, or *Spacebar* keys. Press the *Esc* key to collapse the menu. The *Right Arrow* key opens submenus and the *Esc* key collapses submenus. To return focus to the content area from the menu bar, use the *Esc* key.
 
 === Navigating the toolbar
 
 ==== General toolbar navigation
 
-To focus on the editor toolbars, press *Alt+F10*; which moves the keyboard focus to the first toolbar button on the first toolbar. To move between toolbar buttons _within_ toolbar groups (visual groups of toolbar buttons), use the *Left Arrow* and *Right Arrow* keys. To move the focus _between_ toolbar groups, use the *Tab* or *Shift+Tab* keys. When you reach the end of a toolbar group the *Right Arrow* key will return the focus to the start of the toolbar group. To activate or select the highlighted toolbar button, use the *Enter*, *Return*, or *Spacebar* keys. To return focus to the content area from the toolbar, use the *Esc* key.
+To focus on the editor toolbars, press *Alt+F10* (or *⌥+F10*); which moves the keyboard focus to the first toolbar button on the first toolbar. To move between toolbar buttons _within_ toolbar groups (visual groups of toolbar buttons), use the *Left Arrow* and *Right Arrow* keys. To move the focus _between_ toolbar groups, use the *Tab* or *Shift+Tab* keys. When you reach the end of a toolbar group the *Right Arrow* key will return the focus to the start of the toolbar group. To activate or select the highlighted toolbar button, use the *Enter*, *Return*, or *Spacebar* keys. To return focus to the content area from the toolbar, use the *Esc* key.
 
 ==== Navigating toolbar buttons that contain menus or grids
 

--- a/modules/ROOT/partials/commands/advtemplate-cmds.adoc
+++ b/modules/ROOT/partials/commands/advtemplate-cmds.adoc
@@ -3,6 +3,7 @@
 |Command |Description
 |AdvTemplateAddDialog |Opens the `Add Template` dialog, allowing the current selection to be added as a template.
 |AdvTemplateInsertDialog |Opens the `Insert Template` dialog, allowing a template to be inserted at the current selection
+|AdvTemplateInsertTemplateById |Adds a new template specified by the value of its ID.
 |===
 
 .Example
@@ -10,4 +11,7 @@
 ----
 tinymce.activeEditor.execCommand('AdvTemplateAddDialog');
 tinymce.activeEditor.execCommand('AdvTemplateInsertDialog');
+
+// Adds a new template, which ID is 122, to the document.
+tinymce.activeEditor.execCommand('AdvTemplateInsertTemplateById', false, '122')
 ----

--- a/modules/ROOT/partials/configuration/ai_shortcuts.adoc
+++ b/modules/ROOT/partials/configuration/ai_shortcuts.adoc
@@ -19,33 +19,35 @@ When configured with an instance-specific object array, the {pluginname} shortcu
 [source, js]
 ----
 [
-  { title: 'Summarize', prompt: 'Briefly summarize this.' },
-  { title: 'Explain', prompt: 'Give a short explanation of this.' },
-  { title: 'Improve grammar', prompt: 'Correct grammar.' },
-  { title: 'Improve writing', prompt: 'Enhance this text.' },
-  { title: 'Simplify language', prompt: 'Simplify this.' },
-  { title: 'Make longer', prompt: 'Expand this.' },
-  { title: 'Make shorter', prompt: 'Condense this.' },
+  { title: 'Summarize content', prompt: 'Provide the key points and concepts in this content in a succinct summary.' },
+  { title: 'Improve writing', prompt: 'Rewrite this content with no spelling mistakes, proper grammar, and with more descriptive language, using best writing practices without losing the original meaning.' },
+  { title: 'Simplify language', prompt: 'Rewrite this content with simplified language and reduce the complexity of the writing, so that the content is easier to understand.' },
+  { title: 'Expand upon', prompt: 'Expand upon this content with descriptive language and more detailed explanations, to make the writing easier to understand and increase the length of the content.' },
+  { title: 'Trim content', prompt: 'Remove any repetitive, redundant, or non-essential writing in this content without changing the meaning or losing any key information.' },
   { title: 'Change tone', subprompts: [
-    { title: 'Descriptive', prompt: 'Make this descriptive.' },
-    { title: 'Formal', prompt: 'Make this formal.' },
-    { title: 'Casual', prompt: 'Make this casual.' },
-    { title: 'Humour', prompt: 'Add humour to this.' },
-    { title: 'Inspirational', prompt: 'Inspire reader with this.' },
-    { title: 'Persuasive', prompt: 'Make this persuasive.' },
+    { title: 'Professional', prompt: 'Rewrite this content using polished, formal, and respectful language to convey professional expertise and competence.' },
+    { title: 'Casual', prompt: 'Rewrite this content with casual, informal language to convey a casual conversation with a real person.' },
+    { title: 'Direct', prompt: 'Rewrite this content with direct language using only the essential information.' },
+    { title: 'Confident', prompt: 'Rewrite this content using compelling, optimistic language to convey confidence in the writing.' },
+    { title: 'Friendly', prompt: 'Rewrite this content using friendly, comforting language, to convey understanding and empathy.' },
   ] },
   { title: 'Change style', subprompts: [
-    { title: 'Business', prompt: 'Make this business-like.' },
-    { title: 'Legal', prompt: 'Legal style this.' },
-    { title: 'Journalism', prompt: 'Journalistic style this.' },
-    { title: 'Medical', prompt: 'Medical style this.' },
-    { title: 'Poetic', prompt: 'Make this poetic.' },
+    { title: 'Business', prompt: 'Rewrite this content as a business professional with formal language.' },
+    { title: 'Legal', prompt: 'Rewrite this content as a legal professional using valid legal terminology.' },
+    { title: 'Journalism', prompt: 'Rewrite this content as a journalist using engaging language to convey the importance of the information.' },
+    { title: 'Medical', prompt: 'Rewrite this content as a medical professional using valid medical terminology.' },
+    { title: 'Poetic', prompt: 'Rewrite this content as a poem using poetic techniques without losing the original meaning.' },
   ] },
 ]
 ----
 
-NOTE: The default shortcuts are subject to change in an upcoming release. If you intend to keep these shortcuts, include them within your integration.
+[NOTE]
+.Translations and changes
+====
+The default {pluginname} shortcuts are only available in English. They have not been translated into any other languages, and switching {productname} to a language other than English does not change the default {pluginname} shortcuts.
 
+Also, the default {pluginname} shortcuts are subject to change. If you prefer to keep these shortcuts, include them within your integration.
+====
 
 === Example: using `ai_shortcuts` to present a customised set of {pluginname} shortcuts
 

--- a/modules/ROOT/partials/configuration/help_accessibility.adoc
+++ b/modules/ROOT/partials/configuration/help_accessibility.adoc
@@ -1,0 +1,40 @@
+[[help_accessibility]]
+== `help_accessibility`
+
+include::partial$misc/admon-requires-6.7v.adoc[]
+
+When the xref:help.adoc[Help] plugin is loaded, the {productname} editor displays the keyboard shortcut for accessing the Help dialog in the {productname} status bar by default.
+
+The `help_accessibility` option allows for this display to be turned off.
+
+*Type:* `+Boolean+`
+
+*Possible values:* `true`, `false`
+
+*Default value:* `true`
+
+=== Example: turning `help_accessibility` off
+
+[source,js]
+----
+tinymce.init({
+  selector: "textarea",  // change this value according to your html
+  plugins: "help",
+  help_accessibility: false,
+});
+----
+
+=== Example: explicitly turning `help_accessibility` on
+
+The `help_accessibility` option is set to true by default when the *Help* plugin is loaded.
+
+It is not necessary, but may be useful, to explicitly set the option to `true`.
+
+[source,js]
+----
+tinymce.init({
+  selector: "textarea",  // change this value according to your html
+  plugins: "help",
+  help_accessibility: true,
+});
+----

--- a/modules/ROOT/partials/configuration/tableofcontents_header.adoc
+++ b/modules/ROOT/partials/configuration/tableofcontents_header.adoc
@@ -12,7 +12,7 @@ Table of contents has a header and by default it will be marked up with `+H2+` t
 [source,js]
 ----
 tinymce.init({
-  selector: 'textarea',
+  selector: 'textarea', // change this value according to your HTML
   plugins: 'tableofcontents',
   toolbar: 'tableofcontents',
   tableofcontents_header: 'div' // case doesn't matter

--- a/modules/ROOT/partials/configuration/tableofcontents_includeheader.adoc
+++ b/modules/ROOT/partials/configuration/tableofcontents_includeheader.adoc
@@ -1,0 +1,23 @@
+[[tableofcontents_includeheader]]
+== `+tableofcontents_includeheader+`
+
+By default, Tables of Contents include a header string, *Table of Contents*.
+
+The `+tableofcontents_includeheader+` option allows this header to be turned off.
+
+*Type:* `+Boolean+`
+
+*Default value:* `+'true'+`
+
+*Possible values:* `+'true'+`, `+'false'+`
+
+=== Example: using `tableofcontents_includeheader` to turn the Table of Contents header string off
+[source, js]
+----
+tinymce.init({
+  selector: "textarea", // change this value according to your HTML
+  plugins: "tableofcontents",
+  toolbar: "tableofcontents",
+  tableofcontents_includeheader: false,
+});
+----

--- a/modules/ROOT/partials/configuration/tableofcontents_orderedlist.adoc
+++ b/modules/ROOT/partials/configuration/tableofcontents_orderedlist.adoc
@@ -1,0 +1,35 @@
+[[tableofcontents_orderedlist]]
+== `+tableofcontents_orderedlist+`
+
+By default, Tables of Contents are rendered as unordered lists.
+
+The `+tableofcontents_orderedlist+` option allows Tables of Contents to be rendered as an ordered list.
+
+When the `+tableofcontents_orderedlist+` option is set to `+true+`, Tables of Contents are rendered as numeric ordered lists.
+
+To customise the type of ordered list, add the `+xref:tableofcontents_orderedlist_type[tableofcontents_orderedlist_type]+` option to the configuration.
+
+*Type:* `+Boolean+`
+
+*Default value:* `+'false'+`
+
+*Possible values:* `+'true'+`, `+'false'+`
+
+=== Example: using `+tableofcontents_orderedlist+` to switch from an unordered to an ordered list
+
+[source, js]
+----
+tinymce.init({
+  selector: "textarea", // change this value according to your HTML
+  plugins: "tableofcontents",
+  toolbar: "tableofcontents",
+  tableofcontents_orderedlist: true,
+});
+----
+
+[NOTE]
+====
+If the `tableofcontents_orderedlist: true` option is set and no `tableofcontents_orderedlist_type` option is set, the **Table of Contents** plugin defaults to using a numeric ordered list.
+
+This is equivalent to setting `tableofcontents_orderedlist_type: '1'`.
+====

--- a/modules/ROOT/partials/configuration/tableofcontents_orderedlist_type.adoc
+++ b/modules/ROOT/partials/configuration/tableofcontents_orderedlist_type.adoc
@@ -1,0 +1,57 @@
+[[tableofcontents_orderedlist_type]]
+== `+tableofcontents_orderedlist_type+`
+
+By default, Tables of Contents are rendered as unordered lists.
+
+Setting the option `+tableofcontents_orderedlist: true+`, switches this to a numeric ordered list.
+
+And setting the `+tableofcontents_orderedlist_type+` to one of its available values switches the rendered Table of Contents to the specified https://html.spec.whatwg.org/dev/grouping-content.html#the-ol-element[ordered list type].
+
+
+
+*Type:* `+String+`
+
+*Possible values:* `+'1'+`, `+'A'+`, `+'a'+`, `+'I'+`, `+'i'+`
+
+*Default value:* `+'1'+`
+
+The possible values set the type attribute of the ordered list, `<ol>` as follows:
+
+[cols="10%,90%"]
+|===
+|Value | Ordered list type
+
+|`+'1'+`
+|A list sorted by Arabic/Hindu numerals.
+
+This is the default.
+
+|`+'A'+`
+|A list sorted alphabetically by capital letter.
+
+|`+'a'+`
+|A list sorted alphabetically by lowercase letter.
+
+|`+'I'+`
+|A list sorted by uppercase Roman numerals.
+
+|`+'i'+`
+|A list sorted by lowercase Roman numerals.
+|===
+
+=== Example: using `tableofcontents_orderedlist` to render a Table of Contents as uppercase Roman numerals
+[source, js]
+----
+tinymce.init({
+  selector: "textarea", // change this value according to your HTML
+  plugins: "tableofcontents",
+  toolbar: "tableofcontents",
+  tableofcontents_orderedlist: true, // required to enable tableofcontents_orderedlist_type configuration.
+  tableofcontents_orderedlist_type: 'I',
+});
+----
+
+[IMPORTANT]
+====
+The `tableofcontents_orderedlist: true` option must be present in a {productname} configuration for whatever `tableofcontents_orderedlist_type` setting to come into effect.
+====

--- a/modules/ROOT/partials/misc/purchase-premium-plugins.adoc
+++ b/modules/ROOT/partials/misc/purchase-premium-plugins.adoc
@@ -1,3 +1,7 @@
+// 2023-09-06: the logic herein must be updated to cater to
+// extant commercial plan structures before this file can, once again
+// be added to Premium plugin pages via an `include::` statement.
+
 ifeval::["{extensionType}" != "Packs"]
 :extensionType: plugin
 endif::[]

--- a/modules/ROOT/partials/misc/supported-versions.adoc
+++ b/modules/ROOT/partials/misc/supported-versions.adoc
@@ -6,6 +6,7 @@ Supported versions of {productname}:
 [cols="^,^,^",options="header"]
 |===
 |Version |Release Date |End of Support
+|6.7 |2023-09-13 |2025-03-13
 |6.6 |2023-07-19 |2025-01-19
 |6.5 |2023-06-21 |2024-12-21
 |6.4 |2023-03-29 |2024-09-29
@@ -14,10 +15,6 @@ Supported versions of {productname}:
 |6.1 |2022-07-13 |2024-01-13
 |6.0 |2022-04-07 |2023-10-07
 |===
-
-
-
-
 
 To view our Software License Agreements, visit:
 


### PR DESCRIPTION
DOC-2042: TinyMCE 6.7 Enterprise docs release

Changes:
* All the TinyMCE 6.7-specific documentation changes and additions.

Pre-checks:
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] (New product features only) Release Note added

Review:
- [ ] Documentation Team Lead has reviewed
