### PR TITLE
DOC-2270: Removed `InsertOrderedList` and `InsertUnorderedList` commands from core.

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -404,6 +404,7 @@
 **** xref:7.0-release-notes.adoc#improvements[Improvements]
 **** xref:7.0-release-notes.adoc#additions[Additions]
 **** xref:7.0-release-notes.adoc#changes[Changes]
+**** xref:7.0-release-notes.adoc#removed[Removed]
 **** xref:7.0-release-notes.adoc#bug-fixes[Bug fixes]
 **** xref:7.0-release-notes.adoc#security-fixes[Security fixes]
 **** xref:7.0-release-notes.adoc#deprecated[Deprecated]

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -22,6 +22,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 * xref:improvements[Improvements]
 * xref:additions[Additions]
 * xref:changes[Changes]
+* xref:removed[Removed]
 * xref:bug-fixes[Bug fixes]
 * xref:security-fixes[Security fixes]
 * xref:deprecated[Deprecated]
@@ -262,6 +263,20 @@ To prevent any expected iframes from being sandboxed, we recommend adding the so
 
 For further details on the `+sandbox_iframes+` option, see the xref:content-filtering.adoc#sandbox-iframes[the content filtering options], or refer to the xref:security.adoc#sandbox-iframes[security guide], or the link:https://www.tiny.cloud/docs/tinymce/6/6.8.1-release-notes/#new-sandbox_iframes-option-that-controls-whether-iframe-elements-will-be-added-a-sandbox-attribute-to-mitigate-malicious-intent[{productname} 6.8.1 release notes].
 
+
+[[removed]]
+== Removed
+
+=== Removed InsertOrderedList and InsertUnorderedList commands from core.
+// #TINY-10644
+
+Previously, native list commands could be executed by various text patterns.
+
+This resulted in undefined browser behavior due to the inherent list code within it.
+
+{productname} 7.0 addresses this, by removing the core list commands, effectively eliminating the insertion of lists into the content.
+
+As a result, users no longer experience unexpected list insertions.
 
 [[bug-fixes]]
 == Bug fixes


### PR DESCRIPTION
Ticket: DOC-2270

Site: [DOC-2270_TINY-10644 site](http://docs-feature-70-doc-2270tiny-10644.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#removedinsertorderedlistandinsertunorderedlistcommands-from-core)

Changes:
* Removed `InsertOrderedList` and `InsertUnorderedList` commands from core.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`

Review:
- [x] Documentation Team Lead has reviewed