### PR TITLE
DOC-2270_TINY-10581: The toolbar width was miscalculated for the inline editor positioned inside a scrollable container.

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -137,7 +137,7 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 === The toolbar width was miscalculated for the inline editor positioned inside a scrollable container.
 // #TINY-10581
 
-Previously in {productname}, the toolbar's width was calculated using the `outerContainer` width.
+Previously in {productname}, the inline editor's toolbar width was calculated using the `outerContainer` width.
 
 Consequently, the toolbar was given a width of `0`, resulting in the toolbar collapsing to the minimum width.
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -134,6 +134,17 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 // CCFR here.
 
+=== The toolbar width was miscalculated for the inline editor positioned inside a scrollable container.
+// #TINY-10581
+
+Previously in {productname}, the toolbar's width was calculated using the `outerContainer` width.
+
+Consequently, the toolbar was given a width of `0`, resulting in the toolbar collapsing to the minimum width.
+
+{productname} 7.0 addresses this issue, now, a check has been introduced to prevent the adjustment of the toolbar's width if the calculated value is `0`.
+
+As a result, the inline editor now correctly displays the toolbar's width when positioned inside a scrollable container.
+
 [[security-fixes]]
 == Security fixes
 


### PR DESCRIPTION
Ticket: DOC-2270
Release notes entry for: TINY-10581

Site: [DOC-2270_TINY-10581 site](http://docs-feature-70-doc-2270tiny-10581.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#the-toolbar-width-was-miscalculated-for-the-inline-editor-positioned-inside-a-scrollable-container)

Changes:
* DOC-2270_TINY-10581: The toolbar width was miscalculated for the inline editor positioned inside a scrollable container.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] Added `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed