### PR TITLE
DOC-2275: updates to `cloud-troubleshooting.adoc` with new links to `invalid-api-key.adoc` page.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+
+### 2024-01-31
+
 - DOC-2275: updates to `cloud-troubleshooting.adoc` with new links to `invalid-api-key.adoc` page.
 
 ### 2024-01-30

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2275: updates to `cloud-troubleshooting.adoc` with new links to `invalid-api-key.adoc` page.
 
 ### 2024-01-30
 

--- a/modules/ROOT/pages/cloud-troubleshooting.adoc
+++ b/modules/ROOT/pages/cloud-troubleshooting.adoc
@@ -3,7 +3,7 @@
 :description: Causes and solutions to common issues when using Tiny Cloud
 :keywords: tinymce, cloud, script, textarea, apiKey, troubleshooting, banners, domain, referer
 
-When {cloudname} detects a problem, it will display an editor notification providing information about the issue. This page describes the common {cloudname} error notifications along with their causes and solutions.
+When {cloudname} detects a problem, it will show an editor notification containing information about the problem. This page describes the cause and solution for common {cloudname} error notifications.
 
 NOTE: The wording of the notifications shown here may differ from the actual notifications from {cloudname}.
 
@@ -12,12 +12,12 @@ NOTE: The wording of the notifications shown here may differ from the actual not
 
 === Cause (1)
 
-This notification can be shown when:
+This notification is *only shown* when either:
 
 * An `+apiKey+` is not provided in the script tag.
 * `+no-api-key+` is provided as the API key.
 
-For example:
+Such as:
 
 [source,html,subs="attributes+"]
 ----
@@ -41,7 +41,7 @@ NOTE: Visit our xref:invalid-api-key.adoc[Invalid API key] page for more informa
 
 === Cause (2)
 
-Additionally, this notification can be shown when the provided API key cannot be found on the {cloudname} server.
+This notification is shown when the API key provided cannot be found on the {cloudname} server.
 
 The `+apiKey+` must be:
 

--- a/modules/ROOT/pages/cloud-troubleshooting.adoc
+++ b/modules/ROOT/pages/cloud-troubleshooting.adoc
@@ -7,10 +7,10 @@ When {cloudname} detects a problem, it will show an editor notification containi
 
 NOTE: The wording of the notifications shown here may differ from the actual notifications from {cloudname}.
 
-[[A-valid-API-key-is-required-starting-2024-to-continue-using-TinyMCE.-Please-alert-your-admin-to-sign-up-to-get-your-free-API-key.]]
-== "A valid API key is required, starting 2024, to continue using TinyMCE. Please alert your admin to sign-up to get your free API key."
+[[A-valid-API-key-is-required-to-continue-using-TinyMCE.-Please-alert-the-admin-to-check-the-current-API-key]]
+== "A valid API key is required to continue using {productname}. **Please alert the admin** to check the current API key. xref:invalid-api-key.adoc[Click here to learn more.]"
 
-=== Cause
+=== Cause (1)
 
 This notification is *only shown* when either:
 
@@ -24,7 +24,7 @@ Such as:
 <script src="{cdnurl}" referrerpolicy="origin"></script>
 ----
 
-=== Solution
+=== Solution (1)
 
 Update the `+src+` URL to include your (website or application developer's) {cloudname} API Key. Your API key should replace the string `+no-api-key+`. For example, if your API is `+abcd1234+`:
 
@@ -37,10 +37,9 @@ To retrieve your API key, or to sign up for an API key, visit: link:{accountsign
 
 NOTE: Visit our xref:invalid-api-key.adoc[Invalid API key] page for more information on how to fix a `invalid API key` with {productname}.
 
-[[A-valid-API-key-is-required-starting-2024-to-continue-using-TinyMCE.-Please-alert-your-admin-to-check-the-current-API-key]]
-== "A valid API key is required, starting 2024, to continue using TinyMCE. Please alert your admin to check the current API key."
+'''
 
-=== Cause
+=== Cause (2)
 
 This notification is shown when the API key provided cannot be found on the {cloudname} server.
 
@@ -50,7 +49,7 @@ The `+apiKey+` must be:
 * comprised of certain characters, and
 * created with a {cloudname} account on the link:{accountsignup}/[{accountpage} page].
 
-=== Solution
+=== Solution (2)
 
 Check the `+apiKey+` provided in the script tag:
 
@@ -60,8 +59,10 @@ Check the `+apiKey+` provided in the script tag:
 
 NOTE: Visit our xref:invalid-api-key.adoc[Invalid API key] page for more information on how to fix a `invalid API key` with {productname}.
 
-[[This-domain-is-not-registered-with-Tiny-Cloud.-To-continue-using-TinyMCE-a-registered-domain-is-required-starting-2024.-Please-alert-your-admin-to-review-the-approved-domains-and-add-this-one-if-required.]]
-== "This domain is not registered with Tiny Cloud. To continue using TinyMCE, a registered domain is required, starting 2024. Please alert your admin to review the approved domains and add this one if required."
+'''
+
+[[This-domain-is-not-registered-in-the-TinyMCE-Customer-Portal.-Please-alert-the-admin-to-add-it-to-the-approved-domains-to-continue-using-TinyMCE.]]
+== "This domain is not registered in the {productname} Customer Portal. **Please alert the admin** to add it to the approved domains to continue using {productname}. xref:invalid-api-key.adoc[Click here to learn more.]"
 
 === Cause
 
@@ -80,6 +81,8 @@ In the section called *Request Headers* there should be a field for *Referer*. T
 
 If the `+Referer+` is correct for the site, ensure that the domain is included in your list of approved domains on link:{accountpageurl}/[{accountpage}]. If the `+Referer+` is not what you are expecting, you may need to adjust your application's https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer[*Referer* header] settings.
 
+'''
+
 [[were-unable-to-check-your-domain-because-the-referer-header-is-missing-please-read-the-guide-on-how-to-ensure-your-referer-header-is-present-so-we-can-then-customize-your-editor-experience]]
 == "We’re unable to check your domain because the referer header is missing. Please read the Guide on how to ensure your referer header is present, so we can then customize your editor experience."
 
@@ -97,6 +100,8 @@ Identify which browser setting or extension is responsible for blocking the *Ref
 * https://addons.mozilla.org/en-US/firefox/addon/referercontrol/[Firefox]
 
 Once you have identified the setting or extension, modify it to allow just the `+Origin+` of the `+Referer+` to be sent. Alternatively, disable the extension or setting for any pages using {cloudname}.
+
+'''
 
 [[the-___-premium-plugin-is-not-enabled-on-your-api-key-upgrade-your-account]]
 == "The ___ premium plugin is not enabled on your API key. Upgrade your account."

--- a/modules/ROOT/pages/cloud-troubleshooting.adoc
+++ b/modules/ROOT/pages/cloud-troubleshooting.adoc
@@ -10,23 +10,27 @@ NOTE: The wording of the notifications shown here may differ from the actual not
 [[A-valid-API-key-is-required-to-continue-using-TinyMCE.-Please-alert-the-admin-to-check-the-current-API-key]]
 == "A valid API key is required to continue using {productname}. **Please alert the admin** to check the current API key. xref:invalid-api-key.adoc[Click here to learn more.]"
 
-=== Cause (1)
+=== Scenario (one)
+
+==== Cause
 
 This notification is *only shown* when either:
 
 * An `+apiKey+` is not provided in the script tag.
 * `+no-api-key+` is provided as the API key.
 
-Such as:
+For example:
 
 [source,html,subs="attributes+"]
 ----
 <script src="{cdnurl}" referrerpolicy="origin"></script>
 ----
 
-=== Solution (1)
+==== Solution
 
-Update the `+src+` URL to include your (website or application developer's) {cloudname} API Key. Your API key should replace the string `+no-api-key+`. For example, if your API is `+abcd1234+`:
+Update the `+src+` URL to include your (website or application developer's) {cloudname} API Key. Your API key should replace the string `+no-api-key+`.
+
+For example: if your API is `+abcd1234+`:
 
 [source,html,subs="attributes+"]
 ----
@@ -37,9 +41,9 @@ To retrieve your API key, or to sign up for an API key, visit: link:{accountsign
 
 NOTE: Visit our xref:invalid-api-key.adoc[Invalid API key] page for more information on how to fix a `invalid API key` with {productname}.
 
-'''
+=== Scenario (two)
 
-=== Cause (2)
+==== Cause
 
 This notification is shown when the API key provided cannot be found on the {cloudname} server.
 
@@ -49,7 +53,7 @@ The `+apiKey+` must be:
 * comprised of certain characters, and
 * created with a {cloudname} account on the link:{accountsignup}/[{accountpage} page].
 
-=== Solution (2)
+==== Solution
 
 Check the `+apiKey+` provided in the script tag:
 
@@ -64,7 +68,9 @@ NOTE: Visit our xref:invalid-api-key.adoc[Invalid API key] page for more informa
 [[This-domain-is-not-registered-in-the-TinyMCE-Customer-Portal.-Please-alert-the-admin-to-add-it-to-the-approved-domains-to-continue-using-TinyMCE.]]
 == "This domain is not registered in the {productname} Customer Portal. **Please alert the admin** to add it to the approved domains to continue using {productname}. xref:invalid-api-key.adoc[Click here to learn more.]"
 
-=== Cause
+=== Scenario
+
+==== Cause
 
 This notification is shown when the https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer[*Referer*] of the page does not match the list of approved domains stored against your `+apiKey+`. {cloudname} verifies the domain {productname} is loading from by checking the domain portion of the *Referer* header in the network request. You can view a list of your approved domains on your link:{accountpageurl}/[{accountpage}].
 
@@ -77,7 +83,7 @@ Sometimes the domain in the *Referer* header does not match with the URL in the 
 
 In the section called *Request Headers* there should be a field for *Referer*. This is the value that {productname} is checking against your approved domains. It must match one of your approved domains listed on your link:{accountpageurl}/[{accountpage}].
 
-=== Solution
+==== Solution
 
 If the `+Referer+` is correct for the site, ensure that the domain is included in your list of approved domains on link:{accountpageurl}/[{accountpage}]. If the `+Referer+` is not what you are expecting, you may need to adjust your application's https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer[*Referer* header] settings.
 
@@ -86,13 +92,15 @@ If the `+Referer+` is correct for the site, ensure that the domain is included i
 [[were-unable-to-check-your-domain-because-the-referer-header-is-missing-please-read-the-guide-on-how-to-ensure-your-referer-header-is-present-so-we-can-then-customize-your-editor-experience]]
 == "We’re unable to check your domain because the referer header is missing. Please read the Guide on how to ensure your referer header is present, so we can then customize your editor experience."
 
-=== Cause
+=== Scenario
+
+==== Cause
 
 This notification is shown if the https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer[*Referer* header] is absent for the network request when loading {productname} from {cloudname}. {cloudname} verifies the domain {productname} is loading from by checking the domain of the *Referer* header in the network request.
 
 _Referer_ headers are sometimes removed by browser settings or browser extensions. {cloudname} only needs the domain in the *Referer* header, so for improved performance and privacy {companyname} recommends setting the `+referrerpolicy+` to `+origin+` when requesting {cloudname} resources.
 
-=== Solution
+==== Solution
 
 Identify which browser setting or extension is responsible for blocking the *Referer* being sent. A common extension is `+Referer Control+`:
 
@@ -106,13 +114,15 @@ Once you have identified the setting or extension, modify it to allow just the `
 [[the-___-premium-plugin-is-not-enabled-on-your-api-key-upgrade-your-account]]
 == "The ___ premium plugin is not enabled on your API key. Upgrade your account."
 
-=== Cause
+=== Scenario
+
+==== Cause
 
 This notification is shown when your API key does not have access to the premium plugin being requested. This could be the result of a trial expiring, and your {productname} configuration attempting to load premium plugins you can no longer access.
 
 You may also be seeing this notification if you are using the wrong API key. Ensure that you are using the API key that has the right entitlements.
 
-=== Solution
+==== Solution
 
 Either remove the premium plugin from your {productname} configuration, or upgrade your subscription to provide access to that premium plugin.
 

--- a/modules/ROOT/pages/cloud-troubleshooting.adoc
+++ b/modules/ROOT/pages/cloud-troubleshooting.adoc
@@ -3,7 +3,7 @@
 :description: Causes and solutions to common issues when using Tiny Cloud
 :keywords: tinymce, cloud, script, textarea, apiKey, troubleshooting, banners, domain, referer
 
-When {cloudname} detects a problem, it will show an editor notification containing information about the problem. This page describes the cause and solution for common {cloudname} error notifications.
+When {cloudname} detects a problem, it will display an editor notification providing information about the issue. This page describes the common {cloudname} error notifications along with their causes and solutions.
 
 NOTE: The wording of the notifications shown here may differ from the actual notifications from {cloudname}.
 
@@ -12,12 +12,12 @@ NOTE: The wording of the notifications shown here may differ from the actual not
 
 === Cause (1)
 
-This notification is *only shown* when either:
+This notification can be shown when:
 
 * An `+apiKey+` is not provided in the script tag.
 * `+no-api-key+` is provided as the API key.
 
-Such as:
+For example:
 
 [source,html,subs="attributes+"]
 ----
@@ -41,7 +41,7 @@ NOTE: Visit our xref:invalid-api-key.adoc[Invalid API key] page for more informa
 
 === Cause (2)
 
-This notification is shown when the API key provided cannot be found on the {cloudname} server.
+Additionally, this notification can be shown when the provided API key cannot be found on the {cloudname} server.
 
 The `+apiKey+` must be:
 


### PR DESCRIPTION
Ticket: DOC-2275

Changes:
* updates to `cloud-troubleshooting.adoc` with new links to `invalid-api-key.adoc` page.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`
- [x] Changelog entry added
- [x] Approval from GMT

Review:
- [x] Documentation Team Lead has reviewed
