### PR TITLE
DOC-2329 removed the paid addon admonitions for `Import from Word`, `Export to Word`, and `Export to PDF`.

### DIFF
--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -39,25 +39,25 @@ The following new Premium plugins was released alongside {productname} 7.0.
 
 The new Premium plugin, **Revision History**, allows you to track changes made to content in the {productname} editor and restore previous versions of the content.
 
-For information on the **Revision History** plugin, see xref:revisionhistory.adoc[Revision History].
+For information on the **Revision History Premium Plugin**, see xref:revisionhistory.adoc[Revision History].
 
 === Import from Word
 
-The new Premium plugin, **Import from Word** provides a way to import `.docx` (Word documents) or `.dotx` (Word templates) files into the editor.
+The new Premium plugin, **Import from Word**, provides a way to import `.docx` (Word documents) or `.dotx` (Word templates) files into the editor.
 
-For information on the **Import from Word Premium Plugin** see xref:importword.adoc[Import from Word docs].
+For information on the **Import from Word Premium Plugin**, see xref:importword.adoc[Import from Word docs].
 
 === Export to Word
 
-The new Premium plugin, **Export to Word** feature lets you generate a `.docx` file directly from the editor.
+The new Premium plugin, **Export to Word**, provides a way to generate a `.docx` file directly from the editor.
 
-For information on the **Export to Word Premium Plugin** see xref:exportword.adoc[Export to Word docs].
+For information on the **Export to Word Premium Plugin**, see xref:exportword.adoc[Export to Word docs].
 
 === Export to PDF
 
-The new Premium plugin, **Export to PDF** feature lets you generate a `.pdf` file directly from the editor.
+The new Premium plugin, **Export to PDF**, provides a way to generate a `.pdf` file directly from the editor.
 
-For information on the **Export to PDF Premium Plugin** see xref:exportpdf.adoc[Export to PDF docs].
+For information on the **Export to PDF Premium Plugin**, see xref:exportpdf.adoc[Export to PDF docs].
 
 === Markdown
 
@@ -65,7 +65,7 @@ The new Premium plugin, **Markdown**, detects pure markdown from a paste event w
 
 include::partial$misc/admon-premium-plugin.adoc[]
 
-For information on the **Markdown** plugin see xref:markdown.adoc[Markdown].
+For information on the **Markdown Premium Plugin**, see xref:markdown.adoc[Markdown].
 
 
 [[accompanying-premium-plugin-changes]]

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -39,31 +39,31 @@ The following new Premium plugins was released alongside {productname} 7.0.
 
 The new Premium plugin, **Revision History**, allows you to track changes made to content in the {productname} editor and restore previous versions of the content.
 
-For information on the **Revision History Premium Plugin**, see xref:revisionhistory.adoc[Revision History].
+For information on the **Revision History** plugin, see xref:revisionhistory.adoc[Revision History].
 
 === Import from Word
 
 The new Premium plugin, **Import from Word**, provides a way to import `.docx` (Word documents) or `.dotx` (Word templates) files into the editor.
 
-For information on the **Import from Word Premium Plugin**, see xref:importword.adoc[Import from Word docs].
+For information on the **Import from Word** plugin, see xref:importword.adoc[Import from Word].
 
 === Export to Word
 
 The new Premium plugin, **Export to Word**, provides a way to generate a `.docx` file directly from the editor.
 
-For information on the **Export to Word Premium Plugin**, see xref:exportword.adoc[Export to Word docs].
+For information on the **Export to Word** plugin, see xref:exportword.adoc[Export to Word].
 
 === Export to PDF
 
 The new Premium plugin, **Export to PDF**, provides a way to generate a `.pdf` file directly from the editor.
 
-For information on the **Export to PDF Premium Plugin**, see xref:exportpdf.adoc[Export to PDF docs].
+For information on the **Export to PDF** plugin, see xref:exportpdf.adoc[Export to PDF].
 
 === Markdown
 
 The new Premium plugin, **Markdown**, detects pure markdown from a paste event within a {productname} editor instance and converts it to HTML.
 
-For information on the **Markdown Premium Plugin**, see xref:markdown.adoc[Markdown].
+For information on the **Markdown** plugin, see xref:markdown.adoc[Markdown].
 
 
 [[accompanying-premium-plugin-changes]]

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -45,23 +45,17 @@ For information on the **Revision History** plugin, see xref:revisionhistory.ado
 
 The new Premium plugin, **Import from Word** provides a way to import `.docx` (Word documents) or `.dotx` (Word templates) files into the editor.
 
-include::partial$misc/admon-paid-addon-pricing.adoc[]
-
 For information on the **Import from Word Premium Plugin** see xref:importword.adoc[Import from Word docs].
 
 === Export to Word
 
 The new Premium plugin, **Export to Word** feature lets you generate a `.docx` file directly from the editor.
 
-include::partial$misc/admon-paid-addon-pricing.adoc[]
-
 For information on the **Export to Word Premium Plugin** see xref:exportword.adoc[Export to Word docs].
 
 === Export to PDF
 
 The new Premium plugin, **Export to PDF** feature lets you generate a `.pdf` file directly from the editor.
-
-include::partial$misc/admon-paid-addon-pricing.adoc[]
 
 For information on the **Export to PDF Premium Plugin** see xref:exportpdf.adoc[Export to PDF docs].
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -63,8 +63,6 @@ For information on the **Export to PDF Premium Plugin**, see xref:exportpdf.adoc
 
 The new Premium plugin, **Markdown**, detects pure markdown from a paste event within a {productname} editor instance and converts it to HTML.
 
-include::partial$misc/admon-premium-plugin.adoc[]
-
 For information on the **Markdown Premium Plugin**, see xref:markdown.adoc[Markdown].
 
 

--- a/modules/ROOT/pages/7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.0-release-notes.adoc
@@ -381,7 +381,7 @@ Any editors using this `highlight_on_focus: true` option, can remove this option
 === Improved Custom Elements
 // #TINY-9980 / TINY-9979
 
-{productname} 7.0 introduces enhancements to the existing xref:content-filtering.adoc#custom_elements.adoc[custom_elements] option and xref:apis/tinymce.html.schema.adoc#addCustomElements[addCustomElements] API. This update allows the structure of custom elements to be refined, offering users more flexibility and customization options.
+{productname} 7.0 introduces enhancements to the existing xref:content-filtering.adoc#custom_elements[custom_elements] option and xref:apis/tinymce.html.schema.adoc#addCustomElements[addCustomElements] API. This update allows the structure of custom elements to be refined, offering users more flexibility and customization options.
 
 Key Improvements:
 
@@ -389,7 +389,7 @@ Key Improvements:
 * **Attributes and Inheritance:** Elements can inherit attributes and children from other specified elements using the extends property in the Custom Element Spec.
 * **Attribute and Children Specifications:** The Custom Element Spec includes properties such as attributes and children, enabling precise customization of element behavior.
 
-For more information and details for `addCustomElements` see xref:content-filtering.adoc#custom-elements[custom_elements].
+For more information and details for `addCustomElements` see xref:content-filtering.adoc#custom_elements[custom_elements].
 
 === Optional Tooltip for Dialog Footer Toggle Buttons
 //#TINY-10672


### PR DESCRIPTION
Ticket: DOC-2329

Site: [DOC-2329 site](http://docs-feature-70-doc-2329.staging.tiny.cloud/docs/tinymce/latest/7.0-release-notes/#new-premium-plugins)

Changes:
* DOC-2329 removed the paid addon admonitions for `Import from Word`, `Export to Word`, and `Export to PDF`.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`

Review:
- [x] Documentation Team Lead has reviewed