### PR TITLE
DOC-2270: Add entry to the release notes for new CM6 shortcuts.

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -118,6 +118,14 @@ During the integration process, {productname} made necessary adjustments to ensu
 
 This update from CodeMirror 5 to 6 should have no impact on customers utilizing the Enhanced Code Editor feature. More information about CodeMirror 6 will be included in future patch releases.
 
+==== Updated keyboard shortcuts for Enhanced Code Editor.
+
+With the update from CodeMirror 6 with {productname} 7.0, brings the below updated keyboard shortcuts for Enhanced Code Editor.
+
+include::partial$misc/advcode-shortcuts.adoc[leveloffset=+1]
+
+For information on the Enhanced Code Editor plugin, see: xref:advcode.adoc[Enhanced Code Editor].
+
 ==== Tab and shift + tab didn't not navigate to the next tab stop inside the code dialog.
 // #TINY-10596
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -120,7 +120,7 @@ This update from CodeMirror 5 to 6 should have no impact on customers utilizing 
 
 ==== Updated keyboard shortcuts for Enhanced Code Editor.
 
-With the update from CodeMirror 6 with {productname} 7.0, brings the below updated keyboard shortcuts for Enhanced Code Editor.
+With the update to CodeMirror 6 with {productname} 7.0, brings the below updated keyboard shortcuts for Enhanced Code Editor.
 
 include::partial$misc/advcode-shortcuts.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Ticket: DOC-2270 and DOC-2322

Site: [DOC-2270_DOC-2322 site](http://docs-feature-70-doc-2270doc-2322.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#enhanced-code-editor-search-and-replace-keyboard-shortcuts)

Changes:
* Add entry to the 7.0 release notes for new `CM6 shortcuts`.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`

Review:
- [x] Documentation Team Lead has reviewed