### PR TITLE
DOC-2229: typo correction for admon note include for `building-plugins.adoc`.

### DIFF
--- a/modules/ROOT/partials/module-loading/admon-bundling-plugin-langs.adoc
+++ b/modules/ROOT/partials/module-loading/admon-bundling-plugin-langs.adoc
@@ -1,1 +1,1 @@
-NOTE: The plugin language files (such as `+./plugins/plugin/langs/sv_SE.js+`) are required where the editor user interface is localized using the xref:ui-localization.adoc#language[language option]. Please prefer to xref:bundling-plugins.adoc#plugin-language-files[plugin-language-files]
+NOTE: The plugin language files (such as `+./plugins/plugin/langs/sv_SE.js+`) are required where the editor user interface is localized using the xref:ui-localization.adoc#language[language option]. Please refer to xref:bundling-plugins.adoc#plugin-language-files[plugin-language-files]


### PR DESCRIPTION
Ticket: DOC-2229

Changes:
* fix single `typo` for admon note include for `building-plugins.adoc` to replace `prefer` with `refer`.
* no-changelog required.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`

Review:
- [x] Documentation Team Lead has reviewed
