### PR TITLE
DOC-2303: add sandbox_iframes breaking changes to 7.0 release notes.

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -220,12 +220,11 @@ Any editors using this `highlight_on_focus: true` option, can remove this option
 
 === `sandbox_iframes` editor option is now defaulted to `true`.
 
-In {productname} 6.8.1, `sandbox_iframes` editor option was introduced to allow iframes to be sandboxed by default when inserted into the editor.
+In {productname} 6.8.1, xref:content-filtering.adoc#sandbox-iframes[sandbox iframes] editor option was introduced to allow iframes to be sandboxed by default when inserted into the editor.
 
-With the release of {productname} 7.0, the default for `sandbox_iframes` editor option has been changed to `true`, constituting a breaking change for users whose editor version is below 7.0.
+With the release of {productname} 7.0, the default for `+sandbox_iframes+` editor option has been changed to `true`, constituting a breaking change for users whose editor version is below 7.0.
 
-
-For further details on this option, refer to the xref:security.adoc#sandbox-iframes-option[sandbox_iframes] option, or see xref:migration-from-6x.adoc#sandbox-iframes[migration from 6x guide].
+For further details on this option, refer to the xref:content-filtering.adoc#sandbox-iframes[sandbox iframes], or see link:https://www.tiny.cloud/docs/tinymce/6/6.8.1-release-notes/#new-sandbox_iframes-option-that-controls-whether-iframe-elements-will-be-added-a-sandbox-attribute-to-mitigate-malicious-intent[{productname} 6.8.1 release notes].
 
 
 [[bug-fixes]]

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -220,7 +220,7 @@ Any editors using this `highlight_on_focus: true` option, can remove this option
 
 === `sandbox_iframes` editor option is now defaulted to `true`.
 
-In {productname} 6.8.1, `sandbox_iframes` editor option was introduced to support a security vulnerability issue with {productname} loading iframes `unsandboxed` which as a result could allow arbitrary code execution inside {productname} content.
+In {productname} 6.8.1, `sandbox_iframes` editor option was introduced to allow iframes to be sandboxed by default when inserted into the editor.
 
 With the release of {productname} 7.0, the default for `sandbox_iframes` editor option has been changed to `true`, constituting a breaking change for users whose editor version is below 7.0.
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -218,6 +218,17 @@ Any editors using this `highlight_on_focus: true` option, can remove this option
 
 // CCFR here.
 
+=== `sandbox_iframes` editor option is now defaulted to `true`.
+
+In {productname} 6.8.1, `sandbox_iframes` editor option was introduced to support a security vulnerability issue with {productname} loading iframes `unsandboxed` which as a result could allow arbitrary code execution inside {productname} content.
+
+With the release of {productname} 7.0, the default for `sandbox_iframes` editor option has been changed to `true`, constituting a breaking change for users whose editor version is below 7.0.
+
+[IMPORTANT]
+The premium **Enhanced Media Embed** plugin uses `iframes` extensively and are currently no workarounds available except to keep a record of allowed sources. Customers who want to continue to use **Enhanced Media Embed** plugin in {productname} 7.0 will be required to add the option `sandbox_iframes: false` to their {productname} init configuration.
+
+For further details on this option, refer to the xref:security.adoc#sandbox-iframes-option[sandbox_iframes] option, or see xref:migration-from-6x.adoc#sandbox-iframes[migration from 6x guide].
+
 
 [[bug-fixes]]
 == Bug fixes

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -224,8 +224,6 @@ In {productname} 6.8.1, `sandbox_iframes` editor option was introduced to suppor
 
 With the release of {productname} 7.0, the default for `sandbox_iframes` editor option has been changed to `true`, constituting a breaking change for users whose editor version is below 7.0.
 
-[IMPORTANT]
-The premium **Enhanced Media Embed** plugin uses `iframes` extensively and are currently no workarounds available except to keep a record of allowed sources. Customers who want to continue to use **Enhanced Media Embed** plugin in {productname} 7.0 will be required to add the option `sandbox_iframes: false` to their {productname} init configuration.
 
 For further details on this option, refer to the xref:security.adoc#sandbox-iframes-option[sandbox_iframes] option, or see xref:migration-from-6x.adoc#sandbox-iframes[migration from 6x guide].
 

--- a/modules/ROOT/partials/security/securing-embedded-external-resources.adoc
+++ b/modules/ROOT/partials/security/securing-embedded-external-resources.adoc
@@ -7,7 +7,7 @@ This option controls whether the editor will add a `sandbox=""` attribute to all
 
 *Possible values:* `true`, `false`
 
-*Default value:* `false`
+*Default value:* `true`
 
 ===== Example: using `sandbox_iframes` option
 
@@ -15,7 +15,7 @@ This option controls whether the editor will add a `sandbox=""` attribute to all
 ----
 tinymce.init({
   selector: 'textarea',  // change this value according to your html
-  sandbox_iframes: true
+  sandbox_iframes: false
 });
 ----
 


### PR DESCRIPTION
Ticket: DOC-2303: add sandbox_iframes breaking changes to 7.0 release notes.

Site: [DOC-2303 site](http://docs-feature-70-doc-2303.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#sandbox_iframes-editor-option-is-now-defaulted-to-true)

Site Page 2: [DOC-2303 site for changes to value](http://docs-feature-70-doc-2303.staging.tiny.cloud/docs/tinymce/latest/security/#sandbox-iframes-option)

Changes:
* add sandbox_iframes breaking changes to 7.0 release notes.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`

Review:
- [ ] Documentation Team Lead has reviewed