### PR TITLE
DOC-2270: add entry to `release notes` mentioning removal of open source Template plugin from TinyMCE 7.0

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -506,6 +506,15 @@ NOTE: The new `trigger` option can handle multiple character strings as the trig
 
 For more information, visit the updated xref:autocompleter.adoc[Autocompleter] documentation.
 
+=== The open-source `Template` plugin has been removed.
+// #TINY-10654
+
+The open-source `Template` plugin and associated config options have been removed in {productname} 7.0.
+
+Customers using the `template` plugin will need to migrate to the premium `advtemplate` which was renamed `Templates` in {productname} 7.0, which contains all the functionality except some esoteric options.
+
+For more information, see xref:migration-from-6x.adoc#deprecated-plugins-template-plugin[Migrating from {productname} 6 to {productname} 7].
+
 [[bug-fixes]]
 == Bug fixes
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -511,7 +511,7 @@ For more information, visit the updated xref:autocompleter.adoc[Autocompleter] d
 
 The open-source `template` plugin and associated config options have been removed in {productname} 7.0.
 
-Customers using the `template` plugin will need to migrate to the premium `advtemplate` which was renamed to `Templates` in {productname} 7.0, which contains all the functionality except some esoteric options.
+Customers using the `template` plugin will need to migrate to the premium xref:advtemplate.adoc['advtemplate'] plugin in {productname} 7.0, which contains all the functionality except some esoteric options.
 
 For more information, see xref:migration-from-6x.adoc#deprecated-plugins-template-plugin[Migrating from {productname} 6 to {productname} 7].
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -506,10 +506,10 @@ NOTE: The new `trigger` option can handle multiple character strings as the trig
 
 For more information, visit the updated xref:autocompleter.adoc[Autocompleter] documentation.
 
-=== The open-source `Template` plugin has been removed.
+=== The open-source `template` plugin has been removed.
 // #TINY-10654
 
-The open-source `Template` plugin and associated config options have been removed in {productname} 7.0.
+The open-source `template` plugin and associated config options have been removed in {productname} 7.0.
 
 Customers using the `template` plugin will need to migrate to the premium `advtemplate` which was renamed to `Templates` in {productname} 7.0, which contains all the functionality except some esoteric options.
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -511,7 +511,7 @@ For more information, visit the updated xref:autocompleter.adoc[Autocompleter] d
 
 The open-source `Template` plugin and associated config options have been removed in {productname} 7.0.
 
-Customers using the `template` plugin will need to migrate to the premium `advtemplate` which was renamed `Templates` in {productname} 7.0, which contains all the functionality except some esoteric options.
+Customers using the `template` plugin will need to migrate to the premium `advtemplate` which was renamed to `Templates` in {productname} 7.0, which contains all the functionality except some esoteric options.
 
 For more information, see xref:migration-from-6x.adoc#deprecated-plugins-template-plugin[Migrating from {productname} 6 to {productname} 7].
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -511,7 +511,7 @@ For more information, visit the updated xref:autocompleter.adoc[Autocompleter] d
 
 The open-source `template` plugin and associated config options have been removed in {productname} 7.0.
 
-Customers using the `template` plugin will need to migrate to the premium xref:advtemplate.adoc['advtemplate'] plugin in {productname} 7.0, which contains all the functionality except some esoteric options.
+Customers using the `template` plugin will need to migrate to the premium xref:advanced-templates.adoc['advtemplate'] plugin in {productname} 7.0, which contains all the functionality except some esoteric options.
 
 For more information, see xref:migration-from-6x.adoc#deprecated-plugins-template-plugin[Migrating from {productname} 6 to {productname} 7].
 


### PR DESCRIPTION
Ticket: DOC-2270

Site: [DOC-2270_TINY-10654 site](http://docs-feature-70-doc-2270tiny-10654.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#the-open-source-template-plugin-has-been-removed)

Changes:
* added entry to `release notes` mentioning removal of open source Template plugin from TinyMCE 7.0

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`

Review:
- [x] Documentation Team Lead has reviewed