### PR TITLE
DOC-2270_TINY-10459 release notes entry: The `DOMUtils.isEmpty` API function has been modified to consider nodes containing only comments as empty.

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -134,6 +134,20 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 // CCFR here.
 
+=== The `DOMUtils.isEmpty` API function has been modified to consider nodes containing only comments as empty.
+// #TINY-10459
+
+In previous versions of {productname} (prior to version 7.0), the function `DomUtils.isEmpty` behaved inconsistently, considering elements with only comment nodes as non-empty.
+
+As a consequence, elements visually appearing empty due to containing only comment nodes could lead to inconsistent behavior in caret placement and selection handling.
+
+{productname} 7.0 addresses this issue, now, when using `DomUtils.isEmpty`, elements containing only comment nodes are correctly recognized as empty.
+
+As a result, caret placement and selection handling within elements containing only comment nodes now behave consistently.
+
+[NOTE]
+Users who relied on `DOMUtils.isEmpty` returning `false` for elements with only comments should update their implementation. Elements with only comment nodes are now recognized as empty in {productname} 7.0.
+
 [[security-fixes]]
 == Security fixes
 


### PR DESCRIPTION
Ticket: DOC-2270
Release notes entry for: TINY-10459

Site: [DOC-2270_TINY-10459 site](http://docs-feature-70-doc-2270tiny-10459.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#the-domutils-isempty-api-function-has-been-modified-to-consider-nodes-containing-only-comments-as-empty)

Changes:
* DOC-2270_TINY-10459 release notes entry: The `DOMUtils.isEmpty` API function has been modified to consider nodes containing only comments as empty.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] Added `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed
