### PR TITLE
DOC-2270_TINY-10482 release notes entry: Inline mode with persisted toolbar would show regardless of the skin being loaded, causing css issues.

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -137,7 +137,7 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 === Inline mode with persisted toolbar would show regardless of the skin being loaded, causing css issues.
 // #TINY-10482
 
-Previously when `toolbar_persist` and `inline` mode was set to `true`, the toolbar could set itself prior to the skin even though the skin may not have been loaded yet.
+Previously when `toolbar_persist` and `inline` mode was set to `true`, the toolbar could be shown before the skin was loaded. Whereas now it will always wait for the skin to load first.
 
 .example setup
 [source, js]

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -134,6 +134,25 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 // CCFR here.
 
+=== Inline mode with persisted toolbar would show regardless of the skin being loaded, causing css issues.
+// #TINY-10482
+
+Previously when `toolbar_persist` and `inline` mode was set to `true`, the toolbar could set itself prior to the skin even though the skin may not have been loaded yet.
+
+.example setup
+[source, js]
+----
+tinymce.init({
+  selector: "div",
+  inline: true,
+  toolbar_persist: true
+});
+----
+
+As a consequence, this would result in the menubar and/or the toolbar to be squashed when the host browser was operating over a relatively slow connection.
+
+{productname} 7.0 addresses this issue, now, the toolbar is no longer squashed in `inline` mode with `toolbar_persist` enabled, when the page takes longer to load the skin.
+
 [[security-fixes]]
 == Security fixes
 


### PR DESCRIPTION
Ticket: DOC-2270
Release notes entry for: TINY-10482

Site: [DOC-2270_TINY-10482 site](http://docs-feature-70-doc-2270tiny-10482.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#inline-mode-with-persisted-toolbar-would-show-regardless-of-the-skin-being-loaded-causing-css-issues)

Changes:
* DOC-2270_TINY-10482 release notes entry: Inline mode with persisted toolbar would show regardless of the skin being loaded, causing css issues.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] Added `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed
