### PR TITLE
DOC-2194: add fix documentation for TINY-10268 in the 6.7.2 Release notes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2194: add fix documentation for TINY-10268 in the 6.7.2 Release notes.
 - DOC-2194: added file, `6.7.2-release-notes.adoc` to project; added 6.7.2-specific outline to file; edited known issue entry in `6.7-release-notes.adoc` addressed in the 6.7.2 release.; added 6.7.2-specific entries to `nav.adoc`.
 
 ### 2023-10-20

--- a/modules/ROOT/pages/6.7.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.7.2-release-notes.adoc
@@ -45,7 +45,7 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 // CCFR
 
 
-=== List items containing a nested list between two text caused some list operations to fail.
+=== Indenting or outdenting a list item that contained non list item siblings after it would result in those siblings being removed.
 // TINY-10268
 Previously, when the editor encounter's a list inside an `<li>` element, the editor would only account for scenarios where the list is either the first or last element within the `<li>`. In such cases, {productname} would treat the content contained within the `<li>` as plain HTML, disregarding any nested lists.
 

--- a/modules/ROOT/pages/6.7.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.7.2-release-notes.adoc
@@ -69,7 +69,7 @@ the editor would encounter problems when attempting to apply list-related action
 
 {productname} 6.7.2 addresses this issue, now, when an `<li>` contains both non-list elements at its beginning and end, and also contains a nested list, the editor now will consider actions on the nested list independently, instead of treating the entire content as a single block.
 
-As a result, actions like indent and unindent a nested list works as expected.
+As a result, the actions of indenting and unindenting a nested list now work as expected.
 
 === css loading in `toolbardrawertoggletest` flickering.
 // TINY-10249

--- a/modules/ROOT/pages/6.7.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.7.2-release-notes.adoc
@@ -47,9 +47,29 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 === List items containing a nested list between two text caused some list operations to fail.
 // TINY-10268
+Previously, when the editor encounter's a list inside an `<li>` element, the editor would only account for scenarios where the list is either the first or last element within the `<li>`. In such cases, {productname} would treat the content contained within the `<li>` as plain HTML, disregarding any nested lists.
 
-// CCFR
+Consequently, when dealing with a structure like the following:
 
+[source,html]
+----
+<ul>
+  <li>
+    <p>A</p>
+    <ul>
+      <li>L1</li>
+      <li>L2</li>
+    </ul>
+    <p>B</p>
+  </li>
+</ul>
+----
+
+the editor would encounter problems when attempting to apply list-related actions, such as indentation, to the inner list.
+
+{productname} 6.7.2 addresses this issue, now, when an `<li>` contains both non-list elements at its beginning and end, and also contains a nested list, the editor now will consider actions on the nested list independently, instead of treating the entire content as a single block.
+
+As a result, actions like indent and unindent a nested list works as expected.
 
 === css loading in `toolbardrawertoggletest` flickering.
 // TINY-10249


### PR DESCRIPTION
Ticket: DOC-2194

Changes:
* add fix documentation for TINY-10268 in the 6.7.2 Release notes.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
