### PR TITLE
DOC-2300: Rename Advanced Lists plugin to List Styles for TinyMCE 7.0.

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -352,7 +352,6 @@
 **** xref:tinydrive-changelog.adoc[Changelog]
 ** Open source plugins
 *** xref:accordion.adoc[Accordion]
-*** xref:advlist.adoc[Advanced List]
 *** xref:anchor.adoc[Anchor]
 *** xref:autolink.adoc[Autolink]
 *** xref:autoresize.adoc[Autoresize]
@@ -369,6 +368,7 @@
 *** xref:insertdatetime.adoc[Insert Date/Time]
 *** xref:link.adoc[Link]
 *** xref:lists.adoc[Lists]
+*** xref:advlist.adoc[List Styles]
 *** xref:media.adoc[Media]
 *** xref:nonbreaking.adoc[Nonbreaking Space]
 *** xref:pagebreak.adoc[Page Break]

--- a/modules/ROOT/pages/advlist.adoc
+++ b/modules/ROOT/pages/advlist.adoc
@@ -1,12 +1,16 @@
-= Advanced List plugin
-:navtitle: Advanced List
+= List Styles plugin
+:navtitle: List Styles
 :description: Create styled number and bulleted lists.
 :keywords: advlist, advlist_bullet_styles, advlist_number_styles
+:pluginname: List Styles
 :plugincode: advlist
 
 The `+advlist+` plugin extends the core `+bullist+` and `+numlist+` toolbar controls by adding CSS `+list-style-type+` styled number formats and bullet types to the controls.
 
 IMPORTANT: The xref:lists.adoc[Lists] (`+lists+`) plugin must be activated for the `+advlist+` plugin to work.
+
+[TIP]
+As of {productname} 7.0, the Advanced Lists plugin has been renamed to {pluginname}. When adding {pluginname} in your editor, continue to use {plugincode}.
 
 == Basic setup
 
@@ -28,7 +32,7 @@ include::partial$configuration/advlist_number_styles.adoc[leveloffset=+1]
 
 == Commands
 
-The Advanced Lists plugin provides the following {productname} commands.
+The List Styles plugin provides the following {productname} commands.
 
 include::partial$commands/advlist-cmds.adoc[]
 

--- a/modules/ROOT/pages/advlist.adoc
+++ b/modules/ROOT/pages/advlist.adoc
@@ -1,7 +1,7 @@
 = List Styles plugin
 :navtitle: List Styles
 :description: Create styled number and bulleted lists.
-:keywords: advlist, advlist_bullet_styles, advlist_number_styles
+:keywords: advlist, advlist_bullet_styles, advlist_number_styles, list_style
 :pluginname: List Styles
 :plugincode: advlist
 

--- a/modules/ROOT/pages/advlist.adoc
+++ b/modules/ROOT/pages/advlist.adoc
@@ -32,7 +32,7 @@ include::partial$configuration/advlist_number_styles.adoc[leveloffset=+1]
 
 == Commands
 
-The List Styles plugin provides the following {productname} commands.
+The {pluginname} plugin provides the following {productname} commands.
 
 include::partial$commands/advlist-cmds.adoc[]
 

--- a/modules/ROOT/pages/basic-setup.adoc
+++ b/modules/ROOT/pages/basic-setup.adoc
@@ -83,7 +83,7 @@ For information on the differences between the classic and inline editing modes,
 
 The functionality of {productname} is extended by using plugins, which are enabled using the `+plugins+` option.
 
-The following example enables the lists (`+lists+`), Advanced Lists (`+advlist+`), Link (`+link+`), and Image (`+image+`) plugins.
+The following example enables the lists (`+lists+`), List Styles (`+advlist+`), Link (`+link+`), and Image (`+image+`) plugins.
 
 [source,js]
 ----

--- a/modules/ROOT/pages/editor-command-identifiers.adoc
+++ b/modules/ROOT/pages/editor-command-identifiers.adoc
@@ -213,7 +213,6 @@ include::partial$commands/core-table-cmds.adoc[]
 Commands are available for the following plugins:
 
 * xref:advancedcode[Advanced Code]
-* xref:advancedlists[Advanced Lists]
 * xref:advancedtables[Advanced Tables]
 * xref:anchor[Anchor]
 * xref:autoresize[Autoresize]
@@ -234,6 +233,7 @@ Commands are available for the following plugins:
 * xref:insertdatetime[Insert Date/Time]
 * xref:link[Link]
 * xref:lists[Lists]
+* xref:advancedlists[List Styles]
 * xref:media[Media]
 * xref:nonbreakingspace[Nonbreaking Space]
 * xref:pagebreak[Page Break]
@@ -255,13 +255,6 @@ Commands are available for the following plugins:
 The following command requires the xref:advcode.adoc[Advanced Code (`+advcode+`)] plugin.
 
 include::partial$commands/code-cmds.adoc[leveloffset=+3]
-
-[[advancedlists]]
-==== Advanced Lists
-
-The following commands require the xref:advlist.adoc[Advanced Lists (`+advlist+`)] plugin.
-
-include::partial$commands/advlist-cmds.adoc[leveloffset=+3]
 
 [[advancedtables]]
 ==== Advanced Tables
@@ -403,6 +396,13 @@ include::partial$commands/link-cmds.adoc[leveloffset=+3]
 The following commands require the xref:lists.adoc[Lists (`+lists+`)] plugin.
 
 include::partial$commands/lists-cmds.adoc[leveloffset=+3]
+
+[[liststyles]]
+==== List Styles
+
+The following commands require the xref:advlist.adoc[List Styles (`+advlist+`)] plugin.
+
+include::partial$commands/advlist-cmds.adoc[leveloffset=+3]
 
 [[media]]
 ==== Media

--- a/modules/ROOT/pages/lists.adoc
+++ b/modules/ROOT/pages/lists.adoc
@@ -5,7 +5,7 @@
 :pluginname: Lists
 :plugincode: lists
 
-The `+lists+` plugin allows you to add numbered and bulleted lists to {productname}. To enable advanced lists (e.g. alpha numbered lists, square bullets) you should also enable the xref:advlist.adoc[Advanced List] (`+advlist+`) plugin.
+The `+lists+` plugin allows you to add numbered and bulleted lists to {productname}. To enable List Styles (e.g. alpha numbered lists, square bullets) you should also enable the xref:advlist.adoc[List Style] (`+advlist+`) plugin.
 
 The plugin also normalizes list behavior between browsers. Enable it if you have problems with consistency making lists.
 

--- a/modules/ROOT/pages/lists.adoc
+++ b/modules/ROOT/pages/lists.adoc
@@ -5,7 +5,7 @@
 :pluginname: Lists
 :plugincode: lists
 
-The `+lists+` plugin allows you to add numbered and bulleted lists to {productname}. To enable List Styles (e.g. alpha numbered lists, square bullets) you should also enable the xref:advlist.adoc[List Style] (`+advlist+`) plugin.
+The `+lists+` plugin allows you to add numbered and bulleted lists to {productname}. To enable List Styles (e.g. alpha numbered lists, square bullets) you should also enable the xref:advlist.adoc[List Styles] (`+advlist+`) plugin.
 
 The plugin also normalizes list behavior between browsers. Enable it if you have problems with consistency making lists.
 

--- a/modules/ROOT/pages/work-with-plugins.adoc
+++ b/modules/ROOT/pages/work-with-plugins.adoc
@@ -4,7 +4,7 @@
 :description: TinyMCE is an incredibly powerful, flexible and customizable rich text editor. This section demonstrates the power of plugins with several working examples.
 :keywords: plugin
 
-For most developers, the real power of {productname}'s functionality is found in its plugins. xref:plugins.adoc[Plugins] either extend default editor functionality or add new functionality. For example, the xref:advlist.adoc[Advanced List] plugin adds extra options to the toolbar's existing list controls, while the xref:code.adoc[Code] plugin adds entirely new functionality.
+For most developers, the real power of {productname}'s functionality is found in its plugins. xref:plugins.adoc[Plugins] either extend default editor functionality or add new functionality. For example, the xref:advlist.adoc[List Styles] plugin adds extra options to the toolbar's existing list controls, while the xref:code.adoc[Code] plugin adds entirely new functionality.
 
 Because most people install {productname} via {cloudname} or by downloading a package, they mistakenly think plugins are part of the {productname} "core". While all of the plugins (excluding the professional features) are included in those packages, each plugin is in a separate .js file. In fact, if you use the link:{gettiny}/custom-builds/[custom package] download option (TinyMCE 4 only), you're able to select only the plugins you want to be included, or you can exclude all of the plugins built by the {productname} team.
 
