### PR TITLE
DOC-2238: TinyMCE 7 now GPL licensed, with updated documentation reflecting this change.

### DIFF
--- a/modules/ROOT/pages/invalid-api-key.adoc
+++ b/modules/ROOT/pages/invalid-api-key.adoc
@@ -1,3 +1,4 @@
+
 = Invalid API key
 :description_short: Fixing the invalid API key error | {productname}
 :description: Learn why you’re receiving an invalid {productname} API key error notification, and how to fix the issue.
@@ -30,7 +31,7 @@ We require an API key for all {productname} editors on our cloud platform in ord
 
 {productname} can be accessed through a variety of licensing and hosting methods, including both free and paid options. 
 
-The free, open source option for {productname} is available under an MIT license explained https://www.tiny.cloud/legal/tiny-self-hosted-oem-saas-agreement/[here]. Users must self-host {productname} to take advantage of the MIT license. **This type of license does not require an API key**.
+The free, open source option for {productname} is available under the _GNU General Public License Version 2 or later_. Users must self-host {productname} to take advantage of the open source license. **This type of license does not require an API key**.
 
 The cloud hosted option for {productname} is available under commercial license, as described https://www.tiny.cloud/legal/cloud-use-subscription-agreement/[here]. **This type of license requires an active API key.**
 
@@ -60,7 +61,7 @@ You can view the list of approved domains by logging into https://www.tiny.cloud
 
 == I would prefer to self-host {productname}. What are my options?
 
-* If you plan to use only open-source {productname} features, the open-source version is available under the MIT license.
+* If you plan to use only open-source {productname} features, the open-source version is available under the _GNU General Public License Version 2 or later license_.
 * If you want to self-host {productname} and use our Premium features, https://www.tiny.cloud/contact/[get in touch with our Sales team] for a custom quote.
 
 TIP: For additional information on Troubleshooting Tiny Cloud visit: xref:cloud-troubleshooting.adoc[Cloud Troubleshooting].

--- a/modules/ROOT/partials/configuration/branding.adoc
+++ b/modules/ROOT/partials/configuration/branding.adoc
@@ -3,9 +3,7 @@
 
 Use the `+branding+` option to disable the "*Powered by Tiny*" link displayed in the status bar for link:{legalpages}/attribution-requirements/[product attribution].
 
-IMPORTANT: Product attribution is required for free users utilizing the Tiny Cloud infrastructure.
-If using TinyMCE under the MIT license, then support for the open source project would be appreciated by keeping attribution turned on in your editor.
-For information on {productname} attribution requirements, see: link:{legalpages}/attribution-requirements/[Logo & attribution requirements].
+IMPORTANT: Product attribution is required for free users utilizing the Tiny Cloud infrastructure. If using {productname} under the _GNU General Public License Version 2 or later_ license, then support for the open source project would be appreciated by keeping attribution turned on in your editor. For information on {productname} attribution requirements, see: link:{legalpages}/attribution-requirements/[Logo & attribution requirements].
 
 *Type:* `+Boolean+`
 


### PR DESCRIPTION
Ticket: DOC-2238

Site: [DOC-2238 Invalid-API-Key Changes site](http://docs-feature-70-doc-2238.staging.tiny.cloud/docs/tinymce/latest/invalid-api-key/#:~:text=The%20free%2C%20open%20source%20option%20for%20TinyMCE%20is%20available%20under%20the%20GNU%20General%20Public%20License%20Version%202%20or%20later.%20Users%20must%20self%2Dhost%20TinyMCE%20to%20take%20advantage%20of%20the%20open%20source%20license.%20This%20type%20of%20license%20does%20not%20require%20an%20API%20key.)

Site: [DOC-2238 Invalid-API-Key Changes site](http://docs-feature-70-doc-2238.staging.tiny.cloud/docs/tinymce/latest/invalid-api-key/#:~:text=If%20you%20plan%20to%20use%20only%20open%2Dsource%20TinyMCE%20features%2C%20the%20open%2Dsource%20version%20is%20available%20under%20the%20GNU%20General%20Public%20License%20Version%202%20or%20later%20license.)

Site: [DOC-2238 "StatusBar Changes"site](http://docs-feature-70-doc-2238.staging.tiny.cloud/docs/tinymce/latest/statusbar-configuration-options/#:~:text=Product%20attribution%20is,attribution%20requirements.)

Changes:
* TinyMCE 7 now GPL licensed, with updated documentation reflecting this change.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`

Review:
- [ ] Documentation Team Lead has reviewed