### PR TITLE
DOC-2300: Replace `Skins & Icons Packs` with `Enhanced Skins & Icon Packs` in 7x docs.

### DIFF
--- a/-new-material-templates/release-notes-template/ROOT/nav.adoc
+++ b/-new-material-templates/release-notes-template/ROOT/nav.adoc
@@ -10,7 +10,7 @@
 **** xref:<x.y[.z]>-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]
 **** xref:<x.y[.z]>-release-notes.adoc#accompanying-premium-plugin-end-of-life-announcement[Accompanying Premium Plugin end-of-life announcement]
 **** xref:<x.y[.z]>-release-notes.adoc#accompanying-open-source-plugin-end-of-life-announcement[Accompanying Open Source Plugin end-of-life announcement]
-**** xref:<x.y[.z]>-release-notes.adoc#accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]
+**** xref:<x.y[.z]>-release-notes.adoc#accompanying-enhanced-skins-and-icon-packs-changes[Accompanying Enhanced Skins & Icon Packs changes]
 **** xref:<x.y[.z]>-release-notes.adoc#improvements[Improvements]
 **** xref:<x.y[.z]>-release-notes.adoc#additions[Additions]
 **** xref:<x.y[.z]>-release-notes.adoc#changes[Changes]

--- a/-new-material-templates/release-notes-template/ROOT/pages/<x.y[.z]>-release-notes.adoc
+++ b/-new-material-templates/release-notes-template/ROOT/pages/<x.y[.z]>-release-notes.adoc
@@ -18,7 +18,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 * xref:accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
 * xref:accompanying-premium-plugin-end-of-life-announcement[Accompanying Premium plugin end-of-life announcement]
 * xref:accompanying-open-source-plugin-end-of-life-announcement[Accompanying open source plugin end-of-life-announcement]
-* xref:accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]
+* xref:accompanying-enhanced-skins-and-icon-packs-changes[Accompanying Enhanced Skins & Icon Packs changes]
 * xref:improvements[Improvements]
 * xref:additions[Additions]
 * xref:changes[Changes]
@@ -80,18 +80,18 @@ The following Premium plugin has been announced as reaching its end-of-life:
 {productname}’s xref:<plugincode>.adoc[<Premium plugin name eol>] plugin will be deactivated on <month> <DD>, <YYYY>, and is no longer available for purchase.
 
 
-[[accompanying-premium-skins-and-icon-packs-changes]]
-== Accompanying Premium Skins and Icon Packs changes
+[[accompanying-enhanced-skins-and-icon-packs-changes]]
+== Accompanying Enhanced Skins & Icon Packs changes
 
-The {productname} <x.y[.z]> release includes an accompanying release of the **Premium Skins and Icon Packs**.
+The {productname} <x.y[.z]> release includes an accompanying release of the **Enhanced Skins & Icon Packs**.
 
-=== Premium Skins and Icon Packs
+=== Enhanced Skins & Icon Packs
 
-The **Premium Skins and Icon Packs** release includes the following updates:
+The **Enhanced Skins & Icon Packs** release includes the following updates:
 
-The **Premium Skins and Icon Packs** were rebuilt to pull in the changes also incorporated into the default {productname} <x.y[.z]> skin, Oxide.
+The **Enhanced Skins & Icon Packs** were rebuilt to pull in the changes also incorporated into the default {productname} <x.y[.z]> skin, Oxide.
 
-For information on using premium skins and icon packs, see: xref:premium-skins-and-icons.adoc[Premium Skins and Icon Packs].
+For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-and-icon-packs.adoc[Enhanced Skins & Icon Packs].
 
 
 [[improvements]]

--- a/-new-material-templates/release-notes-template/antora.yml
+++ b/-new-material-templates/release-notes-template/antora.yml
@@ -36,7 +36,7 @@ asciidoc:
     supportname: Tiny Support
     betaprogram: Tiny Insights Program
     #### some plugin names
-    prem_skins_icons: Tiny Skins and Icon Packs
+    prem_skins_icons: Enhanced Skins & Icon Packs
     #### Plan names
     tieroneplan: Tiny Cloud Core Plan
     tiertwoplan: Tiny Cloud Essential Plan

--- a/antora.yml
+++ b/antora.yml
@@ -33,7 +33,7 @@ asciidoc:
     supportname: Tiny Support
     betaprogram: Tiny Insights Program
     #### some plugin names
-    prem_skins_icons: Tiny Skins and Icon Packs
+    prem_skins_icons: Enhanced Skins & Icon Packs
     #### Plan names
     tieroneplan: Tiny Cloud Core Plan
     tiertwoplan: Tiny Cloud Essential Plan

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -254,7 +254,7 @@
 ** Editor appearance
 *** xref:editor-skin.adoc[Skins]
 *** xref:editor-icons.adoc[Icons]
-*** xref:premium-skins-and-icons.adoc[Tiny Skins and Icon Packs]
+*** xref:enhanced-skins-and-icon-packs.adoc[Enhanced Skins & Icon Packs]
 *** xref:editor-theme.adoc[Themes]
 ** Menus
 *** xref:menus-configuration-options.adoc[Options]
@@ -400,7 +400,7 @@
 **** xref:7.0-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
 **** xref:7.0-release-notes.adoc#accompanying-premium-plugin-end-of-life-announcement[Accompanying Premium plugin end-of-life announcement]
 **** xref:7.0-release-notes.adoc#accompanying-open-source-plugin-end-of-life-announcement[Accompanying open source plugin end-of-life-announcement]
-**** xref:7.0-release-notes.adoc#accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]
+**** xref:7.0-release-notes.adoc#accompanying-enhanced-skins-and-icon-packs-changes[Accompanying Enhanced Skins & Icon Packs changes]
 **** xref:7.0-release-notes.adoc#improvements[Improvements]
 **** xref:7.0-release-notes.adoc#additions[Additions]
 **** xref:7.0-release-notes.adoc#changes[Changes]

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -18,7 +18,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 * xref:accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
 * xref:accompanying-premium-plugin-end-of-life-announcement[Accompanying Premium plugin end-of-life announcement]
 * xref:accompanying-open-source-plugin-end-of-life-announcement[Accompanying open source plugin end-of-life-announcement]
-* xref:accompanying-premium-skins-and-icon-packs-changes[Accompanying Premium Skins and Icon Packs changes]
+* xref:accompanying-enhanced-skins-and-icon-packs-changes[Accompanying Enhanced Skins & Icon Packs changes]
 * xref:improvements[Improvements]
 * xref:additions[Additions]
 * xref:changes[Changes]
@@ -80,18 +80,18 @@ The following Premium plugin has been announced as reaching its end-of-life:
 {productname}’s xref:<plugincode>.adoc[<Premium plugin name eol>] plugin will be deactivated on <month> <DD>, <YYYY>, and is no longer available for purchase.
 
 
-[[accompanying-premium-skins-and-icon-packs-changes]]
-== Accompanying Premium Skins and Icon Packs changes
+[[accompanying-enhanced-skins-and-icon-packs-changes]]
+== Accompanying Enhanced Skins & Icon Packs changes
 
-The {productname} <x.y[.z]> release includes an accompanying release of the **Premium Skins and Icon Packs**.
+The {productname} <x.y[.z]> release includes an accompanying release of the **Enhanced Skins & Icon Packs**.
 
-=== Premium Skins and Icon Packs
+=== Enhanced Skins & Icon Packs
 
-The **Premium Skins and Icon Packs** release includes the following updates:
+The **Enhanced Skins & Icon Packs** release includes the following updates:
 
-The **Premium Skins and Icon Packs** were rebuilt to pull in the changes also incorporated into the default {productname} <x.y[.z]> skin, Oxide.
+The **Enhanced Skins & Icon Packs** were rebuilt to pull in the changes also incorporated into the default {productname} <x.y[.z]> skin, Oxide.
 
-For information on using premium skins and icon packs, see: xref:premium-skins-and-icons.adoc[Premium Skins and Icon Packs].
+For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-and-icon-packs.adoc[Enhanced Skins & Icon Packs].
 
 
 [[improvements]]

--- a/modules/ROOT/pages/creating-an-icon-pack.adoc
+++ b/modules/ROOT/pages/creating-an-icon-pack.adoc
@@ -20,7 +20,7 @@ A {productname} icon pack is a `+.js+` file containing strings of https://develo
 
 An icon pack only requires the custom icons to be included; the default {productname} icons are used as a fallback for icons missing from the custom icon pack.
 
