### PR TITLE
DOC-2313: add note to `export.adoc` to inform users about plugin name change in v7.

### DIFF
--- a/modules/ROOT/pages/export.adoc
+++ b/modules/ROOT/pages/export.adoc
@@ -8,8 +8,8 @@
 
 include::partial$misc/admon-premium-plugin.adoc[]
 
-[NOTE]
-The {pluginname} plugin has been replaced by the improved **Export to PDF** and **Export to Word** plugins starting with {productname} 7.
+[IMPORTANT]
+{productname}'s {pluginname} plugin will be retired and deactivated upon the release of {productname} 7, and will no longer available for purchase. In {productname} 7, the **Export to PDF** and **Export to Word** plugins will provide similar functionality to the {pluginname} plugin.
 
 The {pluginname} plugin adds the ability to export content from the editor to a user's local machine in various formats. For a list of available exporters and information on what they support, see the xref:exporters[Exporters section].
 

--- a/modules/ROOT/pages/export.adoc
+++ b/modules/ROOT/pages/export.adoc
@@ -8,6 +8,9 @@
 
 include::partial$misc/admon-premium-plugin.adoc[]
 
+[NOTE]
+The {pluginname} plugin has been replaced by the improved **Export to PDF** and **Export to Word** plugins starting with {productname} 7.
+
 The {pluginname} plugin adds the ability to export content from the editor to a user's local machine in various formats. For a list of available exporters and information on what they support, see the xref:exporters[Exporters section].
 
 == Interactive example


### PR DESCRIPTION
Ticket: DOC-2313

Site: [DOC-2313 site](http://docs-hotfix-6-doc-2313.staging.tiny.cloud/docs/tinymce/6/export/)

Changes:
* add note to `export.adoc` in `tinymce 6x docs` to inform users about plugin name change in v7.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`

Review:
- [x] Documentation Team Lead has reviewed
- [x] Merge once 7.0 has been published