### PR TITLE
DOC-2225: TinyMCE 6.8.2 release notes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,12 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+### 2023-12-13
+
+- DOC-2225: added `6.8.2-release-notes.adoc` to project; updated `changelog.adoc`, `nav.adoc` and `release-notes.adoc` for the TinyMCE 6.8.2 release.
+
+### 2023-12-08
+
 - DOC-2230: add new `How to fix invalid API key in TinyMCE` page to `tinymce/docs` project.
 
 ### 2023-12-06

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -405,6 +405,10 @@
 ** xref:tinymce-and-cors.adoc[Cross-Origin Resource Sharing (CORS)]
 * Release information
 ** xref:release-notes.adoc[Release notes for TinyMCE 6]
+*** TinyMCE 6.8.2
+**** xref:6.8.2-release-notes.adoc#overview[Overview]
+**** xref:6.8.2-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]
+**** xref:6.8.2-release-notes.adoc#bug-fixes[Bug fixes]
 *** TinyMCE 6.8.1
 **** xref:6.8.1-release-notes.adoc#overview[Overview]
 **** xref:6.8.1-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]

--- a/modules/ROOT/pages/6.8.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.8.2-release-notes.adoc
@@ -1,0 +1,66 @@
+= TinyMCE 6.8.2
+:navtitle: TinyMCE 6.8.2
+:description: Release notes for TinyMCE 6.8.2
+:keywords: releasenotes, new, changes, bugfixes
+:page-toclevels: 1
+
+include::partial$misc/admon-releasenotes-for-stable.adoc[]
+
+[[overview]]
+== Overview
+
+{productname} 6.8.2 was released for {enterpriseversion} and {cloudname} on Wednesday, December 13^th^, 2023. These release notes provide an overview of the changes for {productname} 6.8.2, including:
+
+* xref:accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
+* xref:bug-fixes[Bug fixes]
+
+
+[[accompanying-premium-plugin-changes]]
+== Accompanying Premium plugin changes
+
+The following premium plugin updates were released alongside {productname} 6.8.2.
+
+=== PowerPaste 6.2.4
+
+The {productname} 6.8.2 release includes an accompanying release of the **PowerPaste** premium plugin.
+
+**PowerPaste** 6.2.4 includes the following fix.
+
+==== `white-space-collapse` CSS property was not correctly supported when pasting from Google Docs.
+// #TINY-9967
+
+// CCFR here.
+
+
+For information on the **PowerPaste** plugin, see: xref:introduction-to-powerpaste.adoc[PowerPaste].
+
+
+[[bug-fixes]]
+== Bug fixes
+
+{productname} 6.8.2 also includes the following bug fix<es>:
+
+=== Bespoke select toolbar buttons including `fontfamily`, `fontsize`, `blocks`, and `styles` incorrectly used plural words in their accessible names.
+// #TINY-10426
+
+// CCFR here.
+
+=== The `align` bespoke select toolbar button had an accessible name that was misleading and grammatically incorrect in certain cases.
+// #TINY-10435
+
+// CCFR here.
+
+=== Accessible names of bespoke select toolbar buttons including `align`, `fontfamily`, `fontsize`, `blocks`, and `styles` were incorrectly translated.
+// #TINY-10426 #TINY-10435
+
+// CCFR here.
+
+=== Clicking inside table cells with heavily nested content could cause the browser to hang.
+// #TINY-10380
+
+// CCFR here.
+
+=== Toggling a list that contains an LI element having another list as its first child would remove the remaining content within that LI element.
+// #TINY-10414
+
+// CCFR here.

--- a/modules/ROOT/pages/6.8.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.8.2-release-notes.adoc
@@ -38,7 +38,7 @@ For information on the **PowerPaste** plugin, see: xref:introduction-to-powerpas
 [[bug-fixes]]
 == Bug fixes
 
-{productname} 6.8.2 also includes the following bug fix<es>:
+{productname} 6.8.2 also includes the following bug fixes:
 
 === Bespoke select toolbar buttons including `fontfamily`, `fontsize`, `blocks`, and `styles` incorrectly used plural words in their accessible names.
 // #TINY-10426

--- a/modules/ROOT/pages/6.8.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.8.2-release-notes.adoc
@@ -59,7 +59,7 @@ As of {productname} 6.8.2, the name of the `align` bespoke select button is chan
 
 As of {productname} 6.8.1, the accessible label of the `align` bespoke select toolbar button announced both the name of the button and the currently selected value, for example “Block Paragraph”. However, corresponding translation strings with placeholders were not added. This resulted in the current value being translated as expected, but not the name of the button. 
 
-In {productname} 6.8.2, new translation strings were added to ensure names of the bespoke select toolbar buttons are translated as well, making their accessible labels appropriately translated.
+In {productname} 6.8.2, new translation strings were added to ensure names of the bespoke select toolbar buttons are translated as well, making their accessible labels appropriately internationalized.
 
 === Clicking inside table cells with heavily nested content could cause the browser to hang.
 // #TINY-10380

--- a/modules/ROOT/pages/6.8.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.8.2-release-notes.adoc
@@ -57,7 +57,7 @@ As of {productname} 6.8.2, the name of the `align` bespoke select button is chan
 === Accessible names of bespoke select toolbar buttons including `align`, `fontfamily`, `fontsize`, `blocks`, and `styles` were incorrectly translated.
 // #TINY-10426 #TINY-10435
 
-As of {productname} 6.8.1, the accessible label of the `align` bespoke select toolbar button announced both the name of the button and the currently selected value, for example “Block Paragraph”. However, corresponding translation strings with placeholders were not added. This resulted in the current value being translated as expected, but not the name of the button. 
+As of {productname} 6.8.1, the accessible labels of the bespoke select toolbar buttons announced both the name of the button and the currently selected value, for example “Block Paragraph”. However, corresponding translation strings with placeholders were not added. This resulted in the current value being translated as expected, but not the name of the button. 
 
 In {productname} 6.8.2, new translation strings were added to ensure names of the bespoke select toolbar buttons are translated as well, making their accessible labels appropriately internationalized.
 

--- a/modules/ROOT/pages/6.8.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.8.2-release-notes.adoc
@@ -71,7 +71,7 @@ As a result, the browser no longer hangs, when clicking inside table cells with 
 
 === Toggling a list that contains an LI element having another list as its first child would remove the remaining content within that LI element.
 // #TINY-10414
-In a previous xref:6.7.2-release-notes.adoc#toggling-a-list-that-contained-a-list-item-element-li-which-in-turn-contained-another-list-item-element-as-its-first-child-removed-other-content-within-the-first-list-item-element[fix] _(toggling-a-list-that-contained-a-list-item-element-li-which-in-turn-contained-another-list-item-element-as-its-first-child-removed-other-content-within-the-first-list-item-element)_ for lists, some element structures would not recreate the `<li>` tags when a list element was toggled using the `bullist` button in the toolbar.
+In a previous xref:6.7.2-release-notes.adoc#toggling-a-list-that-contained-a-list-item-element-li-which-in-turn-contained-another-list-item-element-as-its-first-child-removed-other-content-within-the-first-list-item-element[bugfix] for lists, some element structures would not recreate the `<li>` tags when a list element was toggled using the `bullist` button in the toolbar.
 
 .Example structure 
 [source, html]

--- a/modules/ROOT/pages/6.8.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.8.2-release-notes.adoc
@@ -82,7 +82,7 @@ In a previous xref:6.7.2-release-notes.adoc#toggling-a-list-that-contained-a-lis
 </li>
 ----
 
-As a consequence, any tags nested within the `li` would be deleted from the {productname} document, resulting in content loss for the user.
+As a consequence, any tags nested within the `<li>` would be deleted from the {productname} document, resulting in content loss for the user.
 
 {productname} 6.8.2 addresses this by improving the representation of the list to manage this case.
 

--- a/modules/ROOT/pages/6.8.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.8.2-release-notes.adoc
@@ -65,7 +65,7 @@ In {productname} 6.8.2, new translation strings were added to ensure names of th
 // #TINY-10380
 Previously when clicking below content that is heavily nested inside a block such as a table cell, would cause the browser to hang.
 
-{productname} 6.8.2 addresses this, by optimizing the code responsible for the hang while updating the algorithm.
+{productname} 6.8.2 addresses this, by optimizing algorithm that was causing the browser to hang.
 
 As a result, the browser no longer hangs, when clicking inside table cells with heavily nested content.
 

--- a/modules/ROOT/pages/6.8.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.8.2-release-notes.adoc
@@ -28,9 +28,9 @@ The {productname} 6.8.2 release includes an accompanying release of the **PowerP
 
 ==== `white-space-collapse` CSS property was not correctly supported when pasting from Google Docs.
 // #TINY-9967
+From major version 114, Google Chrome and Microsoft Edge added support for the CSS4 shorthand `white-space` property. The shorthand `white-space` property would be expanded into the `white-space-collapse` and `text-wrap` properties. This resulted in PowerPaste not being able to remove the `white-space-collapse` and `text-wrap` properties from the emitted content even after `white-space: pre` is removed. This issue was particularly noticeable when copying content from Google Docs.
 
-// CCFR here.
-
+As of {productname} 6.8.2, PowerPaste now supports working with the shorthand `white-space` property by removing the expanded `white-space-collapse` and `text-wrap` properties when present from Google Docs content.
 
 For information on the **PowerPaste** plugin, see: xref:introduction-to-powerpaste.adoc[PowerPaste].
 
@@ -57,10 +57,27 @@ For information on the **PowerPaste** plugin, see: xref:introduction-to-powerpas
 
 === Clicking inside table cells with heavily nested content could cause the browser to hang.
 // #TINY-10380
+Previously when clicking below content that is heavily nested inside a block such as a table cell, would cause the browser to hang.
 
-// CCFR here.
+{productname} 6.8.2 addresses this, by optimizing the code responsible for the hang while updating the algorithm.
+
+As a result, the browser no longer hangs, when clicking inside table cells with heavily nested content.
 
 === Toggling a list that contains an LI element having another list as its first child would remove the remaining content within that LI element.
 // #TINY-10414
+In a previous xref:6.7.2-release-notes.adoc#toggling-a-list-that-contained-a-list-item-element-li-which-in-turn-contained-another-list-item-element-as-its-first-child-removed-other-content-within-the-first-list-item-element[fix] _(toggling-a-list-that-contained-a-list-item-element-li-which-in-turn-contained-another-list-item-element-as-its-first-child-removed-other-content-within-the-first-list-item-element)_ for lists, some element structures would not recreate the `<li>` tags when a list element was toggled using the `bullist` button in the toolbar.
 
-// CCFR here.
+.Example structure 
+[source, html]
+----
+<li>
+  <ul>...</ul>
+  <something-else/>
+</li>
+----
+
+As a consequence, any tags nested within the `li` would be deleted from the {productname} document, resulting in content loss for the user.
+
+{productname} 6.8.2 addresses this by improving the representation of the list to manage this case.
+
+As a result, now, when toggling `<li>` elements using the `bullist` button, content within a list is now correctly recreated the content is retained as expected.

--- a/modules/ROOT/pages/6.8.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.8.2-release-notes.adoc
@@ -52,7 +52,7 @@ As of {productname} 6.8.2, the accessible labels of `fontfamily`, `fontsize`, `b
 
 As of {productname} 6.8.1, the accessible label of the `align` bespoke select toolbar button announced both the name of the button, “Align”, and the currently selected value. This would result in the accessible label of the select button to be “Align left”, “Align right”, “Align center”, or “Align justify” depending on the value selected. However, the problem with the first three labels is that they are the same as the normal align toolbar buttons. This is misleading as unlike the normal align buttons, the bespoke button does not result in the aligning action, and instead opens a dropdown. The problem with “Align justify” is that the two verbs do not make grammatical sense in terms of describing the text alignment.
 
-As of {productname} 6.8.2, the name of the `align` bespoke select button is changed to “Alignment”, followed by the currently selected value. This results in the accessible labels being “Alignment left”, “Alignment right”, “Alignment center”, or “Alignment justify” depending on the values selected, which more clearly indicates the currently selected text alignment.
+As of {productname} 6.8.2, the name of the `align` bespoke select button is changed to “Alignment”, followed by the currently selected value. This results in the accessible labels being “Alignment left”, “Alignment right”, “Alignment center”, or “Alignment justify” depending on the value selected, which more clearly indicates the currently selected text alignment.
 
 === Accessible names of bespoke select toolbar buttons including `align`, `fontfamily`, `fontsize`, `blocks`, and `styles` were incorrectly translated.
 // #TINY-10426 #TINY-10435

--- a/modules/ROOT/pages/6.8.2-release-notes.adoc
+++ b/modules/ROOT/pages/6.8.2-release-notes.adoc
@@ -1,6 +1,6 @@
-= TinyMCE 6.8.2
-:navtitle: TinyMCE 6.8.2
-:description: Release notes for TinyMCE 6.8.2
+= {productname} 6.8.2
+:navtitle: {productname} 6.8.2
+:description: Release notes for {productname} 6.8.2
 :keywords: releasenotes, new, changes, bugfixes
 :page-toclevels: 1
 
@@ -43,17 +43,23 @@ For information on the **PowerPaste** plugin, see: xref:introduction-to-powerpas
 === Bespoke select toolbar buttons including `fontfamily`, `fontsize`, `blocks`, and `styles` incorrectly used plural words in their accessible names.
 // #TINY-10426
 
-// CCFR here.
+As of {productname} 6.8.1, the accessible labels of bespoke select toolbar buttons announced both the name of the button and the current value of the visible selected option. However, some bespoke button names, including `fontfamily`, `fontsize`, `blocks`, and `styles` have plural names, such as “Fonts”. This resulted in incorrect grammar when combined with the current value, an example being "Fonts Arial".
+
+As of {productname} 6.8.2, the accessible labels of `fontfamily`, `fontsize`, `blocks`, and `styles` bespoke buttons use singular words for the names. This results in grammatically correct labels such as “Font Arial”.
 
 === The `align` bespoke select toolbar button had an accessible name that was misleading and grammatically incorrect in certain cases.
 // #TINY-10435
 
-// CCFR here.
+As of {productname} 6.8.1, the accessible label of the `align` bespoke select toolbar button announced both the name of the button, “Align”, and the currently selected value. This would result in the accessible label of the select button to be “Align left”, “Align right”, “Align center”, or “Align justify” depending on the value selected. However, the problem with the first three labels is that they are the same as the normal align toolbar buttons. This is misleading as unlike the normal align buttons, the bespoke button does not result in the aligning action, and instead opens a dropdown. The problem with “Align justify” is that the two verbs do not make grammatical sense in terms of describing the text alignment.
+
+As of {productname} 6.8.2, the name of the `align` bespoke select button is changed to “Alignment”, followed by the currently selected value. This results in the accessible labels being “Alignment left”, “Alignment right”, “Alignment center”, or “Alignment justify” depending on the values selected, which more clearly indicates the currently selected text alignment.
 
 === Accessible names of bespoke select toolbar buttons including `align`, `fontfamily`, `fontsize`, `blocks`, and `styles` were incorrectly translated.
 // #TINY-10426 #TINY-10435
 
-// CCFR here.
+As of {productname} 6.8.1, the accessible label of the `align` bespoke select toolbar button announced both the name of the button and the currently selected value, for example “Block Paragraph”. However, corresponding translation strings with placeholders were not added. This resulted in the current value being translated as expected, but not the name of the button. 
+
+In {productname} 6.8.2, new translation strings were added to ensure names of the bespoke select toolbar buttons are translated as well, making their accessible labels appropriately translated.
 
 === Clicking inside table cells with heavily nested content could cause the browser to hang.
 // #TINY-10380

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -73,14 +73,6 @@ NOTE: This is the {productname} Community version changelog. For information abo
 * Removed use of async for editor rendering which caused visual blinking when reloading the editor in-place.
 * Toggling a list that contained a list item element — <li> — which, in turn, contained another list item element as its first child, removed other content within the first list item element.
 
-== 6.7.2 - 2023-10-25
-
-=== Fixed
-* The function `getModifierState` did not work on events passed through the editor as expected.
-* Indenting or outdenting a list item that contained non list item siblings after it would result in those siblings being removed.
-* Removed use of async for editor rendering which caused visual blinking when reloading the editor in-place.
-* Toggling a list that contained a list item element — <li> — which, in turn, contained another list item element as its first child, removed other content within the first list item element.
-
 == 6.7.1 - 2023-10-19
 
 === Fixed

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -11,6 +11,12 @@ This section lists the releases for {productname} 6 and the changes made in each
 
 a|
 [.lead]
+xref:6.8.2-release-notes.adoc#overview[{productname} 6.8.2]
+
+Release notes for {productname} 6.8.2
+
+a|
+[.lead]
 xref:6.8.1-release-notes.adoc#overview[{productname} 6.8.1]
 
 Release notes for {productname} 6.8.1


### PR DESCRIPTION
Ticket: DOC-2225

Changes:
* added `6.8.2-release-notes.adoc` to project; updated `changelog.adoc`, `nav.adoc` and `release-notes.adoc` for the TinyMCE 6.8.2 release.
* removal of `duplication` entry notes in the `changelog.adoc` for `6.7.2` release.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [x] Files has been included where required (if applicable)
- [x] Files removed have been deleted, not just excluded from the build (if applicable)
- [x] ~(New product features only) Release Note added~

Review:
- [x] Documentation Team Lead has reviewed
