### PR TITLE
DOC-2174: added documentation for Mentions plugin's getUsers API deprecation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,13 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+
+### 2023-01-15
+
+- DOC-2235: changes and updates to `invalid-api-key.adoc` page.
+
+### 2023-01-11
+
 - DOC-2201: Added link to `ai.adoc` to direct users to the AI Assistant demo.
 
 ### 2023-01-10

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2201: Added link to `ai.adoc` to direct users to the AI Assistant demo.
+
+### 2023-01-10
+
 - DOC-2178: add fix to `live-demos/full-featured/index.js` for `advtemplate` when inserting template.
 
 ### 2023-12-20

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+### 2023-12-20
+
+- DOC-1020: add `language_load` option to `ui-localization.adoc` page that configures whether additional plugin/theme languages are loaded when bundling.
+
 ### 2023-12-19
 
 - DOC-2220: add generation of `latest` and `6` documentation in parallel.

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 ### Unreleased
 
 
+### 2024-01-30
+
+- DOC-2240: add new `understanding-editor-loads.adoc` to `how-to-guide` section.
+
 ### 2023-01-15
 
 - DOC-2235: changes and updates to `invalid-api-key.adoc` page.

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+### 2024-02-05
+
+- DOC-2276: updates to `cloud-troubleshooting.adoc` with new `read-only` ref and links to `invalid-api-key.adoc` page.
 
 ### 2024-01-31
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 ### Unreleased
 
 
+### 2024-01-31
+
+- DOC-2275: updates to `cloud-troubleshooting.adoc` with new links to `invalid-api-key.adoc` page.
+
 ### 2024-01-30
 
 - DOC-2240: add new `understanding-editor-loads.adoc` to `how-to-guide` section.

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Unreleased
 
+- DOC-2178: add fix to `live-demos/full-featured/index.js` for `advtemplate` when inserting template.
+
 ### 2023-12-20
 
 - DOC-1020: add `language_load` option to `ui-localization.adoc` page that configures whether additional plugin/theme languages are loaded when bundling.

