### PR TITLE
DOC-2330: update code sample for `markdown_symbols` example.

### DIFF
--- a/modules/ROOT/partials/configuration/markdown.adoc
+++ b/modules/ROOT/partials/configuration/markdown.adoc
@@ -22,6 +22,7 @@ The `markdown_symbols` option allows you to define `key/value` pairs where the `
 ----
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
+  plugins: 'markdown',
   markdown_symbols: {
     C: '©',
     TM: '™',


### PR DESCRIPTION
Ticket: DOC-2330

Site: [DOC-2330 site](http://docs-feature-70-doc-2330.staging.tiny.cloud/docs/tinymce/latest/markdown/#example-using-markdown_symbols)

Changes:
* update code sample for `markdown_symbols` as it was missing the `markdown` plugin and we want users to be able to copy and paste these code samples.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`

Review:
- [x] Documentation Team Lead has reviewed