### PR TITLE
DOC-2318: Fix `skip_focus` check to the `ToggleToolbarDrawer` command from 6.4.1 release notes.

### DIFF
--- a/modules/ROOT/examples/live-demos/comments-callback/index.js
+++ b/modules/ROOT/examples/live-demos/comments-callback/index.js
@@ -649,7 +649,7 @@ tinymce.ScriptLoader.loadScripts(
     setup: (editor) => {
       editor.on('SkinLoaded', () => {
         editor.execCommand('ToggleSidebar', false, 'showcomments', {
-          skip_focus: true,
+          skipFocus: true,
         });
       });
     },

--- a/modules/ROOT/examples/live-demos/comments-embedded/index.js
+++ b/modules/ROOT/examples/live-demos/comments-embedded/index.js
@@ -25,7 +25,7 @@ tinymce.init({
   /* The following setup callback opens the comments sidebar when the editor loads */
   setup: (editor) => {
     editor.on('SkinLoaded', () => {
-      editor.execCommand('ToggleSidebar', false, 'showcomments', { skip_focus: true });
+      editor.execCommand('ToggleSidebar', false, 'showcomments', { skipFocus: true });
     });
   }
 });

--- a/modules/ROOT/examples/live-demos/comments-embedded/index.js
+++ b/modules/ROOT/examples/live-demos/comments-embedded/index.js
@@ -25,7 +25,7 @@ tinymce.init({
   /* The following setup callback opens the comments sidebar when the editor loads */
   setup: (editor) => {
     editor.on('SkinLoaded', () => {
-      editor.execCommand('ToggleSidebar', false, 'showcomments', { skipFocus: true });
+      editor.execCommand('ToggleSidebar', false, 'showcomments');
     });
   }
 });

--- a/modules/ROOT/pages/6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.1-release-notes.adoc
@@ -228,7 +228,7 @@ This update fixes this bug. When the Comments plugin loads, the comment model da
 
 If the Comments sidebar was opened with an editor command and `grabFocus` was set to true — `editor.execCommand("'tc-open-comment'", false, "showcomments", { grabFocus: true });` — the sidebar still stole focus.
 
-This update corrects this: `grabFocus: true` is honored, as expected, and the sidebar does not steal focus.
+This update corrects this: `grabFocus: true` is honored, as expected, and the sidebar does not have the focus.
 
 
 ==== Comments did not block the sidebar UI while saving the data in callback mode

--- a/modules/ROOT/pages/6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.1-release-notes.adoc
@@ -226,7 +226,7 @@ This update fixes this bug. When the Comments plugin loads, the comment model da
 
 ==== Opening the comments sidebar via an editor command did not respect the `skipFocus` argument
 
-If the Comments sidebar was opened with an editor command and `skipFocus` was set to true — `editor.execCommand("ToggleSidebar", false, "showcomments", { skipFocus: true });` — the sidebar still stole focus.
+If the Comments sidebar was opened with an editor command and `grabFocus` was set to true — `editor.execCommand("'tc-open-comment'", false, "showcomments", { grabFocus: true });` — the sidebar still stole focus.
 
 This update corrects this: `skipFocus: true` is honored, as expected, and the sidebar does not steal focus.
 

--- a/modules/ROOT/pages/6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.1-release-notes.adoc
@@ -224,7 +224,7 @@ This caused {productname} to present as if an undo option was available when the
 This update fixes this bug. When the Comments plugin loads, the comment model data is no longer placed into an undo level and no Undo actions will present as available until there are actual changes available to undo.
 
 
-==== Opening the comments sidebar via an editor command did not respect the `skipFocus` argument
+==== Opening the comments sidebar via an editor command did not respect the `grabFocus` argument
 
 If the Comments sidebar was opened with an editor command and `grabFocus` was set to true — `editor.execCommand("'tc-open-comment'", false, "showcomments", { grabFocus: true });` — the sidebar still stole focus.
 

--- a/modules/ROOT/pages/6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.1-release-notes.adoc
@@ -224,11 +224,11 @@ This caused {productname} to present as if an undo option was available when the
 This update fixes this bug. When the Comments plugin loads, the comment model data is no longer placed into an undo level and no Undo actions will present as available until there are actual changes available to undo.
 
 
-==== Opening the comments sidebar via an editor command did not respect the `skip_focus` argument
+==== Opening the comments sidebar via an editor command did not respect the `skipFocus` argument
 
-If the Comments sidebar was opened with an editor command and `skip_focus` was set to true — `editor.execCommand("ToggleSidebar", false, "showcomments", { skip_focus: true });` — the sidebar still stole focus.
+If the Comments sidebar was opened with an editor command and `skipFocus` was set to true — `editor.execCommand("ToggleSidebar", false, "showcomments", { skipFocus: true });` — the sidebar still stole focus.
 
-This update corrects this: `skip_focus: true` is honored, as expected, and the sidebar does not steal focus.
+This update corrects this: `skipFocus: true` is honored, as expected, and the sidebar does not steal focus.
 
 
 ==== Comments did not block the sidebar UI while saving the data in callback mode

--- a/modules/ROOT/pages/6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.1-release-notes.adoc
@@ -226,7 +226,7 @@ This update fixes this bug. When the Comments plugin loads, the comment model da
 
 ==== Opening the comments sidebar via an editor command did not respect the `grabFocus` argument
 
-If the Comments sidebar was opened with an editor command and `grabFocus` was set to true — `editor.execCommand("'tc-open-comment'", false, "showcomments", { grabFocus: true });` — the sidebar still stole focus.
+If the Comments sidebar was opened with an editor command and `grabFocus` was set to true — `editor.execCommand("tc-open-comment", false, "showcomments", { grabFocus: true });` — the sidebar still stole focus.
 
 This update corrects this: `grabFocus: true` is honored, as expected, and the sidebar does not have the focus.
 

--- a/modules/ROOT/pages/6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.1-release-notes.adoc
@@ -228,7 +228,7 @@ This update fixes this bug. When the Comments plugin loads, the comment model da
 
 If the Comments sidebar was opened with an editor command and `grabFocus` was set to true — `editor.execCommand("'tc-open-comment'", false, "showcomments", { grabFocus: true });` — the sidebar still stole focus.
 
-This update corrects this: `skipFocus: true` is honored, as expected, and the sidebar does not steal focus.
+This update corrects this: `grabFocus: true` is honored, as expected, and the sidebar does not steal focus.
 
 
 ==== Comments did not block the sidebar UI while saving the data in callback mode

--- a/modules/ROOT/pages/6.4.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.1-release-notes.adoc
@@ -395,6 +395,8 @@ In {productname} 6.4.1, an improvement was made to the focusing code which now c
 
 As a result of the fix, when using the *ToggleToolbarDrawer* command, the toolbar is now not focused when `skipFocus: true` is set.
 
+NOTE: As of {productname} 6.8.3, when using `+skipFocus: true+`, the *ToggleToolbarDrawer* command does not toggle the toolbar drawer when the `+toolbar_mode+` option is set to `+'sliding'+`.
+
 === New font_size_input_default_unit option allows to use of numbers without a unit in `fontsizeinput` and have them parsed with the default unit, if it is not defined the default is `pt`
 //#TINY-9585
 

--- a/modules/ROOT/pages/6.4.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.1-release-notes.adoc
@@ -386,6 +386,15 @@ tinymce.init({
 [NOTE]
 More details about this component and the possible values that can be used within the new `fontsizeinput` input field can be found in `xref:available-toolbar-buttons.adoc#the-core-toolbar-buttons[fontsizeinput]`.
 
+=== Added `skipFocus` check to the ToggleToolbarDrawer command
+//#TINY-9337
+
+In previous versions of {productname}, the *ToggleToolbarDrawer* command contained an incorrect focus call. As a consequence, this meant that when the *ToggleToolbarDrawer* command option `skipFocus: true` was set the toolbar drawer would take focus when it was not meant to.
+
+In {productname} 6.4.1, an improvement was made to the focusing code which now checks for `skipFocus`.
+
+As a result of the fix, when using the *ToggleToolbarDrawer* command, the toolbar is now not focused when `skipFocus: true` is set.
+
 === New font_size_input_default_unit option allows to use of numbers without a unit in `fontsizeinput` and have them parsed with the default unit, if it is not defined the default is `pt`
 //#TINY-9585
 

--- a/modules/ROOT/pages/6.4.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.1-release-notes.adoc
@@ -386,15 +386,6 @@ tinymce.init({
 [NOTE]
 More details about this component and the possible values that can be used within the new `fontsizeinput` input field can be found in `xref:available-toolbar-buttons.adoc#the-core-toolbar-buttons[fontsizeinput]`.
 
-=== Added `skip_focus` check to the ToggleToolbarDrawer command
-//#TINY-9337
-
-In previous versions of {productname}, the *ToggleToolbarDrawer* command contained an incorrect focus call. As a consequence, this meant that when the *ToggleToolbarDrawer* command option `skip_focus: true` was set the toolbar drawer would take focus when it was not meant to.
-
-In {productname} 6.4.1, an improvement was made to the focusing code which now checks for `skip_focus`.
-
-As a result of the fix, when using the *ToggleToolbarDrawer* command, the toolbar now avoids stealing focus when `skip_focus: true` is set.
-
 === New font_size_input_default_unit option allows to use of numbers without a unit in `fontsizeinput` and have them parsed with the default unit, if it is not defined the default is `pt`
 //#TINY-9585
 

--- a/modules/ROOT/pages/6.4.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.1-release-notes.adoc
@@ -389,7 +389,7 @@ More details about this component and the possible values that can be used withi
 === Added `skipFocus` check to the ToggleToolbarDrawer command
 //#TINY-9337
 
-In previous versions of {productname}, the *ToggleToolbarDrawer* command contained an incorrect focus call. As a consequence, this meant that when the *ToggleToolbarDrawer* command option `skipFocus: true` was set the toolbar drawer would take focus when it was not meant to.
+In previous versions of {productname}, the *ToggleToolbarDrawer* command contained an incorrect focus call. As a consequence, when the *ToggleToolbarDrawer* command option `skipFocus: true` was set, the toolbar drawer would take focus when it was not meant to.
 
 In {productname} 6.4.1, an improvement was made to the focusing code which now checks for `skipFocus`.
 

--- a/modules/ROOT/pages/6.4.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.4.1-release-notes.adoc
@@ -395,8 +395,6 @@ In {productname} 6.4.1, an improvement was made to the focusing code which now c
 
 As a result of the fix, when using the *ToggleToolbarDrawer* command, the toolbar is now not focused when `skipFocus: true` is set.
 
-NOTE: As of {productname} 6.8.3, when using `+skipFocus: true+`, the *ToggleToolbarDrawer* command does not toggle the toolbar drawer when the `+toolbar_mode+` option is set to `+'sliding'+`.
-
 === New font_size_input_default_unit option allows to use of numbers without a unit in `fontsizeinput` and have them parsed with the default unit, if it is not defined the default is `pt`
 //#TINY-9585
 
@@ -1113,3 +1111,9 @@ After conducting a thorough investigation into the new **Advanced Template** plu
 We have identified that the "Insert link" dialog is an example of a dialog that does **not work** correctly in this regard, while the "Insert image" dialog functions as expected. These issues were discovered while examining mobile performance within the new **Advanced Template** plugin, and we are working to address them in order to provide a smoother and more user-friendly experience.
 
 Unfortunately, at this time there is no known workaround for the issue with dialogs.
+
+=== The *ToggleToolbarDrawer* command does not toggle the toolbar drawer in some situations
+
+It has been identified that as of {productname} 6.8.3, when using `+skipFocus: true+`, the *ToggleToolbarDrawer* command does not toggle the toolbar drawer when the `+toolbar_mode+` option is set to `+'sliding'+`.
+
+Unfortunately, at this time there is no known workaround for the issue.

--- a/modules/ROOT/pages/6.5.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.5.1-release-notes.adoc
@@ -172,7 +172,7 @@ In previous versions of {productname}, the default behavior of `editor.execComma
 
 As a consequence, when pressing the fullscreen button the editor used `editor.execCommand('mceFullScreen')`, which caused the insertion point to be positioned incorrectly on iOS.
 
-To resolve this issue, {productname} 6.5.1, includes `skip_focus: true` as a parameter for the `mceFullScreen` command. Consequently, the Full Screen button no longer attempts to focus back on the editor.
+To resolve this issue, {productname} 6.5.1, includes `skipFocus: true` as a parameter for the `mceFullScreen` command. Consequently, the Full Screen button no longer attempts to focus back on the editor.
 
 ==== Advanced Code Editor did not preserve changes to _font size_ or _dark/light mode_ state.
 //#TINY-9749

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -313,7 +313,7 @@ NOTE: This is the {productname} Community version changelog. For information abo
 * New `setText` and `setIcon` methods added to menu button and toolbar button APIs.
 * New `highlight_on_focus` option which enables highlighting the content area on focus.
 * New `fontsizeinput` toolbar item which allows the user to set the size via input and also increase and decrease it with `+` and `-` buttons.
-* Added `skip_focus` check to the ToggleToolbarDrawer command.
+* Added `skipFocus` check to the ToggleToolbarDrawer command.
 * New `font_size_input_default_unit` option allows to use of numbers without a unit in `fontsizeinput` and have them parsed with the default unit, if it is not defined the default is `pt`.
 * New `group` and `togglebutton` in view.
 * New `togglebutton` in dialog footer buttons.


### PR DESCRIPTION
Ticket: DOC-2318

Site: [DOC-2318 site](http://docs-hotfix-641-doc-2318.staging.tiny.cloud/docs/tinymce/6/6.4.1-release-notes/#overview)

Changes:
* ~Remove `skip_focus` check to the `ToggleToolbarDrawer` command from 6.4.1 release notes.~
- [x] Update PR with the below:
* the `skipFocus` argument was incorrectly documented. One [review comment](https://github.com/tinymce/tinymce-docs/pull/2655#discussion_r1162183137) accidentally changed the argument from `skipFocus` to `skip_focus`.
* Update the release notes entry rather than removing it, as the argument still works correctly.
* Update the wording to use "the toolbar is now not focused" instead of "the toolbar now avoids stealing focus" to avoid confusion about retaining focus, since focus outside the editor is lost when the command is run.

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`

Review:
- [x] Documentation Team Lead has reviewed