### PR TITLE
DOC-2270_TINY-10433: Fixed incorrect object processor for `event_root` option.

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -132,6 +132,17 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 === <TINY-vwxyz 1 changelog entry>
 //#TINY-vwxyz1
 
+=== Fixed incorrect object processor for `event_root` option.
+// #TINY-10433
+
+Previously in {productname}, the `inline` mode `event_root` option incorrectly used an `object` processor.
+
+This caused the option to be unregistered when passing a `string` value, resulting in the option being unusable.
+
+{productname} 7.0 addresses this, now, the `event_root` option uses the correctly uses the `string` processor.
+
+As the result, the `event_root` option can now be correctly used to specify a CSS selector for an element.
+
 // CCFR here.
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-2270
Release notes entry for: TINY-10433

Site: [DOC-2270_TINY-10433 site](http://docs-feature-70-doc-2270tiny-10433.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#fixed-incorrect-object-processor-for-event_root-option)

Changes:
* DOC-2270_TINY-10433: Fixed incorrect object processor for `event_root` option.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] Added `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed