### PR TITLE
DOC-2315: add TinyMCE 7.0 plugin naming unification to release notes.

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -399,7 +399,6 @@
 *** TinyMCE 7.0
 **** xref:7.0-release-notes.adoc#overview[Overview]
 **** xref:7.0-release-notes.adoc#new-premium-plugin<s>[New Premium plugin<s>]
-**** xref:7.0-release-notes.adoc#new-open-source-plugin<s>[New Open Source plugin<s>]
 **** xref:7.0-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
 **** xref:7.0-release-notes.adoc#accompanying-premium-plugin-end-of-life-announcement[Accompanying Premium plugin end-of-life announcement]
 **** xref:7.0-release-notes.adoc#accompanying-open-source-plugin-end-of-life-announcement[Accompanying open source plugin end-of-life-announcement]

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -78,7 +78,7 @@ Below is a table outlining the renaming of certain plugins:
 | Advanced Tables | Enhanced Tables
 | Advanced Templates | Templates
 | Enhanced Image Editing | Image Editing
-| Enhanced Skins & Icons Packs | Skins & Icons Packs
+| Skins & Icons Packs | Enhanced Skins & Icons Packs
 | Spell Checker Pro | Spell Checker
 |===
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -11,10 +11,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 {productname} 7.0 was released for {enterpriseversion} and {cloudname} on Wednesday, March 20^th^, 2024. These release notes provide an overview of the changes for {productname} 7.0, including:
 
-// Remove sections and section boilerplates as necessary.
-// Pluralise as necessary or remove the placeholder plural marker.
 * xref:new-premium-plugin<s>[New Premium plugins]
-* xref:new-open-source-plugin<s>[New Open Source plugin<s>]
 * xref:accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
 * xref:accompanying-premium-plugin-end-of-life-announcement[Accompanying Premium plugin end-of-life announcement]
 * xref:accompanying-open-source-plugin-end-of-life-announcement[Accompanying open source plugin end-of-life-announcement]
@@ -59,34 +56,31 @@ include::partial$misc/admon-paid-addon-pricing.adoc[]
 For information on the **Export to PDF Premium Plugin** see xref:exportpdf.adoc[Export to PDF docs].
 
 
-[[new-open-source-plugin]]
-== New Open Source plugin
-
-The following new Open Source plugin was released alongside {productname} <x.y[.z]>.
-
-=== <Open source plugin name> 1.0.0
-
-The new open source plugin, **<Open source plugin name>** // description here.
-
-For information on the **<Open source plugin name>** plugin see xref:<plugincode>.adoc[<Open source plugin name>].
-
-
 [[accompanying-premium-plugin-changes]]
 == Accompanying Premium plugin changes
 
-The following premium plugin updates were released alongside {productname} <x.y[.z]>.
+The following premium plugin updates were released alongside {productname} 7.0.
 
-=== <Premium plugin name 1> <Premium plugin name 1 version>
+=== TinyMCE 7.0 plugin naming unification
 
-The {productname} <x.y[.z]> release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+With the release of {productname} 7.0, the below plugins are adopting the following name changes.
 
-**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+[NOTE]
+That while these changes are to update the plugin names used in documentation and communication materials, this does not alter the plugin identifiers themselves at this time. This means that existing integrations and configurations will remain unaffected by this change.
 
-==== <Premium plugin name 1 change 1>
+Below is a table outlining the renaming of certain plugins:
 
-// CCFR here.
-
-For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+[options="header"]
+|===
+| Old Name | New Name
+| Advanced Code Editor | Enhanced Code Editor
+| Advanced Lists | List Styles
+| Advanced Tables | Enhanced Tables
+| Advanced Templates | Templates
+| Enhanced Image Editing | Image Editing
+| Enhanced Skins & Icons Packs | Skins & Icons Packs
+| Spell Checker Pro | Spell Checker
+|===
 
 === Templates
 


### PR DESCRIPTION
Ticket: DOC-2315

Site: [DOC-2315 site](http://docs-feature-70-doc-2315.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#tinymce-7-0-plugin-naming-unification)

Changes:
* add TinyMCE 7.0 plugin naming unification to release notes, to support DOC-2230
* removed some `template-placeholders` for new `open-source-plugins`

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`

Review:
- [x] Documentation Team Lead has reviewed