### PR TITLE
DOC-2270_TINY-10490 release notes entry: Directly right clicking on a `<ol>`/ `<li>` in FireFox didn't enable the button `List Properties...` in the context menu

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -134,6 +134,21 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 // CCFR here.
 
+=== Directly right clicking on a `<ol>`/ `<li>` in FireFox didn't enable the button `List Properties...` in the context menu
+// #TINY-10490
+
+In previous versions of {productname}, two issues where identified that affected `list properties`;
+
+. in old versions of Firefox (prior to version 121), the caret was not moved to the target position, and;
+
+. as {productname} creates a bookmark when there is no selection for Firefox, when a user opened a context menu the editor would jump back to the newly created bookmark.
+
+As a consequence, since the selection is still on the first element, the menu voiceover was `disabled`.
+
+{productname} 7.0 addresses this issue, now when the user opens a context menu, {productname} creates a new bookmark to avoid the jump back.
+
+As a result, the selection is in the correct place and the context menu voice over is `enabled`.
+
 [[security-fixes]]
 == Security fixes
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -137,9 +137,9 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 === Directly right clicking on a `<ol>`/ `<li>` in FireFox didn't enable the button `List Properties...` in the context menu
 // #TINY-10490
 
-In previous versions of {productname}, two issues where identified that affected `list properties`;
+In previous versions of {productname}, two issues where identified that affected `list properties` for `<ol><li>` tags:
 
-. in old versions of Firefox (prior to version 121), the caret was not moved to the target position, and;
+. in old versions of Firefox (prior to version 121), the caret was not moved to the target position when using the right click, and;
 
 . as {productname} creates a bookmark when there is no selection for Firefox, when a user opened a context menu the editor would jump back to the newly created bookmark.
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -143,11 +143,11 @@ In previous versions of {productname}, two issues where identified that affected
 
 . as {productname} creates a bookmark when there is no selection for Firefox, when a user opened a context menu the editor would jump back to the newly created bookmark.
 
-As a consequence, since the selection is still on the first element, the menu voiceover was `disabled`.
+As a consequence, since the selection is still on the first element, the `List Properties...` context menu item was `disabled`.
 
 {productname} 7.0 addresses this issue, now when the user opens a context menu, {productname} creates a new bookmark to avoid the jump back.
 
-As a result, the selection is in the correct place and the context menu voice over is `enabled`.
+As a result, the selection is in the correct place and the `List Properties...` context menu item is `enabled`.
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-2270
Release notes entry for: TINY-10490

Site: [DOC-2270_TINY-10490 site](http://docs-feature-70-doc-2270tiny-10490.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#directly-right-clicking-on-a-ol-li-in-firefox-didnt-enable-the-button-list-properties-in-the-context-menu)

Changes:
* DOC-2270_TINY-10490 release notes entry: Directly right clicking on a `<ol>`/ `<li>` in FireFox didn't enable the button `List Properties...` in the context menu

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] Added `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed
