### PR TITLE
DOC-2234: Modify workflow to not overwrite 5 docs

### DIFF
--- a/.github/workflows/feature_6_docs.yml
+++ b/.github/workflows/feature_6_docs.yml
@@ -56,7 +56,7 @@ jobs:
         echo $S3_BUCKET > S3_BUCKET
 
     - name: (deploy) Upload website to S3
-      run: aws s3 sync --acl=public-read --delete ./build/site $(cat S3_BUCKET)/docs
+      run: aws s3 sync --acl=public-read --delete ./build/site $(cat S3_BUCKET)/docs --exclude 'tinymce/5'
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release_6_docs.yml
+++ b/.github/workflows/release_6_docs.yml
@@ -40,8 +40,8 @@ jobs:
       run: |
         mv ./build/site/sitemap.xml ./build/site/antora-sitemap.xml
 
-    - name: (deploy) Upload to S3
-      run: aws s3 sync --acl=public-read --delete ./build/site s3://tiny-cloud-antora-docs-production/docs
+    - name: (deploy) Upload site to S3
+      run: aws s3 sync --acl=public-read --delete ./build/site s3://tiny-cloud-antora-docs-production/docs --exclude 'tinymce/5'
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/staging_6_docs.yml
+++ b/.github/workflows/staging_6_docs.yml
@@ -40,8 +40,8 @@ jobs:
       run: |
         mv ./build/site/sitemap.xml ./build/site/antora-sitemap.xml
 
-    - name: (deploy) Upload to S3
-      run: aws s3 sync --acl=public-read --delete ./build/site s3://tiny-cloud-antora-docs-staging/docs
+    - name: (deploy) Upload site to S3
+      run: aws s3 sync --acl=public-read --delete ./build/site s3://tiny-cloud-antora-docs-staging/docs --exclude 'tinymce/5'
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Ticket: DOC-2234

Changes:
* Site build sync won't interfere with new 5 docs site

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`

Review:
- [x] Documentation Team Lead has reviewed
