### PR TITLE
DOC-2270: Add improved documentation for TINY-10611 to the TinyMCE release notes

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -285,6 +285,14 @@ In {productname} 7.0, this problem has been addressed.
 
 As a result, the table ghost element now accurately mirrors adjustments in table height when resized using the corner resize handles.
 
+=== Improved support of `data` elements
+//# TINY-10611
+
+Previously, when inserting a `data` element within the editor, the `data` element would be removed.
+
+In {productname} 7.0, this problem has been addressed.
+
+As a result, the `data` elements are recognized as valid elements within the editor, ensuring they are properly retained along with their value attributes.
 
 [[additions]]
 == Additions


### PR DESCRIPTION
Ticket: DOC-2270

Site: [DOC-2270 site](http://docs-feature-70-doc-2270.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* Add release notes entry for TINY-10611

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [x] Files has been included where required `(if applicable)`
- [x] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed