### PR TITLE
DOC-2270: Add `advtemplate` documentation for TINY-10615 to the TinyMCE 7.0 release notes

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -87,17 +87,17 @@ The {productname} <x.y[.z]> release includes an accompanying release of the **<P
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
-=== Advanced Templates 7.0
+=== Templates
 
-The {productname} 7.0 release includes an accompanying release of the **Advanced Templates** premium plugin.
+The {productname} 7.0 release includes an accompanying release of the **Templates** premium plugin.
 
-**Advanced Templates** 7.0 includes the following fixes, additions, and improvements.
+**Templates** includes the following fixes, additions, and improvements.
 
-==== Missing tooltip for category and template three dots menu button in the **Advanced Templates** dialog
+==== Missing tooltip for category and template three dots menu button in the **Templates** dialog
 
-Previously, the three dots menu button for category and template in the **Advanced Templates** dialog were missing a tooltip, making them inaccessible.
+Previously, the three dots menu button for category and template in the **Templates** dialog were missing a tooltip, making them inaccessible.
 
-In {productname} 7.0, the three dot menu buttons for categories and templates in the Advanced Templates dialog now have informative tooltips. This clarifies their purpose for all users, enhancing discoverability and improving the overall experience, especially for those relying on assistive technologies.
+In {productname} 7.0, the three dot menu buttons for categories and templates in the Templates dialog now have informative tooltips. This clarifies their purpose for all users, enhancing discoverability and improving the overall experience, especially for those relying on assistive technologies.
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -87,11 +87,11 @@ The {productname} <x.y[.z]> release includes an accompanying release of the **<P
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
-=== Advanced Templates
+=== Advanced Templates 7.0
 
 The {productname} 7.0 release includes an accompanying release of the **Advanced Templates** premium plugin.
 
-**Advanced Templates** 3.1.0 includes the following fixes, additions, and improvements.
+**Advanced Templates** 7.0 includes the following fixes, additions, and improvements.
 
 ==== Missing tooltip for category and template three dots menu button in the **Advanced Templates** dialog
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -87,6 +87,17 @@ The {productname} <x.y[.z]> release includes an accompanying release of the **<P
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Advanced Templates
+
+The {productname} 7.0 release includes an accompanying release of the **Advanced Templates** premium plugin.
+
+**Advanced Templates** 3.1.0 includes the following fixes, additions, and improvements.
+
+==== Missing tooltip for category and template three dots menu button in the **Advanced Templates** dialog
+
+Previously, the three dots menu button for category and template in the **Advanced Templates** dialog were missing a tooltip, making them inaccessible.
+
+In {productname} 7.0, the three dot menu buttons for categories and templates in the Advanced Templates dialog now have informative tooltips. This clarifies their purpose for all users, enhancing discoverability and improving the overall experience, especially for those relying on assistive technologies.
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -94,6 +94,7 @@ The {productname} 7.0 release includes an accompanying release of the **Template
 **Templates** includes the following fixes, additions, and improvements.
 
 ==== Missing tooltip for category and template three dots menu button in the **Templates** dialog
+//# TINY-10615
 
 Previously, the three dots menu button for category and template in the **Templates** dialog were missing a tooltip, making them inaccessible.
 


### PR DESCRIPTION
Ticket: DOC-2270

Site: [DOC-2270 site](http://docs-feature-70-doc-2270tiny-10615.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#advanced-templates)

Changes:
* Add tooltip release notes for `advtemplate`

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [x] Files has been included where required `(if applicable)`
- [x] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed