### PR TITLE
DOC-2270_TINY-10389 release notes entry: Removed manually dispatching `dragend` event on drop in Firefox.

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -59,7 +59,7 @@ The following premium plugin updates were released alongside {productname} 7.0.
 
 === <Premium plugin name 1> <Premium plugin name 1 version>
 
-The {productname} <x.y[.z]> release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+The {productname} 7.0 release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
 
 **<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -55,7 +55,7 @@ For information on the **<Open source plugin name>** plugin see xref:<plugincode
 [[accompanying-premium-plugin-changes]]
 == Accompanying Premium plugin changes
 
-The following premium plugin updates were released alongside {productname} <x.y[.z]>.
+The following premium plugin updates were released alongside {productname} 7.0.
 
 === <Premium plugin name 1> <Premium plugin name 1 version>
 
@@ -68,6 +68,25 @@ The {productname} <x.y[.z]> release includes an accompanying release of the **<P
 // CCFR here.
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+
+=== PowerPaste
+
+The {productname} 7.0 release includes an accompanying release of the **PowerPaste** premium plugin.
+
+**PowerPaste** includes the following fix.
+
+==== Removed manually dispatching `dragend` event on drop in Firefox.
+// #TINY-10389
+
+Dragging and dropping an image between two cells in a `table` with PowerPaste enabled triggered the manual dispatching of the `dragend` event on Firefox.
+
+The image was duplicated into the new cell instead of being moved from the old cell to the new one.
+
+The manual dispatching of the `dragend` event on Firefox has been removed.
+
+As a result, the image now correctly moves from one cell to another without duplicating.
+
+For information on the **PowerPaste** plugin, see: xref:introduction-to-powerpaste.adoc[PowerPaste].
 
 
 [[accompanying-premium-plugin-end-of-life-announcement]]


### PR DESCRIPTION
Ticket: DOC-2270
Release notes entry for: TINY-10389

Site: [DOC-2270_TINY-10389 site](http://docs-feature-70-doc-2270tiny-10389.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#removed-manually-dispatching-dragend-event-on-drop-in-firefox)

Changes:
* DOC-2270_TINY-10389 release notes entry: Removed manually dispatching `dragend` event on drop in Firefox.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] Added `release note` entry.

Review:
- [ ] Documentation Team Lead has reviewed
