### PR TITLE
DOC-2222: Fix broken mergetags in demos, warnings and errors

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -63,7 +63,7 @@ asciidoc:
     newline: '<br>'
     virt_ellps: '&#8942;'
     ellps: '&#133;'
-    # Prevent Mergetags as variables
+    # Prevent Mergetags becoming variables
     prefix: '{{'
     suffix: '}}'
     # Demo logos

--- a/antora.yml
+++ b/antora.yml
@@ -63,9 +63,9 @@ asciidoc:
     newline: '<br>'
     virt_ellps: '&#8942;'
     ellps: '&#133;'
-    # Mergetag Variable replacement in Demos
-    mce-cursor: '{{mce-cursor}}'
-    mce-clipboard: '{{mce-clipboard}}'
+    # Prevent Mergetags as variables
+    prefix: '{{'
+    suffix: '}}'
     # Demo logos
     logofordemos: 'https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png'
     logofordemoshtml: '<p><img style="display: block; margin-left: auto; margin-right: auto;" title="Tiny Logo" src="https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128"></p>'

--- a/antora.yml
+++ b/antora.yml
@@ -63,6 +63,8 @@ asciidoc:
     newline: '<br>'
     virt_ellps: '&#8942;'
     ellps: '&#133;'
+    # Mergetag Variable replacement in Demos
+    mce-cursor: '{{mce-cursor}}'
     # Demo logos
     logofordemos: 'https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png'
     logofordemoshtml: '<p><img style="display: block; margin-left: auto; margin-right: auto;" title="Tiny Logo" src="https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128"></p>'

--- a/antora.yml
+++ b/antora.yml
@@ -65,6 +65,7 @@ asciidoc:
     ellps: '&#133;'
     # Mergetag Variable replacement in Demos
     mce-cursor: '{{mce-cursor}}'
+    mce-clipboard: '{{mce-clipboard}}'
     # Demo logos
     logofordemos: 'https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png'
     logofordemoshtml: '<p><img style="display: block; margin-left: auto; margin-right: auto;" title="Tiny Logo" src="https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128"></p>'

--- a/modules/ROOT/examples/live-demos/advtemplate-insertionpoint/index.html
+++ b/modules/ROOT/examples/live-demos/advtemplate-insertionpoint/index.html
@@ -11,10 +11,10 @@
   Select the template to add to the TinyMCE document from the <strong>Templates</strong> dialog that presents.
     <ol>
       <li>
-      Click the <strong>Without an insertion point marker</strong> category to see and select a template that does not use the <code>{{mce-cursor}}</code> insertion point marker.
+      Click the <strong>Without an insertion point marker</strong> category to see and select a template that does not use the <code>{{prefix}}mce-cursor{{suffix}}</code> insertion point marker.
       </li>
       <li>
-      Click the <strong>With an insertion point marker</strong> category to see and select a template that does use the <code>{{mce-cursor}}</code> insertion point marker.
+      Click the <strong>With an insertion point marker</strong> category to see and select a template that does use the <code>{{prefix}}mce-cursor{{suffix}}</code> insertion point marker.
       </li>
     </ol>
   </li>
@@ -23,21 +23,21 @@
 
 <h4>Noting the difference</h4>
 
-<p>The <em>Name entry prompt</em> template without the <code>{{mce-cursor}}</code> insertion point marker, places the insertion point at the end of the template text.</p>
+<p>The <em>Name entry prompt</em> template without the <code>{{prefix}}mce-cursor{{suffix}}</code> insertion point marker, places the insertion point at the end of the template text.</p>
 
-<p>By contrast, the <em>Name entry prompt</em> template with the <code>{{mce-cursor}}</code> insertion point marker places the insertion point at the right spot for someone to enter their name, as requested.</p>
+<p>By contrast, the <em>Name entry prompt</em> template with the <code>{{prefix}}mce-cursor{{suffix}}</code> insertion point marker places the insertion point at the right spot for someone to enter their name, as requested.</p>
 
-<p>Similarly, the <em>Letter outline</em> template without the <code>{{mce-cursor}}</code> insertion point marker, places the insertion point at the end of the template text.</p>
+<p>Similarly, the <em>Letter outline</em> template without the <code>{{prefix}}mce-cursor{{suffix}}</code> insertion point marker, places the insertion point at the end of the template text.</p>
 
-<p>And, by equivalent contrast, the <em>Letter outline</em> template with the <code>{{mce-cursor}}</code> insertion point marker places the insertion point at the right spot for someone to start writing a letter.</p>
+<p>And, by equivalent contrast, the <em>Letter outline</em> template with the <code>{{prefix}}mce-cursor{{suffix}}</code> insertion point marker places the insertion point at the right spot for someone to start writing a letter.</p>
 
 <h4>Working with Merge Tags</h4>
 
-<p>The second pre-defined template in this demonstration — the <em>Letter outline</em> template — shows the <code>{{mce-cursor}}</code> string working in conjunction with the <a href="https://tiny.cloud/docs/tinymce/6/mergetags/">Merge Tags</a> Premium plugin.</p>
+<p>The second pre-defined template in this demonstration — the <em>Letter outline</em> template — shows the <code>{{prefix}}mce-cursor{{suffix}}</code> string working in conjunction with the <a href="https://tiny.cloud/docs/tinymce/6/mergetags/">Merge Tags</a> Premium plugin.</p>
 
 <p>The fixed string that is the Insertion Point Marker uses the same delimiting characters as are used by default by the Merge Tags plugin.</p>
 
-<p>The <strong>Merge Tags</strong> plugin knows nothing about the <code>{{mce-cursor}}</code> being a marker string for the <strong>Advanced Templates</strong> plugin. And, if this particular string was used in a Merge Tags configuration, the <strong>Merge Tags</strong> plugin would recognise it and substitute it with whatever contents it was set to substitute, as expected.
+<p>The <strong>Merge Tags</strong> plugin knows nothing about the <code>{{prefix}}mce-cursor{{suffix}}</code> being a marker string for the <strong>Advanced Templates</strong> plugin. And, if this particular string was used in a Merge Tags configuration, the <strong>Merge Tags</strong> plugin would recognise it and substitute it with whatever contents it was set to substitute, as expected.
 
 <p>The <strong>Advanced Templates</strong> plugin removes the Insertion Point Marker before inserting a template containing the string in to a TinyMCE instance, however.</p>
 

--- a/modules/ROOT/examples/live-demos/advtemplate-insertionpoint/index.js
+++ b/modules/ROOT/examples/live-demos/advtemplate-insertionpoint/index.js
@@ -12,7 +12,7 @@ tinymce.init({
         },
         {
           title: 'Letter outline',
-          content: '<p>{{Current.Date}}</p><p>{{Honorific}} {{Person.Name.Last}},</p><p></p><p>&nbsp;</p><p>Regards,</p><p>{{staff.digital.signature}}</p><p>{{Staff.Name}}</p><p>{{Staff.Email}}</p>'
+          content: '<p>{\{Current.Date\}}</p><p>{\{Honorific\}} {\{Person.Name.Last\}},</p><p></p><p>&nbsp;</p><p>Regards,</p><p>{\{staff.digital.signature\}}</p><p>{\{Staff.Name\}}</p><p>{\{Staff.Email\}}</p>'
         },
       ],
     },
@@ -21,11 +21,11 @@ tinymce.init({
       items: [
         {
           title: 'Name entry prompt',
-          content: '<p><strong>Enter your name:</strong>{{mce-cursor}}</p><p><em>Include both your given and family names, in your preferred order.</em></p>'
+          content: '<p><strong>Enter your name:</strong>{\{mce-cursor\}}</p><p><em>Include both your given and family names, in your preferred order.</em></p>'
         },
         {
           title: 'Letter outline',
-          content: '<p>{{Current.Date}}</p><p>{{Honorific}} {{Person.Name.Last}},</p><p>{{mce-cursor}}&nbsp;</p><p>Regards,</p><p>{{staff.digital.signature}}</p><p>{{Staff.Name}}</p><p>{{Staff.Email}}</p>'
+          content: '<p>{\{Current.Date\}}</p><p>{\{Honorific\}} {\{Person.Name.Last\}},</p><p>{\{mce-cursor\}}&nbsp;</p><p>Regards,</p><p>{\{staff.digital.signature\}}</p><p>{\{Staff.Name\}}</p><p>{\{Staff.Email\}}</p>'
         },
       ],
     },

--- a/modules/ROOT/examples/live-demos/advtemplate-insertionpoint/index.js
+++ b/modules/ROOT/examples/live-demos/advtemplate-insertionpoint/index.js
@@ -12,7 +12,7 @@ tinymce.init({
         },
         {
           title: 'Letter outline',
-          content: '<p>{\{Current.Date\}}</p><p>{\{Honorific\}} {\{Person.Name.Last\}},</p><p></p><p>&nbsp;</p><p>Regards,</p><p>{\{staff.digital.signature\}}</p><p>{\{Staff.Name\}}</p><p>{\{Staff.Email\}}</p>'
+          content: '<p>{{prefix}}Current.Date{{suffix}}</p><p>{{prefix}}Honorific{{suffix}} {{prefix}}Person.Name.Last{{suffix}},</p><p></p><p>&nbsp;</p><p>Regards,</p><p>{{prefix}}staff.digital.signature{{suffix}}</p><p>{{prefix}}Staff.Name{{suffix}}</p><p>{{prefix}}Staff.Email{{suffix}}</p>'
         },
       ],
     },
