### PR TITLE
DOC-2178: add fix to `live-demos/full-featured/index.js` for `advtemplate` when inserting template.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2178: add fix to `live-demos/full-featured/index.js` for `advtemplate` when inserting template.
+
 ### 2023-12-20
 
 - DOC-1020: add `language_load` option to `ui-localization.adoc` page that configures whether additional plugin/theme languages are loaded when bundling.

--- a/modules/ROOT/examples/live-demos/full-featured/index.js
+++ b/modules/ROOT/examples/live-demos/full-featured/index.js
@@ -204,15 +204,14 @@ tinymce.ScriptLoader.loadScripts(['https://cdn.jsdelivr.net/npm/faker@5/dist/fak
 			'common/punctuation/hellip'
 		],
 		typography_ignore: [ 'code' ],
-		advtemplate_list: () => {
-			return Promise.resolve([
-				{
-					id: '1',
-					title: 'Resolving tickets',
-					content: '<p>As we have not heard back from you in over a week, we have gone ahead and resolved your ticket.</p>'
-				},
-				{
-					id: '2',
+    advtemplate_templates: [
+      {
+        id: '1',
+        title: 'Resolving tickets',
+        content: '<p>As we have not heard back from you in over a week, we have gone ahead and resolved your ticket.</p>'
+      },
+      {
+        id: '2',
 					title: 'Quick replies',
 					items: [
 						{
@@ -223,12 +222,11 @@ tinymce.ScriptLoader.loadScripts(['https://cdn.jsdelivr.net/npm/faker@5/dist/fak
 						{
 							id: '4',
 							title: 'Progress update',
-							content: '</p>Just a quick note to let you know we are still working on your case</p>'
+							content: '<p>Just a quick note to let you know we are still working on your case</p>'
 						}
 					]
-				}
-			]);
-		},
+      }
+    ],
     link_list: [
       { title: 'My page 1', value: 'https://www.tiny.cloud' },
       { title: 'My page 2', value: 'http://www.moxiecode.com' }


### PR DESCRIPTION
Ticket: DOC-2178

Changes:
* add hotfix to `live-demos/full-featured/index.js` for `advtemplate` when inserting template.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
