### PR TITLE
DOC-2356: fix broken links in `sandbox-iframes.adoc` and `sandbox-iframe-exclusions.adoc`.

### DIFF
--- a/modules/ROOT/partials/configuration/sandbox_iframes.adoc
+++ b/modules/ROOT/partials/configuration/sandbox_iframes.adoc
@@ -1,7 +1,7 @@
 [[sandbox-iframes]]
 == `sandbox_iframes`
 
-This option allows control of whether `<iframe>` elements are [sandboxed](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox) when inserted into the editor. When enabled, all `<iframe>` elements will be given the `sandbox=""` attribute, applying all restrictions.
+This option allows control of whether `<iframe>` elements are link:https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox[sandboxed] when inserted into the editor. When enabled, all `<iframe>` elements will be given the `sandbox=""` attribute, applying all restrictions.
 
 *Type:* `+Boolean+`
 

--- a/modules/ROOT/partials/configuration/sandbox_iframes_exclusions.adoc
+++ b/modules/ROOT/partials/configuration/sandbox_iframes_exclusions.adoc
@@ -1,7 +1,7 @@
 [[sandbox-iframes-exclusions]]
 == `sandbox_iframes_exclusions`
 
-This option allows a list of domains to be specified that should be excluded from having the `sandbox=""` attribute applied when the `sandbox_iframes` option is enabled. This option takes an array of strings, each denoting at least the top and second level of a domain to be excluded. By default, this option is set to an array of domains that are provided in embed code by popular websites. To enable [sandboxing](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox) on all iframes, set this option to an empty array `[]`.
+This option allows a list of domains to be specified that should be excluded from having the `sandbox=""` attribute applied when the `sandbox_iframes` option is enabled. This option takes an array of strings, each denoting at least the top and second level of a domain to be excluded. By default, this option is set to an array of domains that are provided in embed code by popular websites. To enable link:https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox[sandboxing] on all iframes, set this option to an empty array `[]`.
 
 [NOTE]
 When the `sandbox_iframes` option is set to `false`, all domains will be excluded from sandboxing.


### PR DESCRIPTION
Ticket: DOC-2356

Site: [DOC-2356 site](http://docs-hotfix-70-doc-2356.staging.tiny.cloud/docs/tinymce/latest/content-filtering/#sandbox-iframes)

Changes:
* fix broken links in `sandbox-iframes.adoc` and `sandbox-iframe-exclusions.adoc`.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`

Review:
- [x] Documentation Team Lead has reviewed