### PR TITLE
DOC-2270: Add improved documentation for TINY-10672 in TinyMCE 7.0 release notes

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -252,6 +252,13 @@ For more information about `highlight_on_focus` see the xref:accessibility.adoc#
 [NOTE]
 Any editors using this `highlight_on_focus: true` option, can remove this option from their {productname} init configuration when upgrading to {productname} 7.0.
 
+=== Optional Tooltip for Dialog Footer Toggle Buttons
+//#TINY-10672
+
+Previously, the `DialogFooterToggleButton` component required a tooltip property. This meant including a tooltip for all toggle buttons displayed in dialog footers, even if the information wasn't necessary.
+
+As of {productname} 7.0, the tooltip property is now optional for DialogFooterToggleButton. This flexibility allows developers to omit the tooltip for buttons where it's not required, providing a cleaner and more focused user experience.
+
 === Change table height resizing handling to remove heights from `td`/`th` elements and only apply to `tr` elements.
 //# TINY-10589
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -257,7 +257,7 @@ Any editors using this `highlight_on_focus: true` option, can remove this option
 
 Previously, the `DialogFooterToggleButton` component required a tooltip property. This meant including a tooltip for all toggle buttons displayed in dialog footers, even if the information wasn't necessary.
 
-As of {productname} 7.0, the tooltip property is now optional for DialogFooterToggleButton. This flexibility allows developers to omit the tooltip for buttons where it's not required, providing a cleaner and more focused user experience.
+As of {productname} 7.0, the tooltip property is now optional for `DialogFooterToggleButton`. This flexibility allows developers to omit the tooltip for buttons where it's not required, providing a cleaner and more focused user experience.
 
 === Change table height resizing handling to remove heights from `td`/`th` elements and only apply to `tr` elements.
 //# TINY-10589


### PR DESCRIPTION
Ticket: DOC-2270

Site: [DOC-2270 site](http://docs-feature-70-doc-2270.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* Add release notes for TINY-10672

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [x] Files has been included where required `(if applicable)`
- [x] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed