### PR TITLE
DOC-2270: add improvement documentation for TINY-9641 to the TinyMCE 7.0 release notes.

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -257,6 +257,13 @@ To address this, {productname} 7.0, introduces custom tooltips for these buttons
 
 See the xref:custom-basic-toolbar-button.adoc[Basic toolbar button], xref:custom-toggle-toolbar-button.adoc[Toggle toolbar button] and xref:shortcuts.adoc[Keyboard Shortcuts] documentation for more information.
 
+=== Added tooltips to `Click for more info` button in the accessibility checker dialog.
+//# TINY-9641
+
+The absence of a tooltip on the "Click for more info" button within the `accessibility` dialog rendered it inaccessible for keyboard-only users, affecting their ability to fully engage with the functionality.
+
+{productname} 7.0 addresses this issue, by adding the tooltip to the button, ensuring its visibility both on mouse hover and keyboard focus.
+
 === The `highlight_on_focus` option now defaults to true, adding a focus outline to every editor.
 //#TINY-10574
 


### PR DESCRIPTION
Ticket: DOC-2270

Site: [DOC-2270_TINY-9641 site](http://docs-feature-70-doc-2270tiny-9641.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#added-tooltips-to-click-for-more-info-button-in-the-accessibility-checker-dialog)

Changes:
* add improvement documentation for TINY-9641 to the TinyMCE 7.0 release notes.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`

Review:
- [x] Documentation Team Lead has reviewed