### PR TITLE
DOC-2219: TinyMCE 6.8 community release typo and corrections.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+
+### 2023-11-22
+
 - DOC-2180: Added 6.8-specific entry to `changelog.adoc`.
 
 ### 2023-11-15

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -4,23 +4,23 @@
 
 NOTE: This is the {productname} Community version changelog. For information about the latest {cloudname} or {enterpriseversion} Release, see: xref:release-notes.adoc[{productname} Release Notes].
 
-== 6.8 - 2023-11-22
+== 6.8.0 - 2023-11-22
 
-== Added
+=== Added
 * CSS files are now also generated as separate JS files to improve bundling of all resources.
 * Added new StylesheetLoader.loadRawCss API that can be used to load CSS into a style element.
 * Added new StylesheetLoader.unloadRawCss API that can be used to unload CSS that was loaded into a style element.
-* Added force_hex_color editor option. Option 'always' converts all RGB & RGBA colours to hex, 'rgb_only' will only convert RGB and not RGBA colours to hex, 'off' won't convert any colours to hex.
+* Added force_hex_color editor option. Option 'always' converts all RGB & RGBA colors to hex, 'rgb_only' will only convert RGB and not RGBA colors to hex, 'off' won't convert any colors to hex.
 * Added default_font_stack editor option that makes it possible to define what is considered a system font stack.
 * New `sandbox_iframes` option that controls whether iframe elements will be added a `sandbox=""` attribute to mitigate malicious intent.
 * New `convert_unsafe_embeds` option that controls whether `<object>` and `<embed>` elements will be converted to more restrictive alternatives, namely `<img>` for image MIME types, `<video>` for video MIME types, `<audio>` audio MIME types, or `<iframe>` for other or unspecified MIME types.
 
-== Improved
+=== Improved
 * Improved the tooltips of picker buttons for the urlinput components in the "Insert/Edit Image" and "Insert/Edit Link" dialogs.
 * Inline dialog will now respect `size: 'large'` argument in the dialog spec.
 * Bespoke dropdown toolbar buttons including `align`, `fontfamily`, `fontsize`, `blocks`, and `styles` did not include their visible text labels in their accessible names.
 
-== Fixed
+=== Fixed
 * Editor would convert urls that are not http/s or relative resulting in broken links.
 * Calling the `setProgressState` API would cause the window to be scrolled when the editor wasn't fully visible.
 * Applying heading formatting to the content of the `summary` element extended its application to the content of the parent details element.
@@ -48,11 +48,11 @@ NOTE: This is the {productname} Community version changelog. For information abo
 
 == 6.7.3 - 2023-11-15
 
-### Changed
+=== Changed
 * Zero width no-break space (U+FEFF) characters are removed from content passed to `setContent`, `insertContent`, and `resetContent` APIs.
 * Zero width no-break space (U+FEFF) characters in initial content are not loaded into the editor upon initialization.
 
-### Fixed
+=== Fixed
 * Specific HTML content containing unescaped text nodes caused mXSS when using undo/redo.
 * Specific HTML content containing unescaped text nodes caused mXSS when using the `getContent` and `setContent` APIs with the `format: 'raw'` option, which also affected the `resetContent` API and the draft restoration feature of the Autosave plugin.
 


### PR DESCRIPTION
Ticket: DOC-2219

Changes:
* TinyMCE 6.8 community release typo and corrections to heading levels.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`

Review:
- [x] Documentation Team Lead has reviewed
