### PR TITLE
DOC-461: Add documentation for accessing TinyMCE and native context menus on mobile devices

### DIFF
--- a/modules/ROOT/pages/tinymce-for-mobile.adoc
+++ b/modules/ROOT/pages/tinymce-for-mobile.adoc
@@ -21,6 +21,8 @@ The mobile experience allows most of the {productname} plugins to work on mobile
 
 NOTE: iPads do not use the `+mobile+` part of the {productname} init configuration. This is due to a constraint added by Apple to return the environment as a "desktop environment" for iPads. iPad users will receive the other changes to touch functionality, such as context toolbars and context menus.
 
+include::partial$misc/admon-mobile-context-menus.adoc[]
+
 include::partial$misc/mobile-platform-compatibility.adoc[]
 
 == Configuring mobile

--- a/modules/ROOT/partials/configuration/contextmenu.adoc
+++ b/modules/ROOT/partials/configuration/contextmenu.adoc
@@ -21,6 +21,8 @@ To disable the editor's context menu, set this option to `+false+`.
 
 include::partial$misc/admon-ctrl-right-click.adoc[]
 
+include::partial$misc/admon-mobile-context-menus.adoc[]
+
 === Example: using `+contextmenu+`
 
 [source,js]

--- a/modules/ROOT/partials/misc/admon-mobile-context-menus.adoc
+++ b/modules/ROOT/partials/misc/admon-mobile-context-menus.adoc
@@ -1,0 +1,3 @@
+NOTE: When a {productname} context menu is configured, a user on a mobile device can access the {productname} context menu by a _long press_. However, when a {productname} context menu is not configured but a {productname} context toolbar is, _long press_ will instead open the context toolbar. 
+
+IMPORTANT: The native context menu on a mobile device can still be accessed with a {productname} context menu configured, either by a _single tap_ on iOS, or by a _double tap_ on Android. However if the `+contextmenu_never_use_native+` option is enabled, neither _single_ nor _double tap_ will have any effect.

--- a/modules/ROOT/partials/misc/mobile-context-menus.adoc
+++ b/modules/ROOT/partials/misc/mobile-context-menus.adoc
@@ -1,3 +1,0 @@
-== Using Context Menus on Mobile
-
-When TinyMCE is configured with a context menu, the xref:contextmenu.adoc[TinyMCE context menu] will appear when the user right-clicks, instead of the native context menu.

--- a/modules/ROOT/partials/misc/mobile-context-menus.adoc
+++ b/modules/ROOT/partials/misc/mobile-context-menus.adoc
@@ -1,0 +1,3 @@
+== Using Context Menus on Mobile
+
+When TinyMCE is configured with a context menu, the xref:contextmenu.adoc[TinyMCE context menu] will appear when the user right-clicks, instead of the native context menu.


### PR DESCRIPTION
Ticket: DOC-461

Changes:
* Added note which describes accessing the TinyMCE context menu/toolbar on a mobile device
* Added note which describes accessing the native context menu on a mobile device, when a TinyMCE context menu is configured
* Added new notes to context menu and tinymce for mobile pages.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] ~Changelog entry added~
- [x] ~`modules/ROOT/nav.adoc` has been updated (if applicable)~
- [x] Files has been included where required (if applicable)
- [x] ~Files removed have been deleted, not just excluded from the build (if applicable)~
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
