### PR TITLE
DOC-2270_TINY-10312 release notes entry: Heading formatting would be partially applied to the content within the `summary` element when the caret was positioned between words.

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -137,10 +137,7 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 === Heading formatting would be partially applied to the content within the `summary` element when the caret was positioned between words.
 // #TINY-10312
 
-With the release of {productname} 6.8, applying heading formatting to the content within the `<summary>` element was introduced. However, an issue was identified: 
-
-- if the caret was positioned between words, and;
-- before or after a **`+&nbsp;+`** space character.
+With the release of {productname} 6.8, applying heading formatting to the content within the `<summary>` element was introduced. However, an issue was identified: if the caret was positioned between words, the editor's selection expand range functionality would not expand the selection to include the entire content within the `<summary>` element.
 
 As a consequence, the heading formatting was partially applied to some of the content within the `<summary>` element.
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -134,6 +134,20 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 // CCFR here.
 
+=== Heading formatting would be partially applied to the content within the `summary` element when the caret was positioned between words.
+// #TINY-10312
+
+With the release of {productname} 6.8, applying heading formatting to the content within the `<summary>` element was introduced. However, an issue was identified: 
+
+- if the caret was positioned between words, and;
+- before or after a **`+&nbsp;+`** space character.
+
+As a consequence, the heading formatting was partially applied to some of the content within the `<summary>` element.
+
+{productname} 7.0 addresses this issue, now, updates were made to the editor's selection expand range functionality.
+
+As a result, the heading format is applied to the entire content within the `<summary>` element, regardless of the carets location.
+
 [[security-fixes]]
 == Security fixes
 


### PR DESCRIPTION
Ticket: DOC-2270
Release notes entry for: TINY-10312

Site: [DOC-2270_TINY-10312 site](http://docs-feature-70-doc-2270tiny-10312.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#heading-formatting-would-be-partially-applied-to-the-content-within-the-summary-element-when-the-caret-was-positioned-between-words)

Changes:
* DOC-2270_TINY-10312 release notes entry: Heading formatting would be partially applied to the content within the `summary` element when the caret was positioned between words.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] Added `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed
