### PR TITLE
DOC-2270: add `new feature` documentation for TINY-10324 in the TinyMCE release notes.

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -150,7 +150,7 @@ to the following new preconfigured defaults:
 ----
 
 [IMPORTANT]
-Customers that wish to revert back to the previous default block `text_patterns` execution on `Enter` key pressing will be required to replace the preconfigured text_patterns with following array:
+Customers that wish to revert back to the previous default block `text_patterns` execution on `Enter` key pressing will be required to replace the preconfigured `text_patterns` with following array:
 
 [source, js]
 ----
@@ -170,7 +170,7 @@ Customers that wish to revert back to the previous default block `text_patterns`
 ----
 
 [TIP]
-The trigger property is exclusively applicable to the configuration of block text patterns. It is not recognized in the configurations for inline and replacement text patterns.
+The `trigger` property is exclusively applicable to the configuration of block text patterns. It is not recognized in the configurations for inline and replacement text patterns.
 
 For information on the **text_patterns**, see xref:content-behavior-options.adoc#text_patterns[Text Patterns]
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -99,10 +99,68 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 {productname} <x.y[.z]> also includes the following improvement<s>:
 
-=== <TINY-vwxyz 1 changelog entry>
-//#TINY-vwxyz1
+[[a-new-trigger-property-for-block-text-pattern-configurations-allowing-pattern-activation-with-either-space-or-enter-keys]]
+=== A new `trigger` property for block text pattern configurations, allowing pattern activation with either Space or Enter keys
+//#TINY-10324
 
-// CCFR here.
+This release introduces a new `trigger` property for block text pattern configurations, allowing pattern activation with either `Space` or `Enter` keys.
+
+In {productname} 7.0 the default preconfigured text patterns **was changed from**:
+
+[source, js]
+----
+[     
+  { start: '*', end: '*', format: 'italic' },
+  { start: '**', end: '**', format: 'bold' },
+  { start: '#', format: 'h1', trigger: 'enter' },
+  { start: '##', format: 'h2', trigger: 'enter' },
+  { start: '###', format: 'h3', trigger: 'enter' },
+  { start: '####', format: 'h4', trigger: 'enter' },
+  { start: '#####', format: 'h5', trigger: 'enter' },
+  { start: '######', format: 'h6', trigger: 'enter' },
+  { start: '1. ', cmd: 'InsertOrderedList', trigger: 'enter' },
+  { start: '* ', cmd: 'InsertUnorderedList', trigger: 'enter' },
+  { start: '- ', cmd: 'InsertUnorderedList', trigger: 'enter' },
+]
+----
+
+**to the following**:
+
+[source, js]
+----
+[     
+  { start: '*', end: '*', format: 'italic' },
+  { start: '**', end: '**', format: 'bold' },
+  { start: '#', format: 'h1', trigger: 'space' },
+  { start: '##', format: 'h2', trigger: 'space' },
+  { start: '###', format: 'h3', trigger: 'space' },
+  { start: '####', format: 'h4', trigger: 'space' },
+  { start: '#####', format: 'h5', trigger: 'space' },
+  { start: '######', format: 'h6', trigger: 'space' },
+  { start: '1.', cmd: 'InsertOrderedList', trigger: 'space' },
+  { start: '*', cmd: 'InsertUnorderedList', trigger: 'space' },
+  { start: '-', cmd: 'InsertUnorderedList', trigger: 'space' },
+  { start: '>', cmd: 'mceBlockQuote', trigger: 'space' },
+  { start: '---', cmd: 'InsertHorizontalRule', trigger: 'space' },
+]
+----
+
+Notice that new configuration of start prefixes for inserting lists doesn’t contain space character.
+
+[source, js]
+----
+{
+  { start: '*', cmd: 'InsertUnorderedList', trigger: 'space' },
+  { start: '-', cmd: 'InsertUnorderedList', trigger: 'space' },
+}
+----
+
+[IMPORTANT]
+Customers that wish to revert back to the previous default block `text_patterns` settings will be required to replace `trigger: 'space'` with `trigger: 'enter'` for the trigger value.
+
+[NOTE]
+The trigger property is exclusively applicable to the configuration of block text patterns. It is not recognized in the configurations for inline and replacement text patterns.
+Incorporating new text patterns into the preconfigured set requires the inclusion of default values. This is essential because the entire `text_patterns` option will be overwritten, and without the default values, the original configuration will not be preserved.
 
 
 [[additions]]

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -149,23 +149,28 @@ to the following new preconfigured defaults:
 ]
 ----
 
