### PR TITLE
DOC-2325: Add new `sandbox_iframes_exclusions` option to `content-filtering.adoc` to support `sandbox_iframes`.

### DIFF
--- a/modules/ROOT/pages/content-filtering.adoc
+++ b/modules/ROOT/pages/content-filtering.adoc
@@ -47,6 +47,8 @@ include::partial$configuration/protect.adoc[]
 
 include::partial$configuration/sandbox_iframes.adoc[]
 
+include::partial$configuration/sandbox_iframes_exclusions.adoc[]
+
 include::partial$configuration/schema.adoc[]
 
 include::partial$configuration/valid_children.adoc[]

--- a/modules/ROOT/partials/configuration/sandbox_iframes.adoc
+++ b/modules/ROOT/partials/configuration/sandbox_iframes.adoc
@@ -1,7 +1,7 @@
 [[sandbox-iframes]]
 == `sandbox_iframes`
 
-This option controls whether the editor will add a `sandbox=""` attribute to all `<iframe>` elements. This will restrict the iframe’s embedded resource from performing potentially malicious actions including scripting, file downloads, browser popups, passing the same-origin policy, among others. Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox[MDN].
+This option allows you to control whether `<iframe>` elements are [sandboxed](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox) when inserted into the editor. When enabled, all `<iframe>` elements will be given the `sandbox=""` attribute, applying all restrictions.
 
 *Type:* `+Boolean+`
 

--- a/modules/ROOT/partials/configuration/sandbox_iframes.adoc
+++ b/modules/ROOT/partials/configuration/sandbox_iframes.adoc
@@ -1,5 +1,5 @@
-[[sandbox-iframes-option]]
-== `sandbox_iframes` option
+[[sandbox-iframes]]
+== `sandbox_iframes`
 
 This option controls whether the editor will add a `sandbox=""` attribute to all `<iframe>` elements. This will restrict the iframe’s embedded resource from performing potentially malicious actions including scripting, file downloads, browser popups, passing the same-origin policy, among others. Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox[MDN].
 

--- a/modules/ROOT/partials/configuration/sandbox_iframes.adoc
+++ b/modules/ROOT/partials/configuration/sandbox_iframes.adoc
@@ -1,7 +1,7 @@
 [[sandbox-iframes]]
 == `sandbox_iframes`
 
-This option allows you to control whether `<iframe>` elements are [sandboxed](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox) when inserted into the editor. When enabled, all `<iframe>` elements will be given the `sandbox=""` attribute, applying all restrictions.
+This option allows control of whether `<iframe>` elements are [sandboxed](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox) when inserted into the editor. When enabled, all `<iframe>` elements will be given the `sandbox=""` attribute, applying all restrictions.
 
 *Type:* `+Boolean+`
 

--- a/modules/ROOT/partials/configuration/sandbox_iframes_exclusions.adoc
+++ b/modules/ROOT/partials/configuration/sandbox_iframes_exclusions.adoc
@@ -1,7 +1,7 @@
 [[sandbox-iframes-exclusions]]
 == `sandbox_iframes_exclusions`
 
-This option allows you to specify a list of domains to exclude from having the `sandbox=""` attribute applied, when the `sandbox_iframes` option is enabled. This option takes an array of strings, each denoting at least the top and second level of a domain to be excluded. By default this option is set to an array of domains which are provided in embed code by popular websites. To enable [sandboxing](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox) on all iframes, set this option to an empty array `[]`.
+This option allows a list of domains to be specified that should be excluded from having the `sandbox=""` attribute applied when the `sandbox_iframes` option is enabled. This option takes an array of strings, each denoting at least the top and second level of a domain to be excluded. By default, this option is set to an array of domains that are provided in embed code by popular websites. To enable [sandboxing](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox) on all iframes, set this option to an empty array `[]`.
 
 [NOTE]
 When the `sandbox_iframes` option is set to `false`, all domains will be excluded from sandboxing.

--- a/modules/ROOT/partials/configuration/sandbox_iframes_exclusions.adoc
+++ b/modules/ROOT/partials/configuration/sandbox_iframes_exclusions.adoc
@@ -1,0 +1,35 @@
+[[sandbox-iframes-exclusions]]
+== `sandbox_iframes_exclusions`
+
+This option holds a list of URL host names to be excluded from iframe sandboxing when sandbox_iframes is set to true.
+
+[NOTE]
+`sandbox_iframes` option is required to be set in the editor configuration for this option to affect the  is not enabled, this option will have no effect.
+
+*Type:* `+String+`, `+Array+`
+
+*Possible values:* `true`, `false`
+
+*Default value:* `true`
+
+=== Example: using `sandbox_iframes_exclusions` option
+
+[source,js]
+----
+tinymce.init({
+  selector: "textarea",
+  sandbox_iframes: false,
+  sandbox_iframes_exclusions: [
+    'youtube.com',
+    'youtu.be',
+    'vimeo.com',
+    'player.vimeo.com',
+    'dailymotion.com',
+    'embed.music.apple.com',
+    'open.spotify.com',
+    'giphy.com',
+    'dai.ly',
+    'codepen.io'
+  ],
+});
+----

