### PR TITLE
DOC-2270: Add improved documentation for TINY-10603 to the TinyMCE 7.0 release notes

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -290,7 +290,7 @@ As a result, the table ghost element now accurately mirrors adjustments in table
 
 Previously, the bespoke `styles` select toolbar button in {productname} defaulted to "Paragraph" as the selected option even when there was no actual "Paragraph" style configured.
 
-{productname} 7.0 addresses this, the fallback option for the bespoke `styles` toolbar button has been reverted to "Formats" in situations where the "Paragraph" style is not defined in the style_formats option. This ensures a more accurate reflection of available styles.
+{productname} 7.0 addresses this, the fallback option for the bespoke `styles` toolbar button has been reverted to "Formats" in situations where the "Paragraph" style is not defined in the `style_formats` option. This ensures a more accurate reflection of available styles.
 
 [[additions]]
 == Additions

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -285,6 +285,12 @@ In {productname} 7.0, this problem has been addressed.
 
 As a result, the table ghost element now accurately mirrors adjustments in table height when resized using the corner resize handles.
 
+=== Accurate default options in the `styles` bespoke select toolbar button
+//# TINY-10603
+
+Previously, the bespoke `styles` select toolbar button in {productname} defaulted to "Paragraph" as the selected option even when there was no actual "Paragraph" style configured.
+
+{productname} 7.0 addresses this, the fallback option for the bespoke `styles` toolbar button has been reverted to "Formats" in situations where the "Paragraph" style is not defined in the style_formats option. This ensures a more accurate reflection of available styles.
 
 [[additions]]
 == Additions


### PR DESCRIPTION
Ticket: DOC-2270

Site: [DOC-2270 site](http://docs-feature-70-doc-2270.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* Add release notes for TINY-10603

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [x] Files has been included where required `(if applicable)`
- [x] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed