### PR TITLE
DOC-2209: Added docs for the new default_font_size option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2209: add new default_font_stack `user-formatting-option.adoc` file.
 
 ### 2023-11-15
 

--- a/modules/ROOT/pages/user-formatting-options.adoc
+++ b/modules/ROOT/pages/user-formatting-options.adoc
@@ -4,6 +4,8 @@
 
 include::partial$configuration/block_formats.adoc[]
 
+include::partial$configuration/default_font_stack.adoc[]
+
 include::partial$configuration/font_family_formats.adoc[]
 
 include::partial$configuration/font_size_formats.adoc[]

--- a/modules/ROOT/partials/configuration/default_font_stack.adoc
+++ b/modules/ROOT/partials/configuration/default_font_stack.adoc
@@ -1,0 +1,20 @@
+[[default_font_stack]]
+== `+default_font_stack+`
+
+This option changes the default font stack that is considered as the "System Font" stack in the fontfamily toolbar and menu items. It's should be an
+array of font family names that matches the default fonts in the the configured xref:add-css-options.adoc#content_css[content_css] CSS file.
+
+*Type:* `+Array+`
+
+*Default value:* `[ '-apple-system', 'Segoe UI', 'Roboto', 'Helvetica Neue', 'sans-serif' ]`
+
+=== Example: using `+default_font_stack+`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  toolbar: 'fontsize',
+  default_font_stack: [ '-apple-system', 'Arial' ]
+});
+----


### PR DESCRIPTION
Ticket: DOC-2209, Document new `default_font_stack` option.

Changes:
* Added docs for the `default_font_stack` option.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
