### PR TITLE
add release note entry for TINY-8929: The autocompleter `ch` configuration property has been removed. Use the `trigger` property instead.

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -368,9 +368,9 @@ As a result, users no longer experience unexpected list insertions.
 
 Previously, the `ch` configuration property was used to specify the character that would trigger the autocompleter.
 
-This property was deprecated in https://www.tiny.cloud/docs/tinymce/latest/6.2-release-notes/#deprecated[{productname} 6.2] and has been removed in {productname} 7.0. Instead, use the `trigger` property to specify the `string` that will trigger the autocompleter.
+This property was deprecated in link:https://www.tiny.cloud/docs/tinymce/6/6.2-release-notes/#deprecated[{productname} 6.2] and has been removed in {productname} 7.0. Instead, use the `trigger` property to specify the `string` that will trigger the autocompleter.
 
-If you previously used `+editor.ui.registry.addAutocompleter(name, options)+` in your configuration, then update your configuration from `ch: '<string>',` to `trigger: '<string>',`.
+If `+editor.ui.registry.addAutocompleter(name, options)+` was used  in your configuration, updating your configuration from `ch: '<string>',` to `trigger: '<string>',` is required.
 
 NOTE: The new `trigger` option can handle multiple character strings as the trigger.
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -370,7 +370,7 @@ Previously, the `ch` configuration property was used to specify the character th
 
 This property was deprecated in link:https://www.tiny.cloud/docs/tinymce/6/6.2-release-notes/#deprecated[{productname} 6.2] and has been removed in {productname} 7.0. Instead, use the `trigger` property to specify the `string` that will trigger the autocompleter.
 
-If `+editor.ui.registry.addAutocompleter(name, options)+` was used  in your configuration, updating your configuration from `ch: '<string>',` to `trigger: '<string>',` is required.
+If `+editor.ui.registry.addAutocompleter(name, options)+` was used in your configuration, updating your configuration from `ch: '<string>',` to `trigger: '<string>',` is required.
 
 NOTE: The new `trigger` option can handle multiple character strings as the trigger.
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -363,6 +363,19 @@ This resulted in undefined browser behavior due to the inherent list code within
 
 As a result, users no longer experience unexpected list insertions.
 
+=== The autocompleter `ch` configuration property has been removed. Use the `trigger` property instead.
+// #TINY-8929
+
+Previously, the `ch` configuration property was used to specify the character that would trigger the autocompleter.
+
+This property was deprecated in https://www.tiny.cloud/docs/tinymce/latest/6.2-release-notes/#deprecated[{productname} 6.2] and has been removed in {productname} 7.0. Instead, use the `trigger` property to specify the `string` that will trigger the autocompleter.
+
+If you previously used `+editor.ui.registry.addAutocompleter(name, options)+` in your configuration, then update your configuration from `ch: '<string>',` to `trigger: '<string>',`.
+
+NOTE: The new `trigger` option can handle multiple character strings as the trigger.
+
+For more information, visit the updated xref:autocompleter.adoc[Autocompleter] documentation.
+
 [[bug-fixes]]
 == Bug fixes
 


### PR DESCRIPTION
Ticket: DOC-2320
Release note entry for: TINY-8929
Related: DOC-2270

Site: [DOC-2320 site](http://docs-feature-70-doc-2320.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#the-autocompleter-ch-configuration-property-has-been-removed-use-the-trigger-property-instead)

Changes:
* add release note entry for TINY-8929: The autocompleter `ch` configuration property has been removed. Use the `trigger` property instead.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] release note entry added

Review:
- [x] Documentation Team Lead has reviewed