### PR TITLE
DOC-2289: Add link tables to empty index pages (#3154)

### DIFF
--- a/modules/ROOT/pages/advanced/index.adoc
+++ b/modules/ROOT/pages/advanced/index.adoc
@@ -3,3 +3,119 @@
 :title_nav: Advanced topics
 :type: folder
 
+// 2 Columns, both asciidoc
+[cols=2*a]
+|===
+
+|
+[.lead]
+xref:advanced/accessibility.adoc[Accessibility]
+
+Learn how TinyMCE works with screen readers and how screen readers work with TinyMCE.
+
+|
+[.lead]
+xref:advanced/security.adoc[Security]
+
+Security information for TinyMCE.
+
+|
+[.lead]
+xref:advanced/creating-a-skin.adoc[Create a skin]
+
+Introducing skin creation.
+
+|
+[.lead]
+xref:advanced/creating-an-icon-pack.adoc[Create an icon pack]
+
+Introducing icon pack creation.
+
+|
+[.lead]
+xref:advanced/creating-a-plugin.adoc[Create a plugin]
+
+Introducing plugin creation, with an example.
+
+|
+[.lead]
+xref:advanced/annotations.adoc[Annotations]
+
+TinyMCE Annotations provides the ability to describe particular features or add general information to a...
+
+|
+[.lead]
+xref:advanced/yeoman-generator.adoc[Yeoman generator]
+
+How to use the Yeoman generator to bootstrap a new TinyMCE plugin
+
+|
+[.lead]
+xref:advanced/creating-custom-notifications.adoc[Create custom notifications]
+
+Learn how to make custom notifications.
+
+|
+[.lead]
+xref:advanced/php-upload-handler.adoc[PHP image upload handler]
+
+A server-side upload handler PHP script.
+
+|
+[.lead]
+xref:advanced/available-menu-items.adoc[Available Menu Items]
+
+Complete list of menu items available for the menu bar and context menus.
+
+|
+[.lead]
+xref:advanced/available-toolbar-buttons.adoc[Available Toolbar Buttons]
+
+Complete list of toolbar buttons available for the toolbar and quick toolbars.
+
+|
+[.lead]
+xref:advanced/editor-command-identifiers.adoc[Available Commands]
+
+Complete list of editor commands.
+
+|
+[.lead]
+xref:advanced/editor-icon-identifiers.adoc[Available Icons]
+
+Complete list of icon identifiers.
+
+|
+[.lead]
+xref:advanced/editor-context-menu-identifiers.adoc[Available Context Menu Items]
+
+Complete list of available context menu sections.
+
+|
+[.lead]
+xref:advanced/events.adoc[Available Events]
+
+List of common editor events
+
+|
+[.lead]
+xref:advanced/keyboard-shortcuts.adoc[Keyboard shortcuts]
+
+Complete list of keyboard shortcuts.
+
+|
+[.lead]
+xref:advanced/usage-with-module-loaders/introduction_to_bundling_tinymce.adoc[Bundling TinyMCE]
+
+Bundling TinyMCE with Webpack, rollup.js, or Browserify.
+
+|
+[.lead]
+xref:advanced/generate-rsa-key-pairs.adoc[Generate public key pairs]
+
+Instructions on how to generate private/public key pairs for the Tiny Cloud
+
+// Empty cell to even out rows
+// | 
+
+|===

--- a/modules/ROOT/pages/configure/index.adoc
+++ b/modules/ROOT/pages/configure/index.adoc
@@ -5,3 +5,89 @@
 :type: folder
 
 
+// 2 Columns, both asciidoc
+[cols=2*a]
+|===
+
+|
+[.lead]
+xref:configure/integration-and-setup.adoc[Integration options]
+
+Essential editor configuration, including `selector` and `plugins` keys.
+
+|
+[.lead]
+xref:configure/editor-appearance.adoc[User interface options]
+
+Configure the editor's appearance, including menu and toolbar controls.
+
+|
+[.lead]
+xref:configure/content-appearance.adoc[Content appearance options]
+
+Configure the appearance of content inside TinyMCE's editable area.
+
+|
+[.lead]
+xref:configure/content-filtering.adoc[Content filtering options]
+
+Learn how to create clean, maintainable and readable content.
+
+|
+[.lead]
+xref:configure/content-formatting.adoc[Content formatting options]
+
+Learn how to create clean, maintainable and readable content.
+
+|
+[.lead]
+xref:configure/spelling.adoc[Spelling options]
+
+TinyMCE spell checking.
+
+|
+[.lead]
+xref:configure/file-image-upload.adoc[Image & file options]
+
+These settings affect TinyMCE's image and file handling capabilities.
+
+|
+[.lead]
+xref:configure/accessibility.adoc[Accessibility options]
+
+Configure the accessibility of TinyMCE.
+
+|
+[.lead]
+xref:configure/localization.adoc[Localization options]
+
+Localize TinyMCE for your language, including directionality.
+
+|
+[.lead]
+xref:configure/url-handling.adoc[URL handling options]
+
+These settings affect the way URLs are handled by the editor.
+
+|
+[.lead]
+xref:configure/advanced-editing-behavior.adoc[Advanced editing options]
+
+Learn about some edge case editor behavior.
+
+|
+[.lead]
+xref:configure/contributing-to-open-source.adoc[Contribute to TinyMCE]
+
+Contribute to the open source project.
+
+|
+[.lead]
+xref:configure/contributing-docs.adoc[Contribute to documentation]
+
+Contribute to TinyMCE's developer documentation.
+
+// Empty cell to even out rows
+| 
+
+|===

--- a/modules/ROOT/pages/enterprise/index.adoc
+++ b/modules/ROOT/pages/enterprise/index.adoc
@@ -3,3 +3,137 @@
 :title_nav: Premium features
 :type: folder
 
+// 2 Columns, both asciidoc
+[cols=2*a]
+|===
+
+|
+[.lead]
+xref:enterprise/tiny-comments.adoc[Commenting & collaboration]
+
+The Comments plugin provides the ability to add comments to the content and collaborate with other users for content editing.
+
+|
+[.lead]
+xref:enterprise/tinydrive.adoc[Cloud-based file management]
+
+Tiny Drive - a premium plugin to manage files & images.
+
+|
+[.lead]
+xref:enterprise/moxiemanager.adoc[Self-hosted file management]
+
+MoxieManager is a premium plugin to manage files & images.
+
+|
+[.lead]
+xref:enterprise/premium-skins-and-icon-packs/index.adoc[Tiny Skins and Icon Packs]
+
+Quickly give TinyMCE a new look.
+
+|
+[.lead]
+xref:enterprise/pageembed.adoc[Page Embed]
+
+Easily inserts iframe into the content.
+
+|
+[.lead]
+xref:enterprise/permanentpen.adoc[Permanent Pen]
+
+Apply formats while typing.
+
+|
+[.lead]
+xref:enterprise/formatpainter.adoc[Format Painter]
+
+Quickly apply formats to multiple pieces of text.
+
+|
+[.lead]
+xref:enterprise/checklist.adoc[Checklist]
+
+Add checklists to your content.
+
+|
+[.lead]
+xref:enterprise/paste-from-word.adoc[Paste from Word]
+
+PowerPaste is a premium plugin for clean Word copy-and-paste.
+
+|
+[.lead]
+xref:enterprise/check-spelling/index.adoc[Spell checking as-you-type]
+
+Spell Checker Pro is a premium plugin and server to check spelling as-you-type.
+
+|
+[.lead]
+xref:enterprise/casechange.adoc[Case Change]
+
+Change the case of text.
+
+|
+[.lead]
+xref:enterprise/check-links.adoc[Hyperlink checking]
+
+Check for valid hyperlinks inside the editor
+
+|
+[.lead]
+xref:enterprise/embed-media/index.adoc[Media embedding]
+
+Add rich media previews inside TinyMCE.
+
+|
+[.lead]
+xref:enterprise/accessibility.adoc[Accessibility checking]
+
+WCAG & Section 508 compliant accessibility checking.
+
+|
+[.lead]
+xref:enterprise/mentions.adoc[Mentions]
+
+Mentions brings social sharing to TinyMCE.
+
+|
+[.lead]
+xref:enterprise/server/index.adoc[Server-side component installation]
+
+Server-side components for premium plugins like spelling as-you-type.
+
+|
+[.lead]
+xref:enterprise/advcode.adoc[Advanced source code editing]
+
+An IDE-like code editor for TinyMCE.
+
+|
+[.lead]
+xref:enterprise/advanced-tables.adoc[Advanced Tables]
+
+Add advanced functionality to tables.
+
+|
+[.lead]
+xref:enterprise/export.adoc[Export]
+
+Export content from TinyMCE, into varying formats.
+
+|
+[.lead]
+xref:enterprise/support.adoc[Professional support]
+
+Find how to contact Tiny support.
+
+|
+[.lead]
+xref:enterprise/system-requirements.adoc[Supported Premium Versions]
+
+Supported versions and platforms for TinyMCE and TinyMCE premium features.
+
+// Empty cell to even out rows
+|
+
+|===

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -3,3 +3,117 @@
 :meta_title: Documentation
 :type: index
 
+// 2 Columns, both asciidoc
+[cols=2*a]
+|===
+
+|
+[.lead]
+xref:quick-start.adoc[Quick start]
+
+Setup a basic TinyMCE 5 editor using the Tiny Cloud.
+
+|
+[.lead]
+xref:general-configuration-guide/basic-setup.adoc[Introduction & getting started]
+
+New to self-hosting TinyMCE? Start here.
+
+|
+[.lead]
+xref:cloud-deployment-guide/editor-and-features.adoc[Cloud deployment guide]
+
+Start here for Tiny Cloud.
+
+|
+[.lead]
+xref:demo/basic-example.adoc[Examples]
+
+Working examples of TinyMCE's popular functionality.
+
+|
+[.lead]
+xref:mobile.adoc[Mobile]
+
+The TinyMCE rich text editing experience for mobile devices.
+
+|
+[.lead]
+xref:configure/index.adoc[Configuration reference]
+
+The most customizable rich text editor.
+
+|
+[.lead]
+xref:plugins/index.adoc[Plugins]
+
+This section will help you configure and extend your editor instance.
+
+|
+[.lead]
+xref:ui-components/index.adoc[UI components]
+
+The configurable UI components available for customization.
+
+|
+[.lead]
+xref:enterprise/index.adoc[Premium features]
+
+Premium features from the makers of TinyMCE.
+
+|
+[.lead]
+xref:tinydrive/introduction.adoc[Tiny Drive]
+
+Tiny Drive
+
+|
+[.lead]
+xref:rtc/introduction.adoc[Real-time Collaboration (RTC)]
+
+The TinyMCE Real-time Collaboration plugin
+
+|
+[.lead]
+xref:advanced/index.adoc[Advanced topics]
+
+Information and guides for developers wanting to build advanced capabilities into TinyMCE.
+
+|
+[.lead]
+xref:integrations/index.adoc[Integrations]
+
+Faster development with integrations of TinyMCE into your favorite framework or CMS.
+
+|
+[.lead]
+xref:migration-from-4x.adoc[Migrating from TinyMCE 4]
+
+Guidance for migrating from TinyMCE 4 to TinyMCE 5.
+
+|
+[.lead]
+xref:migration-from-froala.adoc[Migrating from Froala]
+
+Upgrading your rich text editor from Froala Editor v3 to TinyMCE 5.
+
+|
+[.lead]
+xref:release-notes/index.adoc[Release notes for TinyMCE 5]
+
+|
+[.lead]
+xref:changelog.adoc[Changelog]
+
+The history of TinyMCE releases.
+
+|
+[.lead]
+xref:api/tinymce/index.adoc[API Reference]
+
+JavaScript API reference for TinyMCE
+
+// Empty cell to even out rows
+// | 
+
+|===

--- a/modules/ROOT/pages/integrations/index.adoc
+++ b/modules/ROOT/pages/integrations/index.adoc
@@ -2,3 +2,102 @@
 :description: Faster development with integrations of TinyMCE into your favorite framework or CMS.
 :title_nav: Integrations
 :type: folder
+
+// 2 Columns, both asciidoc
+[cols=2*a]
+|===
+
+|
+[.lead]
+xref:integrations/angularjs.adoc[AngularJS]
+
+This directive allows you to add a TinyMCE editor to your form elements.
+
+|
+[.lead]
+xref:integrations/angular.adoc[Angular 5+]
+
+Using TinyMCE together with Angular with the @tinymce/tinymce-angular component
+
+|
+[.lead]
+xref:integrations/blazor.adoc[Blazor]
+
+Blazor TinyMCE component.
+
+|
+[.lead]
+xref:integrations/bootstrap.adoc[Bootstrap]
+
+How to override the built-in block on `focusin` in Bootstrap dialogs when using TinyMCE.
+
+|
+[.lead]
+xref:integrations/django.adoc[Django]
+
+Django TinyMCE component.
+
+|
+[.lead]
+xref:integrations/jquery.adoc[jQuery]
+
+Documentation for the official TinyMCE jQuery integration.
+
+|
+[.lead]
+xref:integrations/laravel/laravel-introduction.adoc[Laravel]
+
+A guide to using TinyMCE with the PHP-based Laravel framework.
+
+|
+[.lead]
+xref:integrations/expressjs.adoc[Node.js + Express]
+
+A quick start guide on integrating TinyMCE into an Express JS Application
+
+|
+[.lead]
+xref:integrations/rails.adoc[Rails]
+
+Seamlessly integrates TinyMCE into the Rails asset pipeline.
+
+|
+[.lead]
+xref:integrations/react.adoc[React]
+
+React TinyMCE component.
+
+|
+[.lead]
+xref:integrations/svelte.adoc[Svelte]
+
+Svelte TinyMCE component.
+
+|
+[.lead]
+xref:integrations/swing.adoc[Swing]
+
+Seamlessly integrates TinyMCE into Swing applications.
+
+|
+[.lead]
+xref:integrations/vue.adoc[Vue]
+
+The Official TinyMCE Vue.js component
+
+|
+[.lead]
+xref:integrations/webcomponent.adoc[Web Components]
+
+The TinyMCE Web Component integration guide
+
+|
+[.lead]
+xref:integrations/wordpress.adoc[WordPress]
+
+WordPress TinyMCE component
+
+// Empty cell to even out rows
+| 
+
+|===

--- a/modules/ROOT/pages/plugins/index.adoc
+++ b/modules/ROOT/pages/plugins/index.adoc
@@ -3,3 +3,24 @@
 :description_short: This section will help you configure and extend your editor instance.
 :title_nav: Plugins
 :type: folder
+
+// 2 Columns, both asciidoc
+[cols=2*a]
+|===
+
+|
+[.lead]
+xref:plugins/premium/index.adoc[Premium plugins]
+
+TinyMCE premium plugins
+
+|
+[.lead]
+xref:plugins/opensource/index.adoc[Open source plugins]
+
+TinyMCE open source plugins
+
+// Empty cell to even out rows
+// | 
+
+|===

--- a/modules/ROOT/pages/plugins/opensource/index.adoc
+++ b/modules/ROOT/pages/plugins/opensource/index.adoc
@@ -1,5 +1,262 @@
-= Open source for TinyMCE
+= Open source plugins for TinyMCE
 :description: This section lists the open source plugins provided with TinyMCE.
 :description_short: TinyMCE open source plugins
 :title_nav: Open source plugins
 :type: folder
+
+
+
+// 2 Columns, both asciidoc
+[cols=2*a]
+|===
+
+|
+[.lead]
+xref:plugins/opensource/advlist.adoc[Advanced List]
+
+Create styled number and bulleted lists.
+
+|
+[.lead]
+xref:plugins/opensource/anchor.adoc[Anchor]
+
+Insert anchors (sometimes referred to as a bookmarks).
+
+|
+[.lead]
+xref:plugins/opensource/autolink.adoc[Autolink]
+
+Automatically create hyperlinks.
+
+|
+[.lead]
+xref:plugins/opensource/autoresize.adoc[Autoresize]
+
+Automatically resize TinyMCE to fit content.
+
+|
+[.lead]
+xref:plugins/opensource/autosave.adoc[Autosave]
+
+Automatically save content in your local browser.
+
+|
+[.lead]
+xref:plugins/opensource/bbcode.adoc[BBCode]
+
+Add basic BBCode input/output to TinyMCE.
+
+|
+[.lead]
+xref:plugins/opensource/charmap.adoc[Character Map]
+
+Insert special characters into TinyMCE.
+
+|
+[.lead]
+xref:plugins/opensource/code.adoc[Code]
+
+Edit your content's HTML source.
+
+|
+[.lead]
+xref:plugins/opensource/codesample.adoc[Code Sample]
+
+Insert and embed syntax highlighted code snippets.
+
+|
+[.lead]
+xref:plugins/opensource/directionality.adoc[Directionality]
+
+Toolbar buttons for setting the left-to-right or right-to-left direction of content.
+
+|
+[.lead]
+xref:plugins/opensource/emoticons.adoc[Emoticons]
+
+Bring a smiley to your content.
+
+|
+[.lead]
+xref:plugins/opensource/fullpage.adoc[Full Page]
+
+Edit all metadata and document properties such as title, keywords and description.
+
+|
+[.lead]
+xref:plugins/opensource/fullscreen.adoc[Full Screen]
+
+Zoom TinyMCE up to the whole screen.
+
+|
+[.lead]
+xref:plugins/opensource/help.adoc[Help]
+
+Shows the help dialog.
+
+|
+[.lead]
+xref:plugins/opensource/hr.adoc[Horizontal Rule]
+
+Insert a horizontal line.
+
+|
+[.lead]
+xref:plugins/opensource/image.adoc[Image]
+
+Insert an image into TinyMCE.
+
+|
+[.lead]
+xref:plugins/opensource/imagetools.adoc[Image Tools]
+
+Image editing features for TinyMCE.
+
+|
+[.lead]
+xref:plugins/opensource/importcss.adoc[Import CSS]
+
+Automatically populate CSS class names into the Format dropdown.
+
+|
+[.lead]
+xref:plugins/opensource/insertdatetime.adoc[Insert Date/Time]
+
+Insert the current date and/or time into TinyMCE.
+
+|
+[.lead]
+xref:plugins/opensource/legacyoutput.adoc[Legacy Output]
+
+Changes HTML output to old HTML syntax such as font, b and i
+
+|
+[.lead]
+xref:plugins/opensource/link.adoc[Link]
+
+Add hyperlinks to content.
+
+|
+[.lead]
+xref:plugins/opensource/lists.adoc[Lists]
+
+Normalizes list behavior between browsers.
+
+|
+[.lead]
+xref:plugins/opensource/media.adoc[Media]
+
+Add HTML5 video and audio elements.
+
+|
+[.lead]
+xref:plugins/opensource/nonbreaking.adoc[Nonbreaking Space]
+
+Insert a nonbreaking space.
+
+|
+[.lead]
+xref:plugins/opensource/noneditable.adoc[Noneditable]
+
+Prevent users from changing content within elements. Ideal for templates.
+
+|
+[.lead]
+xref:plugins/opensource/pagebreak.adoc[Page Break]
+
+Add a page break.
+
+|
+[.lead]
+xref:plugins/opensource/paste.adoc[Paste]
+
+Standard version of features for copying-and-pasting content from Microsoft Word.
+
+|
+[.lead]
+xref:plugins/opensource/preview.adoc[Preview]
+
+Shows a popup of the current content in read-only format.
+
+|
+[.lead]
+xref:plugins/opensource/print.adoc[Print]
+
+Print the content in TinyMCE.
+
+|
+[.lead]
+xref:plugins/opensource/quickbars.adoc[Quick Toolbars]
+
+User interface controls to create content faster.
+
+|
+[.lead]
+xref:plugins/opensource/save.adoc[Save]
+
+Adds a save button to the TinyMCE toolbar.
+
+|
+[.lead]
+xref:plugins/opensource/searchreplace.adoc[Search and Replace]
+
+Find and replace content in TinyMCE.
+
+|
+[.lead]
+xref:plugins/opensource/spellchecker.adoc[Spell Checker]
+
+Enables TinyMCE's spellcheck functionality.
+
+|
+[.lead]
+xref:plugins/opensource/tabfocus.adoc[Tab Focus]
+
+Tab into and out of the TinyMCE control in your web form.
+
+|
+[.lead]
+xref:plugins/opensource/table.adoc[Table]
+
+Table editing features.
+
+|
+[.lead]
+xref:plugins/opensource/template.adoc[Template]
+
+Custom templates for your content.
+
+|
+[.lead]
+xref:plugins/opensource/textpattern.adoc[Text Pattern]
+
+Matches special patterns in the text and applies formats or executed commands on these patterns.
+
+|
+[.lead]
+xref:plugins/opensource/toc.adoc[Table of Contents]
+
+Insert a simple Table of Contents into TinyMCE editor
+
+|
+[.lead]
+xref:plugins/opensource/visualblocks.adoc[Visual Blocks]
+
+Allows a user to see block level elements such as paragraphs.
+
+|
+[.lead]
+xref:plugins/opensource/visualchars.adoc[Visual Characters]
+
+See invisible characters like non-breaking spaces.
+
+|
+[.lead]
+xref:plugins/opensource/wordcount.adoc[Word Count]
+
+Show a word count in the TinyMCE status bar.
+
+// Empty cell to even out rows
+| 
+
+|===

--- a/modules/ROOT/pages/plugins/premium/index.adoc
+++ b/modules/ROOT/pages/plugins/premium/index.adoc
@@ -3,3 +3,119 @@
 :description_short: TinyMCE premium plugins
 :title_nav: Premium plugins
 :type: folder
+
+
+// 2 Columns, both asciidoc
+[cols=2*a]
+|===
+
+|
+[.lead]
+xref:plugins/premium/a11ychecker.adoc[Accessibility Checker]
+
+Checks the contents of the editor for WCAG & Section 508 accessibility problems.
+
+|
+[.lead]
+xref:plugins/premium/advcode.adoc[Advanced Code Editor]
+
+How to setup TinyMCE's Advanced Code Editor plugin.
+
+|
+[.lead]
+xref:plugins/premium/advtable.adoc[Advanced Tables]
+
+Add advanced functionality to tables.
+
+|
+[.lead]
+xref:plugins/premium/casechange.adoc[Case Change]
+
+Change the case of text.
+
+|
+[.lead]
+xref:plugins/premium/checklist.adoc[Checklist]
+
+Add checklists to your content.
+
+|
+[.lead]
+xref:plugins/premium/comments/introduction_to_tiny_comments.adoc[Comments]
+
+The TinyMCE Comments plugin
+
+|
+[.lead]
+xref:plugins/premium/mediaembed.adoc[Enhanced Media Embed]
+
+Add rich media previews inside TinyMCE.
+
+|
+[.lead]
+xref:plugins/premium/export.adoc[Export]
+
+Export content from TinyMCE, into various formats.
+
+|
+[.lead]
+xref:plugins/premium/formatpainter.adoc[Format Painter]
+
+Quickly apply formats to multiple pieces of text.
+
+|
+[.lead]
+xref:plugins/premium/linkchecker.adoc[Link Checker]
+
+Validate links, as you type.
+
+|
+[.lead]
+xref:plugins/premium/mentions.adoc[Mentions]
+
+Enables @mention functionality.
+
+|
+[.lead]
+xref:plugins/premium/moxiemanager.adoc[MoxieManager]
+
+File and image management plugin and service
+
+|
+[.lead]
+xref:plugins/premium/pageembed.adoc[Page Embed]
+
+Easily inserts iframe into the content.
+
+|
+[.lead]
+xref:plugins/premium/permanentpen.adoc[Permanent Pen]
+
+Apply formats while typing.
+
+|
+[.lead]
+xref:plugins/premium/powerpaste.adoc[PowerPaste]
+
+|
+[.lead]
+xref:plugins/premium/tinymcespellchecker.adoc[Spell Checker Pro]
+
+Check spelling as-you-type in TinyMCE.
+
+|
+[.lead]
+xref:plugins/premium/tinydrive.adoc[Tiny Drive]
+
+Cloud-based file and image management for TinyMCE.
+
+|
+[.lead]
+xref:plugins/premium/rtc.adoc[Real-time Collaboration]
+
+The Real-time Collaboration plugin for TinyMCE
+
+// Empty cell to even out rows
+// | 
+
+|===

--- a/modules/ROOT/pages/release-notes/index.adoc
+++ b/modules/ROOT/pages/release-notes/index.adoc
@@ -2,3 +2,259 @@
 :keywords: releasenotes newfeatures deleted technologypreview bugfixes knownissues
 :title_nav: Release notes for TinyMCE 5
 :type: folder
+
+
+// 2 Columns, both asciidoc
+[cols=2*a]
+|===
+|
+[.lead]
+xref:release-notes/6.0-upcoming-changes.adoc[Upcoming changes for TinyMCE 6]
+
+List of upcoming changes for TinyMCE 6, including deprecated features.
+
+|
+[.lead]
+xref:release-notes/release-notes5109.adoc[TinyMCE 5.10.9]
+
+Release notes for TinyMCE 5.10.9
+
+|
+[.lead]
+xref:release-notes/release-notes5108.adoc[TinyMCE 5.10.8]
+
+Release notes for TinyMCE 5.10.8
+
+|
+[.lead]
+xref:release-notes/release-notes5107.adoc[TinyMCE 5.10.7]
+
+Release notes for TinyMCE 5.10.7
+
+|
+[.lead]
+xref:release-notes/release-notes5106.adoc[TinyMCE 5.10.6]
+
+Release notes for TinyMCE 5.10.6
+
+|
+[.lead]
+xref:release-notes/release-notes5105.adoc[TinyMCE 5.10.5]
+
+Release notes for TinyMCE 5.10.5
+
+|
+[.lead]
+xref:release-notes/release-notes5104.adoc[TinyMCE 5.10.4]
+
+Release notes for TinyMCE 5.10.4
+
+|
+[.lead]
+xref:release-notes/release-notes5103.adoc[TinyMCE 5.10.3]
+
+Release notes for TinyMCE 5.10.3
+
+|
+[.lead]
+xref:release-notes/release-notes5102.adoc[TinyMCE 5.10.2]
+
+Release notes for TinyMCE 5.10.2
+
+|
+[.lead]
+xref:release-notes/release-notes5101.adoc[TinyMCE 5.10.1]
+
+Release notes for TinyMCE 5.10.1
+
+|
+[.lead]
+xref:release-notes/release-notes510.adoc[TinyMCE 5.10]
+
+Release notes for TinyMCE 5.10
+
+|
+[.lead]
+xref:release-notes/release-notes59.adoc[TinyMCE 5.9]
+
+Release notes for TinyMCE 5.9
+
+|
+[.lead]
+xref:release-notes/release-notes582.adoc[TinyMCE 5.8.2]
+
+Release notes for TinyMCE 5.8.2
+
+|
+[.lead]
+xref:release-notes/release-notes581.adoc[TinyMCE 5.8.1]
+
+Release notes for TinyMCE 5.8.1
+
+|
+[.lead]
+xref:release-notes/release-notes58.adoc[TinyMCE 5.8]
+
+Release notes for TinyMCE 5.8
+
+|
+[.lead]
+xref:release-notes/release-notes571.adoc[TinyMCE 5.7.1]
+
+Release notes for TinyMCE 5.7.1
+
+|
+[.lead]
+xref:release-notes/release-notes57.adoc[TinyMCE 5.7]
+
+Release notes for TinyMCE 5.7
+
+|
+[.lead]
+xref:release-notes/release-notes562.adoc[TinyMCE 5.6.2]
+
+Release notes for TinyMCE 5.6.2
+
+|
+[.lead]
+xref:release-notes/release-notes56.adoc[TinyMCE 5.6]
+
+Release notes for TinyMCE 5.6
+
+|
+[.lead]
+xref:release-notes/release-notes55.adoc[TinyMCE 5.5]
+
+Release notes for TinyMCE 5.5
+
+|
+[.lead]
+xref:release-notes/release-notes542.adoc[TinyMCE 5.4.2]
+
+Release notes for TinyMCE 5.4.2
+
+|
+[.lead]
+xref:release-notes/release-notes54.adoc[TinyMCE 5.4]
+
+Release notes for TinyMCE 5.4
+
+|
+[.lead]
+xref:release-notes/release-notes53.adoc[TinyMCE 5.3]
+
+Release notes for TinyMCE 5.3
+
+|
+[.lead]
+xref:release-notes/release-notes522.adoc[TinyMCE 5.2.2]
+
+Release notes for TinyMCE 5.2.2
+
+|
+[.lead]
+xref:release-notes/release-notes521.adoc[TinyMCE 5.2.1]
+
+Release notes for TinyMCE 5.2.1
+
+|
+[.lead]
+xref:release-notes/release-notes52.adoc[TinyMCE 5.2]
+
+Release notes for TinyMCE 5.2
+
+|
+[.lead]
+xref:release-notes/release-notes516.adoc[TinyMCE 5.1.6]
+
+Release notes for TinyMCE 5.1.6
+
+|
+[.lead]
+xref:release-notes/release-notes515.adoc[TinyMCE 5.1.5]
+
+Release notes for TinyMCE 5.1.5
+
+|
+[.lead]
+xref:release-notes/release-notes514.adoc[TinyMCE 5.1.4]
+
+Release notes for TinyMCE 5.1.4
+
+|
+[.lead]
+xref:release-notes/release-notes51.adoc[TinyMCE 5.1]
+
+Release notes for TinyMCE 5.1
+
+|
+[.lead]
+xref:release-notes/release-notes5014.adoc[TinyMCE 5.0.14]
+
+Release notes for TinyMCE 5.0.14
+
+|
+[.lead]
+xref:release-notes/release-notes5013.adoc[TinyMCE 5.0.13]
+
+Release notes for TinyMCE 5.0.13
+
+|
+[.lead]
+xref:release-notes/release-notes509.adoc[TinyMCE 5.0.9]
+
+Release notes for TinyMCE 5.0.9
+
+|
+[.lead]
+xref:release-notes/release-notes507.adoc[TinyMCE 5.0.7]
+
+Release notes for TinyMCE 5.0.7
+
+|
+[.lead]
+xref:release-notes/release-notes506.adoc[TinyMCE 5.0.6]
+
+Release notes for TinyMCE 5.0.6
+
+|
+[.lead]
+xref:release-notes/release-notes505.adoc[TinyMCE 5.0.5]
+
+Release notes for TinyMCE 5.0.5
+
+|
+[.lead]
+xref:release-notes/release-notes504.adoc[TinyMCE 5.0.4]
+
+Release notes for TinyMCE 5.0.4
+
+|
+[.lead]
+xref:release-notes/release-notes503.adoc[TinyMCE 5.0.3]
+
+Release notes for TinyMCE 5.0.3
+
+|
+[.lead]
+xref:release-notes/release-notes502.adoc[TinyMCE 5.0.2]
+
+Release notes for TinyMCE 5.0.2
+
+|
+[.lead]
+xref:release-notes/release-notes501.adoc[TinyMCE 5.0.1]
+
+Release notes for TinyMCE 5.0.1
+
+|
+[.lead]
+xref:release-notes/release-notes50.adoc[TinyMCE 5.0]
+
+Release notes for TinyMCE 5.0
+
+
+// Empty cell to even out rows
+| 
+
+|===

--- a/modules/ROOT/pages/ui-components/index.adoc
+++ b/modules/ROOT/pages/ui-components/index.adoc
@@ -4,3 +4,77 @@
 :title_nav: UI components
 :type: folder
 
+
+// 2 Columns, both asciidoc
+[cols=2*a]
+|===
+|
+[.lead]
+xref:ui-components/autocompleter.adoc[Autocompleter]
+
+Add a custom autocompleter to TinyMCE 5.
+
+|
+[.lead]
+xref:ui-components/contextform.adoc[Context forms]
+
+Context forms overview
+
+|
+[.lead]
+xref:ui-components/contextmenu.adoc[Context menu]
+
+Context menu overview
+
+|
+[.lead]
+xref:ui-components/contexttoolbar.adoc[Context toolbar]
+
+Context toolbar overview
+
+|
+[.lead]
+xref:ui-components/menuitems.adoc[Custom menu items]
+
+This section demonstrates different types of menu items.
+
+|
+[.lead]
+xref:ui-components/customsidebar.adoc[Custom sidebar]
+
+Introducing sidebar panel creation.
+
+|
+[.lead]
+xref:ui-components/dialog.adoc[Dialog]
+
+An overview of TinyMCE dialogs and how to create custom dialogs.
+
+|
+[.lead]
+xref:ui-components/dialogcomponents.adoc[Dialog components]
+
+A reference list of all TinyMCE dialog components.
+
+|
+[.lead]
+xref:ui-components/urldialog.adoc[URL dialog]
+
+URL dialogs are a TinyMCE UI component used to display an external page.
+
+|
+[.lead]
+xref:ui-components/toolbarbuttons.adoc[Toolbar buttons]
+
+Add a custom buttons to the TinyMCE 5 toolbar.
+
+|
+[.lead]
+xref:ui-components/typesoftoolbarbuttons.adoc[Types of toolbar buttons]
+
+This section demonstrates different types of toolbar buttons.
+
+// Empty cell to even out rows
+| 
+
+|===


### PR DESCRIPTION
Ticket: DOC-2289

Site: [Staging site](http://staging.tiny.cloud/docs/tinymce/5/)

Changes:
* Updating index page link tables

Review:
- [x] Documentation Team Lead has reviewed