--- a/modules/ROOT/partials/configuration/sandbox_iframes_exclusions.adoc
+++ b/modules/ROOT/partials/configuration/sandbox_iframes_exclusions.adoc
@@ -1,10 +1,10 @@
 [[sandbox-iframes-exclusions]]
 == `sandbox_iframes_exclusions`
 
-This option holds a list of URL host names to be excluded from iframe sandboxing when sandbox_iframes is set to true.
+This option allows you to specify a list of domains to exclude from having the `sandbox=""` attribute applied, when the `sandbox_iframes` option is enabled. This option takes an array of strings, each denoting at least the top and second level of a domain to be excluded. By default this option is set to an array of domains which are provided in embed code by popular websites. To enable [sandboxing](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox) on all iframes, set this option to an empty array `[]`.
 
 [NOTE]
-`sandbox_iframes` option is required to be set in the editor configuration for this option to affect the  is not enabled, this option will have no effect.
+When the `sandbox_iframes` option is disabled, all domains will be excluded from sandboxing.
 
 *Type:* `+Array+`
 

--- a/modules/ROOT/partials/configuration/sandbox_iframes_exclusions.adoc
+++ b/modules/ROOT/partials/configuration/sandbox_iframes_exclusions.adoc
@@ -4,7 +4,7 @@
 This option allows you to specify a list of domains to exclude from having the `sandbox=""` attribute applied, when the `sandbox_iframes` option is enabled. This option takes an array of strings, each denoting at least the top and second level of a domain to be excluded. By default this option is set to an array of domains which are provided in embed code by popular websites. To enable [sandboxing](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox) on all iframes, set this option to an empty array `[]`.
 
 [NOTE]
-When the `sandbox_iframes` option is disabled, all domains will be excluded from sandboxing.
+When the `sandbox_iframes` option is set to `false`, all domains will be excluded from sandboxing.
 
 *Type:* `+Array+`
 

--- a/modules/ROOT/partials/configuration/sandbox_iframes_exclusions.adoc
+++ b/modules/ROOT/partials/configuration/sandbox_iframes_exclusions.adoc
@@ -31,7 +31,7 @@ When the `sandbox_iframes` option is set to `false`, all domains will be exclude
 ----
 tinymce.init({
   selector: "textarea",
-  sandbox_iframes: false,
+  sandbox_iframes: true,
   sandbox_iframes_exclusions: [
     'youtube.com',
     'youtu.be',

--- a/modules/ROOT/partials/configuration/sandbox_iframes_exclusions.adoc
+++ b/modules/ROOT/partials/configuration/sandbox_iframes_exclusions.adoc
@@ -6,11 +6,24 @@ This option holds a list of URL host names to be excluded from iframe sandboxing
 [NOTE]
 `sandbox_iframes` option is required to be set in the editor configuration for this option to affect the  is not enabled, this option will have no effect.
 
-*Type:* `+String+`, `+Array+`
+*Type:* `+Array+`
 
-*Possible values:* `true`, `false`
-
-*Default value:* `true`
+*Default value:*
+[source,js]
+----
+[
+  'youtube.com',
+  'youtu.be',
+  'vimeo.com',
+  'player.vimeo.com',
+  'dailymotion.com',
+  'embed.music.apple.com',
+  'open.spotify.com',
+  'giphy.com',
+  'dai.ly',
+  'codepen.io'
+]
+----
 
 === Example: using `sandbox_iframes_exclusions` option
 


### PR DESCRIPTION
Ticket: DOC-<num>

Site: [DOC-2325 new options added](http://docs-feature-70-doc-2325.staging.tiny.cloud/docs/tinymce/latest/content-filtering/#sandbox-iframes-exclusions)

Site: [DOC-2325 release notes link](http://docs-feature-70-doc-2325.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#sandbox_iframes-editor-option-is-now-defaulted-to-true:~:text=sandbox_iframes_exclusions)

Changes:
* New `sandbox_iframes_exclusions` option to `content-filtering.adoc
* Remove string `option` ref in the title for `content-filtering/#sandbox-iframes-option` 

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] Verified link from release notes, anchors to `content-filtering/#sandbox_iframes_exclusions` as expected.

Review:
- [x] Documentation Team Lead has reviewed