### PR TITLE
DOC-2270: add additions documentation for TINY-9979 to the release notes

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -425,6 +425,24 @@ As a result, the `data` elements are recognized as valid elements within the edi
 
 // CCFR here.
 
+=== Element preset support for the `valid_children` option and `Schema.addValidChildren` API.
+
+{productname} 7.0 updates the xref:content-filtering.adoc#valid_elements[`+valid_elements+`] option and `schema.addValidChildren` function, which now support preset names such as `@blocks`, `@phrasing`, and `@flow`. These presets will be automatically expanded into corresponding lists of valid elements, simplifying the definition process.
+
+For instance, specifying valid_children: `+'custom-elm[@flow]'+` will configure the custom-elm element to contain all elements considered as flow elements according to the schema. This streamlines the process of defining valid elements and eliminates the need to manually list all elements from the schema spec.
+
+.Example
+[source, js]
+----
+tinymce.init({
+    selector: "textarea",
+	custom_elements: 'block-container,phrasing-container,flow-container',
+	valid_children: 'block-container[@blocks],phrasing-container[@phrasing],flow-container[@flow]'
+});
+----
+
+For more information on content filtering for custom elements, see xref:content-filtering.adoc#custom_elements.adoc[`custom_elements`]
+
 [[changes]]
 == Changes
 


### PR DESCRIPTION
Ticket: DOC-2270

Site: [DOC-2270_TINY-9979 site](http://docs-feature-70-doc-2270tiny-9979.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#additions)

Changes:
* add additions documentation for TINY-9979 to the release notes
* add link back to new `custom_elements` recent changes. 

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`

Review:
- [ ] Documentation Team Lead has reviewed