@@ -84,11 +84,11 @@ tinymce.init({
 
 Even if you found the above example quite easy, hang with us we'll show you how to extend {productname}'s default ordered and unordered lists. If on the other hand that was all a bit new, read this example to help your understanding.
 
-=== Advanced List
+=== List Styles
 
-The xref:advlist.adoc[Advanced List] plugin extends the default unordered and ordered list toolbar controls provided in the Lists plugin by adding CSS `+list-style-type+` styled number formats and bullet types to the controls.
+The xref:advlist.adoc[List Styles] plugin extends the default unordered and ordered list toolbar controls provided in the Lists plugin by adding CSS `+list-style-type+` styled number formats and bullet types to the controls.
 
-As before, let's start by adding the `+plugins+` key and assign the value `+'advlist lists'+`. This will enable the Advanced List and Lists plugins.
+As before, let's start by adding the `+plugins+` key and assign the value `+'advlist lists'+`. This will enable the List Styles and Lists plugins.
 
 [source,js]
 ----
@@ -110,7 +110,7 @@ Many plugin options have more than one possible value. The `+advlist_bullet_styl
 
 Don't worry if you can't remember all these values. The xref:plugins.adoc[plugins section] goes into great detail explaining all the plugins options, toolbars, and menu controls.
 
-Let's add the Advanced List options and give them some of the available options.
+Let's add the List Styles options and give them some of the available options.
 
 [source,js]
 ----

--- a/modules/ROOT/partials/index-pages/opensource-plugins.adoc
+++ b/modules/ROOT/partials/index-pages/opensource-plugins.adoc
@@ -11,12 +11,6 @@ Create expandable and collapsible sections.
 
 a|
 [.lead]
-xref:advlist.adoc[Advanced List]
-
-Create styled number and bulleted lists.
-
-a|
-[.lead]
 xref:anchor.adoc[Anchor]
 
 Insert anchors (sometimes referred to as a bookmarks).
@@ -110,6 +104,12 @@ a|
 xref:lists.adoc[Lists]
 
 Normalize list behavior between browsers.
+
+a|
+[.lead]
+xref:advlist.adoc[List Styles]
+
+Create styled number and bulleted lists.
 
 a|
 [.lead]

--- a/modules/ROOT/partials/module-loading/bundling-plugin-files.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-plugin-files.adoc
@@ -24,7 +24,7 @@ include::partial$module-loading/bundling-plugins-that-cant-bundle.adoc[]
 ** xref:autocorrect[Spelling Autocorrect]
 ** xref:table-of-contents[Table of Contents (tableofcontents)]
 * xref:community-plugins[Community plugins]
-** xref:advanced-list[Advanced List (advlist)]
+** xref:advanced-list[List Styles (advlist)]
 ** xref:anchor[Anchor (anchor)]
 ** xref:autolink[Autolink (autolink)]
 ** xref:autoresize[Autoresize (autoresize)]
@@ -181,8 +181,8 @@ include::partial$plugin-files/plugin-file-list-tableofcontents.adoc[]
 [[community-plugins]]
 == Community plugins
 
-[[advanced-list]]
-=== Advanced List (`+advlist+`)
+[[list-styles]]
+=== List Styles (`+advlist+`)
 
 include::partial$plugin-files/plugin-file-list-advlist.adoc[]
 


### PR DESCRIPTION
Ticket: DOC-2300

Site: [DOC-2300_DOC-2305 site](http://docs-feature-70-doc-2300doc-2305.staging.tiny.cloud/docs/tinymce/latest/advlist/)

Changes:
* Rename Advanced Lists plugin to List Styles for TinyMCE 7.0.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [x] Files has been included where required `(if applicable)`
- [x] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed