### PR TITLE
DOC-2235: changes and updates to `invalid-api-key.adoc` page.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2235: changes and updates to `invalid-api-key.adoc` page.
+
 ### 2023-12-20
 
 - DOC-1020: add `language_load` option to `ui-localization.adoc` page that configures whether additional plugin/theme languages are loaded when bundling.

--- a/modules/ROOT/pages/invalid-api-key.adoc
+++ b/modules/ROOT/pages/invalid-api-key.adoc
@@ -1,49 +1,66 @@
 = Invalid API key
-:description_short: Fixing with invalid API key error | {productname}
-:description: Learn what you need to do when getting a message about invalid {productname} API key. Find out the reasons for this error as well as how to fix it.
+:description_short: Fixing the invalid API key error | {productname}
+:description: Learn why you’re receiving an invalid {productname} API key error notification, and how to fix the issue.
 :keywords: {productname}, cloud, script, textarea, apiKey, faq, invalid api key, frequently asked questions,
 
 [IMPORTANT]
 ====
-All editors on our cloud platform are required (from early 2024) to have a valid API key. Without a valid API key, your editor will transition to **read-only** mode, limiting your ability to make changes.
+**Starting in early 2024, all editors on our cloud platform will be required to have a valid API key.** Without a valid API key, **your editor will transition to read-only mode**, limiting your ability to make changes.
 
-* This change will only affect users who do not have a valid API key and use Tiny Cloud.
-* Affected users should see a xref:cloud-troubleshooting.adoc[notification in their editor]. If you see it, please contact the  Administrator for your application/site. Admins need to https://www.tiny.cloud/my-account/integrate/[get a valid API key] and paste it into the code to continue using {productname}.
+Affected users will receive a xref:cloud-troubleshooting.adoc#A-valid-API-key-is-required-starting-2024-to-continue-using-TinyMCE.-Please-alert-your-admin-to-sign-up-to-get-your-free-API-key.[notification in their editor]. If you receive this notification, please contact the Administrator for your application/site. Admins will need to https://www.tiny.cloud/my-account/integrate/[get a valid API key] and paste it into the code to continue using {productname}.
 ====
 
-== How can I verify this change will affect me?
+== How will I know if this change affects me?
 
-If {productname} detects an invalid API key, it will display a notification. If you know or suspect you have been actively hiding or suppressing this notification, please remove these overrides. If you then see a notification, please follow the instructions to resolve the issue. If no notification pops up, everything's fine. 
+If {productname} detects an invalid API key, it will display a notification. If you know or suspect you have been actively hiding or suppressing this notification, please remove these overrides. If you then see a notification, please follow the instructions to resolve the issue. If no notification appears, you are not affected. 
 
-== How to get your API key:
+== How can I get an API key?
 
-The Admin who owns this {productname} implementation needs to log in https://www.tiny.cloud/my-account/integrate/[here] to get the account’s API key. If you do not have an account yet, you can https://www.tiny.cloud/pricing/[sign up for a free API key]. If you need help, please https://www.tiny.cloud/contact/[contact our Customer Success Team]. 
+The Admin who owns your {productname} implementation will need to log in https://www.tiny.cloud/my-account/integrate/[here] to get your account’s API key. If you do not have an account yet, you can https://www.tiny.cloud/pricing/[sign up for a free API key]. Paid users can https://www.tiny.cloud/contact/[contact our Technical Support] team for help.
 
 == What will happen if I don't provide a valid API key?
 
-All editors without valid API keys on Tiny Cloud will be set to read-only mode in the beginning of 2024. You will not be impacted if you self-host {productname}.
+All editors on our cloud platform without a valid API key will be set to read-only mode in the beginning of 2024. If you self-host {productname}, you will not be impacted.
 
-== Why do I need the API key?
+== Why is an API key required?
  
-In order to maintain the quality of our service, ensure reliable security, and keep up with industry best practices, all {productname} Cloud editors will require an active and valid API key beginning in early 2024. 
+We require an API key for all {productname} editors on our cloud platform in order to maintain the quality of our service, ensure reliable security, and keep up with industry best practices. 
 
-== If {productname} is free and open source, why am I now getting warnings saying an API key is required?
+== If {productname} is free and open source, why is an API key required?
 
 {productname} can be accessed through a variety of licensing and hosting methods, including both free and paid options. 
-{productname} is available under an MIT license explained https://www.tiny.cloud/legal/tiny-self-hosted-oem-saas-agreement/[here]. Users must self-host {productname} to take advantage of the MIT license. 
 
-{productname} Cloud offerings are available under commercial license, as described https://www.tiny.cloud/legal/cloud-use-subscription-agreement/[here]. There is a free Cloud plan called “Core”, that is completely free but is limited to 1,000 editor loads per month. There are also 2 Cloud plans called “Essential” and “Professional” with increased editor load limits, and additional premium features. You can find more information on editor load limits, feature breakdowns, and pricing of our Cloud plans https://www.tiny.cloud/pricing/[here].
+The free, open source option for {productname} is available under an MIT license explained https://www.tiny.cloud/legal/tiny-self-hosted-oem-saas-agreement/[here]. Users must self-host {productname} to take advantage of the MIT license. **This type of license does not require an API key**.
 
-All of our Cloud plans require an active API key, so if you’re seeing this error message you need to either migrate to the self-hosted open source version under the MIT license, or you need to acquire an active API key by https://www.tiny.cloud/pricing/[signing up] for a cloud plan. 
+The cloud hosted option for {productname} is available under commercial license, as described https://www.tiny.cloud/legal/cloud-use-subscription-agreement/[here]. **This type of license requires an active API key.**
 
-== I installed the npm package, which I assumed would be self-hosted. Why do I get a notification that an API key is required? 
+If you are receiving an error notification, you are using the cloud-hosted option of {productname} under a commercial license. If you want to continue using {productname} without an API key, you will need to either migrate to the free, open source, self-hosted option or use a 3rd party-hosted CDN option under an MIT license. 
 
-Our integrations default to using the {productname} Cloud service. If you see a notification that an API key is required, it means that you’re using Tiny Cloud service that now requires a valid API key and lets you have 1,000 editor loads per month for free. 
+== I installed the npm package, which I assumed would be self-hosted. Why am I getting a notification that an API key is required? 
+
+Our integrations default to using the {productname} Cloud service. If you’re receiving the notification that an API key is required, it means that you’re using the cloud-hosted option for {productname} under commercial license which requires a valid API key and allows for 1,000 editor loads per month for free. 
 
 Please xref:installation.adoc[read our docs] to learn how to self-host {productname} or https://www.tiny.cloud/pricing/[sign up here] to continue using {productname} Cloud.
 
-== I used {productname} for years. Why am I now getting warnings saying an API key is required?
+== I’ve used {productname} for years. Why am I now receiving notification that an API key is required? 
 
-Thank you for your long-time use of {productname} and for selecting it for your projects. If you're suddenly seeing this message, it means that previous versions of this notification were hidden within your {productname} editor. We are working to ensure that all active users of {productname} are aware of this API key requirement, including those that may have hidden these warnings in the past. If action is not taken before early 2024, these editors will stop functioning. 
+Thank you for your long-term use of {productname} and for selecting it for your projects. If you're suddenly receiving this notification, it means that previous versions of the notification were hidden within your {productname} editor. We are working to ensure that all active users of {productname} are aware of the API key requirement, including those that may have hidden these notifications in the past.
+
+== What does the message "This domain is not registered with Tiny Cloud" mean?
+
+This message means that the domain attempting to use {productname} is not registered with Tiny Cloud. Starting in 2024, a registered domain will be required to continue using {productname}.
+
+== How can I resolve the issue of an unregistered domain?
+
+To resolve this issue, please inform your administrator and request that they review the list of approved domains on your Tiny Account. If necessary, they will need to add the unregistered domain to the approved list. xref:cloud-troubleshooting.adoc#This-domain-is-not-registered-with-Tiny-Cloud.-To-continue-using-TinyMCE-a-registered-domain-is-required-starting-2024.-Please-alert-your-admin-to-review-the-approved-domains-and-add-this-one-if-required.[Learn more here].
+
+== Where can I view the list of approved domains for my Tiny Cloud account?
+
+You can view the list of approved domains by logging into https://www.tiny.cloud/my-account/domains/[your Tiny Account]. The approved domains are stored against your API Key.
+
+== I would prefer to self-host {productname}. What are my options?
+
+* If you plan to use only open-source {productname} features, the open-source version is available under the MIT license.
+* If you want to self-host {productname} and use our Premium features, https://www.tiny.cloud/contact/[get in touch with our Sales team] for a custom quote.
 
 TIP: For additional information on Troubleshooting Tiny Cloud visit: xref:cloud-troubleshooting.adoc[Cloud Troubleshooting].


### PR DESCRIPTION
Ticket: DOC-2235

Changes:
* changes and updates to `invalid-api-key.adoc` page, which include updating initial content, links.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