@@ -21,11 +21,11 @@ tinymce.init({
       items: [
         {
           title: 'Name entry prompt',
-          content: '<p><strong>Enter your name:</strong>{\{mce-cursor\}}</p><p><em>Include both your given and family names, in your preferred order.</em></p>'
+          content: '<p><strong>Enter your name:</strong>{{prefix}}mce-cursor{{suffix}}</p><p><em>Include both your given and family names, in your preferred order.</em></p>'
         },
         {
           title: 'Letter outline',
-          content: '<p>{\{Current.Date\}}</p><p>{\{Honorific\}} {\{Person.Name.Last\}},</p><p>{\{mce-cursor\}}&nbsp;</p><p>Regards,</p><p>{\{staff.digital.signature\}}</p><p>{\{Staff.Name\}}</p><p>{\{Staff.Email\}}</p>'
+          content: '<p>{{prefix}}Current.Date{{suffix}}</p><p>{{prefix}}Honorific{{suffix}} {{prefix}}Person.Name.Last{{suffix}},</p><p>{{prefix}}mce-cursor{{suffix}}&nbsp;</p><p>Regards,</p><p>{{prefix}}staff.digital.signature{{suffix}}</p><p>{{prefix}}Staff.Name{{suffix}}</p><p>{{prefix}}Staff.Email{{suffix}}</p>'
         },
       ],
     },

--- a/modules/ROOT/examples/live-demos/advtemplate-predefined/index.js
+++ b/modules/ROOT/examples/live-demos/advtemplate-predefined/index.js
@@ -4,15 +4,15 @@ const advtemplate_templates = [
     items: [
       {
         title: 'Message received',
-        content: '<p dir="ltr">Hey {{Customer.FirstName}}!</p>\n<p dir="ltr">Just a quick note to say we&rsquo;ve received your message, and will get back to you within 48 hours.</p>\n<p dir="ltr">For reference, your ticket number is: {{Ticket.Number}}</p>\n<p dir="ltr">Should you have any questions in the meantime, just reply to this email and it will be attached to this ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Regards,</p>\n<p dir="ltr">{{Agent.FirstName}}</p>'
+        content: '<p dir="ltr">Hey {\{Customer.FirstName\}}!</p>\n<p dir="ltr">Just a quick note to say we&rsquo;ve received your message, and will get back to you within 48 hours.</p>\n<p dir="ltr">For reference, your ticket number is: {\{Ticket.Number\}}</p>\n<p dir="ltr">Should you have any questions in the meantime, just reply to this email and it will be attached to this ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Regards,</p>\n<p dir="ltr">{\{Agent.FirstName\}}</p>'
       },
       {
         title: 'Thanks for the feedback',
-        content: '<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p dir="ltr">We appreciate you taking the time to provide feedback on {{Product.Name}}.</p>\n<p dir="ltr">It sounds like it wasn&rsquo;t able to fully meet your expectations, for which we apologize. Rest assured our team looks at each piece of feedback and uses it to decide what to focus on next with {{Product.Name}}.</p>\n<p dir="ltr"><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best, and let us know if there&rsquo;s anything else we can do to help.</p>\n<p dir="ltr">-{{Agent.FirstName}}</p>'
+        content: '<p dir="ltr">Hi {\{Customer.FirstName\}},</p>\n<p dir="ltr">We appreciate you taking the time to provide feedback on {\{Product.Name\}}.</p>\n<p dir="ltr">It sounds like it wasn&rsquo;t able to fully meet your expectations, for which we apologize. Rest assured our team looks at each piece of feedback and uses it to decide what to focus on next with {\{Product.Name\}}.</p>\n<p dir="ltr"><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best, and let us know if there&rsquo;s anything else we can do to help.</p>\n<p dir="ltr">-{\{Agent.FirstName\}}</p>'
       },
       {
         title: 'Still working on case',
-        content: '<p dir="ltr"><img src="https://lh4.googleusercontent.com/-H7w_COxrsy2fVpjO6RRnoBsujhaLyg6AXux5zidqmQ_ik1mrE6BtnaTUdWYQuVbtKpviRqQiuPBOHNGUsEXvrRliEHc4-hKDrCLgQQ9Co-MI4uY2ehUvYtU1nn3EeS0WiUzST-7MQB2Z5YFXrMDwRk" width="320" height="240"></p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p dir="ltr">Just a quick note to let you know we&rsquo;re still working on your case. It&rsquo;s taking a bit longer than we hoped, but we&rsquo;re aiming to get you an answer in the next 48 hours.</p>\n<p dir="ltr">Stay tuned,</p>\n<p dir="ltr">{{Agent.FirstName}}</p>'
+        content: '<p dir="ltr">Hi {\{Customer.FirstName\}},</p>\n<p dir="ltr">Just a quick note to let you know we&rsquo;re still working on your case. It&rsquo;s taking a bit longer than we hoped, but we&rsquo;re aiming to get you an answer in the next 48 hours.</p>\n<p dir="ltr">Stay tuned,</p>\n<p dir="ltr">{\{Agent.FirstName\}}</p>'
       }
     ]
   },
@@ -21,11 +21,11 @@ const advtemplate_templates = [
     items: [
       {
         title: 'Closing ticket',
-        content: '<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p dir="ltr">We haven&rsquo;t heard back from you in over a week, so we have gone ahead and closed your ticket number {{Ticket.Number}}.</p>\n<p dir="ltr">If you&rsquo;re still running into issues, not to worry, just reply to this email and we will re-open your ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best,</p>\n<p dir="ltr">{{Agent.FirstName}}</p>'
+        content: '<p dir="ltr">Hi {\{Customer.FirstName\}},</p>\n<p dir="ltr">We haven&rsquo;t heard back from you in over a week, so we have gone ahead and closed your ticket number {\{Ticket.Number\}}.</p>\n<p dir="ltr">If you&rsquo;re still running into issues, not to worry, just reply to this email and we will re-open your ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best,</p>\n<p dir="ltr">{\{Agent.FirstName\}}</p>'
       },
       {
         title: 'Post-call survey',
-        content: '<p dir="ltr">Hey {{Customer.FirstName}}!</p>\n<p dir="ltr">&nbsp;</p>\n<p dir="ltr">How did we do?</p>\n<p dir="ltr">If you have a few moments, we&rsquo;d love you to fill out our post-support survey: {{Survey.Link}}</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks in advance!<br>{{Company.Name}} Customer Support</p>'
+        content: '<p dir="ltr">Hey {\{Customer.FirstName\}}!</p>\n<p dir="ltr">&nbsp;</p>\n<p dir="ltr">How did we do?</p>\n<p dir="ltr">If you have a few moments, we&rsquo;d love you to fill out our post-support survey: {\{Survey.Link\}}</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks in advance!<br>{\{Company.Name\}} Customer Support</p>'
       }
     ]
   },
@@ -34,11 +34,11 @@ const advtemplate_templates = [
     items: [
       {
         title: 'How to find model number',
-        content: '<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">My name is {{Agent.FirstName}} and I will be glad to assist you today.</p>\n<p dir="ltr">To troubleshoot your issue, we first need your model number, which can be found on the underside of your product beneath the safety warning label.&nbsp;</p>\n<p dir="ltr">It should look something like the following: XX.XXXXX.X</p>\n<p dir="ltr">Once you send it over, I will advise on next steps.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks!</p>\n<p dir="ltr">{{Agent.FirstName}}</p>'
+        content: '<p dir="ltr">Hi {\{Customer.FirstName\}},</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">My name is {\{Agent.FirstName\}} and I will be glad to assist you today.</p>\n<p dir="ltr">To troubleshoot your issue, we first need your model number, which can be found on the underside of your product beneath the safety warning label.&nbsp;</p>\n<p dir="ltr">It should look something like the following: XX.XXXXX.X</p>\n<p dir="ltr">Once you send it over, I will advise on next steps.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks!</p>\n<p dir="ltr">{\{Agent.FirstName\}}</p>'
       },
       {
         title: 'Support escalation',
-        content: '<p dir="ltr"><img src="https://lh3.googleusercontent.com/z4hleIymnERrS9OQQMBwmkqVne8kYZA0Kly9Ny64pp4fi47CWWUy30Q0-UkjGf-K-50zrfR-wltHUTbExzZ7VUSUAUG60Fll5f2E0UZcKjKoa-ZVlIcuOoe-RRckFWqiihUOfVds7pXtM8Y59uy2hpw" width="295" height="295"></p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p dir="ltr">We have escalated your ticket {{Ticket.Number}} to second-level support.</p>\n<p dir="ltr">You should hear back from the new agent on your case, {{NewAgent.FirstName}}, shortly.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks,</p>\n<p dir="ltr">{{Company.Name}} Customer Support</p>'
+        content: '<p dir="ltr">Hi {\{Customer.FirstName\}},</p>\n<p dir="ltr">We have escalated your ticket {\{Ticket.Number\}} to second-level support.</p>\n<p dir="ltr">You should hear back from the new agent on your case, {\{NewAgent.FirstName\}}, shortly.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks,</p>\n<p dir="ltr">{\{Company.Name\}} Customer Support</p>'
       }
     ]
   }

--- a/modules/ROOT/examples/live-demos/advtemplate-predefined/index.js
+++ b/modules/ROOT/examples/live-demos/advtemplate-predefined/index.js
@@ -4,15 +4,15 @@ const advtemplate_templates = [
     items: [
       {
         title: 'Message received',
-        content: '<p dir="ltr">Hey {\{Customer.FirstName\}}!</p>\n<p dir="ltr">Just a quick note to say we&rsquo;ve received your message, and will get back to you within 48 hours.</p>\n<p dir="ltr">For reference, your ticket number is: {\{Ticket.Number\}}</p>\n<p dir="ltr">Should you have any questions in the meantime, just reply to this email and it will be attached to this ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Regards,</p>\n<p dir="ltr">{\{Agent.FirstName\}}</p>'
+        content: '<p dir="ltr">Hey {{prefix}}Customer.FirstName{{suffix}}!</p>\n<p dir="ltr">Just a quick note to say we&rsquo;ve received your message, and will get back to you within 48 hours.</p>\n<p dir="ltr">For reference, your ticket number is: {{prefix}}Ticket.Number{{suffix}}</p>\n<p dir="ltr">Should you have any questions in the meantime, just reply to this email and it will be attached to this ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Regards,</p>\n<p dir="ltr">{{prefix}}Agent.FirstName{{suffix}}</p>'
       },
       {
         title: 'Thanks for the feedback',
-        content: '<p dir="ltr">Hi {\{Customer.FirstName\}},</p>\n<p dir="ltr">We appreciate you taking the time to provide feedback on {\{Product.Name\}}.</p>\n<p dir="ltr">It sounds like it wasn&rsquo;t able to fully meet your expectations, for which we apologize. Rest assured our team looks at each piece of feedback and uses it to decide what to focus on next with {\{Product.Name\}}.</p>\n<p dir="ltr"><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best, and let us know if there&rsquo;s anything else we can do to help.</p>\n<p dir="ltr">-{\{Agent.FirstName\}}</p>'
+        content: '<p dir="ltr">Hi {{prefix}}Customer.FirstName{{suffix}},</p>\n<p dir="ltr">We appreciate you taking the time to provide feedback on {{prefix}}Product.Name{{suffix}}.</p>\n<p dir="ltr">It sounds like it wasn&rsquo;t able to fully meet your expectations, for which we apologize. Rest assured our team looks at each piece of feedback and uses it to decide what to focus on next with {{prefix}}Product.Name{{suffix}}.</p>\n<p dir="ltr"><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best, and let us know if there&rsquo;s anything else we can do to help.</p>\n<p dir="ltr">-{{prefix}}Agent.FirstName{{suffix}}</p>'
       },
       {
         title: 'Still working on case',
-        content: '<p dir="ltr">Hi {\{Customer.FirstName\}},</p>\n<p dir="ltr">Just a quick note to let you know we&rsquo;re still working on your case. It&rsquo;s taking a bit longer than we hoped, but we&rsquo;re aiming to get you an answer in the next 48 hours.</p>\n<p dir="ltr">Stay tuned,</p>\n<p dir="ltr">{\{Agent.FirstName\}}</p>'
+        content: '<p dir="ltr">Hi {{prefix}}Customer.FirstName{{suffix}},</p>\n<p dir="ltr">Just a quick note to let you know we&rsquo;re still working on your case. It&rsquo;s taking a bit longer than we hoped, but we&rsquo;re aiming to get you an answer in the next 48 hours.</p>\n<p dir="ltr">Stay tuned,</p>\n<p dir="ltr">{{prefix}}Agent.FirstName{{suffix}}</p>'
       }
     ]
   },
@@ -21,11 +21,11 @@ const advtemplate_templates = [
     items: [
       {
         title: 'Closing ticket',
-        content: '<p dir="ltr">Hi {\{Customer.FirstName\}},</p>\n<p dir="ltr">We haven&rsquo;t heard back from you in over a week, so we have gone ahead and closed your ticket number {\{Ticket.Number\}}.</p>\n<p dir="ltr">If you&rsquo;re still running into issues, not to worry, just reply to this email and we will re-open your ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best,</p>\n<p dir="ltr">{\{Agent.FirstName\}}</p>'
+        content: '<p dir="ltr">Hi {{prefix}}Customer.FirstName{{suffix}},</p>\n<p dir="ltr">We haven&rsquo;t heard back from you in over a week, so we have gone ahead and closed your ticket number {{prefix}}Ticket.Number{{suffix}}.</p>\n<p dir="ltr">If you&rsquo;re still running into issues, not to worry, just reply to this email and we will re-open your ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best,</p>\n<p dir="ltr">{{prefix}}Agent.FirstName{{suffix}}</p>'
       },
       {
         title: 'Post-call survey',
-        content: '<p dir="ltr">Hey {\{Customer.FirstName\}}!</p>\n<p dir="ltr">&nbsp;</p>\n<p dir="ltr">How did we do?</p>\n<p dir="ltr">If you have a few moments, we&rsquo;d love you to fill out our post-support survey: {\{Survey.Link\}}</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks in advance!<br>{\{Company.Name\}} Customer Support</p>'
+        content: '<p dir="ltr">Hey {{prefix}}Customer.FirstName{{suffix}}!</p>\n<p dir="ltr">&nbsp;</p>\n<p dir="ltr">How did we do?</p>\n<p dir="ltr">If you have a few moments, we&rsquo;d love you to fill out our post-support survey: {{prefix}}Survey.Link{{suffix}}</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks in advance!<br>{{prefix}}Company.Name{{suffix}} Customer Support</p>'
       }
     ]
   },
@@ -34,11 +34,11 @@ const advtemplate_templates = [
     items: [
       {
         title: 'How to find model number',
-        content: '<p dir="ltr">Hi {\{Customer.FirstName\}},</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">My name is {\{Agent.FirstName\}} and I will be glad to assist you today.</p>\n<p dir="ltr">To troubleshoot your issue, we first need your model number, which can be found on the underside of your product beneath the safety warning label.&nbsp;</p>\n<p dir="ltr">It should look something like the following: XX.XXXXX.X</p>\n<p dir="ltr">Once you send it over, I will advise on next steps.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks!</p>\n<p dir="ltr">{\{Agent.FirstName\}}</p>'
+        content: '<p dir="ltr">Hi {{prefix}}Customer.FirstName{{suffix}},</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">My name is {{prefix}}Agent.FirstName{{suffix}} and I will be glad to assist you today.</p>\n<p dir="ltr">To troubleshoot your issue, we first need your model number, which can be found on the underside of your product beneath the safety warning label.&nbsp;</p>\n<p dir="ltr">It should look something like the following: XX.XXXXX.X</p>\n<p dir="ltr">Once you send it over, I will advise on next steps.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks!</p>\n<p dir="ltr">{{prefix}}Agent.FirstName{{suffix}}</p>'
       },
       {
         title: 'Support escalation',
-        content: '<p dir="ltr">Hi {\{Customer.FirstName\}},</p>\n<p dir="ltr">We have escalated your ticket {\{Ticket.Number\}} to second-level support.</p>\n<p dir="ltr">You should hear back from the new agent on your case, {\{NewAgent.FirstName\}}, shortly.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks,</p>\n<p dir="ltr">{\{Company.Name\}} Customer Support</p>'
+        content: '<p dir="ltr">Hi {{prefix}}Customer.FirstName{{suffix}},</p>\n<p dir="ltr">We have escalated your ticket {{prefix}}Ticket.Number{{suffix}} to second-level support.</p>\n<p dir="ltr">You should hear back from the new agent on your case, {{prefix}}NewAgent.FirstName{{suffix}}, shortly.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks,</p>\n<p dir="ltr">{{prefix}}Company.Name{{suffix}} Customer Support</p>'
       }
     ]
   }

--- a/modules/ROOT/examples/live-demos/advtemplate/index.js
+++ b/modules/ROOT/examples/live-demos/advtemplate/index.js
@@ -4,15 +4,15 @@ const data = [
     items: [
       {
         title: 'Message received',
-        content: '<p dir="ltr">Hey {{Customer.FirstName}}!</p>\n<p dir="ltr">Just a quick note to say we&rsquo;ve received your message, and will get back to you within 48 hours.</p>\n<p dir="ltr">For reference, your ticket number is: {{Ticket.Number}}</p>\n<p dir="ltr">Should you have any questions in the meantime, just reply to this email and it will be attached to this ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Regards,</p>\n<p dir="ltr">{{Agent.FirstName}}</p>'
+        content: '<p dir="ltr">Hey \{\{Customer.FirstName\}\}!</p>\n<p dir="ltr">Just a quick note to say we&rsquo;ve received your message, and will get back to you within 48 hours.</p>\n<p dir="ltr">For reference, your ticket number is: \{\{Ticket.Number\}\}</p>\n<p dir="ltr">Should you have any questions in the meantime, just reply to this email and it will be attached to this ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Regards,</p>\n<p dir="ltr">\{\{Agent.FirstName\}\}</p>'
       },
       {
         title: 'Thanks for the feedback',
-        content: '<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p dir="ltr">We appreciate you taking the time to provide feedback on {{Product.Name}}.</p>\n<p dir="ltr">It sounds like it wasn&rsquo;t able to fully meet your expectations, for which we apologize. Rest assured our team looks at each piece of feedback and uses it to decide what to focus on next with {{Product.Name}}.</p>\n<p dir="ltr"><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best, and let us know if there&rsquo;s anything else we can do to help.</p>\n<p dir="ltr">-{{Agent.FirstName}}</p>'
+        content: '<p dir="ltr">Hi \{\{Customer.FirstName\}\},</p>\n<p dir="ltr">We appreciate you taking the time to provide feedback on \{\{Product.Name\}\}.</p>\n<p dir="ltr">It sounds like it wasn&rsquo;t able to fully meet your expectations, for which we apologize. Rest assured our team looks at each piece of feedback and uses it to decide what to focus on next with \{\{Product.Name\}\}.</p>\n<p dir="ltr"><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best, and let us know if there&rsquo;s anything else we can do to help.</p>\n<p dir="ltr">-\{\{Agent.FirstName\}\}</p>'
       },
       {
         title: 'Still working on case',
-        content: '<p dir="ltr"><img src="https://lh4.googleusercontent.com/-H7w_COxrsy2fVpjO6RRnoBsujhaLyg6AXux5zidqmQ_ik1mrE6BtnaTUdWYQuVbtKpviRqQiuPBOHNGUsEXvrRliEHc4-hKDrCLgQQ9Co-MI4uY2ehUvYtU1nn3EeS0WiUzST-7MQB2Z5YFXrMDwRk" width="320" height="240"></p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p dir="ltr">Just a quick note to let you know we&rsquo;re still working on your case. It&rsquo;s taking a bit longer than we hoped, but we&rsquo;re aiming to get you an answer in the next 48 hours.</p>\n<p dir="ltr">Stay tuned,</p>\n<p dir="ltr">{{Agent.FirstName}}</p>'
+        content: '<p dir="ltr">Hi \{\{Customer.FirstName\}\},</p>\n<p dir="ltr">Just a quick note to let you know we&rsquo;re still working on your case. It&rsquo;s taking a bit longer than we hoped, but we&rsquo;re aiming to get you an answer in the next 48 hours.</p>\n<p dir="ltr">Stay tuned,</p>\n<p dir="ltr">\{\{Agent.FirstName\}\}</p>'
       }
     ]
   },
@@ -21,11 +21,11 @@ const data = [
     items: [
       {
         title: 'Closing ticket',
-        content: '<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p dir="ltr">We haven&rsquo;t heard back from you in over a week, so we have gone ahead and closed your ticket number {{Ticket.Number}}.</p>\n<p dir="ltr">If you&rsquo;re still running into issues, not to worry, just reply to this email and we will re-open your ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best,</p>\n<p dir="ltr">{{Agent.FirstName}}</p>'
+        content: '<p dir="ltr">Hi \{\{Customer.FirstName\}\},</p>\n<p dir="ltr">We haven&rsquo;t heard back from you in over a week, so we have gone ahead and closed your ticket number \{\{Ticket.Number\}\}.</p>\n<p dir="ltr">If you&rsquo;re still running into issues, not to worry, just reply to this email and we will re-open your ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best,</p>\n<p dir="ltr">\{\{Agent.FirstName\}\}</p>'
       },
       {
         title: 'Post-call survey',
-        content: '<p dir="ltr">Hey {{Customer.FirstName}}!</p>\n<p dir="ltr">&nbsp;</p>\n<p dir="ltr">How did we do?</p>\n<p dir="ltr">If you have a few moments, we&rsquo;d love you to fill out our post-support survey: {{Survey.Link}}</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks in advance!<br>{{Company.Name}} Customer Support</p>'
+        content: '<p dir="ltr">Hey \{\{Customer.FirstName\}\}!</p>\n<p dir="ltr">&nbsp;</p>\n<p dir="ltr">How did we do?</p>\n<p dir="ltr">If you have a few moments, we&rsquo;d love you to fill out our post-support survey: \{\{Survey.Link\}\}</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks in advance!<br>\{\{Company.Name\}\} Customer Support</p>'
       }
     ]
   },
@@ -34,11 +34,11 @@ const data = [
     items: [
       {
         title: 'How to find model number',
-        content: '<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">My name is {{Agent.FirstName}} and I will be glad to assist you today.</p>\n<p dir="ltr">To troubleshoot your issue, we first need your model number, which can be found on the underside of your product beneath the safety warning label.&nbsp;</p>\n<p dir="ltr">It should look something like the following: XX.XXXXX.X</p>\n<p dir="ltr">Once you send it over, I will advise on next steps.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks!</p>\n<p dir="ltr">{{Agent.FirstName}}</p>'
+        content: '<p dir="ltr">Hi \{\{Customer.FirstName\}\},</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">My name is \{\{Agent.FirstName\}\} and I will be glad to assist you today.</p>\n<p dir="ltr">To troubleshoot your issue, we first need your model number, which can be found on the underside of your product beneath the safety warning label.&nbsp;</p>\n<p dir="ltr">It should look something like the following: XX.XXXXX.X</p>\n<p dir="ltr">Once you send it over, I will advise on next steps.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks!</p>\n<p dir="ltr">\{\{Agent.FirstName\}\}</p>'
       },
       {
         title: 'Support escalation',
-        content: '<p dir="ltr"><img src="https://lh3.googleusercontent.com/z4hleIymnERrS9OQQMBwmkqVne8kYZA0Kly9Ny64pp4fi47CWWUy30Q0-UkjGf-K-50zrfR-wltHUTbExzZ7VUSUAUG60Fll5f2E0UZcKjKoa-ZVlIcuOoe-RRckFWqiihUOfVds7pXtM8Y59uy2hpw" width="295" height="295"></p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p dir="ltr">We have escalated your ticket {{Ticket.Number}} to second-level support.</p>\n<p dir="ltr">You should hear back from the new agent on your case, {{NewAgent.FirstName}}, shortly.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks,</p>\n<p dir="ltr">{{Company.Name}} Customer Support</p>'
+        content: '<p dir="ltr">Hi \{\{Customer.FirstName\}\},</p>\n<p dir="ltr">We have escalated your ticket \{\{Ticket.Number\}\} to second-level support.</p>\n<p dir="ltr">You should hear back from the new agent on your case, \{\{NewAgent.FirstName\}\}, shortly.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks,</p>\n<p dir="ltr">\{\{Company.Name\}\} Customer Support</p>'
       }
     ]
   }

--- a/modules/ROOT/examples/live-demos/advtemplate/index.js
+++ b/modules/ROOT/examples/live-demos/advtemplate/index.js
@@ -4,15 +4,15 @@ const data = [
     items: [
       {
         title: 'Message received',
-        content: '<p dir="ltr">Hey \{\{Customer.FirstName\}\}!</p>\n<p dir="ltr">Just a quick note to say we&rsquo;ve received your message, and will get back to you within 48 hours.</p>\n<p dir="ltr">For reference, your ticket number is: \{\{Ticket.Number\}\}</p>\n<p dir="ltr">Should you have any questions in the meantime, just reply to this email and it will be attached to this ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Regards,</p>\n<p dir="ltr">\{\{Agent.FirstName\}\}</p>'
+        content: '<p dir="ltr">Hey {{prefix}}Customer.FirstName\}}!</p>\n<p dir="ltr">Just a quick note to say we&rsquo;ve received your message, and will get back to you within 48 hours.</p>\n<p dir="ltr">For reference, your ticket number is: {{mergetag-open}}Ticket.Number{{suffix}}</p>\n<p dir="ltr">Should you have any questions in the meantime, just reply to this email and it will be attached to this ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Regards,</p>\n<p dir="ltr">{{prefix}}Agent.FirstName{{suffix}}</p>'
       },
       {
         title: 'Thanks for the feedback',
-        content: '<p dir="ltr">Hi \{\{Customer.FirstName\}\},</p>\n<p dir="ltr">We appreciate you taking the time to provide feedback on \{\{Product.Name\}\}.</p>\n<p dir="ltr">It sounds like it wasn&rsquo;t able to fully meet your expectations, for which we apologize. Rest assured our team looks at each piece of feedback and uses it to decide what to focus on next with \{\{Product.Name\}\}.</p>\n<p dir="ltr"><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best, and let us know if there&rsquo;s anything else we can do to help.</p>\n<p dir="ltr">-\{\{Agent.FirstName\}\}</p>'
+        content: '<p dir="ltr">Hi {{prefix}}Customer.FirstName{{suffix}},</p>\n<p dir="ltr">We appreciate you taking the time to provide feedback on {{prefix}}Product.Name{{suffix}}.</p>\n<p dir="ltr">It sounds like it wasn&rsquo;t able to fully meet your expectations, for which we apologize. Rest assured our team looks at each piece of feedback and uses it to decide what to focus on next with {{prefix}}Product.Name{{suffix}}.</p>\n<p dir="ltr"><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best, and let us know if there&rsquo;s anything else we can do to help.</p>\n<p dir="ltr">-{{prefix}}Agent.FirstName{{suffix}}</p>'
       },
       {
         title: 'Still working on case',
-        content: '<p dir="ltr">Hi \{\{Customer.FirstName\}\},</p>\n<p dir="ltr">Just a quick note to let you know we&rsquo;re still working on your case. It&rsquo;s taking a bit longer than we hoped, but we&rsquo;re aiming to get you an answer in the next 48 hours.</p>\n<p dir="ltr">Stay tuned,</p>\n<p dir="ltr">\{\{Agent.FirstName\}\}</p>'
+        content: '<p dir="ltr">Hi {{prefix}}Customer.FirstName{{suffix}},</p>\n<p dir="ltr">Just a quick note to let you know we&rsquo;re still working on your case. It&rsquo;s taking a bit longer than we hoped, but we&rsquo;re aiming to get you an answer in the next 48 hours.</p>\n<p dir="ltr">Stay tuned,</p>\n<p dir="ltr">{{prefix}}Agent.FirstName{{suffix}}</p>'
       }
     ]
   },
@@ -21,11 +21,11 @@ const data = [
     items: [
       {
         title: 'Closing ticket',
-        content: '<p dir="ltr">Hi \{\{Customer.FirstName\}\},</p>\n<p dir="ltr">We haven&rsquo;t heard back from you in over a week, so we have gone ahead and closed your ticket number \{\{Ticket.Number\}\}.</p>\n<p dir="ltr">If you&rsquo;re still running into issues, not to worry, just reply to this email and we will re-open your ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best,</p>\n<p dir="ltr">\{\{Agent.FirstName\}\}</p>'
+        content: '<p dir="ltr">Hi {{prefix}}Customer.FirstName{{suffix}},</p>\n<p dir="ltr">We haven&rsquo;t heard back from you in over a week, so we have gone ahead and closed your ticket number {{prefix}}Ticket.Number{{suffix}}.</p>\n<p dir="ltr">If you&rsquo;re still running into issues, not to worry, just reply to this email and we will re-open your ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best,</p>\n<p dir="ltr">{{prefix}}Agent.FirstName{{suffix}}</p>'
       },
       {
         title: 'Post-call survey',
-        content: '<p dir="ltr">Hey \{\{Customer.FirstName\}\}!</p>\n<p dir="ltr">&nbsp;</p>\n<p dir="ltr">How did we do?</p>\n<p dir="ltr">If you have a few moments, we&rsquo;d love you to fill out our post-support survey: \{\{Survey.Link\}\}</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks in advance!<br>\{\{Company.Name\}\} Customer Support</p>'
+        content: '<p dir="ltr">Hey {{prefix}}Customer.FirstName{{suffix}}!</p>\n<p dir="ltr">&nbsp;</p>\n<p dir="ltr">How did we do?</p>\n<p dir="ltr">If you have a few moments, we&rsquo;d love you to fill out our post-support survey: {{prefix}}Survey.Link{{suffix}}</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks in advance!<br>{{prefix}}Company.Name{{suffix}} Customer Support</p>'
       }
     ]
   },
@@ -34,11 +34,11 @@ const data = [
     items: [
       {
         title: 'How to find model number',
-        content: '<p dir="ltr">Hi \{\{Customer.FirstName\}\},</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">My name is \{\{Agent.FirstName\}\} and I will be glad to assist you today.</p>\n<p dir="ltr">To troubleshoot your issue, we first need your model number, which can be found on the underside of your product beneath the safety warning label.&nbsp;</p>\n<p dir="ltr">It should look something like the following: XX.XXXXX.X</p>\n<p dir="ltr">Once you send it over, I will advise on next steps.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks!</p>\n<p dir="ltr">\{\{Agent.FirstName\}\}</p>'
+        content: '<p dir="ltr">Hi {{prefix}}Customer.FirstName{{suffix}},</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">My name is {{prefix}}Agent.FirstName{{suffix}} and I will be glad to assist you today.</p>\n<p dir="ltr">To troubleshoot your issue, we first need your model number, which can be found on the underside of your product beneath the safety warning label.&nbsp;</p>\n<p dir="ltr">It should look something like the following: XX.XXXXX.X</p>\n<p dir="ltr">Once you send it over, I will advise on next steps.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks!</p>\n<p dir="ltr">{{prefix}}Agent.FirstName{{suffix}}</p>'
       },
       {
         title: 'Support escalation',
-        content: '<p dir="ltr">Hi \{\{Customer.FirstName\}\},</p>\n<p dir="ltr">We have escalated your ticket \{\{Ticket.Number\}\} to second-level support.</p>\n<p dir="ltr">You should hear back from the new agent on your case, \{\{NewAgent.FirstName\}\}, shortly.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks,</p>\n<p dir="ltr">\{\{Company.Name\}\} Customer Support</p>'
+        content: '<p dir="ltr">Hi {{prefix}}Customer.FirstName{{suffix}},</p>\n<p dir="ltr">We have escalated your ticket {{prefix}}Ticket.Number{{suffix}} to second-level support.</p>\n<p dir="ltr">You should hear back from the new agent on your case, {{prefix}}NewAgent.FirstName{{suffix}}, shortly.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks,</p>\n<p dir="ltr">{{prefix}}Company.Name{{suffix}} Customer Support</p>'
       }
     ]
   }

--- a/modules/ROOT/pages/6.3-release-notes.adoc
+++ b/modules/ROOT/pages/6.3-release-notes.adoc
@@ -226,7 +226,7 @@ tinymce.init({
 });
 ----
 
-In this example, typing `{{string}}` followed by a word boundary character (such as a space, full-stop, question mark or comma) will result in the _string_ being turned into an active merge tag.
+In this example, typing `{\{string\}}` followed by a word boundary character (such as a space, full-stop, question mark or comma) will result in the _string_ being turned into an active merge tag.
 
 ==== Merge tags cannot exceed 255 characters in length
 
@@ -691,4 +691,3 @@ This presentation issue does not affect functionality. Selecting a new *Backgrou
 A workaround is to apply inline formatting after applying the Text and Background color. When the inline formatting is applied after the Text and Background colors are applied, the presentation error does not occur.
 
 NOTE: This checkmark presentation issue occurs in conjunction with the similar checkmark presentation issue documented above. When this presentation issue occurs, the checkmark does denote the current background color in either the *Background color* menu or toolbar item.
-

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -85,7 +85,7 @@ This command enables the adding of a new template, specified by its ID, to a {pr
 
 See the xref:advanced-templates.adoc#commands[Commands] section of the xref:advanced-templates.adoc[Advanced Templates] documentation for an example of the command in use.
 
-==== New {{mce-cursor}} marker to indicate the cursor position after the template is inserted
+==== New {\{mce-cursor\}} marker to indicate the cursor position after the template is inserted
 // TINY-9973
 
 The new insertion point marker is a fixed string for adding to any template.

--- a/modules/ROOT/pages/6.7.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.7.2-release-notes.adoc
@@ -68,7 +68,7 @@ include::partial$misc/admon-no-functionality-changes-in-updated-server-side-comp
 
 {productname} 6.7.2 also includes the following bug fixes:
 
-==== The function `getModifierState` did not work on events passed through the editor as expected.
+=== The function `getModifierState` did not work on events passed through the editor as expected.
 // TINY-10263
 The exception error "Uncaught TypeError: Illegal invocation" was displayed in the console, when an integrator called the 'getModifierState' function on a **keydown** event object.
 
@@ -76,7 +76,7 @@ As a consequence, any attempts to invoke this function resulted in the TypeError
 
 {productname} 6.7.2 addresses this, now, when a integrator uses the `getModifierState` on the event object a keydown event no longer triggers an error.
 
-==== Indenting or outdenting a list item that contained non list item siblings after it would result in those siblings being removed.
+=== Indenting or outdenting a list item that contained non list item siblings after it would result in those siblings being removed.
 // TINY-10268
 Previously, when the editor encounter's a list inside an `<li>` element, the editor would only account for scenarios where the list is either the first or last element within the `<li>`. In such cases, {productname} would treat the content contained within the `<li>` as plain HTML, disregarding any nested lists.
 
@@ -102,7 +102,7 @@ the editor would encounter problems when attempting to apply list-related action
 
 As a result, the actions of indenting and unindenting a nested list now work as expected.
 
-==== Removed use of async for editor rendering which caused visual blinking when reloading the editor in-place.
+=== Removed use of async for editor rendering which caused visual blinking when reloading the editor in-place.
 // TINY-10249
 
 In contrast to {productname} version 5, where the editor would initiate rendering without waiting for the completion of CSS loading, in version 6, the editor instance now deliberately synchronizes with the loading of CSS. This modification aims to prevent flickering by ensuring that the necessary styles have finished loading before proceeding with the rendering process.
@@ -111,7 +111,7 @@ In contrast to {productname} version 5, where the editor would initiate renderin
 
 As a result, the editor no longer renders the flicker previously displayed when the editor is refreshed.
 
-==== Toggling a list that contained a list item element — `<li>` — which, in turn, contained another list item element as its first child, removed other content within the first list item element.
+=== Toggling a list that contained a list item element — `<li>` — which, in turn, contained another list item element as its first child, removed other content within the first list item element.
 // TINY-10213
 When a user attempted to indent or outdent a list element inside a nested list, the list was converted into a model which resulted in it being recreated from that model.
 

--- a/modules/ROOT/pages/accordion.adoc
+++ b/modules/ROOT/pages/accordion.adoc
@@ -9,7 +9,7 @@
 
 include::partial$misc/admon-requires-6.5v.adoc[]
 
-The Accordion plugin allows for the creation of sections in a document that can be expanded or collapsed to show or hide additional content.
+The {pluginname} plugin allows for the creation of sections in a document that can be expanded or collapsed to show or hide additional content.
 
 == Interactive example
 

--- a/modules/ROOT/pages/ai-proxy.adoc
+++ b/modules/ROOT/pages/ai-proxy.adoc
@@ -80,7 +80,7 @@ To prevent this, a moderation service can pre-filter abusive content and reject 
 
 Below is a flow diagram that illustrates how the above components work together to provide the AI enhanced experience.
 
-image::{imagesdir}/ai-plugin/ai-proxy-call-flows.png[OpenAI Proxy Call Flows]
+image::ai-plugin/ai-proxy-call-flows.png[OpenAI Proxy Call Flows]
 
 == Example Reference Application
 

--- a/modules/ROOT/pages/ai.adoc
+++ b/modules/ROOT/pages/ai.adoc
@@ -93,7 +93,6 @@ The following configuration options affect the behavior of the {pluginname} plug
 
 include::partial$configuration/ai_request.adoc[][leveloffset=+1]
 
-[ai_shortcuts]
 include::partial$configuration/ai_shortcuts.adoc[][leveloffset=+1]
 
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]

--- a/modules/ROOT/pages/full-featured-open-source-demo.adoc
+++ b/modules/ROOT/pages/full-featured-open-source-demo.adoc
@@ -19,3 +19,4 @@ The following plugins are excluded from this example:
 
 |xref:autoresize.adoc[Autoresize]
 |Resizes the editor to fit the content.
+|===

--- a/modules/ROOT/pages/full-featured-premium-demo.adoc
+++ b/modules/ROOT/pages/full-featured-premium-demo.adoc
@@ -29,3 +29,4 @@ The following plugins are excluded from this example:
 
 |xref:moxiemanager.adoc[MoxieManager]
 |xref:tinydrive-introduction.adoc[*{cloudfilemanager}*] included instead.
+|===

--- a/modules/ROOT/partials/configuration/dialog_persistent.adoc
+++ b/modules/ROOT/partials/configuration/dialog_persistent.adoc
@@ -52,7 +52,7 @@ To prevent this
 
 * add a check that the dialog is already open; and
 
-* use the xref:apis/tinymce.editor/#focus[`focus`] method in the xref:apis/tinymce.windowmanager/#return-value[`DialogInstanceAPI`] to transfer focus to the open dialog rather than creating a new instance of the same dialog.
+* use the `focus` method in the xref:apis/tinymce.windowmanager.adoc#open[`DialogInstanceAPI`] to transfer focus to the open dialog rather than creating a new instance of the same dialog.
 
 
 [source,js]

--- a/modules/ROOT/partials/release-notes/6.0-release-notes-apis.adoc
+++ b/modules/ROOT/partials/release-notes/6.0-release-notes-apis.adoc
@@ -45,7 +45,7 @@ The new `FakeClipboard` API provides a means for storing state that can be set a
 
 The new `Resource.unload` API makes it possible to unload resources in the resource loader.
 
-[[setdata]]
+[[setdata-api]]
 === `setData` method in the Dialog API
 
 The dialog API’s `setData` method now uses a deep merge algorithm.

--- a/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
+++ b/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
@@ -1,5 +1,3 @@
-// tag::contents[]
-[[contents]]
 = Contents
 
 * xref:core-changes[Core changes]
@@ -12,12 +10,12 @@
 
 
 [[summary]]
-= Summary
+== Summary
 This section documents the four core changes made to {productname} 6.0.
 
 // tag::core-changes[]
 [[core-changes]]
-== Core changes
+=== Core changes
 
 . Browsers supported by {productname} 6.0 have changed. {productname} 6.0 supports the current and previous major versions of Google Chrome, Mozilla Firefox, Microsoft Edge, and Apple Safari. {productname} 6.0 also supports the current Long Term Release of each of the above browsers (eg, Mozilla Firefox ESR and Google Chrome ESR).
 
@@ -48,7 +46,7 @@ This section also includes four tables that set out the:
 
 // tag::things-we-renamed[]
 [[things-we-renamed]]
-== Things we renamed
+=== Things we renamed
 
 [cols="2,2,1,2"]
 |===
@@ -143,7 +141,7 @@ Where an Option name has changed, configurations using that option must be chang
 
 // tag::default-value-changes[]
 [[default-value-changes]]
-== Default value changes
+=== Default value changes
 
 [cols="1,1,1,1"]
 |===
@@ -170,7 +168,7 @@ Where an Option name has changed, configurations using that option must be chang
 
 // tag::previously-deprecated-items-now-removed[]
 [[previously-deprecated-items-now-removed]]
-== Previously deprecated items now removed
+=== Previously deprecated items now removed
 
 The following elements were previously deprecated and have, with this release, been removed entirely from {productname}.
 
@@ -283,7 +281,7 @@ The following elements were previously deprecated and have, with this release, b
 
 // tag::previously-undocumented-items-removed-without-prior-deprecation[]
 [[previously-undocumented-items-removed-without-prior-deprecation]]
-== Previously undocumented items removed without prior deprecation
+=== Previously undocumented items removed without prior deprecation
 
 The following elements were never documented and have never been formally supported.
 


### PR DESCRIPTION
Ticket: DOC-2222

Changes:
* Fixed missing content wrapped in double curly brackets
* Fixed all current warnings and errors in local builds

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] (New product features only) Release Note added

Review:
- [x] Documentation Team Lead has reviewed
