### PR TITLE
DOC-2299: Add new plugin documentation for `importWord`, `exportWord` & `exportPDF` to 7.0 release notes.

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -38,7 +38,6 @@ The following new Premium plugins were released alongside {productname} 7.0.
 The new Premium plugin, **Import from Word** provides a way to import `.docx` (Word documents) or `.dotx` (Word templates) files into the editor.
 
 include::partial$misc/admon-paid-addon-pricing.adoc[]
-
 For information on the **Import from Word Premium Plugin** see xref:importword.adoc[Import from Word docs].
 
 === Export to Word

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -35,7 +35,7 @@ The following new Premium plugins where released alongside {productname} 7.0.
 
 === Import Word
 
-The new Premium plugin, **Import Word** provides a way to import `.docx` (Word documents) or `.dotx` (Word templates) files into the editor.
+The new Premium plugin, **Import from Word** provides a way to import `.docx` (Word documents) or `.dotx` (Word templates) files into the editor.
 
 include::partial$misc/admon-paid-addon-pricing.adoc[]
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -33,7 +33,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following new Premium plugins where released alongside {productname} 7.0.
 
-=== Import Word
+=== Import from Word
 
 The new Premium plugin, **Import from Word** provides a way to import `.docx` (Word documents) or `.dotx` (Word templates) files into the editor.
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -39,23 +39,23 @@ The new Premium plugin, **Import from Word** provides a way to import `.docx` (W
 
 include::partial$misc/admon-paid-addon-pricing.adoc[]
 
-For information on the **Import Word Premium Plugin** see xref:importword.adoc[Import Word docs].
+For information on the **Import from Word Premium Plugin** see xref:importword.adoc[Import from Word docs].
 
-=== Export Word
+=== Export to Word
 
-The new Premium plugin, **Export Word** feature lets you generate a `.docx` file directly from the editor.
-
-include::partial$misc/admon-paid-addon-pricing.adoc[]
-
-For information on the **Export Word Premium Plugin** see xref:exportword.adoc[Export Word docs].
-
-=== Export PDF
-
-The new Premium plugin, **Export PDF** feature lets you generate a `PDF` file directly from the editor.
+The new Premium plugin, **Export to Word** feature lets you generate a `.docx` file directly from the editor.
 
 include::partial$misc/admon-paid-addon-pricing.adoc[]
 
-For information on the **Export PDF Premium Plugin** see xref:exportpdf.adoc[Export PDF docs].
+For information on the **Export to Word Premium Plugin** see xref:exportword.adoc[Export to Word docs].
+
+=== Export to PDF
+
+The new Premium plugin, **Export to PDF** feature lets you generate a `.pdf` file directly from the editor.
+
+include::partial$misc/admon-paid-addon-pricing.adoc[]
+
+For information on the **Export to PDF Premium Plugin** see xref:exportpdf.adoc[Export to PDF docs].
 
 
 [[new-open-source-plugin]]

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -13,7 +13,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 // Remove sections and section boilerplates as necessary.
 // Pluralise as necessary or remove the placeholder plural marker.
-* xref:new-premium-plugin<s>[New Premium plugin<s>]
+* xref:new-premium-plugin<s>[New Premium plugins]
 * xref:new-open-source-plugin<s>[New Open Source plugin<s>]
 * xref:accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
 * xref:accompanying-premium-plugin-end-of-life-announcement[Accompanying Premium plugin end-of-life announcement]
@@ -28,16 +28,34 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 * xref:known-issues[Known issues]
 
 
-[[new-premium-plugin<s>]]
-New Premium plugin<s>
+[[new-premium-plugins]]
+== New Premium plugins
 
-The following new Premium plugin was released alongside {productname} <x.y[.z]>.
+The following new Premium plugins where released alongside {productname} 7.0.
 
-=== <Premium plugin name> 1.0.0
+=== Import Word
 
-The new Premium plugin, **<Premium plugin name>** // description here.
+The new Premium plugin, **Import Word** provides a way to import `.docx` (Word documents) or `.dotx` (Word templates) files into the editor.
 
-For information on the **<Premium plugin name>** see xref:<plugincode>.adoc[<Premium plugin name>].
+include::partial$misc/admon-paid-addon-pricing.adoc[]
+
+For information on the **Import Word Premium Plugin** see xref:importword.adoc[Import Word docs].
+
+=== Export Word
+
+The new Premium plugin, **Export Word** feature lets you generate a `.docx` file directly from the editor.
+
+include::partial$misc/admon-paid-addon-pricing.adoc[]
+
+For information on the **Export Word Premium Plugin** see xref:exportword.adoc[Export Word docs].
+
+=== Export PDF
+
+The new Premium plugin, **Export PDF** feature lets you generate a `PDF` file directly from the editor.
+
+include::partial$misc/admon-paid-addon-pricing.adoc[]
+
+For information on the **Export PDF Premium Plugin** see xref:exportpdf.adoc[Export PDF docs].
 
 
 [[new-open-source-plugin]]

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -31,7 +31,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 [[new-premium-plugins]]
 == New Premium plugins
 
-The following new Premium plugins where released alongside {productname} 7.0.
+The following new Premium plugins were released alongside {productname} 7.0.
 
 === Import from Word
 

--- a/modules/ROOT/partials/misc/admon-paid-addon-pricing.adoc
+++ b/modules/ROOT/partials/misc/admon-paid-addon-pricing.adoc
@@ -1,0 +1,1 @@
+NOTE: This plugin is only available as a **paid add-on** see more link:{pricingpage}/[a TinyMCE subscription].


### PR DESCRIPTION
Ticket: DOC-2299

Site: [DOC-2299 site](http://docs-feature-70-doc-2270doc-2299.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#new-premium-plugins)

Changes:
* Add new plugin documentation for `importWord`, `exportWord` & `exportPDF` to 7.0 release notes.
* Create new `admon` for paid add-ons.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] Files has been included where required `(if applicable)`

Review:
- [x] Documentation Team Lead has reviewed