### PR TITLE
DOC-2303: add sandbox_iframes breaking changes to 7.0 release notes.

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -244,6 +244,17 @@ In {productname} 7.0, the default value for `+convert_unsafe_embeds+` will chang
 For further details on the `+convert_unsafe_embeds+` option, see the xref:content-filtering.adoc#convert-unsafe-embeds[content filtering options], or refer to the xref:security.adoc#convert-unsafe-embeds[security guide], or the link:https://www.tiny.cloud/docs/tinymce/6/6.8.1-release-notes/#new-convert_unsafe_embeds-option-that-controls-whether-object-and-embed-elements-will-be-converted-to-more-restrictive-alternatives-namely-img-for-image-mime-types-video-for-video-mime-types-audio-audio-mime-types-or-iframe-for-other-or-unspecified-mime-types[{productname} 6.8.1 release notes].
 
 
+=== `sandbox_iframes` editor option is now defaulted to `true`.
+
+In {productname} 6.8.1, the xref:content-filtering.adoc#sandbox-iframes[sandbox iframes] editor option was introduced to allow iframes to be sandboxed by default when inserted into the editor.
+
+In {productname} 7.0, the default for `+sandbox_iframes+` will change from `false` to `true`, meaning that all `+iframe+` elements inserted into the editor will be given the `sandbox=""` attribute by default, preventing most actions, including scripting and same-origin access, which may break existing editor content or produce undesirable effects.
+
+To prevent any expected iframes from being sandboxed, we recommend adding the source domains of such iframes to the new xref:content-filtering.adoc#sandbox-iframes-exclusions[`+sandbox_iframes_exclusions+`] option list, and including the domains in the default list where necessary. To prevent all iframes from being sandboxed, set the option `+sandbox_iframes+` to `+false+` in your editor configuration.
+
+For further details on the `+sandbox_iframes+` option, see the xref:content-filtering.adoc#sandbox-iframes[the content filtering options], or refer to the xref:security.adoc#sandbox-iframes[security guide], or the link:https://www.tiny.cloud/docs/tinymce/6/6.8.1-release-notes/#new-sandbox_iframes-option-that-controls-whether-iframe-elements-will-be-added-a-sandbox-attribute-to-mitigate-malicious-intent[{productname} 6.8.1 release notes].
+
+
 [[bug-fixes]]
 == Bug fixes
 

--- a/modules/ROOT/partials/configuration/sandbox_iframes.adoc
+++ b/modules/ROOT/partials/configuration/sandbox_iframes.adoc
@@ -7,7 +7,7 @@ This option controls whether the editor will add a `sandbox=""` attribute to all
 
 *Possible values:* `true`, `false`
 
-*Default value:* `false`
+*Default value:* `true`
 
 === Example: using `sandbox_iframes` option
 
@@ -15,6 +15,6 @@ This option controls whether the editor will add a `sandbox=""` attribute to all
 ----
 tinymce.init({
   selector: 'textarea',  // change this value according to your html
-  sandbox_iframes: true
+  sandbox_iframes: false
 });
 ----


### PR DESCRIPTION
Ticket: DOC-2303

Site: [DOC-2303 site](http://docs-feature-70-doc-2303.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#sandbox_iframes-editor-option-is-now-defaulted-to-true)

Changes:
* add sandbox_iframes breaking changes to 7.0 release notes.
* update default `value` based on change made in 7.0
* added changes/improvements made by @MitchC1999

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [x] Files has been included where required `(if applicable)`
- [x] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed