### PR TITLE
DOC-2270_TINY-10580 release notes entry: When inline editor toolbar wrapped to multiple lines the top wasn't always calculated.

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -134,6 +134,17 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 // CCFR here.
 
+=== When inline editor toolbar wrapped to multiple lines the top wasn't always calculated.
+// #TINY-10580
+
+Previously when shrinking the inline editor, the top position of the toolbar was calculated before wrapping the toolbar into multiple rows.
+
+As a consequence, the additional rows in the wrapped toolbar would cover the editor content.
+
+{productname} 7.0 addresses this issue, now, the editor shrinking is applied before calculating the top position of the toolbar.
+
+As a result, the truncated toolbar is correctly displayed above the editor content.
+
 [[security-fixes]]
 == Security fixes
 


### PR DESCRIPTION
Ticket: DOC-2270
Release notes entry for: TINY-10580

Site: [DOC-2270_TINY-10580 site](http://docs-feature-70-doc-2270tiny-10580.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#when-inline-editor-toolbar-wrapped-to-multiple-lines-the-top-wasnt-always-calculated)

Changes:
* DOC-2270_TINY-10580 release notes entry: When inline editor toolbar wrapped to multiple lines the top wasn't always calculated.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] Added `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed