### PR TITLE
DOC-2191: updated both `premium`, `non-premium` and `classic` feature demo UI issues.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2191: updated both premium and non-premium full feature demo UI issues for both the menubar and toolbar when scrolling HTML/JS tab content.
 - DOC-2027: added `/modules/ROOT/partials/configuration/help_accessibility.adoc`, documenting the `help_accessibility` option; edits, re-writes and re-structuring of `help.adoc`; plus copy-edits to `keyboard-shortcuts.adoc`, `tinymce-and-screenreaders.adoc` & `accessibility.adoc`.
 - DOC-2176: Removed references to which commercial plans Premium plugins are or are not available with.
 - DOC-2175: Update CODEOWNERS automatic reviewers upon opening new DOC-PRs.

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
-- DOC-2191: updated both premium and non-premium full feature demo UI issues for both the menubar and toolbar when scrolling HTML/JS tab content.
+- DOC-2191: updated both premium, non-premium and classic-mode feature demo UI issues.
 - DOC-2027: added `/modules/ROOT/partials/configuration/help_accessibility.adoc`, documenting the `help_accessibility` option; edits, re-writes and re-structuring of `help.adoc`; plus copy-edits to `keyboard-shortcuts.adoc`, `tinymce-and-screenreaders.adoc` & `accessibility.adoc`.
 - DOC-2176: Removed references to which commercial plans Premium plugins are or are not available with.
 - DOC-2175: Update CODEOWNERS automatic reviewers upon opening new DOC-PRs.

--- a/modules/ROOT/examples/live-demos/classic/index.js
+++ b/modules/ROOT/examples/live-demos/classic/index.js
@@ -48,7 +48,6 @@ const table2 = '<div> ' +
 
 const demoBaseConfig = {
   selector: 'textarea#classic',
-  width: 755,
   height: 500,
   resize: false,
   autosave_ask_before_unload: false,

--- a/modules/ROOT/examples/live-demos/classic/index.js
+++ b/modules/ROOT/examples/live-demos/classic/index.js
@@ -48,6 +48,7 @@ const table2 = '<div> ' +
 
 const demoBaseConfig = {
   selector: 'textarea#classic',
+  width: "100%",
   height: 500,
   resize: false,
   autosave_ask_before_unload: false,

--- a/modules/ROOT/examples/live-demos/full-featured/example.js
+++ b/modules/ROOT/examples/live-demos/full-featured/example.js
@@ -19,8 +19,6 @@ tinymce.init({
   },
   menubar: 'file edit view insert format tools table tc help',
   toolbar: "undo redo | aidialog aishortcuts | blocks fontsizeinput | bold italic | align numlist bullist | link image | table media pageembed | lineheight  outdent indent | strikethrough forecolor backcolor formatpainter removeformat | charmap emoticons checklist | code fullscreen preview | save print export | pagebreak anchor codesample footnotes mergetags | addtemplate inserttemplate | addcomment showcomments | ltr rtl casechange | spellcheckdialog a11ycheck", // Note: if a toolbar item requires a plugin, the item will not present in the toolbar if the plugin is not also loaded.
-  toolbar_sticky: true,
-  toolbar_sticky_offset: isSmallScreen ? 102 : 108,
   autosave_ask_before_unload: true,
   autosave_interval: '30s',
   autosave_prefix: '{path}{query}-{id}-',

--- a/modules/ROOT/examples/live-demos/full-featured/index.js
+++ b/modules/ROOT/examples/live-demos/full-featured/index.js
@@ -162,8 +162,6 @@ tinymce.ScriptLoader.loadScripts(['https://cdn.jsdelivr.net/npm/faker@5/dist/fak
     },
     menubar: 'file edit view insert format tools table tc help',
       toolbar: "undo redo | aidialog aishortcuts | blocks fontsizeinput | bold italic | align numlist bullist | link image | table media pageembed | lineheight  outdent indent | strikethrough forecolor backcolor formatpainter removeformat | charmap emoticons checklist | code fullscreen preview | save print export | pagebreak anchor codesample footnotes mergetags | addtemplate inserttemplate | addcomment showcomments | ltr rtl casechange | spellcheckdialog a11ycheck", // Note: if a toolbar item requires a plugin, the item will not present in the toolbar if the plugin is not also loaded.
-    toolbar_sticky: true,
-    toolbar_sticky_offset: isSmallScreen ? 102 : 108,
     autosave_ask_before_unload: true,
     autosave_interval: '30s',
     autosave_prefix: '{path}{query}-{id}-',

--- a/modules/ROOT/examples/live-demos/open-source-plugins/index.js
+++ b/modules/ROOT/examples/live-demos/open-source-plugins/index.js
@@ -7,8 +7,6 @@ tinymce.init({
   editimage_cors_hosts: ['picsum.photos'],
   menubar: 'file edit view insert format tools table help',
   toolbar: "undo redo | accordion accordionremove | blocks fontfamily fontsize | bold italic underline strikethrough | align numlist bullist | link image | table media | lineheight outdent indent| forecolor backcolor removeformat | charmap emoticons | code fullscreen preview | save print | pagebreak anchor codesample | ltr rtl",
-  toolbar_sticky: true,
-  toolbar_sticky_offset: isSmallScreen ? 102 : 108,
   autosave_ask_before_unload: true,
   autosave_interval: '30s',
   autosave_prefix: '{path}{query}-{id}-',


### PR DESCRIPTION
Ticket: DOC-2191: updated both `premium`, `non-premium` and `classic` feature demo UI issues.

Changes:
* Hotfix to revert changes made in [DOC-1618](https://github.com/tinymce/tinymce-docs/pull/2325/files) files updated:
* `modules/ROOT/examples/live-demos/full-featured/example.js`
*  `modules/ROOT/examples/live-demos/full-featured/index.js`
*  `modules/ROOT/examples/live-demos/open-source-plugins/index.js`
* Additional `fix` added for `modules/ROOT/examples/live-demos/classic/index.js` to correct width breaking `<div class="tox-editor-container">` editor bounds.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] ~Files has been included where required (if applicable)~
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed


[DOC-1618]: https://ephocks.atlassian.net/browse/DOC-1618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