### PR TITLE
DOC-2181: fix documentation for TINY-10153 to the 6.8 release notes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2181: fix documentation for TINY-10153 to the 6.8 release notes.
 - DOC-2181: the TinyMCE 6.8 release notes plus 6.8-specific changes to the TinyMCE documentation.
 - DOC-2075: remove `tinymcespellchecker` configuration workaround from full-featured-demo with Premium plugins examples: `/modules/ROOT/examples/live-demos/full-featured/example.js` and `/modules/ROOT/examples/live-demos/full-featured/index.js`.
 - DOC-2182: added file, `/modules/ROOT/partials/configuration/indent.adoc`, documenting the `indent` option. Added `include::` statement to `/modules/ROOT/pages/content-filtering.adoc` pointing to this file.

--- a/modules/ROOT/pages/6.8-release-notes.adoc
+++ b/modules/ROOT/pages/6.8-release-notes.adoc
@@ -257,6 +257,9 @@ waiting for confirmation on these new feature tickets.
 
 === Editor would convert urls that are not http/s or relative resulting in broken links.
 // #TINY-10153
+In previous versions of {productname}, when using the **Link Plugin**, and inserting a link that is not http/s or relative (such as onenote link), the editor would modify/update the link by adding a new hostname to the url.
+
+{productname} 6.8 addresses this issue, now, the editor no longer changes links that are not http/s or relative.
 
 === Calling the setProgressState API would cause the window to be scrolled when the editor wasn't fully visible.
 // #TINY-10172


### PR DESCRIPTION
Ticket: DOC-2181

Changes:
* fix documentation for TINY-10153 to the 6.8 release notes.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
