### PR TITLE
DOC-2288 Remove close button in Notifications

### DIFF
--- a/modules/ROOT/pages/creating-custom-notifications.adoc
+++ b/modules/ROOT/pages/creating-custom-notifications.adoc
@@ -52,18 +52,6 @@ editor.notificationManager.open({
 });
 ----
 
-== Close Button
-
-Disable the close button to the right of the notification by setting the `+closeButton+` property to *false*. It is recommended to use this in conjunction with a `+timeout+` property that is *not* zero, however it can be used without including a `+timeout+`.
-
-[source,js]
-----
-editor.notificationManager.open({
-  text: 'A test notification that will close automatically after 5 seconds and has the close button disabled.',
-  timeout: 5000,
-  closeButton: false
-});
-----
 
 == Icon
 


### PR DESCRIPTION
Ticket: DOC-2288

Site: [DOC-<num> site](http://docs-<hotfix/feature>-70-doc-<num>.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* Removed the Close Button documentation from Create custom notifications documentation

Pre-checks:
- [ ] Branch prefixed with `feature/7/` or `hotfix/7/`
- [ ] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [*] Files has been included where required `(if applicable)`
- [ ] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [ ] Files added for `New product features`, and included a `release note` entry.

Review:
- [*] Documentation Team Lead has reviewed