### PR TITLE
DOC-2270: add improvement documentation for TINY-10658 to the release notes for 7.0

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -217,6 +217,15 @@ For more information about `highlight_on_focus` see the xref:accessibility.adoc#
 [NOTE]
 Any editors using this `highlight_on_focus: true` option, can remove this option from their {productname} init configuration when upgrading to {productname} 7.0.
 
+=== Make table ghost element better reflect height changes when resizing.
+//# TINY-10658
+
+Previously, the height styles applied to the `tr` and `td` elements within the table did not accurately reflect changes in table height when resized using the corner resize handles.
+
+In {productname} 7.0, this problem has been addressed. Now, the height styles have been eliminated from the last row of the table ghost element, allowing it to adjust its height appropriately during resizing.
+
+As a result, the table ghost element now accurately mirrors adjustments in table height when resized using the corner resize handles.
+
 [[additions]]
 == Additions
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -220,9 +220,9 @@ Any editors using this `highlight_on_focus: true` option, can remove this option
 === Make table ghost element better reflect height changes when resizing.
 //# TINY-10658
 
-Previously, the height styles applied to the `tr` and `td` elements within the table did not accurately reflect changes in table height when resized using the corner resize handles.
+Previously, the table ghost element did not accurately reflect changes in table height when resized using the corner resize handles.
 
-In {productname} 7.0, this problem has been addressed. Now, the height styles have been eliminated from the last row of the table ghost element, allowing it to adjust its height appropriately during resizing.
+In {productname} 7.0, this problem has been addressed.
 
 As a result, the table ghost element now accurately mirrors adjustments in table height when resized using the corner resize handles.
 


### PR DESCRIPTION
Ticket: DOC-2270

Site: [DOC-2270_TINY site](http://docs-feature-70-doc-2270tiny-10658.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#make-table-ghost-element-better-reflect-height-changes-when-resizing)

Changes:
* add improvement documentation for TINY-10658 to the release notes for 7.0

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`

Review:
- [x] Documentation Team Lead has reviewed