### PR TITLE
DOC-2290: add EOSA for v6.8 to `support.adoc` page.

### DIFF
--- a/modules/ROOT/partials/misc/supported-versions.adoc
+++ b/modules/ROOT/partials/misc/supported-versions.adoc
@@ -6,6 +6,7 @@ Supported versions of {productname}:
 [cols="^,^,^",options="header"]
 |===
 |Version |Release Date |End of Support
+|6.8 |2023-12-06 |2025-06-06
 |6.7 |2023-09-13 |2025-03-13
 |6.6 |2023-07-19 |2025-01-19
 |6.5 |2023-06-21 |2024-12-21


### PR DESCRIPTION
Ticket: DOC-2290

Site: [DOC-2290 site](http://docs-feature-70-doc-2290.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
*  add EOSA for v6.8 to `support.adoc` page, to support [Github User Issue 3033](https://github.com/tinymce/tinymce-docs/issues/3033).

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`

Review:
- [x] Documentation Team Lead has reviewed