--- a/modules/ROOT/examples/live-demos/full-featured/index.js
+++ b/modules/ROOT/examples/live-demos/full-featured/index.js
@@ -204,15 +204,14 @@ tinymce.ScriptLoader.loadScripts(['https://cdn.jsdelivr.net/npm/faker@5/dist/fak
 			'common/punctuation/hellip'
 		],
 		typography_ignore: [ 'code' ],
-		advtemplate_list: () => {
-			return Promise.resolve([
-				{
-					id: '1',
-					title: 'Resolving tickets',
-					content: '<p>As we have not heard back from you in over a week, we have gone ahead and resolved your ticket.</p>'
-				},
-				{
-					id: '2',
+    advtemplate_templates: [
+      {
+        id: '1',
+        title: 'Resolving tickets',
+        content: '<p>As we have not heard back from you in over a week, we have gone ahead and resolved your ticket.</p>'
+      },
+      {
+        id: '2',
 					title: 'Quick replies',
 					items: [
 						{
@@ -223,12 +222,11 @@ tinymce.ScriptLoader.loadScripts(['https://cdn.jsdelivr.net/npm/faker@5/dist/fak
 						{
 							id: '4',
 							title: 'Progress update',
-							content: '</p>Just a quick note to let you know we are still working on your case</p>'
+							content: '<p>Just a quick note to let you know we are still working on your case</p>'
 						}
 					]
-				}
-			]);
-		},
+      }
+    ],
     link_list: [
       { title: 'My page 1', value: 'https://www.tiny.cloud' },
       { title: 'My page 2', value: 'http://www.moxiecode.com' }

--- a/modules/ROOT/examples/live-demos/getusers-api-alternative/index.html
+++ b/modules/ROOT/examples/live-demos/getusers-api-alternative/index.html
@@ -1,0 +1,16 @@
+<textarea id="getusers-api-alternative">
+<p>Existing at mention: <span class="mention" data-mce-mentions-id="user-3">@Abraham Lincoln</span></p>
+<p>Add some more at mentions here to track them. Click the <strong>getUsers</strong> button in the toolbar to add a list of currently inserted users to the editor.</p>
+
+<br><br><br>
+
+<h2>Found a bug?</h2>
+
+<p>If you believe you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
+
+<h2>Finally…</h2>
+
+<p>Don’t forget to check out <a href="http://www.plupload.com" target="_blank">Plupload</a>, the upload solution featuring HTML5 upload support.</p>
+<p>Thanks for supporting TinyMCE. We hope it helps you and your users create great content.</p>
+<p>All the best from the TinyMCE team.</p>
+</textarea>

--- a/modules/ROOT/examples/live-demos/getusers-api-alternative/index.js
+++ b/modules/ROOT/examples/live-demos/getusers-api-alternative/index.js
@@ -1,0 +1,54 @@
+const users = [
+  { id: 'user-1', name: 'John Doe' },
+  { id: 'user-2', name: 'Jane Doe' },
+  { id: 'user-3', name: 'Abraham Lincoln' }
+];
+
+const fetchMentions = (query, success) => {
+  const matches = users.filter((user) => user.name.toLowerCase().includes(query.term.toLowerCase()));
+  success(matches);
+};
+
+const insertedUsers = new Set();
+
+const mentionsInsert = (editor, user) => {
+  const span = editor.getDoc().createElement('span');
+  span.className = 'mention';
+  span.appendChild(editor.getDoc().createTextNode('@' + user.name));
+  insertedUsers.add(user);
+  return span;
+};
+
+const getUsers = (editor) => {
+  const spans = Array.from(editor.getBody().querySelectorAll('[data-mce-mentions-id]'));
+  const currentIds = spans.map((elm) => elm.getAttribute('data-mce-mentions-id'));
+  const currentUsers = Array.from(insertedUsers).filter((user) => currentIds.includes(user.id));
+
+  return currentUsers;
+};
+
+tinymce.init({
+  selector: "textarea#getusers-api-alternative",
+  plugins: "mentions code",
+  toolbar: "undo redo | styles | bold italic underline strikethrough | code",
+  mentions_fetch: fetchMentions,
+  mentions_menu_complete: mentionsInsert,
+
+  toolbar: 'getUsersButton',
+  setup: function (editor) {
+	editor.ui.registry.addButton('getUsersButton', {
+	  text: 'getUsers',
+	  onAction: function () {
+		// Get mentioned users
+		var mentionedUsers = getUsers(editor);
+    // Insert mentioned users as a bullet list
+		if (mentionedUsers.length > 0) {
+		  var userList = mentionedUsers.map(function (user) {
+			return '<li>' + user.name + '</li>';
+		  }).join('');
+		  editor.execCommand('mceInsertContent', false, '<p>Mentioned Users:</p><ul>' + userList + '</ul>');
+		}
+	  }
+	});
+  }
+});

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -215,6 +215,7 @@
 ** xref:migration-from-5x.adoc[Migrating from TinyMCE 5]
 ** xref:migration-from-froala.adoc[Migrating from Froala]
 ** xref:generate-rsa-key-pairs.adoc[Generate public key pairs]
+** xref:understanding-editor-loads.adoc[Understanding editor loads]
 * xref:examples.adoc[Examples]
 ** xref:examples.adoc#general-examples[General examples]
 *** xref:basic-example.adoc[Basic example]

--- a/modules/ROOT/pages/6.0-release-notes-premium-changes.adoc
+++ b/modules/ROOT/pages/6.0-release-notes-premium-changes.adoc
@@ -172,6 +172,9 @@ The following change was made to the xref:mentions.adoc[Mentions] plugin:
 
 The `getUsers` API was removed.
 
+View the following demo for an alternative to the `getUsers` API:
+
+liveDemo::getusers-api-alternative[height="400"]
         
 === PowerPaste
 

--- a/modules/ROOT/pages/ai.adoc
+++ b/modules/ROOT/pages/ai.adoc
@@ -21,10 +21,10 @@ Once a response is generated and displayed within the dialog, the user can choos
 
 Users can retrieve a history of their conversations with the AI using the xref:#getThreadLog[`getThreadLog` API], including any discarded responses.
 
-[IMPORTANT]
-.On the absence of an {pluginname} demo
+[NOTE]
+.{pluginname} demo
 ====
-This initial release of the {pluginname} developer documentation does not include an in-page working demo.
+Demos containing the {pluginname} plugin are currently only available on our main website. Check out https://www.tiny.cloud/tinymce/features/ai-integration/[the {pluginname} demo], or the https://www.tiny.cloud/[demo on our home page], to try it out today.
 ====
 
 == Basic setup

--- a/modules/ROOT/pages/cloud-troubleshooting.adoc
+++ b/modules/ROOT/pages/cloud-troubleshooting.adoc
@@ -7,26 +7,30 @@ When {cloudname} detects a problem, it will show an editor notification containi
 
 NOTE: The wording of the notifications shown here may differ from the actual notifications from {cloudname}.
 
-[[A-valid-API-key-is-required-starting-2024-to-continue-using-TinyMCE.-Please-alert-your-admin-to-sign-up-to-get-your-free-API-key.]]
-== "A valid API key is required, starting 2024, to continue using TinyMCE. Please alert your admin to sign-up to get your free API key."
+[[A-valid-API-key-is-required-to-continue-using-TinyMCE.-Please-alert-the-admin-to-check-the-current-API-key]]
+== "A valid API key is required to continue using {productname}. **Please alert the admin** to check the current API key. xref:invalid-api-key.adoc[Click here to learn more.]"
 
-=== Cause
+=== Scenario (one)
+
+==== Cause
 
 This notification is *only shown* when either:
 
 * An `+apiKey+` is not provided in the script tag.
 * `+no-api-key+` is provided as the API key.
 
-Such as:
+For example:
 
 [source,html,subs="attributes+"]
 ----
 <script src="{cdnurl}" referrerpolicy="origin"></script>
 ----
 
-=== Solution
+==== Solution
 
-Update the `+src+` URL to include your (website or application developer's) {cloudname} API Key. Your API key should replace the string `+no-api-key+`. For example, if your API is `+abcd1234+`:
+Update the `+src+` URL to include your (website or application developer's) {cloudname} API Key. Your API key should replace the string `+no-api-key+`.
+
+For example: if your API is `+abcd1234+`:
 
 [source,html,subs="attributes+"]
 ----
@@ -37,10 +41,9 @@ To retrieve your API key, or to sign up for an API key, visit: link:{accountsign
 
 NOTE: Visit our xref:invalid-api-key.adoc[Invalid API key] page for more information on how to fix a `invalid API key` with {productname}.
 
-[[A-valid-API-key-is-required-starting-2024-to-continue-using-TinyMCE.-Please-alert-your-admin-to-check-the-current-API-key]]
-== "A valid API key is required, starting 2024, to continue using TinyMCE. Please alert your admin to check the current API key."
+=== Scenario (two)
 
-=== Cause
+==== Cause
 
 This notification is shown when the API key provided cannot be found on the {cloudname} server.
 
@@ -50,7 +53,7 @@ The `+apiKey+` must be:
 * comprised of certain characters, and
 * created with a {cloudname} account on the link:{accountsignup}/[{accountpage} page].
 
-=== Solution
+==== Solution
 
 Check the `+apiKey+` provided in the script tag:
 
@@ -60,10 +63,14 @@ Check the `+apiKey+` provided in the script tag:
 
 NOTE: Visit our xref:invalid-api-key.adoc[Invalid API key] page for more information on how to fix a `invalid API key` with {productname}.
 
-[[This-domain-is-not-registered-with-Tiny-Cloud.-To-continue-using-TinyMCE-a-registered-domain-is-required-starting-2024.-Please-alert-your-admin-to-review-the-approved-domains-and-add-this-one-if-required.]]
-== "This domain is not registered with Tiny Cloud. To continue using TinyMCE, a registered domain is required, starting 2024. Please alert your admin to review the approved domains and add this one if required."
+'''
 
-=== Cause
+[[This-domain-is-not-registered-in-the-TinyMCE-Customer-Portal.-Please-alert-the-admin-to-add-it-to-the-approved-domains-to-continue-using-TinyMCE.]]
+== "This domain is not registered in the {productname} Customer Portal. **Please alert the admin** to add it to the approved domains to continue using {productname}. xref:invalid-api-key.adoc[Click here to learn more.]"
+
+=== Scenario
+
+==== Cause
 
 This notification is shown when the https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer[*Referer*] of the page does not match the list of approved domains stored against your `+apiKey+`. {cloudname} verifies the domain {productname} is loading from by checking the domain portion of the *Referer* header in the network request. You can view a list of your approved domains on your link:{accountpageurl}/[{accountpage}].
 
@@ -76,20 +83,24 @@ Sometimes the domain in the *Referer* header does not match with the URL in the 
 
 In the section called *Request Headers* there should be a field for *Referer*. This is the value that {productname} is checking against your approved domains. It must match one of your approved domains listed on your link:{accountpageurl}/[{accountpage}].
 
-=== Solution
+==== Solution
 
 If the `+Referer+` is correct for the site, ensure that the domain is included in your list of approved domains on link:{accountpageurl}/[{accountpage}]. If the `+Referer+` is not what you are expecting, you may need to adjust your application's https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer[*Referer* header] settings.
+
+'''
 
 [[were-unable-to-check-your-domain-because-the-referer-header-is-missing-please-read-the-guide-on-how-to-ensure-your-referer-header-is-present-so-we-can-then-customize-your-editor-experience]]
 == "We’re unable to check your domain because the referer header is missing. Please read the Guide on how to ensure your referer header is present, so we can then customize your editor experience."
 
-=== Cause
+=== Scenario
+
+==== Cause
 
 This notification is shown if the https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer[*Referer* header] is absent for the network request when loading {productname} from {cloudname}. {cloudname} verifies the domain {productname} is loading from by checking the domain of the *Referer* header in the network request.
 
 _Referer_ headers are sometimes removed by browser settings or browser extensions. {cloudname} only needs the domain in the *Referer* header, so for improved performance and privacy {companyname} recommends setting the `+referrerpolicy+` to `+origin+` when requesting {cloudname} resources.
 
-=== Solution
+==== Solution
 
 Identify which browser setting or extension is responsible for blocking the *Referer* being sent. A common extension is `+Referer Control+`:
 
@@ -98,16 +109,20 @@ Identify which browser setting or extension is responsible for blocking the *Ref
 
 Once you have identified the setting or extension, modify it to allow just the `+Origin+` of the `+Referer+` to be sent. Alternatively, disable the extension or setting for any pages using {cloudname}.
 
+'''
+
 [[the-___-premium-plugin-is-not-enabled-on-your-api-key-upgrade-your-account]]
 == "The ___ premium plugin is not enabled on your API key. Upgrade your account."
 
-=== Cause
+=== Scenario
+
+==== Cause
 
 This notification is shown when your API key does not have access to the premium plugin being requested. This could be the result of a trial expiring, and your {productname} configuration attempting to load premium plugins you can no longer access.
 
 You may also be seeing this notification if you are using the wrong API key. Ensure that you are using the API key that has the right entitlements.
 
-=== Solution
+==== Solution
 
 Either remove the premium plugin from your {productname} configuration, or upgrade your subscription to provide access to that premium plugin.
 

--- a/modules/ROOT/pages/cloud-troubleshooting.adoc
+++ b/modules/ROOT/pages/cloud-troubleshooting.adoc
@@ -7,12 +7,15 @@ When {cloudname} detects a problem, it will show an editor notification containi
 
 NOTE: The wording of the notifications shown here may differ from the actual notifications from {cloudname}.
 
+'''
+
+[[invalid-api-key-cloud-troubleshooting]]
+== Invalid API Key
+
 [[A-valid-API-key-is-required-to-continue-using-TinyMCE.-Please-alert-the-admin-to-check-the-current-API-key]]
-== "A valid API key is required to continue using {productname}. **Please alert the admin** to check the current API key. xref:invalid-api-key.adoc[Click here to learn more.]"
+=== "A valid API key is required to continue using {productname}. **Please alert the admin** to check the current API key. xref:invalid-api-key.adoc[Click here to learn more.]"
 
-=== Scenario (one)
-
-==== Cause
+==== Cause "No API Key"
 
 This notification is *only shown* when either:
 
@@ -41,9 +44,7 @@ To retrieve your API key, or to sign up for an API key, visit: link:{accountsign
 
 NOTE: Visit our xref:invalid-api-key.adoc[Invalid API key] page for more information on how to fix a `invalid API key` with {productname}.
 
-=== Scenario (two)
-
-==== Cause
+==== Cause "Invalid API Key"
 
 This notification is shown when the API key provided cannot be found on the {cloudname} server.
 
@@ -55,20 +56,21 @@ The `+apiKey+` must be:
 
 ==== Solution
 
-Check the `+apiKey+` provided in the script tag:
+Check the `apiKey` provided in the script tag:
 
-* Remove any leading or trailing spaces.
-* Any other characters that are not in your API key. If you are using variable substitution, ensure that the variable is substituting properly.
-* Matches the API key shown at {accountpageurl}.
+* Remove any leading or trailing spaces
+* Remove any other characters that are not in your `apiKey`. If you are using variable substitution, ensure that the variable is substituting properly
+* Ensure the `apiKey` matches the API key shown at {accountpageurl}.
 
 NOTE: Visit our xref:invalid-api-key.adoc[Invalid API key] page for more information on how to fix a `invalid API key` with {productname}.
 
 '''
 
-[[This-domain-is-not-registered-in-the-TinyMCE-Customer-Portal.-Please-alert-the-admin-to-add-it-to-the-approved-domains-to-continue-using-TinyMCE.]]
-== "This domain is not registered in the {productname} Customer Portal. **Please alert the admin** to add it to the approved domains to continue using {productname}. xref:invalid-api-key.adoc[Click here to learn more.]"
+[[domain-not-registered]]
+== Domain Not Registered
 
-=== Scenario
+[[This-domain-is-not-registered-in-the-TinyMCE-Customer-Portal.-Please-alert-the-admin-to-add-it-to-the-approved-domains-to-continue-using-TinyMCE.]]
+=== "This domain is not registered in the {productname} Customer Portal. **Please alert the admin** to add it to the approved domains to continue using {productname}. xref:invalid-api-key.adoc[Click here to learn more.]"
 
 ==== Cause
 
@@ -76,10 +78,10 @@ This notification is shown when the https://developer.mozilla.org/en-US/docs/Web
 
 Sometimes the domain in the *Referer* header does not match with the URL in the browser's address bar. To check the *Referer* header:
 
-. Open your browser's _Developer's Tools_.
-. Open the _Network_ tab.
-. Find and select the request being made to load {productname} from {cloudname} with your API key.
-. Click on the *Headers* tab.
+* Open your browser's _Developer's Tools_.
+* Open the _Network_ tab.
+* Find and select the request being made to load {productname} from {cloudname} with your API key.
+* Click on the *Headers* tab.
 
 In the section called *Request Headers* there should be a field for *Referer*. This is the value that {productname} is checking against your approved domains. It must match one of your approved domains listed on your link:{accountpageurl}/[{accountpage}].
 
@@ -89,16 +91,16 @@ If the `+Referer+` is correct for the site, ensure that the domain is included i
 
 '''
 
-[[were-unable-to-check-your-domain-because-the-referer-header-is-missing-please-read-the-guide-on-how-to-ensure-your-referer-header-is-present-so-we-can-then-customize-your-editor-experience]]
-== "We’re unable to check your domain because the referer header is missing. Please read the Guide on how to ensure your referer header is present, so we can then customize your editor experience."
+[[referer-heading-missing]]
+== Referer Heading Missing
 
-=== Scenario
+[[were-unable-to-check-your-domain-because-the-referer-header-is-missing-please-read-the-guide-on-how-to-ensure-your-referer-header-is-present-so-we-can-then-customize-your-editor-experience]]
+=== "We’re unable to check your domain because the referer header is missing. Please read the Guide on how to ensure your referer header is present, so we can then customize your editor experience."
 
 ==== Cause
 
-This notification is shown if the https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer[*Referer* header] is absent for the network request when loading {productname} from {cloudname}. {cloudname} verifies the domain {productname} is loading from by checking the domain of the *Referer* header in the network request.
-
-_Referer_ headers are sometimes removed by browser settings or browser extensions. {cloudname} only needs the domain in the *Referer* header, so for improved performance and privacy {companyname} recommends setting the `+referrerpolicy+` to `+origin+` when requesting {cloudname} resources.
+* This notification is shown if the https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer[*Referer* header] is absent for the network request when loading {productname} from {cloudname}. {cloudname} verifies the domain {productname} is loading from by checking the domain of the *Referer* header in the network request.
+* _Referer_ headers are sometimes removed by browser settings or browser extensions. {cloudname} only needs the domain in the *Referer* header, so for improved performance and privacy {companyname} recommends setting the `+referrerpolicy+` to `+origin+` when requesting {cloudname} resources.
 
 ==== Solution
 
@@ -111,10 +113,11 @@ Once you have identified the setting or extension, modify it to allow just the `
 
 '''
 
-[[the-___-premium-plugin-is-not-enabled-on-your-api-key-upgrade-your-account]]
-== "The ___ premium plugin is not enabled on your API key. Upgrade your account."
+[[troubleshooting-premium-plugins]]
+== Troubleshooting Premium Plugins
 
-=== Scenario
+[[the-___-premium-plugin-is-not-enabled-on-your-api-key-upgrade-your-account]]
+=== "The ___ premium plugin is not enabled on your API key. Upgrade your account."
 
 ==== Cause
 
@@ -127,3 +130,49 @@ You may also be seeing this notification if you are using the wrong API key. Ens
 Either remove the premium plugin from your {productname} configuration, or upgrade your subscription to provide access to that premium plugin.
 
 NOTE: Visit our xref:invalid-api-key.adoc[Invalid API key] page for more information on how to fix a `invalid API key` with {productname}.
+
+'''
+
+[[read-only-mode-no-api-key]]
+== Read-only mode - No API Key
+
+=== “{productname} is in read-only mode. **Please alert the admin** that an API key is required for continued use. xref:invalid-api-key.adoc[Learn more] 
+
+==== Cause "No API Key (Read only mode)"
+
+This message is sent when the developer has not supplied an API key, typically because they've copied a getting-started script and have not completed the official https://www.tiny.cloud/auth/signup/[signup] process to get an API key.
+
+==== Solution
+
+* **Please alert your Admin** that an API key is required for continued use. xref:invalid-api-key.adoc[Learn more], or
+* Sign up for a API key by visiting https://www.tiny.cloud/auth/signup/[www.tiny.cloud/auth/signup], and
+* Update your {productname} configuration.
+
+NOTE: Visit our xref:invalid-api-key.adoc[Invalid API key] page for more information on how to fix a `invalid API key` with {productname}.
+
+[[read-only-mode-invalid-api-key]]
+== Read-only mode - Invalid API Key
+
+=== “{productname} is in read-only mode. **Please alert the admin** to provide a valid API key to continue use. xref:invalid-api-key.adoc[Learn more] Your {productname} editor state has been set to read-only mode.”
+
+==== Cause "Invalid API Key (Read only-mode)"
+
+This message is shown when the API key is not correct, perhaps because of a typo.
+
+==== Solution
+
+* Login to your {productname} account and confirm that your API key matches your unique key by visiting https://www.tiny.cloud/auth/login/[www.tiny.cloud/auth/login/].
+* or to sign up for an API key, visit: link:{accountsignup}/[{cloudname}].
+
+[[read-only-mode-invalid-origin]]
+== Read-only mode - Invalid Origin
+
+=== “{productname} is in read-only mode. **Please request that the admin** add this domain to the approved domains in the Customer Portal. xref:invalid-api-key.adoc[Learn more]”
+
+==== Cause "Invalid Origin (Read only mode)"
+
+This message is shown when {productname} is loaded from a domain that has not been added to the approved domains in our account portal.
+
+==== Solution
+
+Please request that your admin add this domain to the approved domains in the Customer Portal xref:invalid-api-key.adoc[Learn more]

--- a/modules/ROOT/pages/invalid-api-key.adoc
+++ b/modules/ROOT/pages/invalid-api-key.adoc
@@ -1,49 +1,66 @@
 = Invalid API key
-:description_short: Fixing with invalid API key error | {productname}
-:description: Learn what you need to do when getting a message about invalid {productname} API key. Find out the reasons for this error as well as how to fix it.
+:description_short: Fixing the invalid API key error | {productname}
+:description: Learn why you’re receiving an invalid {productname} API key error notification, and how to fix the issue.
 :keywords: {productname}, cloud, script, textarea, apiKey, faq, invalid api key, frequently asked questions,
 
 [IMPORTANT]
 ====
-All editors on our cloud platform are required (from early 2024) to have a valid API key. Without a valid API key, your editor will transition to **read-only** mode, limiting your ability to make changes.
+**Starting in early 2024, all editors on our cloud platform will be required to have a valid API key.** Without a valid API key, **your editor will transition to read-only mode**, limiting your ability to make changes.
 
-* This change will only affect users who do not have a valid API key and use Tiny Cloud.
-* Affected users should see a xref:cloud-troubleshooting.adoc[notification in their editor]. If you see it, please contact the  Administrator for your application/site. Admins need to https://www.tiny.cloud/my-account/integrate/[get a valid API key] and paste it into the code to continue using {productname}.
+Affected users will receive a xref:cloud-troubleshooting.adoc#A-valid-API-key-is-required-starting-2024-to-continue-using-TinyMCE.-Please-alert-your-admin-to-sign-up-to-get-your-free-API-key.[notification in their editor]. If you receive this notification, please contact the Administrator for your application/site. Admins will need to https://www.tiny.cloud/my-account/integrate/[get a valid API key] and paste it into the code to continue using {productname}.
 ====
 
-== How can I verify this change will affect me?
+== How will I know if this change affects me?
 
-If {productname} detects an invalid API key, it will display a notification. If you know or suspect you have been actively hiding or suppressing this notification, please remove these overrides. If you then see a notification, please follow the instructions to resolve the issue. If no notification pops up, everything's fine. 
+If {productname} detects an invalid API key, it will display a notification. If you know or suspect you have been actively hiding or suppressing this notification, please remove these overrides. If you then see a notification, please follow the instructions to resolve the issue. If no notification appears, you are not affected. 
 
-== How to get your API key:
+== How can I get an API key?
 
-The Admin who owns this {productname} implementation needs to log in https://www.tiny.cloud/my-account/integrate/[here] to get the account’s API key. If you do not have an account yet, you can https://www.tiny.cloud/pricing/[sign up for a free API key]. If you need help, please https://www.tiny.cloud/contact/[contact our Customer Success Team]. 
+The Admin who owns your {productname} implementation will need to log in https://www.tiny.cloud/my-account/integrate/[here] to get your account’s API key. If you do not have an account yet, you can https://www.tiny.cloud/pricing/[sign up for a free API key]. Paid users can https://www.tiny.cloud/contact/[contact our Technical Support] team for help.
 
 == What will happen if I don't provide a valid API key?
 
-All editors without valid API keys on Tiny Cloud will be set to read-only mode in the beginning of 2024. You will not be impacted if you self-host {productname}.
+All editors on our cloud platform without a valid API key will be set to read-only mode in the beginning of 2024. If you self-host {productname}, you will not be impacted.
 
-== Why do I need the API key?
+== Why is an API key required?
  
-In order to maintain the quality of our service, ensure reliable security, and keep up with industry best practices, all {productname} Cloud editors will require an active and valid API key beginning in early 2024. 
+We require an API key for all {productname} editors on our cloud platform in order to maintain the quality of our service, ensure reliable security, and keep up with industry best practices. 
 
-== If {productname} is free and open source, why am I now getting warnings saying an API key is required?
+== If {productname} is free and open source, why is an API key required?
 
 {productname} can be accessed through a variety of licensing and hosting methods, including both free and paid options. 
-{productname} is available under an MIT license explained https://www.tiny.cloud/legal/tiny-self-hosted-oem-saas-agreement/[here]. Users must self-host {productname} to take advantage of the MIT license. 
 
-{productname} Cloud offerings are available under commercial license, as described https://www.tiny.cloud/legal/cloud-use-subscription-agreement/[here]. There is a free Cloud plan called “Core”, that is completely free but is limited to 1,000 editor loads per month. There are also 2 Cloud plans called “Essential” and “Professional” with increased editor load limits, and additional premium features. You can find more information on editor load limits, feature breakdowns, and pricing of our Cloud plans https://www.tiny.cloud/pricing/[here].
+The free, open source option for {productname} is available under an MIT license explained https://www.tiny.cloud/legal/tiny-self-hosted-oem-saas-agreement/[here]. Users must self-host {productname} to take advantage of the MIT license. **This type of license does not require an API key**.
 
-All of our Cloud plans require an active API key, so if you’re seeing this error message you need to either migrate to the self-hosted open source version under the MIT license, or you need to acquire an active API key by https://www.tiny.cloud/pricing/[signing up] for a cloud plan. 
+The cloud hosted option for {productname} is available under commercial license, as described https://www.tiny.cloud/legal/cloud-use-subscription-agreement/[here]. **This type of license requires an active API key.**
 
-== I installed the npm package, which I assumed would be self-hosted. Why do I get a notification that an API key is required? 
+If you are receiving an error notification, you are using the cloud-hosted option of {productname} under a commercial license. If you want to continue using {productname} without an API key, you will need to either migrate to the free, open source, self-hosted option or use a 3rd party-hosted CDN option under an MIT license. 
 
-Our integrations default to using the {productname} Cloud service. If you see a notification that an API key is required, it means that you’re using Tiny Cloud service that now requires a valid API key and lets you have 1,000 editor loads per month for free. 
+== I installed the npm package, which I assumed would be self-hosted. Why am I getting a notification that an API key is required? 
+
+Our integrations default to using the {productname} Cloud service. If you’re receiving the notification that an API key is required, it means that you’re using the cloud-hosted option for {productname} under commercial license which requires a valid API key and allows for 1,000 editor loads per month for free. 
 
 Please xref:installation.adoc[read our docs] to learn how to self-host {productname} or https://www.tiny.cloud/pricing/[sign up here] to continue using {productname} Cloud.
 
-== I used {productname} for years. Why am I now getting warnings saying an API key is required?
+== I’ve used {productname} for years. Why am I now receiving notification that an API key is required? 
 
-Thank you for your long-time use of {productname} and for selecting it for your projects. If you're suddenly seeing this message, it means that previous versions of this notification were hidden within your {productname} editor. We are working to ensure that all active users of {productname} are aware of this API key requirement, including those that may have hidden these warnings in the past. If action is not taken before early 2024, these editors will stop functioning. 
+Thank you for your long-term use of {productname} and for selecting it for your projects. If you're suddenly receiving this notification, it means that previous versions of the notification were hidden within your {productname} editor. We are working to ensure that all active users of {productname} are aware of the API key requirement, including those that may have hidden these notifications in the past.
+
+== What does the message "This domain is not registered with Tiny Cloud" mean?
+
+This message means that the domain attempting to use {productname} is not registered with Tiny Cloud. Starting in 2024, a registered domain will be required to continue using {productname}.
+
+== How can I resolve the issue of an unregistered domain?
+
+To resolve this issue, please inform your administrator and request that they review the list of approved domains on your Tiny Account. If necessary, they will need to add the unregistered domain to the approved list. xref:cloud-troubleshooting.adoc#This-domain-is-not-registered-with-Tiny-Cloud.-To-continue-using-TinyMCE-a-registered-domain-is-required-starting-2024.-Please-alert-your-admin-to-review-the-approved-domains-and-add-this-one-if-required.[Learn more here].
+
+== Where can I view the list of approved domains for my Tiny Cloud account?
+
+You can view the list of approved domains by logging into https://www.tiny.cloud/my-account/domains/[your Tiny Account]. The approved domains are stored against your API Key.
+
+== I would prefer to self-host {productname}. What are my options?
+
+* If you plan to use only open-source {productname} features, the open-source version is available under the MIT license.
+* If you want to self-host {productname} and use our Premium features, https://www.tiny.cloud/contact/[get in touch with our Sales team] for a custom quote.
 
 TIP: For additional information on Troubleshooting Tiny Cloud visit: xref:cloud-troubleshooting.adoc[Cloud Troubleshooting].

--- a/modules/ROOT/pages/migration-from-5x.adoc
+++ b/modules/ROOT/pages/migration-from-5x.adoc
@@ -309,6 +309,14 @@ The schema must, therefore, be configured to allow usage of the media elements, 
 
 NOTE: As of this release, there are no known cases of this change causing media objects to not work as expected. But, also as of this release, not every potential or possible use-case has been tested.
 
+=== Mentions
+
+The `getUsers` API was a part of the `mentions` plugin and was used to retrieve a list of mentioned users in the current editor session.
+
+This API has been _deprecated_ in {productname} 6.0.
+
+Refer to the xref:6.0-release-notes-premium-changes.adoc#mentions[_{productname} 6.0 Release Notes_] for an alternative to the `getUsers` API.
+
 [[plugins-paste]]
 === Paste
 

--- a/modules/ROOT/pages/ui-localization.adoc
+++ b/modules/ROOT/pages/ui-localization.adoc
@@ -8,7 +8,4 @@ include::partial$configuration/language.adoc[]
 
 include::partial$configuration/language_url.adoc[]
 
-////
-undocumented
 include::partial$configuration/language_load.adoc[]
-////

--- a/modules/ROOT/pages/understanding-editor-loads.adoc
+++ b/modules/ROOT/pages/understanding-editor-loads.adoc
@@ -1,0 +1,48 @@
+= Understanding editor loads
+:navtitle: Understanding editor loads
+:description: Relevant information for Tiny Cloud users to help understand editor loads for {productname}.
+:keywords: invalid-api-key, API, {productname}, cloud, frequently asked questions
+
+== Understanding editor loads for {productname}
+
+[IMPORTANT]
+This information is only relevant to Tiny Cloud users. Users who self-host the open source version of {productname} are not subject to editor load restrictions, but must comply with the https://github.com/tinymce/tinymce/blob/master/LICENSE.TXT[open source license]. 
+
+An editor load is the event that occurs each time {productname} is initialized in your application. The editor dispatches the 'init' event to indicate a successful load. For example, if 100 users load {productname} 10 times each, the result would be 1,000 editor loads. 
+
+The process of initializing an editor involves several steps.
+
+. The integrator initializes one or more editors on the webpage, commonly accomplished through the `tinymce.init({ ... })` method. 
++
+. The `selector` property of the `init` method determines which elements should be replaced with editor instances. For example: if the selector is `textarea` and there are 5 textarea elements on the page, 5 editor instances will be created.
++
+Each editor instance performs the same initialization sequence and then dispatches an `init` event. This event is dispatched even if the the editor is not visible.
++
+. **The 'init' event serves as the conclusive indicator that the editor has completed its loading process**. At this point, the editor has been successfully initialized and is ready for user interaction. 
+
+== How are editor loads counted?
+
+An editor load is counted each time a new {productname} editor instance completes the initialization sequence and dispatches an `init` event.
+
+== What happens if I have multiple editors on a page?
+
+Each individual editor instance on a page is counted as one editor load. For example, if a page has ten editors, a single refresh of that page results in ten editor loads.
+
+== What can contribute to a high number of editor loads?
+
+The most obvious scenario is using multiple editors on a single page (see above). For example:
+
+* An email building app that has a {productname} editor embedded in multiple sections
+* A publicly available page on a high traffic website with multiple editor instances
+
+== How can I get unlimited editor loads?
+
+You can get unlimited editors loads one of three ways:
+
+* The open-source version of {productname} can be self hosted, and is not subject to editor load restrictions.
+* The open-source version of {productname} is also available via third party-hosted CDNs and is not subject to editor load restrictions.
+* For the Enterprise version of Tiny MCE with Premium features, https://www.tiny.cloud/contact/[get in touch with our Sales team] for a custom quote.
+
+== I have an annual plan. Are my editor loads calculated monthly or over the entire year?
+
+If you have an annual plan, your editor loads are calculated on a monthly basis within the structure of your annual plan. Similar to our monthly plans, you have a set monthly editor load limit and are automatically charged $40 USD per every block of 1,000 editor loads over the plan limit.

--- a/modules/ROOT/partials/configuration/language_load.adoc
+++ b/modules/ROOT/partials/configuration/language_load.adoc
@@ -1,0 +1,29 @@
+[[language_load]]
+== `+language_load+`
+
+This option determines whether additional plugin or theme languages are loaded during {productname} editor initialization. By default, plugins which have support for languages other than English will automatically load the additional language packs.
+
+*Type:* `+boolean+`
+
+*Default value:* `+true+`
+
+* When the `+language_load+` option is set to `+true+`, any available language packs can be loaded and used by {productname} and plugins that support multiple-languages.
+* When set to `+false+`, only explicitly configured language packs will load.
+
+[IMPORTANT]
+Setting `+language_load+` option to `+false+` is not recommended unless loading local language packs.
+
+=== Example: using `+language_load+`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea', // Change this value according to your HTML
+  language_load: true, // Disables the automatic loading of additional plugin and theme language files.
+});
+----
+
+[TIP]
+When bundling, it is advisable for plugins that support multiple languages to load the additional language packs locally, and to set this option to `+false+`. This will ensure that all required languages are available for the editor, and that no additional language packs will be retrieved by the plugins.
+
+You can find and download languages link:{gettiny}/language-packages/[here].


### PR DESCRIPTION
Ticket: DOC-2174, getUsers API deprecation in v6 not documented.

Changes:
* added getusers-api-alternative demo to 6.0 release notes and the 5 to 6 migration guide

Pre-checks:
- [ ] Branch prefixed with `feature/6/` or `hotfix/6/`
- [ ] Changelog entry added
- [ ] `modules/ROOT/nav.adoc` has been updated (if applicable)
- [ ] Files has been included where required (if applicable)
- [ ] Files removed have been deleted, not just excluded from the build (if applicable)
- [ ] (New product features only) Release Note added

Review:
- [ ] Documentation Team Lead has reviewed
