### PR TITLE
DOC-2221: add new notification messages to `cloud-troubleshooting.adoc` file.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2221: add new notification messages to `cloud-troubleshooting.adoc` file.
 
 ### 2023-11-22
 

--- a/modules/ROOT/pages/cloud-troubleshooting.adoc
+++ b/modules/ROOT/pages/cloud-troubleshooting.adoc
@@ -7,7 +7,7 @@ When {cloudname} detects a problem, it will show an editor notification containi
 
 NOTE: The wording of the notifications shown here may differ from the actual notifications from {cloudname}.
 
-[[A-valid-API-key-is-required-starting-2024-to-continue-using-TinyMCE.-Please-alert-your-admin-to-check-the-current-API-key.]]
+[[A-valid-API-key-is-required-starting-2024-to-continue-using-TinyMCE.-Please-alert-your-admin-to-check-the-current-API-key-1.]]
 == "A valid API key is required, starting 2024, to continue using TinyMCE. Please alert your admin to check the current API key."
 
 === Cause

--- a/modules/ROOT/pages/cloud-troubleshooting.adoc
+++ b/modules/ROOT/pages/cloud-troubleshooting.adoc
@@ -7,8 +7,8 @@ When {cloudname} detects a problem, it will show an editor notification containi
 
 NOTE: The wording of the notifications shown here may differ from the actual notifications from {cloudname}.
 
-[[this-domain-is-not-registered-with-tiny-cloud-please-see-the-quick-start-guide-or-create-an-account]]
-== "This domain is not registered with Tiny Cloud. Please see the quick start guide or create an account."
+[[A-valid-API-key-is-required-starting-2024-to-continue-using-TinyMCE.-Please-alert-your-admin-to-check-the-current-API-key.]]
+== "A valid API key is required, starting 2024, to continue using TinyMCE. Please alert your admin to check the current API key."
 
 === Cause
 
@@ -35,8 +35,8 @@ Update the `+src+` URL to include your (website or application developer's) {clo
 
 To retrieve your API key, or to sign up for an API key, visit: link:{accountsignup}/[{cloudname}].
 
-[[the-api-key-you-have-entered-is-invalid-please-review-your-api-key]]
-== "The API key you have entered is invalid. Please review your API key."
+[[A-valid-API-key-is-required-starting-2024-to-continue-using-TinyMCE.-Please-alert-your-admin-to-check-the-current-API-key.]]
+== "A valid API key is required, starting 2024, to continue using TinyMCE. Please alert your admin to check the current API key."
 
 === Cause
 
@@ -56,8 +56,8 @@ Check the `+apiKey+` provided in the script tag:
 * Any other characters that are not in your API key. If you are using variable substitution, ensure that the variable is substituting properly.
 * Matches the API key shown at {accountpageurl}.
 
-[[this-domain-is-not-registered-with-tiny-cloud-please-review-your-approved-domains]]
-== "This domain is not registered with Tiny Cloud. Please review your approved domains."
+[[This-domain-is-not-registered-with-Tiny-Cloud.-To-continue-using-TinyMCE-a-registered-domain-is-required-starting-2024.-Please-alert-your-admin-to-review-the-approved-domains-and-add-this-one-if-required.]]
+== "This domain is not registered with Tiny Cloud. To continue using TinyMCE, a registered domain is required, starting 2024. Please alert your admin to review the approved domains and add this one if required."
 
 === Cause
 

--- a/modules/ROOT/pages/cloud-troubleshooting.adoc
+++ b/modules/ROOT/pages/cloud-troubleshooting.adoc
@@ -35,7 +35,7 @@ Update the `+src+` URL to include your (website or application developer's) {clo
 
 To retrieve your API key, or to sign up for an API key, visit: link:{accountsignup}/[{cloudname}].
 
-[[A-valid-API-key-is-required-starting-2024-to-continue-using-TinyMCE.-Please-alert-your-admin-to-check-the-current-API-key.]]
+[[A-valid-API-key-is-required-starting-2024-to-continue-using-TinyMCE.-Please-alert-your-admin-to-check-the-current-API-key-2.]]
 == "A valid API key is required, starting 2024, to continue using TinyMCE. Please alert your admin to check the current API key."
 
 === Cause


### PR DESCRIPTION
Ticket: DOC-2221

Changes:
* add new notification messages to `cloud-troubleshooting.adoc` file for 6x docs.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [ ] Documentation Team Lead has reviewed
