### PR TITLE
DOC-2245: now `highlight_on_focus`'s default is `true`

### DIFF
--- a/modules/ROOT/partials/configuration/highlight_on_focus.adoc
+++ b/modules/ROOT/partials/configuration/highlight_on_focus.adoc
@@ -3,13 +3,16 @@
 
 include::partial$misc/admon-requires-6.4v.adoc[]
 
+[NOTE]
+In {productname} 7.0, the default setting for `highlight_on_focus` was changed from `false` to `true`. Any editors using this `highlight_on_focus: true` option in {productname} , can remove this option from their {productname} init configuration when upgrading to {productname} 7.0.
+
 The `+highlight_on_focus+` option adds a blue outline to an instantiated {productname} editor when that editor is made the input focus. When using the `oxide-dark` skin, the outline is white.
 
 This allows users to clearly see when the editor is in focus, or which editor has focus if more than one {productname} instance is available.
 
 *Type:* `+Boolean+`
 
-*Default value:* `+false+`
+*Default value:* `+true+`
 
 *Possible values:* `+true+`, `+false+`
 
@@ -19,7 +22,7 @@ This allows users to clearly see when the editor is in focus, or which editor ha
 ----
 tinymce.init({
   selector: "textarea",
-  highlight_on_focus: true
+  highlight_on_focus: false
 });
 ----
 


### PR DESCRIPTION
Ticket: DOC-2245

Site: [DOC-2245 site](http://docs-feature-70-doc-2245.staging.tiny.cloud/docs/tinymce/latest/accessibility/#highlight_on_focus)

Changes:
* DOC-2245 update docs to reflect new highlight_on_focus default being true

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`

Review:
- [x] Documentation Team Lead has reviewed