### PR TITLE
DOC-2270: add entry to `TinyMCE 7.0 release notes` for mention of removal of `force_hex_color`.

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -485,7 +485,9 @@ When adjusting row height through the row dialog, any height styles previously a
 === Removed `force_hex_color` option, with the default now being all colors are forced to HEX format and as lower case.
 // #TINY-10436
 
-Previously in {productname} 6, all colors in the content HTML where set to use `RGB` values by default. As the common practice is using `hex` values this change will be **reverted**.
+Previously in {productname} 6, all colors in the content HTML were set to use `rgb` values by default. As the common practice is using `hex` values this change has been **reverted**.
+
+As a result, in {productname} 7, all colors are converted to use `hex` values and the `forced_hex_color` option is removed. The exception being `rgba` color values, they are left as is.
 
 For more information, see xref:migration-from-6x.adoc#force-hex-color[Migrating from {productname} 6 to {productname} 7: "force_hex_color"].
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -482,6 +482,13 @@ When adjusting row height through the row dialog, any height styles previously a
 [[removed]]
 == Removed
 
+=== Removed `force_hex_color` option, with the default now being all colors are forced to HEX format and as lower case.
+// #TINY-10436
+
+Previously in {productname} 6, all colors in the content HTML where set to use `RGB` values by default. As the common practice is using `hex` values this change will be **reverted**.
+
+For more information, see xref:migration-from-6x.adoc#force-hex-color[Migrating from {productname} 6 to {productname} 7: "force_hex_color"].
+
 === Removed InsertOrderedList and InsertUnorderedList commands from core.
 // #TINY-10644
 


### PR DESCRIPTION
Ticket: DOC-2270

Site: [DOC-2270_TINY-10436 site](http://docs-feature-70-doc-2270tiny-10436.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#removed-force_hex_color-option-with-the-default-now-being-all-colors-are-forced-to-hex-format-and-as-lower-case)

Changes:
* add entry to `TinyMCE 7.0 release notes` for mention of removal of `force_hex_color`.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`

Review:
- [x] Documentation Team Lead has reviewed