### PR TITLE
DOC-2270_TINY-10310: Moving focus to the outside of the editor after having clicked a menu would not fire a `blur` event as expected.

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -134,6 +134,17 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 // CCFR here.
 
+=== Moving focus to the outside of the editor after having clicked a menu would not fire a `blur` event as expected.
+// #TINY-10310
+
+Previously in {productname}, some UI events were not detected by the focus controller when clicking outside the editor while a menu was open.
+
+Consequently, the `blur` event was not fired when switching focus to outside the editor.
+
+{productname} 7.0 addresses this, now, events from the UI are considered as part of the normal editor UI.
+
+As a result, the `blur` event is now fired when switching focus to outside the editor.
+
 [[security-fixes]]
 == Security fixes
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -137,7 +137,7 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 === Moving focus to the outside of the editor after having clicked a menu would not dispatch a `blur` event as expected.
 // #TINY-10310
 
-Previously in {productname}, some UI events were not detected by the focus controller when clicking outside the editor while a menu was open.
+In {productname}, an issue was identified where clicking outside the editor while a menu was in either the opened or closed state resulted in the blur event not being triggered as expected.
 
 Consequently, the `blur` event was not dispatched when switching focus outside the editor, as the UI was still considered part of the editor.
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -139,11 +139,11 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 Previously in {productname}, some UI events were not detected by the focus controller when clicking outside the editor while a menu was open.
 
-Consequently, the `blur` event was not fired when switching focus to outside the editor.
+Consequently, the `blur` event was not fired when switching focus outside the editor, as the UI was still considered part of the editor.
 
-{productname} 7.0 addresses this, now, events from the UI are considered as part of the normal editor UI.
+{productname} 7.0 addresses this by now considering UI events as part of the normal editor events.
 
-As a result, the `blur` event is now fired when switching focus to outside the editor.
+As a result, the `blur` event is now properly fired when switching focus outside the editor.
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -134,16 +134,16 @@ For information on using premium skins and icon packs, see: xref:premium-skins-a
 
 // CCFR here.
 
-=== Moving focus to the outside of the editor after having clicked a menu would not fire a `blur` event as expected.
+=== Moving focus to the outside of the editor after having clicked a menu would not dispatch a `blur` event as expected.
 // #TINY-10310
 
 Previously in {productname}, some UI events were not detected by the focus controller when clicking outside the editor while a menu was open.
 
-Consequently, the `blur` event was not fired when switching focus outside the editor, as the UI was still considered part of the editor.
+Consequently, the `blur` event was not dispatched when switching focus outside the editor, as the UI was still considered part of the editor.
 
 {productname} 7.0 addresses this by now considering UI events as part of the normal editor events.
 
-As a result, the `blur` event is now properly fired when switching focus outside the editor.
+As a result, the `blur` event is now properly dispatched when switching focus outside the editor.
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-2270
Release notes entry for: TINY-10310

Site: [DOC-2270_TINY-10310 site](http://docs-feature-70-doc-2270tiny-10310.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#moving-focus-to-the-outside-of-the-editor-after-having-clicked-a-menu-would-not-fire-a-blur-event-as-expected)

Changes:
* DOC-2270_TINY-10310: Moving focus to the outside of the editor after having clicked a menu would not fire a `blur` event as expected.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] Added `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed