### PR TITLE
DOC-2270_TINY-10439 release notes entry: The `link_default_target` option wasn't considered when inserting a link via `quicklink` toolbar.

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -127,12 +127,23 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 [[bug-fixes]]
 == Bug fixes
 
-{productname} <x.y[.z]> also includes the following bug fix<es>:
+{productname} <x.y[.z]> also includes the following bug fixes:
 
 === <TINY-vwxyz 1 changelog entry>
 //#TINY-vwxyz1
 
 // CCFR here.
+
+=== The `link_default_target` option wasn't considered when inserting a link via `quicklink` toolbar.
+// #TINY-10439
+
+Previously when using `quicklink`, the `link_default_target` value was not being considered.
+
+As a consequence, the `target` attribute would not be applied to links created using `quicklink`.
+
+{productname} 7.0 addresses this issue, now, the `quicklink` has been enhanced to consider the `link_default_target` value.
+
+As a result, if a `link_default_target` is specified, `quicklink` will appropriately incorporate it when creating a link.
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-2270
Release notes entry for: TINY-10439

Site: [DOC-2270_TINY-10439 site](http://docs-feature-70-doc-2270tiny-10439.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#the-link_default_target-option-wasnt-considered-when-inserting-a-link-via-quicklink-toolbar)

Changes:
* DOC-2270: add release notes entry for TINY-10439

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] Added `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed