### PR TITLE
DOC-2348 add note to 6.x docs `index.adoc` pointing to latest TinyMCE docs

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,3 +1,5 @@
 = {productname} {productmajorversion} Documentation
 
+NOTE: You are browsing the {productname} {productmajorversion} documentation. link:https://www.tiny.cloud/docs/tinymce/latest[There is a newer version of {productname} available].
+
 include::partial$what-is-tinymce.adoc[]


### PR DESCRIPTION
Ticket: DOC-2348

Site: [DOC-2348 site](http://docs-hotfix-6-doc-2348.staging.tiny.cloud/docs/tinymce/6/)

Changes:
* DOC-2348 add note to 6.x docs `index.adoc` pointing to latest TinyMCE docs

Pre-checks:
- [x] Branch prefixed with `feature/6/` or `hotfix/6/`

Review:
- [x] Documentation Team Lead has reviewed