### PR TITLE
DOC-2190: Add message notification banner to Tinymce 5x docs for LTS.

### DIFF
--- a/_includes/template/bodycontents.html
+++ b/_includes/template/bodycontents.html
@@ -85,6 +85,14 @@
         background-color: transparent;
     }
 
+    .notification-orange-bg {
+        background-color: orange;
+        color: #595959;
+        padding: 10px;
+        width: 850px;
+        margin-bottom: 10px;
+    }
+
     @media screen and (max-width: 1126px) {
         .modern-main {
             flex-direction: column;
@@ -97,6 +105,10 @@
 
         .modern-navigation {
             width: 100%;
+        }
+
+        .notification-orange-bg {
+            width: auto;
         }
     }
 
@@ -179,6 +191,9 @@
     </aside>
 
     <main class="modern-main-container">
+        <div>
+            <p class="notification-orange-bg"><strong>Note</strong>: placeholder for message</p>
+        </div>
         <div class="heading modern-heading">
             <h1 class="light">{{ page.title }}</h1>
             <h2 class="light">{{ page.description }}</h2>

--- a/_includes/template/bodycontents.html
+++ b/_includes/template/bodycontents.html
@@ -88,6 +88,7 @@
     .notification-orange-bg {
         background-color: orange;
         color: #595959;
+        font-size: 16px;
         padding: 10px;
         width: 850px;
         margin-bottom: 10px;
@@ -192,7 +193,7 @@
 
     <main class="modern-main-container">
         <div>
-            <p class="notification-orange-bg"><strong>Note</strong>: placeholder for message</p>
+            <p class="notification-orange-bg"><strong>NOTE:</strong> TinyMCE 5 reached End of Support in April 2023. No more bug fixes, security updates, or new features will be introduced to TinyMCE 5. We recommend you <strong><a href="https://www.tiny.cloud/docs/tinymce/6/upgrading/#upgrading-to-the-latest-version-of-tinymce-6">upgrade to TinyMCE 6</a></strong> or consider <strong><a href="https://www.tiny.cloud/long-term-support/">TinyMCE 5 Long Term Support (LTS)</a></strong> if you need more time.</p>
         </div>
         <div class="heading modern-heading">
             <h1 class="light">{{ page.title }}</h1>


### PR DESCRIPTION
Ticket: DOC-2190: Add message notification banner to Tinymce 5x docs for LTS.

Changes:
* Add message notification banner to `bodycontent.html` for Tinymce 5x docs LTS.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
