### PR TITLE
DOC-2212: Typo correction for missing space in 6.7.3 docs.

### DIFF
--- a/modules/ROOT/pages/6.7.3-release-notes.adoc
+++ b/modules/ROOT/pages/6.7.3-release-notes.adoc
@@ -35,4 +35,5 @@ This vulnerability has been patched in {productname} 6.7.3 by:
 CVE: pending.
 
 GHSA: https://github.com/tinymce/tinymce/security/advisories/GHSA-v626-r774-j7f8[GitHub Advisory].
+
 NOTE: Tiny Technologies would like to thank Masato Kinugawa of https://cure53.de/[Cure53] for discovering this vulnerability.


### PR DESCRIPTION
Ticket: DOC-2212

Changes:
* Typo correction for missing space in 6.7.3 docs.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`

Review:
- [x] Documentation Team Lead has reviewed