-[NOTE]
-The new pre configuration for the `start` prefixes for inserting lists no longer contains a `space` character.
+[IMPORTANT]
+Customers that wish to revert back to the previous default block `text_patterns` execution on `Enter` key pressing will be required to replace the preconfigured text_patterns with following array:
 
 [source, js]
 ----
-{
-  { start: '*', cmd: 'InsertUnorderedList', trigger: 'space' },
-  { start: '-', cmd: 'InsertUnorderedList', trigger: 'space' },
-}
+[     
+    { start: '*', end: '*', format: 'italic' },
+    { start: '**', end: '**', format: 'bold' },
+    { start: '#', format: 'h1', trigger: 'enter' },
+    { start: '##', format: 'h2', trigger: 'enter' },
+    { start: '###', format: 'h3', trigger: 'enter' },
+    { start: '####', format: 'h4', trigger: 'enter' },
+    { start: '#####', format: 'h5', trigger: 'enter' },
+    { start: '######', format: 'h6', trigger: 'enter' },
+    { start: '1. ', cmd: 'InsertOrderedList', trigger: 'enter' },
+    { start: '* ', cmd: 'InsertUnorderedList', trigger: 'enter' },
+    { start: '- ', cmd: 'InsertUnorderedList', trigger: 'enter' },
+]
 ----
-
-[IMPORTANT]
-Customers that wish to revert back to the previous default block `text_patterns` settings will be required to replace the preconfigured text_patterns with the xref:7.0-release-notes.adoc#example-preconfigured-text-patterns-prior-to-TinyMCE-7.0[old defaults].
 
 [TIP]
 The trigger property is exclusively applicable to the configuration of block text patterns. It is not recognized in the configurations for inline and replacement text patterns.
-Incorporating new text patterns into the preconfigured set requires the inclusion of default values. This is essential because the entire `text_patterns` option will be overwritten, and without the default values, the original configuration will not be preserved.
 
 For information on the **text_patterns**, see xref:content-behavior-options.adoc#text_patterns[Text Patterns]
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -107,25 +107,29 @@ This release introduces a new `trigger` property for block text pattern configur
 
 In {productname} 7.0 the default preconfigured text patterns **was changed from**:
 
+[[example-preconfigured-text-patterns-prior-to-TinyMCE-7.0]]
+.Example preconfigured text_patterns prior to {productname} 7.0
 [source, js]
 ----
-[     
+[
   { start: '*', end: '*', format: 'italic' },
   { start: '**', end: '**', format: 'bold' },
-  { start: '#', format: 'h1', trigger: 'enter' },
-  { start: '##', format: 'h2', trigger: 'enter' },
-  { start: '###', format: 'h3', trigger: 'enter' },
-  { start: '####', format: 'h4', trigger: 'enter' },
-  { start: '#####', format: 'h5', trigger: 'enter' },
-  { start: '######', format: 'h6', trigger: 'enter' },
-  { start: '1. ', cmd: 'InsertOrderedList', trigger: 'enter' },
-  { start: '* ', cmd: 'InsertUnorderedList', trigger: 'enter' },
-  { start: '- ', cmd: 'InsertUnorderedList', trigger: 'enter' },
+  { start: '#', format: 'h1' },
+  { start: '##', format: 'h2' },
+  { start: '###', format: 'h3' },
+  { start: '####', format: 'h4' },
+  { start: '#####', format: 'h5' },
+  { start: '######', format: 'h6' },
+  // The following text patterns require the `lists` plugin
+  { start: '1. ', cmd: 'InsertOrderedList' },
+  { start: '* ', cmd: 'InsertUnorderedList' },
+  { start: '- ', cmd: 'InsertUnorderedList' }
 ]
 ----
 
-**to the following**:
+to the following new preconfigured defaults:
 
+.Example preconfigured text_patterns for {productname} 7.0+
 [source, js]
 ----
 [     
@@ -145,7 +149,8 @@ In {productname} 7.0 the default preconfigured text patterns **was changed from*
 ]
 ----
 
-Notice that new configuration of start prefixes for inserting lists doesn’t contain space character.
+[NOTE]
+The new pre configuration for the `start` prefixes for inserting lists no longer contains a `space` character.
 
 [source, js]
 ----
@@ -156,11 +161,13 @@ Notice that new configuration of start prefixes for inserting lists doesn’t co
 ----
 
 [IMPORTANT]
-Customers that wish to revert back to the previous default block `text_patterns` settings will be required to replace `trigger: 'space'` with `trigger: 'enter'` for the trigger value.
+Customers that wish to revert back to the previous default block `text_patterns` settings will be required to replace the preconfigured text_patterns with the xref:7.0-release-notes.adoc#example-preconfigured-text-patterns-prior-to-TinyMCE-7.0[old defaults].
 
-[NOTE]
+[TIP]
 The trigger property is exclusively applicable to the configuration of block text patterns. It is not recognized in the configurations for inline and replacement text patterns.
 Incorporating new text patterns into the preconfigured set requires the inclusion of default values. This is essential because the entire `text_patterns` option will be overwritten, and without the default values, the original configuration will not be preserved.
+
+For information on the **text_patterns**, see xref:content-behavior-options.adoc#text_patterns[Text Patterns]
 
 
 [[additions]]

--- a/modules/ROOT/partials/configuration/text_patterns.adoc
+++ b/modules/ROOT/partials/configuration/text_patterns.adoc
@@ -85,7 +85,7 @@ Block patterns must have the following:
 * A `+start+`.
 * A `+format+` or a `+cmd+`.
 ** If `+cmd+` is specified, an optional `+value+` property is allowed.
-* A `+trigger+`, which takes a string that can be 'space' or 'enter', and specifies the activation key.
+* A `+trigger+`, which takes a string that can be `+'space'+` or `+'enter'+`, and specifies the activation key.
 
 The block patterns do not have an `+end+` property. This allows for patterns to be used to either apply a block format or execute a command, optionally, with the given value.
 

--- a/modules/ROOT/partials/configuration/text_patterns.adoc
+++ b/modules/ROOT/partials/configuration/text_patterns.adoc
@@ -82,11 +82,12 @@ Block patterns must have the following:
 
 * A `+start+`
 * A `+format+` or a `+cmd+`
+* A `+trigger+`
 ** If `+cmd+` is specified, an optional `+value+` property is allowed.
 
 The block patterns do not have an `+end+` property. This allows for patterns to be used to either apply a block format or execute a command, optionally, with the given value.
 
-NOTE: Block patterns are only executed on *Enter*, *not* on pressing the *spacebar*.
+NOTE: Block patterns can be configured to be executed on either *Enter*, or by pressing *Space*.
 
 ==== Example: using block patterns
 
@@ -95,30 +96,33 @@ NOTE: Block patterns are only executed on *Enter*, *not* on pressing the *spaceb
 tinymce.init({
   selector: 'textarea', // change this value according to your HTML
   // The `lists` plugin is required for list-related text patterns
+  // The trigger property can be configured to use either space or enter.
   plugin: 'lists',
   text_patterns: [
-    { start: '#', format: 'h1' },
-    { start: '##', format: 'h2' },
-    { start: '###', format: 'h3' },
-    { start: '####', format: 'h4' },
-    { start: '#####', format: 'h5' },
-    { start: '######', format: 'h6' },
-    { start: '* ', cmd: 'InsertUnorderedList' },
-    { start: '- ', cmd: 'InsertUnorderedList' },
-    { start: '1. ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'decimal' } },
-    { start: '1) ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'decimal' } },
-    { start: 'a. ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'lower-alpha' } },
-    { start: 'a) ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'lower-alpha' } },
-    { start: 'i. ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'lower-roman' } },
-    { start: 'i) ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'lower-roman' } }
+    { start: '*', end: '*', format: 'italic', trigger: 'space' },
+    { start: '**', end: '**', format: 'bold', trigger: 'space' },
+    { start: '#', format: 'h1', trigger: 'space' },
+    { start: '##', format: 'h2', trigger: 'space' },
+    { start: '###', format: 'h3', trigger: 'space' },
+    { start: '####', format: 'h4', trigger: 'space' },
+    { start: '#####', format: 'h5', trigger: 'space' },
+    { start: '######', format: 'h6', trigger: 'space' },
+    { start: '* ', cmd: 'InsertUnorderedList', trigger: 'space' },
+    { start: '- ', cmd: 'InsertUnorderedList', trigger: 'space' },
+    { start: '1. ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'decimal' }, trigger: 'space' },
+    { start: '1) ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'decimal' }, trigger: 'space' },
+    { start: 'a. ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'lower-alpha' }, trigger: 'space' },
+    { start: 'a) ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'lower-alpha' }, trigger: 'space' },
+    { start: 'i. ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'lower-roman' }, trigger: 'space' },
+    { start: 'i) ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'lower-roman' }, trigger: 'space' }
   ]
 });
 ----
 
 Using the configuration in this example:
 
-* `+{ start: '#', format: 'h1' }+` - Typing `+#+`, some text, and then pressing `+Enter+` will convert the text to a `+h1+` heading.
-* Typing `+1.+` followed by a space, the desired text, and then pressing `+Enter+`; the editor will convert the text into an ordered list, with the original text as the first list item, and the new line as the second list item. Since we have specified `+value+`, this pattern will execute `+editor.execCommand('InsertOrderedList', false, { 'list-style-type': 'decimal'})+`.
+* `+{ start: '#', format: 'h1' }+` - Typing `+#+`, some text, and then pressing `+Space+` or `+Enter+` depending on your configuration set will convert the text to a `+h1+` heading.
+* Typing `+1.+` followed by a `+Space+`, the desired text, and then pressing `+Space+` or `+Enter+`; the editor will convert the text into an ordered list, with the original text as the first list item, and the new line as the second list item. Since we have specified `+value+`, this pattern will execute `+editor.execCommand('InsertOrderedList', false, { 'list-style-type': 'decimal'})+`.
 
 === Replacements patterns
 

--- a/modules/ROOT/partials/configuration/text_patterns.adoc
+++ b/modules/ROOT/partials/configuration/text_patterns.adoc
@@ -15,22 +15,30 @@ Any formats or commands used in text patterns need to be registered with the edi
 
 *Type:* `+Array+` or `+false+`
 
+[NOTE]
+The default value for this option was changed with {productname} 7.0, see more xref:7.0-release-notes.adoc#a-new-trigger-property-for-block-text-pattern-configurations-allowing-pattern-activation-with-either-space-or-enter-keys[changes].
+
 *Default value:*
 [source,js]
 ----
 [
+  // Format styling
   { start: '*', end: '*', format: 'italic' },
   { start: '**', end: '**', format: 'bold' },
-  { start: '#', format: 'h1' },
-  { start: '##', format: 'h2' },
-  { start: '###', format: 'h3' },
-  { start: '####', format: 'h4' },
-  { start: '#####', format: 'h5' },
-  { start: '######', format: 'h6' },
+  // Headings
+  { start: '#', format: 'h1', trigger: 'space' },
+  { start: '##', format: 'h2', trigger: 'space' },
+  { start: '###', format: 'h3', trigger: 'space' },
+  { start: '####', format: 'h4', trigger: 'space' },
+  { start: '#####', format: 'h5', trigger: 'space' },
+  { start: '######', format: 'h6', trigger: 'space' },
   // The following text patterns require the `lists` plugin
-  { start: '1. ', cmd: 'InsertOrderedList' },
-  { start: '* ', cmd: 'InsertUnorderedList' },
-  { start: '- ', cmd: 'InsertUnorderedList' }
+  { start: '1.', cmd: 'InsertOrderedList', trigger: 'space' },
+  { start: '*', cmd: 'InsertUnorderedList', trigger: 'space' },
+  { start: '-', cmd: 'InsertUnorderedList', trigger: 'space' },
+  // Other
+  { start: '>', cmd: 'mceBlockQuote', trigger: 'space' },
+  { start: '---', cmd: 'InsertHorizontalRule', trigger: 'space' },
 ]
 ----
 

--- a/modules/ROOT/partials/configuration/text_patterns.adoc
+++ b/modules/ROOT/partials/configuration/text_patterns.adoc
@@ -114,7 +114,7 @@ tinymce.init({
     { start: '1.', cmd: 'InsertOrderedList', value: { 'list-style-type': 'decimal' }, trigger: 'space' },
     { start: '1) ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'decimal' }, trigger: 'enter' },
     { start: 'a.', cmd: 'InsertOrderedList', value: { 'list-style-type': 'lower-alpha' }, trigger: 'space' },
-    { start: 'a) ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'lower-alpha' }, trigger: 'space' },
+    { start: 'a) ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'lower-alpha' }, trigger: 'enter' },
     { start: 'i.', cmd: 'InsertOrderedList', value: { 'list-style-type': 'lower-roman' }, trigger: 'space' },
     { start: 'i) ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'lower-roman' }, trigger: 'enter' }
   ]

--- a/modules/ROOT/partials/configuration/text_patterns.adoc
+++ b/modules/ROOT/partials/configuration/text_patterns.adoc
@@ -22,7 +22,7 @@ The default value for this option was changed with {productname} 7.0, see more x
 [source,js]
 ----
 [
-  // Format styling
+  // Inline text patterns
   { start: '*', end: '*', format: 'italic' },
   { start: '**', end: '**', format: 'bold' },
   // Headings
@@ -41,6 +41,8 @@ The default value for this option was changed with {productname} 7.0, see more x
   { start: '---', cmd: 'InsertHorizontalRule', trigger: 'space' },
 ]
 ----
+[TIP]
+When the `text_patterns` option is set in the TinyMCE editor configuration, the new value entirely overwrites the existing default text patterns. This means that the editor will use the patterns specified in the user's configuration and ignore the default patterns. If one wants to add new patterns without losing the default ones, all the default patterns must be included in the custom `text_patterns` array along with any additional patterns.
 
 === Inline patterns
 
@@ -80,10 +82,10 @@ Using the configuration in this example:
 
 Block patterns must have the following:
 
-* A `+start+`
-* A `+format+` or a `+cmd+`
-* A `+trigger+`
+* A `+start+`.
+* A `+format+` or a `+cmd+`.
 ** If `+cmd+` is specified, an optional `+value+` property is allowed.
+* A `+trigger+`, which takes a string that can be 'space' or 'enter', and specifies the activation key.
 
 The block patterns do not have an `+end+` property. This allows for patterns to be used to either apply a block format or execute a command, optionally, with the given value.
 
@@ -99,30 +101,30 @@ tinymce.init({
   // The trigger property can be configured to use either space or enter.
   plugin: 'lists',
   text_patterns: [
-    { start: '*', end: '*', format: 'italic', trigger: 'space' },
-    { start: '**', end: '**', format: 'bold', trigger: 'space' },
+    { start: '*', end: '*', format: 'italic' },
+    { start: '**', end: '**', format: 'bold' },
     { start: '#', format: 'h1', trigger: 'space' },
     { start: '##', format: 'h2', trigger: 'space' },
     { start: '###', format: 'h3', trigger: 'space' },
     { start: '####', format: 'h4', trigger: 'space' },
     { start: '#####', format: 'h5', trigger: 'space' },
     { start: '######', format: 'h6', trigger: 'space' },
-    { start: '* ', cmd: 'InsertUnorderedList', trigger: 'space' },
-    { start: '- ', cmd: 'InsertUnorderedList', trigger: 'space' },
-    { start: '1. ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'decimal' }, trigger: 'space' },
-    { start: '1) ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'decimal' }, trigger: 'space' },
-    { start: 'a. ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'lower-alpha' }, trigger: 'space' },
+    { start: '*', cmd: 'InsertUnorderedList', trigger: 'space' },
+    { start: '- ', cmd: 'InsertUnorderedList', trigger: 'enter' },
+    { start: '1.', cmd: 'InsertOrderedList', value: { 'list-style-type': 'decimal' }, trigger: 'space' },
+    { start: '1) ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'decimal' }, trigger: 'enter' },
+    { start: 'a.', cmd: 'InsertOrderedList', value: { 'list-style-type': 'lower-alpha' }, trigger: 'space' },
     { start: 'a) ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'lower-alpha' }, trigger: 'space' },
-    { start: 'i. ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'lower-roman' }, trigger: 'space' },
-    { start: 'i) ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'lower-roman' }, trigger: 'space' }
+    { start: 'i.', cmd: 'InsertOrderedList', value: { 'list-style-type': 'lower-roman' }, trigger: 'space' },
+    { start: 'i) ', cmd: 'InsertOrderedList', value: { 'list-style-type': 'lower-roman' }, trigger: 'enter' }
   ]
 });
 ----
 
 Using the configuration in this example:
 
-* `+{ start: '#', format: 'h1' }+` - Typing `+#+`, some text, and then pressing `+Space+` or `+Enter+` depending on your configuration set will convert the text to a `+h1+` heading.
-* Typing `+1.+` followed by a `+Space+`, the desired text, and then pressing `+Space+` or `+Enter+`; the editor will convert the text into an ordered list, with the original text as the first list item, and the new line as the second list item. Since we have specified `+value+`, this pattern will execute `+editor.execCommand('InsertOrderedList', false, { 'list-style-type': 'decimal'})+`.
+* `+{ start: '#', format: 'h1', trigger: 'space' }+` - Typing `+#+`, and then pressing `+Space+` will create an empty `+h1+` heading.
+* Typing `+1)+` followed by a `+Space+`, the desired text, and then pressing `+Enter+`; the editor will convert the text into an ordered list, with the original text as the first list item, and the new line as the second list item. Since we have specified `+value+`, this pattern will execute `+editor.execCommand('InsertOrderedList', false, { 'list-style-type': 'decimal'})+`.
 
 === Replacements patterns
 


### PR DESCRIPTION
Ticket: DOC-2270

- Release notes entry for: DOC-2250 and relates to TINY-10324

Site: [DOC-2270_TINY-10324 site](http://docs-feature-70-doc-2270tiny-10324.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#a-new-trigger-property-for-block-text-pattern-configurations-allowing-pattern-activation-with-either-space-or-enter-keys)

Site: [text_pattern default changes](http://docs-feature-70-doc-2270tiny-10324.staging.tiny.cloud/docs/tinymce/latest/content-behavior-options/#text_patterns) and linked back to release notes entry.

Changes:
* add `new feature` documentation for TINY-10324 in the TinyMCE release notes.
* updated `text_patterns.adoc` to support incoming core changes for `space` trigger.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed