### PR TITLE
DOC-2270_TINY-10303: Pressing Backspace at the start of an empty `summary` element within a `details` element nested in a list item no longer removes the `summary` element.

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -134,6 +134,17 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 // CCFR here.
 
+=== Pressing Backspace at the start of an empty `summary` element within a `details` element nested in a list item no longer removes the `summary` element.
+// #TINY-10303
+
+Previously in {productname}, when a details element was placed inside a list item and contained an empty summary, pressing the Backspace key (with the cursor at the beginning of the summary) resulted in the summary being deleted.
+
+This caused the unexpected behavior of replacing the summary contents with the default summary placeholder.
+
+To address this, the summary element has been included in the list of non-empty elements within the editor's schema.
+
+With this adjustment, the summary element will no longer be deleted under the previously mentioned conditions.
+
 [[security-fixes]]
 == Security fixes
 


### PR DESCRIPTION
Ticket: DOC-2270
Release notes entry for: TINY-10303

Site: [DOC-2270_TINY-10303 site](http://docs-feature-70-doc-2270tiny-10303.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#pressing-backspace-at-the-start-of-an-empty-summary-element-within-a-details-element-nested-in-a-list-item-no-longer-removes-the-summary-element)

Changes:
* DOC-2270_TINY-10303: Pressing Backspace at the start of an empty `summary` element within a `details` element nested in a list item no longer removes the `summary` element.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] Added `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed