### PR TITLE
DOC-2293: Remove `ch` option from `Autocompleter.adoc` page

### DIFF
--- a/modules/ROOT/pages/autocompleter.adoc
+++ b/modules/ROOT/pages/autocompleter.adoc
@@ -23,9 +23,6 @@ The two arguments this method take are:
 [cols="1,2,1,4",options="header"]
 |===
 |Name |Value |Requirement |Description
-|ch |`+string+` (of one character) |Required |The character to trigger the autocompleter.
-include::partial$misc/admon-deprecated-6.2v.adoc[]
-It has been replaced with the `+trigger+` option, which should be used instead.
 |trigger |`+string+` |Required |The string to trigger the autocompleter.
 include::partial$misc/admon-requires-6.2v.adoc[]
 |fetch |`+(pattern: string, maxResults: number, fetchOptions: Record<string, any>) => Promise<AutocompleteItem[] \| CardMenuItem[]+` |Required |A function that is passed the current matched text pattern, the maximum number of expected results and any additional fetch options. The function should return a Promise containing matching results.


### PR DESCRIPTION
Ticket: DOC-2293

Site: [DOC-2293 site](http://docs-feature-70-doc-2293.staging.tiny.cloud/docs/tinymce/latest/autocompleter/#options)

Changes:
* DOC-2293: Remove `ch` option from `Autocompleter.adoc` page

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`

Review:
- [x] Documentation Team Lead has reviewed