### PR TITLE
DOC-2270: Add notification to the top of TinyMCE 7.0 release notes for `GPL` licence and `new` plugins mentions.

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -17,7 +17,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 The release brings new features essential for content producers and managers in the modern workplace. These features improve efficiency through simplified sharing of content and providing improved tools for the asynchronous collaboration needs of remote teams.
 
 * **Revision History**: View changes from one content version to another
-* **Document Converters**: Import content from MS Word. Export content to MS Word or PDF documents
+* **Document Converters**: Import content from Microsoft Word. Export content to Microsoft Word or PDF documents.
 * **Markdown**: Paste markdown from other platforms into the editor for instant rich-text conversion.
 
 These release notes provide an overview of the changes for {productname} 7.0, including:

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -20,7 +20,7 @@ The release brings new features essential for content producers and managers in 
 * **Document Converters**: Import content from Microsoft Word. Export content to Microsoft Word or PDF documents.
 * **Markdown**: Paste markdown from other platforms into the editor for instant rich-text conversion.
 
-These release notes provide an overview of the changes for {productname} 7.0, including:
+These release notes provide an overview of the changes for {productname} 7.0, including the following:
 
 * xref:new-premium-plugin<s>[New Premium plugins]
 * xref:new-open-source-plugin<s>[New Open Source plugin]

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -16,7 +16,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The release brings new features essential for content producers and managers in the modern workplace. These features improve efficiency through simplified sharing of content and providing improved tools for the asynchronous collaboration needs of remote teams.
 
-* **Revision History**: View changes from one content version to another
+* **Revision History**: View changes from one content version to another.
 * **Document Converters**: Import content from Microsoft Word. Export content to Microsoft Word or PDF documents.
 * **Markdown**: Paste markdown from other platforms into the editor for instant rich-text conversion.
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -6,10 +6,21 @@
 
 include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
+[NOTE]
+{productname} 7.0 is _licensed under GPL Version 2 or later_. This version introduces a new `license_key`  configuration setting that gives self-hosted users the ability to select a usage under the GPL or to authenticate their paid license with Tiny.
+
 [[overview]]
 == Overview
 
-{productname} 7.0 was released for {enterpriseversion} and {cloudname} on Wednesday, March 20^th^, 2024. These release notes provide an overview of the changes for {productname} 7.0, including:
+{productname} 7.0 was released for {enterpriseversion} and {cloudname} on Wednesday, March 20^th^, 2024. 
+
+The release brings new features essential for content producers and managers in the modern workplace. These features improve efficiency through simplified sharing of content and providing improved tools for the asynchronous collaboration needs of remote teams.
+
+* **Revision History**: View changes from one content version to another
+* **Document Converters**: Import content from MS Word. Export content to MS Word or PDF documents
+* **Markdown**: Paste markdown from other platforms into the editor for instant rich-text conversion.
+
+These release notes provide an overview of the changes for {productname} 7.0, including:
 
 * xref:new-premium-plugin<s>[New Premium plugins]
 * xref:new-open-source-plugin<s>[New Open Source plugin]


### PR DESCRIPTION
Ticket: DOC-2270

Site: [DOC-2270_DOC-2328 site](http://docs-feature-70-doc-2270doc-2328.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#overview:~:text=TinyMCE%207.0%20is%20licensed%20under%20GPL%20Version%202%20or%20later.%20This%20version%20introduces%20a%20new%20license_key%20configuration%20setting%20that%20gives%20self%2Dhosted%20users%20the%20ability%20to%20select%20a%20usage%20under%20the%20GPL%20or%20to%20authenticate%20their%20paid%20license%20with%20Tiny.)

Changes:
* Add notification to the top of TinyMCE 7.0 release notes for `GPL` licence
* Add message below `Overview` section to introduce TinyMCE 7.0 focus plugins.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`

Review:
- [x] Documentation Team Lead has reviewed