-NOTE: Don't forget to explore our ready-to-use Premium Icon Packs such as 'Material' icons, and a smaller version of our default icons at xref:premium-skins-and-icons.adoc[{prem_skins_icons}].
+NOTE: Don't forget to explore our ready-to-use Premium Icon Packs such as 'Material' icons, and a smaller version of our default icons at xref:enhanced-skins-and-icon-packs.adoc[{prem_skins_icons}].
 
 == Creating a TinyMCE icon pack
 

--- a/modules/ROOT/pages/enhanced-skins-and-icon-packs.adoc
+++ b/modules/ROOT/pages/enhanced-skins-and-icon-packs.adoc
@@ -1,13 +1,13 @@
-= Tiny Skins and Icon Packs
-:navtitle: Tiny Skins and Icon Packs
+= Enhanced Skins & Icon Packs
+:navtitle: Enhanced Skins & Icon Packs
 :description: Quickly give TinyMCE a new look.
 :keywords: skin, skins, icon, icons, material, bootstrap, customize, theme
 
 The {prem_skins_icons} lets you quickly give {productname} a new look. Just choose one of our pre-made skins and icon packs.
 
-== How to use a premium skin
+== How to use a Enhanced skins
 
-NOTE: premium skins are only available with a link:{pricingpage}/[paid TinyMCE subscriptions].
+NOTE: Enhanced skins are only available with a link:{pricingpage}/[paid TinyMCE subscriptions].
 
 Use the xref:editor-skin.adoc#skin[skin] option, in combination with the xref:add-css-options.adoc#content_css[content_css] option and the values listed below.
 
@@ -32,7 +32,7 @@ Available values for xref:add-css-options.adoc#content_css[content_css]:
 * fabric
 * fluent
 
-=== Example: using a premium skin
+=== Example: using a Enhanced skin
 
 [source,js]
 ----

--- a/modules/ROOT/partials/integrations/webcomponent-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/webcomponent-tech-ref.adoc
@@ -403,7 +403,7 @@ To apply a custom skin to the editor, use the `+skin+` attribute. For example:
 For information on:
 
 * Using the `+skin+` option, see: xref:editor-skin.adoc#skin[User interface options - `+skin+`].
-* {companyname} premium skins, see: xref:premium-skins-and-icons.adoc[Tiny Skins and Icon Packs].
+* {companyname} enhanced skins, see: xref:enhanced-skins-and-icon-packs.adoc[Enhanced Skins & Icon Packs].
 * Creating a custom skin for {productname}, see: xref:creating-a-skin.adoc[Create a skin for {productname}].
 
 [[setting-the-images-upload-url]]
@@ -491,7 +491,7 @@ Use this attribute if the icon pack is bundled with {productname} (including cus
 For information on:
 
 * Using the `+icons+` option, see: xref:editor-icons.adoc#icons[User interface options - `+icons+`].
-* {companyname} premium icon packs, see: xref:premium-skins-and-icons.adoc[Tiny Skins and Icon Packs].
+* {companyname} premium icon packs, see: xref:enhanced-skins-and-icon-packs.adoc[Enhanced Skins & Icon Packs].
 * Creating a custom icon pack for {productname}, see: xref:creating-an-icon-pack.adoc[Create an icon pack for {productname}].
 
 [[setting-the-icon-pack-url]]
@@ -509,7 +509,7 @@ Use this attribute if the icon pack is hosted on a web site. If the icon pack is
 For information on:
 
 * Using the `+icons_url+` option, see: xref:editor-icons.adoc#icons_url[User interface options - `+icons_url+`].
-* {companyname} premium icon packs, see: xref:premium-skins-and-icons.adoc[Tiny Skins and Icon Packs].
+* {companyname} premium icon packs, see: xref:enhanced-skins-and-icon-packs.adoc[Enhanced Skins & Icon Packs].
 * Creating a custom icon pack for {productname}, see: xref:creating-an-icon-pack.adoc[Create an icon pack for {productname}].
 
 [[setting-additional-configuration-options]]

--- a/modules/ROOT/partials/misc/plugin-support-table.adoc
+++ b/modules/ROOT/partials/misc/plugin-support-table.adoc
@@ -4,4 +4,4 @@
 The following list of premium plugins are supported by {companynameformal} for {productname} {productminorversion}:
 
 include::partial$misc/premium-plugin-list.adoc[]
-* xref:premium-skins-and-icons.adoc[{prem_skins_icons}]
+* xref:enhanced-skins-and-icon-packs.adoc[{prem_skins_icons}]

--- a/modules/ROOT/partials/misc/shipped-content-css.adoc
+++ b/modules/ROOT/partials/misc/shipped-content-css.adoc
@@ -21,6 +21,6 @@ tinymce.init({
 
 These content CSS files can also be used as a template for creating a custom content CSS file for the editor. For the CSS files, see: https://github.com/tinymce/tinymce-dist/tree/master/skins/content[{prodnamecode}-dist GitHub Repository - Content CSS files].
 
-{companyname} also provides content CSS files with the premium skins, for a list of premium content CSS files, see: xref:premium-skins-and-icons.adoc[{prem_skins_icons}].
+{companyname} also provides content CSS files with the enhanced skins, for a list of premium content CSS files, see: xref:enhanced-skins-and-icon-packs.adoc[{prem_skins_icons}].
 
 {companyname} recommends using the same CSS for both the editor and the page where the editor content will be rendered.

--- a/modules/ROOT/partials/module-loading/bundling-content-css-files.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-content-css-files.adoc
@@ -22,7 +22,7 @@ Writer::
 
 == Premium
 
-For information on premium content CSS, see: xref:premium-skins-and-icons.adoc[{prem_skins_icons}].
+For information on premium content CSS, see: xref:enhanced-skins-and-icon-packs.adoc[{prem_skins_icons}].
 
 Fabric::
 ....

--- a/modules/ROOT/partials/module-loading/bundling-icon-files.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-icon-files.adoc
@@ -7,7 +7,7 @@ Default icons::
 
 == Premium
 
-For information on premium icon packs, see: xref:premium-skins-and-icons.adoc[{prem_skins_icons}].
+For information on premium icon packs, see: xref:enhanced-skins-and-icon-packs.adoc[{prem_skins_icons}].
 
 Bootstrap icons::
 ....

--- a/modules/ROOT/partials/module-loading/bundling-next-steps.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-next-steps.adoc
@@ -5,7 +5,7 @@ For information on:
 * Adding {productname} plugins to the bundle, see: xref:bundling-plugins.adoc[Bundling {productname} plugins using module loading].
 * Using editor content CSS provided by {companyname}, including premium CSS included with the {prem_skins_icons}, see: xref:bundling-content-css.adoc[Bundling {productname} content CSS using module loading].
 * Creating custom editor content CSS, see: xref:add-css-options.adoc#content_css[Content appearance options - `+content_css+`].
-* Using {productname} skins provided by {companyname}, including premium skins included with the {prem_skins_icons}, see: xref:bundling-skins.adoc[Bundling {productname} skins using module loading].
+* Using {productname} skins provided by {companyname}, including enhanced skins included with the {prem_skins_icons}, see: xref:bundling-skins.adoc[Bundling {productname} skins using module loading].
 * Creating a custom skin for {productname}, see: xref:creating-a-skin.adoc[Create a skin for {productname}].
 * Using icon packs provided by {companyname}, including premium icons packs included with the {prem_skins_icons}, see: xref:bundling-icons.adoc[Bundling {productname} icon packs using module loading].
 * Creating a custom icon pack for {productname}, see: xref:creating-an-icon-pack.adoc[Create an icon pack for {productname}].

--- a/modules/ROOT/partials/module-loading/bundling-skin-files.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-skin-files.adoc
@@ -32,9 +32,9 @@ Dark skin (oxide-dark)::
 ./skins/ui/tinymce-5-dark/skin.shadowdom.css
 ....
 
-== Premium Skins
+== Enhanced Skins
 
-For information on premium editor skins, see: xref:premium-skins-and-icons.adoc[{prem_skins_icons}].
+For information on Enhanced editor skins, see: xref:enhanced-skins-and-icon-packs.adoc[{prem_skins_icons}].
 
 Bootstrap skin::
 ....


### PR DESCRIPTION
Ticket: DOC-2300

Site: [DOC-2300_2311 site](http://docs-feature-70-doc-2300doc-2311.staging.tiny.cloud/docs/tinymce/latest/enhanced-skins-and-icon-packs/)

Changes:
* Replace `Skins & Icons Packs` with `Enhanced Skins & Icon Packs` in 7x docs.
* Update some ref to `Tiny Skins & Icons Packs` and removal of `Premium`/ replace with `Enhanced`.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [x] Files has been included where required `(if applicable)`
- [x] Files removed have been deleted, not just excluded from the build `(if applicable)`

Review:
- [x] Documentation Team Lead has reviewed