### PR TITLE
DOC-2201: Added link to `ai.adoc` to direct users to the AI Assistant demo.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2201: Added link to `ai.adoc` to direct users to the AI Assistant demo.
+
+### 2023-01-10
+
 - DOC-2178: add fix to `live-demos/full-featured/index.js` for `advtemplate` when inserting template.
 
 ### 2023-12-20

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2178: add fix to `live-demos/full-featured/index.js` for `advtemplate` when inserting template.
+
 ### 2023-12-20
 
 - DOC-1020: add `language_load` option to `ui-localization.adoc` page that configures whether additional plugin/theme languages are loaded when bundling.

--- a/modules/ROOT/examples/live-demos/full-featured/index.js
+++ b/modules/ROOT/examples/live-demos/full-featured/index.js
@@ -204,15 +204,14 @@ tinymce.ScriptLoader.loadScripts(['https://cdn.jsdelivr.net/npm/faker@5/dist/fak
 			'common/punctuation/hellip'
 		],
 		typography_ignore: [ 'code' ],
-		advtemplate_list: () => {
-			return Promise.resolve([
-				{
-					id: '1',
-					title: 'Resolving tickets',
-					content: '<p>As we have not heard back from you in over a week, we have gone ahead and resolved your ticket.</p>'
-				},
-				{
-					id: '2',
+    advtemplate_templates: [
+      {
+        id: '1',
+        title: 'Resolving tickets',
+        content: '<p>As we have not heard back from you in over a week, we have gone ahead and resolved your ticket.</p>'
+      },
+      {
+        id: '2',
 					title: 'Quick replies',
 					items: [
 						{
@@ -223,12 +222,11 @@ tinymce.ScriptLoader.loadScripts(['https://cdn.jsdelivr.net/npm/faker@5/dist/fak
 						{
 							id: '4',
 							title: 'Progress update',
-							content: '</p>Just a quick note to let you know we are still working on your case</p>'
+							content: '<p>Just a quick note to let you know we are still working on your case</p>'
 						}
 					]
-				}
-			]);
-		},
+      }
+    ],
     link_list: [
       { title: 'My page 1', value: 'https://www.tiny.cloud' },
       { title: 'My page 2', value: 'http://www.moxiecode.com' }

--- a/modules/ROOT/pages/ai.adoc
+++ b/modules/ROOT/pages/ai.adoc
@@ -21,10 +21,10 @@ Once a response is generated and displayed within the dialog, the user can choos
 
 Users can retrieve a history of their conversations with the AI using the xref:#getThreadLog[`getThreadLog` API], including any discarded responses.
 
-[IMPORTANT]
-.On the absence of an {pluginname} demo
+[NOTE]
+.{pluginname} demo
 ====
-This initial release of the {pluginname} developer documentation does not include an in-page working demo.
+For marketing purposes, {productname} will _only_ be providing a demo for **AI Assistant** on our main website. Checkout https://www.tiny.cloud/tinymce/features/ai-integration/[tiny.cloud/tinymce/features/ai-integration].
 ====
 
 == Basic setup

--- a/modules/ROOT/pages/ai.adoc
+++ b/modules/ROOT/pages/ai.adoc
@@ -24,7 +24,7 @@ Users can retrieve a history of their conversations with the AI using the xref:#
 [NOTE]
 .{pluginname} demo
 ====
-For marketing purposes, {productname} will _only_ be providing a demo for **AI Assistant** on our main website. Checkout https://www.tiny.cloud/tinymce/features/ai-integration/[tiny.cloud/tinymce/features/ai-integration].
+Demos containing the {pluginname} plugin are currently only available on our main website. Check out https://www.tiny.cloud/tinymce/features/ai-integration/[the {pluginname} demo], or the https://www.tiny.cloud/[demo on our home page], to try it out today.
 ====
 
 == Basic setup


### PR DESCRIPTION
Ticket: DOC-2201

Changes:
* Added link to `ai.adoc` to direct users to the AI Assistant demo.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added

Review:
- [x] Documentation Team Lead has reviewed
