### PR TITLE
DOC-2270: add fix documentation for TINY-6309 to the release notes.

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -194,7 +194,7 @@ As a consequence, since the selection is still on the first element, the `List P
 
 As a result, the selection is in the correct place and the `List Properties...` context menu item is `enabled`.
 
-=== `TableOperations.opEraseRows` did not calculate the correct row index for colgroup tables.
+=== `mceTableDeleteRow` did not calculate the correct row index for colgroup tables.
 // #TINY-6309
 
 Previously, when deleting a row or column in a table within {productname}, the caret or cursor position would relocate to the first cell of the table.

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -159,6 +159,15 @@ As a consequence, since the selection is still on the first element, the `List P
 
 As a result, the selection is in the correct place and the `List Properties...` context menu item is `enabled`.
 
+=== `TableOperations.opEraseRows` did not calculate the correct row index for colgroup tables.
+// #TINY-6309
+
+Previously, when deleting a row or column in a table within {productname}, the caret or cursor position would relocate to the first cell of the table.
+
+As a consequence, users expected it to be repositioned much closer, such as to an adjacent cell in the previous row or column.
+
+In {productname} 7.0, this issue is addressed, now, when a user deletes a row or column in a table, the caret/cursor position is now relocated to the adjacent cell in the previous row or column.
+
 [[security-fixes]]
 == Security fixes
 


### PR DESCRIPTION
Ticket: DOC-2270

Site: [DOC-2270 site](http://docs-feature-70-doc-2270tiny-6309.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#tableoperations-operaserows-did-not-calculate-the-correct-row-index-for-colgroup-tables)

Changes:
* add fix documentation for TINY-6309 to the release notes.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`

Review:
- [x] Documentation Team Lead has reviewed