### PR TITLE
DOC-2231: add invalid api link to `cloud-troubleshooting.md` file.

### DIFF
--- a/cloud-deployment-guide/cloud-troubleshooting.md
+++ b/cloud-deployment-guide/cloud-troubleshooting.md
@@ -35,7 +35,7 @@ Update the `src` URL to include your (website or application developer's) {{site
 
 To retrieve your API key, or to sign up for an API key, visit: [{{site.cloudname}}]({{site.accountsignup}}).
 
-> **NOTE**: Visit our [Invalid API key](https://www.tiny.cloud/docs/tinymce/6/invalid-api-key/) page for more information on how to fix a invalid API key with TinyMCE.
+> **NOTE**: Visit our [Invalid API key](https://www.tiny.cloud/docs/tinymce/6/invalid-api-key/) page for more information on how to fix an invalid API key with TinyMCE.
 
 ## "A valid API key is required, starting 2024, to continue using TinyMCE. Please alert your admin to check the current API key."
 

--- a/cloud-deployment-guide/cloud-troubleshooting.md
+++ b/cloud-deployment-guide/cloud-troubleshooting.md
@@ -35,6 +35,8 @@ Update the `src` URL to include your (website or application developer's) {{site
 
 To retrieve your API key, or to sign up for an API key, visit: [{{site.cloudname}}]({{site.accountsignup}}).
 
+> **NOTE**: Visit our [Invalid API key](https://www.tiny.cloud/docs/tinymce/6/invalid-api-key/) page for more information on how to fix a invalid API key with TinyMCE.
+
 ## "A valid API key is required, starting 2024, to continue using TinyMCE. Please alert your admin to check the current API key."
 
 ### Cause
@@ -54,6 +56,8 @@ Check the `apiKey` provided in the script tag:
 - Remove any leading or trailing spaces.
 - Any other characters that are not in your API key. If you are using variable substitution, ensure that the variable is substituting properly.
 - Matches the API key shown at {{site.accountpageurl}}.
+
+> **NOTE**: Visit our [Invalid API key](https://www.tiny.cloud/docs/tinymce/6/invalid-api-key/) page for more information on how to fix a invalid API key with TinyMCE.
 
 ## "This domain is not registered with Tiny Cloud. To continue using TinyMCE, a registered domain is required, starting 2024. Please alert your admin to review the approved domains and add this one if required."
 
@@ -101,3 +105,5 @@ You may also be seeing this notification if you are using the wrong API key. Ens
 ### Solution
 
 Either remove the premium plugin from your {{site.productname}} configuration, or upgrade your subscription to provide access to that premium plugin.
+
+> **NOTE**: Visit our [Invalid API key](https://www.tiny.cloud/docs/tinymce/6/invalid-api-key/) page for more information on how to fix a invalid API key with TinyMCE.

--- a/cloud-deployment-guide/cloud-troubleshooting.md
+++ b/cloud-deployment-guide/cloud-troubleshooting.md
@@ -57,7 +57,7 @@ Check the `apiKey` provided in the script tag:
 - Any other characters that are not in your API key. If you are using variable substitution, ensure that the variable is substituting properly.
 - Matches the API key shown at {{site.accountpageurl}}.
 
-> **NOTE**: Visit our [Invalid API key](https://www.tiny.cloud/docs/tinymce/6/invalid-api-key/) page for more information on how to fix a invalid API key with TinyMCE.
+> **NOTE**: Visit our [Invalid API key](https://www.tiny.cloud/docs/tinymce/6/invalid-api-key/) page for more information on how to fix an invalid API key with TinyMCE.
 
 ## "This domain is not registered with Tiny Cloud. To continue using TinyMCE, a registered domain is required, starting 2024. Please alert your admin to review the approved domains and add this one if required."
 

--- a/cloud-deployment-guide/cloud-troubleshooting.md
+++ b/cloud-deployment-guide/cloud-troubleshooting.md
@@ -106,4 +106,4 @@ You may also be seeing this notification if you are using the wrong API key. Ens
 
 Either remove the premium plugin from your {{site.productname}} configuration, or upgrade your subscription to provide access to that premium plugin.
 
-> **NOTE**: Visit our [Invalid API key](https://www.tiny.cloud/docs/tinymce/6/invalid-api-key/) page for more information on how to fix a invalid API key with TinyMCE.
+> **NOTE**: Visit our [Invalid API key](https://www.tiny.cloud/docs/tinymce/6/invalid-api-key/) page for more information on how to fix an invalid API key with TinyMCE.


### PR DESCRIPTION
Ticket: DOC-2231

Changes:
* add `invalid-api-link` in the `cloud-troubleshooting.md` file within the `5x/docs` project, to link back to the newly added `invalid-api-key` page added to the `6x` docs project.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] ~Changelog entry added~

Review:
- [x] Documentation Team Lead has reviewed
