### PR TITLE
DOC-2194: fix documentation for TINY-10249 in the 6.7.2 release notes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2194: fix documentation for TINY-10249 in the 6.7.2 release notes.
 - DOC-2194: added file, `6.7.2-release-notes.adoc` to project; added 6.7.2-specific outline to file; edited known issue entry in `6.7-release-notes.adoc` addressed in the 6.7.2 release.; added 6.7.2-specific entries to `nav.adoc`.
 
 ### 2023-10-20

--- a/modules/ROOT/pages/6.7.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.7.2-release-notes.adoc
@@ -54,9 +54,9 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 === css loading in `toolbardrawertoggletest` flickering.
 // TINY-10249
 
-Previously, when a {productname} editor instance would load the content CSS for the `toolbardrawertoggletest` It would cause a noticeable flicker to the editor's UI.
+Unlike {productname} version 5, when a {productname} version 6 editor instance was loaded it asynchronously waited for the editor styles and content to load.
 
-As a result, the CSS would take a few milliseconds to load, resulting in the UI flicker during a editor refresh.
+As a result the browser was able to render a partially complete editor, resulting in UI flicker if an editor was reloaded.
 
 {productname} 6.7.2 addresses this, by adding a fix that now allows the render function to load the CSS in parallel with other necessary actions for displaying the editor.
 

--- a/modules/ROOT/pages/6.7.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.7.2-release-notes.adoc
@@ -58,7 +58,7 @@ Unlike {productname} version 5, when a {productname} version 6 editor instance w
 
 As a result the browser was able to render a partially complete editor, resulting in UI flicker if an editor was reloaded.
 
-{productname} 6.7.2 addresses this, by adding a fix that now allows the render function to load the CSS in parallel with other necessary actions for displaying the editor.
+{productname} 6.7.2 addresses this, by once again blocking the render function from loading the CSS in parallel with other actions necessary for displaying the editor.
 
 As a result, the editor no longer renders the flicker previously displayed when the editor is refreshed.
 

--- a/modules/ROOT/pages/6.7.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.7.2-release-notes.adoc
@@ -51,7 +51,7 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 // CCFR
 
 
-=== css loading in `toolbardrawertoggletest` flickering.
+=== Removed use of async for editor rendering which caused visual blinking when reloading the editor in-place.
 // TINY-10249
 
 Unlike {productname} version 5, when a {productname} version 6 editor instance was loaded it asynchronously waited for the editor styles and content to load.

--- a/modules/ROOT/pages/6.7.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.7.2-release-notes.adoc
@@ -54,7 +54,7 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 === Removed use of async for editor rendering which caused visual blinking when reloading the editor in-place.
 // TINY-10249
 
-Unlike {productname} version 5, when a {productname} version 6 editor instance was loaded it asynchronously waited for the editor styles and content to load.
+In contrast to {productname} version 5, where the editor would initiate rendering without waiting for the completion of CSS loading, in version 6, the editor instance now deliberately synchronizes with the loading of CSS. This modification aims to prevent flickering by ensuring that the necessary styles are fully loaded before proceeding with the rendering process.
 
 As a result the browser was able to render a partially complete editor, resulting in UI flicker if an editor was reloaded.
 

--- a/modules/ROOT/pages/6.7.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.7.2-release-notes.adoc
@@ -54,8 +54,13 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 === css loading in `toolbardrawertoggletest` flickering.
 // TINY-10249
 
-// CCFR
+Previously, when a {productname} editor instance would load the content CSS for the `toolbardrawertoggletest` It would cause a noticeable flicker to the editor's UI.
 
+As a result, the CSS would take a few milliseconds to load, resulting in the UI flicker during a editor refresh.
+
+{productname} 6.7.2 addresses this, by adding a fix that now allows the render function to load the CSS in parallel with other necessary actions for displaying the editor.
+
+As a result, the editor no longer renders the flicker previously displayed when the editor is refreshed.
 
 === Toggling a list that contained a list item element — `<li>` — which, in turn, contained another list item element as its first child, removed other content within the first list item element.
 // TINY-10213

--- a/modules/ROOT/pages/6.7.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.7.2-release-notes.adoc
@@ -54,9 +54,7 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 === Removed use of async for editor rendering which caused visual blinking when reloading the editor in-place.
 // TINY-10249
 
-In contrast to {productname} version 5, where the editor would initiate rendering without waiting for the completion of CSS loading, in version 6, the editor instance now deliberately synchronizes with the loading of CSS. This modification aims to prevent flickering by ensuring that the necessary styles are fully loaded before proceeding with the rendering process.
-
-As a result the browser was able to render a partially complete editor, resulting in UI flicker if an editor was reloaded.
+In contrast to {productname} version 5, where the editor would initiate rendering without waiting for the completion of CSS loading, in version 6, the editor instance now deliberately synchronizes with the loading of CSS. This modification aims to prevent flickering by ensuring that the necessary styles have finished loading before proceeding with the rendering process.
 
 {productname} 6.7.2 addresses this, by once again blocking the render function from loading the CSS in parallel with other actions necessary for displaying the editor.
 


### PR DESCRIPTION
Ticket: DOC-2194

Changes:
* add bugfix documentation for TINY-10249 in the 6.7.2 release notes.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
