### PR TITLE
DOC-2352: On-premises `Import from Word and Export to Word` documentation.

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -17,7 +17,7 @@ asciidoc:
     jquery_url: https://cdn.jsdelivr.net/npm/@tinymce/tinymce-jquery@2/dist/tinymce-jquery.min.js
     default_meta_keywords: tinymce, documentation, docs, plugins, customizable skins, configuration, examples, html, php, java, javascript, image editor, inline editor, distraction-free editor, classic editor, wysiwyg
     # product docker variables
-    dockerimageimportfromwordexporttoword: registry.containers.tiny.cloud/import-from-word-export-to-word
+    dockerimageimportfromwordexporttoword: registry.containers.tiny.cloud/docx-converter-tiny
     # product variables
     productname: TinyMCE
     productmajorversion: 7

--- a/antora.yml
+++ b/antora.yml
@@ -16,6 +16,8 @@ asciidoc:
     webcomponent_url: https://cdn.jsdelivr.net/npm/@tinymce/tinymce-webcomponent@2/dist/tinymce-webcomponent.min.js
     jquery_url: https://cdn.jsdelivr.net/npm/@tinymce/tinymce-jquery@2/dist/tinymce-jquery.min.js
     default_meta_keywords: tinymce, documentation, docs, plugins, customizable skins, configuration, examples, html, php, java, javascript, image editor, inline editor, distraction-free editor, classic editor, wysiwyg
+    # product docker variables
+    dockerimageimportfromwordexporttoword: registry.containers.tiny.cloud/import-from-word-export-to-word
     # product variables
     productname: TinyMCE
     productmajorversion: 7

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -137,8 +137,7 @@
 ***** xref:individual-hyperlinking-container.adoc[Hyperlinking service]
 ***** xref:individual-spelling-container.adoc[Spelling service]
 ***** xref:individual-export-to-pdf-on-premises.adoc[Export to PDF]
-***** xref:individual-export-to-word-on-premises.adoc[Export to Word]
-***** xref:individual-import-from-word-on-premises.adoc[Import from Word]
+***** xref:individual-import-from-word-and-export-to-word-on-premises.adoc[Import from Word and Export to Word]
 *** Configure the server-side components
 **** xref:configure-required-services.adoc[Required configuration]
 **** xref:configure-common-settings-services.adoc[Optional common settings]

--- a/modules/ROOT/pages/individual-export-to-word-on-premises.adoc
+++ b/modules/ROOT/pages/individual-export-to-word-on-premises.adoc
@@ -1,5 +1,0 @@
-= Deploy the {productname} {pluginname} service server-side component using Docker (individually licensed)
-:navtitle: Export to Word
-:description: Setting up Export to Word using Docker.
-:keywords: server-side, docker, export-to-word, on-premises
-:pluginname: Export to Word

--- a/modules/ROOT/pages/individual-import-from-word-and-export-to-word-on-premises.adoc
+++ b/modules/ROOT/pages/individual-import-from-word-and-export-to-word-on-premises.adoc
@@ -1,0 +1,19 @@
+= Deploy the {productname} {pluginname} service server-side component using Docker (individually licensed)
+:navtitle: Import from Word and Export to Word
+:description: Setting up Import from Word and Export to Word using Docker.
+:keywords: server-side, docker, import-from-word, export-to-word, on-premises
+:pluginname: Import from Word and Export to Word
+
+include::partial$individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-overview-on-premises.adoc[]
+
+include::partial$individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-requirements-on-premises.adoc[]
+
+include::partial$individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc[]
+
+include::partial$individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-autorization-on-premises.adoc[]
+
+include::partial$individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-api-usage-on-premises.adoc[]
+
+include::partial$individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-ssl-communication-on-premises.adoc[]
+
+include::partial$individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-logs-on-premises.adoc[]

--- a/modules/ROOT/pages/individual-import-from-word-on-premises.adoc
+++ b/modules/ROOT/pages/individual-import-from-word-on-premises.adoc
@@ -1,5 +1,0 @@
-= Deploy the {productname} {pluginname} service server-side component using Docker (individually licensed)
-:navtitle: Import from Word
-:description: Setting up Import from Word using Docker.
-:keywords: server-side, docker, import-from-word, on-premises
-:pluginname: Import from Word

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-api-usage-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-api-usage-on-premises.adoc
@@ -6,7 +6,7 @@
 * xref:exportword.adoc[Export to Word] provides conversion from an HTML document to a `.docx` file via Restful API.
 * xref:importword.adoc[Import from Word] allows importing `.docx` file and converting it into a styled HTML document with comments and suggestions attached.
 
-The API is available on `http://localhost:[port]` (by default the port is 8080).
+The API is available on `+http://localhost:[port]+` (by default the port is 8080).
 
 [NOTE]
 The REST API documentation is available at `+http://localhost:[port]/docs+`.

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-api-usage-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-api-usage-on-premises.adoc
@@ -1,0 +1,14 @@
+[[api-usage]]
+== API usage
+
+{pluginname} On-Premises consists of two services:
+
+* xref:exportword.adoc[Export to Word] provides conversion from an HTML document to a `.docx` file via Restful API.
+* xref:importword.adoc[Import from Word] allows importing `.docx` file and converting it into a styled HTML document with comments and suggestions attached.
+
+The API is available on `http://localhost:[port]` (by default the port is 8080).
+
+> The REST API documentation is available at `http://localhost:[port]/docs`.
+Alternatively you can check specification in our public resources for link:https://importdocx.converter.tiny.cloud/docs#section/Import-from-Word[Import from Word^] and the link:https://exportdocx.converter.tiny.cloud/docs#section/Export-to-Word[Export to Word^] plugins.
+
+If you have the authorization for the API enabled, you should provide an authorization token. More instructions you can find in the authorization section.

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-api-usage-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-api-usage-on-premises.adoc
@@ -8,7 +8,8 @@
 
 The API is available on `http://localhost:[port]` (by default the port is 8080).
 
-> The REST API documentation is available at `http://localhost:[port]/docs`.
+[NOTE]
+The REST API documentation is available at `+http://localhost:[port]/docs+`.
 Alternatively you can check specification in our public resources for link:https://importdocx.converter.tiny.cloud/docs#section/Import-from-Word[Import from Word^] and the link:https://exportdocx.converter.tiny.cloud/docs#section/Export-to-Word[Export to Word^] plugins.
 
 If you have the authorization for the API enabled, you should provide an authorization token. More instructions you can find in the authorization section.

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-autorization-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-autorization-on-premises.adoc
@@ -10,7 +10,7 @@ If the `SECRET_KEY` is not setup during the installation, then {pluginname} On-P
 
 === Generating the token
 
-{productname} recommends using the libraries listed on link:http://jwt.io/[jwt.io] to generate the token. The token is considered valid, when:
+{companyname} recommends using the libraries listed on link:http://jwt.io/[jwt.io] to generate the token. The token is considered valid, when:
 
 * it is signed with the same `SECRET_KEY` as passed to the {pluginname} On-Premises instance,
 * it was created within the last 24 hours,

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-autorization-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-autorization-on-premises.adoc
@@ -5,7 +5,8 @@ To enable authorization, set the `SECRET_KEY` environment variable during the xr
 
 If the `SECRET_KEY` variable is set, then all requests must have a header with a JWT (JSON Web Token) signed with this key. The token should be passed as a value of the `Authorization` header for each request sent to the {pluginname} REST API.
 
-> If the `SECRET_KEY` is not setup during the installation, then {pluginname} On-Premises will not require any headers with tokens when sending requests to the {pluginname} REST API. However, this it is not recommend to skip the authorization when running {pluginname} On-Premises in a public network.
+[NOTE]
+If the `SECRET_KEY` is not setup during the installation, then {pluginname} On-Premises will not require any headers with tokens when sending requests to the {pluginname} REST API. However, this it is not recommend to skip the authorization when running {pluginname} On-Premises in a public network.
 
 === Generating the token
 

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-autorization-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-autorization-on-premises.adoc
@@ -1,0 +1,68 @@
+[[authorization]]
+== Authorization
+
+To enable authorization, set the `SECRET_KEY` environment variable during the xref:individual-import-from-word-and-export-to-word-on-premises.adoc#installation[installation].
+
+If the `SECRET_KEY` variable is set, then all requests must have a header with a JWT (JSON Web Token) signed with this key. The token should be passed as a value of the `Authorization` header for each request sent to the {pluginname} REST API.
+
+> If the `SECRET_KEY` is not setup during the installation, then {pluginname} On-Premises will not require any headers with tokens when sending requests to the {pluginname} REST API. However, this it is not recommend to skip the authorization when running {pluginname} On-Premises in a public network.
+
+=== Generating the token
+
+{productname} recommends using the libraries listed on link:http://jwt.io/[jwt.io] to generate the token. The token is considered valid, when:
+
+* it is signed with the same `SECRET_KEY` as passed to the {pluginname} On-Premises instance,
+* it was created within the last 24 hours,
+* it is not issued in the future (e.i. the `iat` timestamp cannot be newer than the current time),
+* it has not expired yet.
+
+Tokens for the {pluginname} On-Premises do not require any additional claims such as the environment ID (which is specific for Collaboration Server On-Premises), the token can be created with an empty payload.
+
+If the specific use case involves sending requests from a backend server, then JWT tokens can be generated locally, as shown in the below request example.
+
+In the case of editor plugins or other frontend usages, a token endpoint should be created, that returns a valid JWT token for authorized users.
+
+=== Using editor plugins
+
+The are are two plugins available for {productname}: the xref:importword.adoc[Import from Word] and the xref:exportword.adoc[Export to Word] plugins. The plugins will automatically request the token from the given `tokenUrl` variable and will set the `Authorization` header when making an export request. Refer to the respective guides for details on adding the {pluginname} features to your WYSIWYG editor!
+
+=== Request example with an Authorization header
+
+The following example presents a request that generates a valid JWT token and sets it as an `Authorization` header:
+
+[source, js]
+----
+const fs = require( 'fs' );
+const jwt = require( 'jsonwebtoken' );
+const axios = require( 'axios' );
+
+const SECRET_KEY = 'secret';
+
+const token = jwt.sign( {}, SECRET_KEY, { algorithm: 'HS256' } );
+
+const data = {
+   html: "<p>I am a teapot</p>",
+   css: "p { color: red; }",
+};
+
+const config = {
+   headers: {
+      Authorization: token
+   },
+   responseType: 'arraybuffer',
+};
+
+axios.post( 'http://localhost:8080/v1/convert', data, config )
+   .then( response => {
+      fs.writeFileSync('./file.docx', response.data, 'binary');
+   } ).catch( error => {
+      console.log( error );
+   } );
+----
+
+`SECRET_KEY`: This is the key what has been passed to the {pluginname} On-Premises instance.
+
+Please refer to the link:https://importdocx.converter.tiny.cloud/docs#section/Import-from-Word[Import from Word^] and the link:https://exportdocx.converter.tiny.cloud/docs#section/Export-to-Word[Export to Word^] REST API documentation to start using the service.
+
+[NOTE]
+If API clients like Postman or Insomnia are used, then set the JWT token as an `Authorization` header in the `Headers` tab. Do not use the built-in token authorization as this will generate invalid header with a `Bearer` prefix added to the token.

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
@@ -15,7 +15,7 @@ Refer to the xref:individual-import-from-word-and-export-to-word-on-premises.ado
 
 === Setting up the application using a Docker container
 
-. Use instructions from the {productname} Ecosystem customer dashboard to log into the {pluginname} On-Premises (PDF converter) Docker registry and pull the Docker image.
+. The username and password credentials supplied by Tiny are utilized for logging into the Docker registry and retrieving the Docker image.
 . Containerize the application using `docker` or `docker-compose`.
 . Use a demo page to verify if the application works properly.
 

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
@@ -20,6 +20,13 @@ Refer to the xref:individual-import-from-word-and-export-to-word-on-premises.ado
 
 ==== Containerize example using docker
 
+Login to Docker registry:
+
+[source, sh, subs="attributes+"]
+----
+docker login -u [username] -p [password] registry.containers.tiny.cloud
+----
+
 Launch the Docker container:
 
 [source, sh, subs="attributes+"]
@@ -43,16 +50,17 @@ Read more about using authorization in the xref:individual-import-from-word-and-
 [source, yml, subs="attributes+"]
 ----
 version: "3.8"
-  services:
+services:
+  doc-converter:
     image: {dockerimageimportfromwordexporttoword}:[version]
-      ports:
-        - "8080:8080"
-      restart: always
-      init: true
-      environment:
-        LICENSE_KEY: your_license_key
-        # Secret Key is optional
-        SECRET_KEY: secret_key
+    ports:
+      - "8080:8080"
+    restart: always
+    init: true
+    environment:
+      LICENSE_KEY: "licensekey"
+      # Secret Key is optional
+      SECRET_KEY: "secret_key"
 ----
 +
 For details on `SECRET_KEY` usage check the xref:individual-import-from-word-and-export-to-word-on-premises.adoc#authorization[authorization] section.

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
@@ -1,7 +1,8 @@
 [[installation]]
 == Installation
 
-> A valid license key is needed in order to install {pluginname} On-Premises.
+[NOTE]
+A valid license key is needed in order to install {pluginname} On-Premises.
 link:https://www.tiny.cloud/contact/[Contact us] for a trial license key.
 
 === Supported technologies

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
@@ -1,0 +1,80 @@
+[[installation]]
+== Installation
+
+> A valid license key is needed in order to install {pluginname} On-Premises.
+link:https://www.tiny.cloud/contact/[Contact us] for a trial license key.
+
+=== Supported technologies
+
+The application is provided as a docker image by default.
+
+It can be run with any Open Container runtime tool e.g. link:https://kubernetes.io/[Kubernetes], link:https://www.redhat.com/en/technologies/cloud-computing/openshift[OpenShift], link:https://podman.io/[Podman], link:https://docs.docker.com/[Docker] and many others.
+
+Refer to the xref:individual-import-from-word-and-export-to-word-on-premises.adoc#requirements[Requirements guide] for more information about the hardware and software requirements to run the {pluginname} On-Premises.
+
+=== Setting up the application using a Docker container
+
+. Use instructions from the {productname} Ecosystem customer dashboard to log into the {pluginname} On-Premises (PDF converter) Docker registry and pull the Docker image.
+. Containerize the application using `docker` or `docker-compose`.
+. Use a demo page to verify if the application works properly.
+
+==== Containerize example using docker
+
+Launch the Docker container:
+
+[source, sh, subs="attributes+"]
+----
+docker run --init -p 8080:8080 -e LICENSE_KEY=[your_license_key] {dockerimageimportfromwordexporttoword}:[version]
+----
+
+If using authorization provide the SECRET_KEY:
+
+[source, sh, subs="attributes+"]
+----
+docker run --init -p 8080:8080 -e LICENSE_KEY=[your_license_key] -e SECRET_KEY=[your_secret_key] {dockerimageimportfromwordexporttoword}:[version]
+----
+
+Read more about using authorization in the xref:individual-import-from-word-and-export-to-word-on-premises.adoc#authorization[authorization] section.
+
+==== Containerize example using docker-compose
+
+. Create the docker-compose.yml file:
++
+[source, yml, subs="attributes+"]
+----
+version: "3.8"
+  services:
+    image: {dockerimageimportfromwordexporttoword}:[version]
+      ports:
+        - "8080:8080"
+      restart: always
+      init: true
+      environment:
+        LICENSE_KEY: your_license_key
+        # Secret Key is optional
+        SECRET_KEY: secret_key
+----
++
+For details on `SECRET_KEY` usage check the xref:individual-import-from-word-and-export-to-word-on-premises.adoc#authorization[authorization] section.
++
+. Run:
+
+[source, bash]
+----
+docker-compose up
+----
+
+[NOTE]
+====
+* Without a correct `LICENSE_KEY` the application will not start.
+** If the license is invalid, a wrong license key error will display in the logs and the application will not run.
+* It is advisable to override the `SECRET_KEY` variable using a unique and hard to guess string for security reasons.
+====
+
+=== Next steps
+
+Use the link:http://localhost:8080/v1/convert[http://localhost:8080/v1/convert] endpoint to export DOCX files. Check out the xref:individual-import-from-word-and-export-to-word-on-premises.adoc#authorization[authorization] section to learn more about tokens and token endpoints.
+
+Use the demo page available on link:http://localhost:8080/demo[http://localhost:8080/demo] to generate an example DOCX file.
+
+Refer to the {pluginname} REST API documentation on link:http://localhost:8080/docs[http://localhost:8080/docs] for more details.

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-logs-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-logs-on-premises.adoc
@@ -58,7 +58,8 @@ The docker has built-in logging mechanisms that capture logs from the output of 
 
 When using this driver, use the `docker logs` command to show logs from a container. Use the `-f` flag to view logs in real time. Refer to the link:https://docs.docker.com/engine/reference/commandline/logs/[official Docker documentation] for more information about the logs command.
 
-> When a container is running for a long period of time, the logs can take up a lot of space. To avoid this problem, you should make sure that the log rotation is enabled. This can be set with the `max-size` option.
+[NOTE]
+When a container is running for a long period of time, the logs can take up a lot of space. To avoid this problem, you should make sure that the log rotation is enabled. This can be set with the `max-size` option.
 
 === Distributed logging
 

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-logs-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-logs-on-premises.adoc
@@ -1,0 +1,210 @@
+[[logs]]
+== Logs
+
+The logs from {pluginname} On-Premises are written to `stdout` and `stderr`. Most of them are formatted in JSON. They can be used for monitoring or debugging purposes. In production environments, It is recommend storing the logs to files or using a distributed logging system (like ELK or CloudWatch).
+
+=== Monitoring {pluginname} with logs
+
+To get more insight into how the {pluginname} On-Premises is performing, logs can be used for monitoring. To enable these, add the `ENABLE_METRIC_LOGS=true` environment variable.
+
+=== Log structure
+
+The log structure contains the following information:
+
+* `handler`: A unified identifier of action. Use this field to identify calls.
+* `traceId`: A unique RPC call ID.
+* `tags`: A semicolon-separated list of tags. Use this field to filter metrics logs.
+* `data`: An object containing additional information. It might vary between different transports.
+* `data.duration`: The request duration in milliseconds.
+* `data.transport`: The type of the request transport. It could be http or ws (websocket).
+* `data.status`: The request status. It can be equal to success, fail, warning.
+* `data.statusCode`: The response status in HTTP status code standard.
+
+Additionally, for the HTTP transport, the following information is included:
+
+* `data.url`: The URL path.
+* `data.method`: The request method.
+
+In case of an error, `data.status` will be equal to `failed` and `data.message` will contain the error message.
+
+An example log for HTTP transport:
+
+[source]
+----
+{
+  "level": 30,
+  "time": "2021-03-09T11:15:09.154Z",
+  "msg": "Request summary",
+  "handler": "postConvert",
+  "traceId": "85f13d92-57df-4b3b-98bb-0ca41a5ae601",
+  "data": {
+    "duration": 752,
+    "transport": "http",
+    "statusCode": 200,
+    "status": "success",
+    "url": "/v1/convert",
+    "method": "POST"
+  },
+  "tags": "metrics"
+}
+----
+////
+See example charts to check how to use logs for monitoring purposes
+////
+
+=== Docker
+
+The docker has built-in logging mechanisms that capture logs from the output of the containers. The default logging driver writes the logs to files.
+
+When using this driver, use the `docker logs` command to show logs from a container. Use the `-f` flag to view logs in real time. Refer to the link:https://docs.docker.com/engine/reference/commandline/logs/[official Docker documentation] for more information about the logs command.
+
+> When a container is running for a long period of time, the logs can take up a lot of space. To avoid this problem, you should make sure that the log rotation is enabled. This can be set with the `max-size` option.
+
+=== Distributed logging
+
+If running more than one instance of {pluginname} On-Premises, It is recommend using a distributed logging system. It allows for viewing and analyzing logs from all instances in one place.
+
+=== AWS CloudWatch and other cloud solutions
+
+If running {pluginname} On-Premises in the cloud, the simplest and recommended way is to use a service that is available at the selected provider.
+
+Here are some of the available services:
+
+* AWS: link:https://aws.amazon.com/CloudWatch[CloudWatch^]
+* Google Cloud: link:https://cloud.google.com/logging[Cloud Logging^]
+* Azure: link:https://azure.microsoft.com/en-us/services/monitor/[Azure Monitor^]
+
+To use CloudWatch with AWS ECS, a log group must be created before, and the log driver must be changed to `awslogs`. When the log driver is configured properly, logs will be streamed directly to CloudWatch.
+
+The `logConfiguration` may look similar to this:
+
+[source, json]
+----
+"logConfiguration": {
+  "logDriver": "awslogs",
+  "options": {
+    "awslogs-region": "us-west-2",
+    "awslogs-group": "cksource",
+    "awslogs-stream-prefix": "ck-docx-converter-logs"
+  }
+}
+----
+
+Refer to the link:https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html[Using the awslogs Log Driver] article for more information.
+
+=== On-Premises solutions
+
+If using a specific infrastructure such as your own or for some reason cannot use the service offered by a provider, some on-premises distributed logging system can be used.
+
+There are a lot of solutions available, including:
+
+* link:https://www.elastic.co/what-is/elk-stack[ELK^] + link:https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-getting-started.html[Filebeat^]
+
+This is a stack built on top of Elasticsearch, Logstash and Kibana. In this configuration, Elasticsearch stores logs, Filebeat reads logs from Docker and sends them to Elasticsearch, and Kibana is used to view them. Logstash is not necessary because logs are already structured.
+
+* link:https://www.fluentd.org/[Fluentd^]
+
+It uses a dedicated link:https://docs.docker.com/config/containers/logging/fluentd[Docker log driver^] to send the logs. It has a built-in frontend, but can also be integrated with Elasticsearch and Kibana for better filtering.
+
+* link:https://www.graylog.org/[Graylog^]
+
+It uses a dedicated link:https://docs.docker.com/config/containers/logging/gelf[Docker^] log driver to send the logs. It has a built-in frontend and needs Elasticsearch to store the logs as well as a MongoDB database to store the configuration.
+
+==== Example configuration
+
+The example configuration uses Fluentd, Elasticsearch and Kibana to capture logs from Docker.
+
+Before running {pluginname} On-Premises, prepare the logging services. For the purposes of this example, Docker Compose is used. Create the `fluentd`, `elasticsearch` and `kibana` services inside the `docker-compose.yml` file:
+
+[source, yaml]
+----
+version: '3.7'
+services:
+  fluentd:
+    build: ./fluentd
+    volumes:
+      - ./fluentd/fluent.conf:/fluentd/etc/fluent.conf
+    ports:
+      - "24224:24224"
+      - "24224:24224/udp"
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.5
+    expose:
+      - 9200
+    ports:
+      - "9200:9200"
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:6.8.5
+    environment:
+      ELASTICSEARCH_HOSTS: "http://elasticsearch:9200"
+    ports:
+      - "5601:5601"
+----
+
+To integrate Fluentd with Elasticsearch, you first need to install `fluent-plugin-elasticsearch` in the Fluentd image. To do this, create a `fluentd/Dockerfile` with the following content:
+
+[source, dockerfile]
+----
+FROM fluent/fluentd:v1.10-1
+
+USER root
+
+RUN apk add --no-cache --update build-base ruby-dev \
+  && gem install fluent-plugin-elasticsearch \
+  && gem sources --clear-all
+----
+
+Next, configure the input server and connection to Elasticsearch in the `fluentd/fluent.conf` file:
+
+[source, xml]
+----
+<source>
+  @type forward
+  port 24224
+  bind 0.0.0.0
+</source>
+<match *.**>
+  @type copy
+  <store>
+    @type elasticsearch
+    host elasticsearch
+    port 9200
+    logstash_format true
+    logstash_prefix fluentd
+    logstash_dateformat %Y%m%d
+    include_tag_key true
+    type_name access_log
+    tag_key @log_name
+    flush_interval 1s
+  </store>
+  <store>
+    @type stdout
+  </store>
+</match>
+----
+
+The services are now ready to run:
+
+[source, bash]
+----
+docker-compose up --build
+----
+
+When the services are ready, start the {pluginname} On-Premises.
+
+[source, bash, subs="attributes+"]
+----
+docker run --init -p 8080:8080 \
+--log-driver=fluentd \
+--log-opt fluentd-address=[Fluentd address]:24224 \
+[Your config here] \
+{dockerimageimportfromwordexporttoword}:[version]
+----
+
+* Open Kibana in your browser.
+** It is available at link:http://localhost:5601/[http://localhost:5601/].
+* During the first run, you may be asked about creating an index.
+* Use the `fluentd-*` pattern and press the “Create” button.
+* After this step, the logs should appear in the “Discover” tab.

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-logs-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-logs-on-premises.adoc
@@ -84,8 +84,8 @@ The `logConfiguration` may look similar to this:
   "logDriver": "awslogs",
   "options": {
     "awslogs-region": "us-west-2",
-    "awslogs-group": "cksource",
-    "awslogs-stream-prefix": "ck-docx-converter-logs"
+    "awslogs-group": "tinysource",
+    "awslogs-stream-prefix": "tiny-docx-converter-logs"
   }
 }
 ----

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-logs-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-logs-on-premises.adoc
@@ -48,9 +48,6 @@ An example log for HTTP transport:
   "tags": "metrics"
 }
 ----
-////
-See example charts to check how to use logs for monitoring purposes
-////
 
 === Docker
 

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-overview-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-overview-on-premises.adoc
@@ -5,7 +5,6 @@
 
 About xref:importword.adoc[Import from Word] and xref:exportword.adoc[Export to Word] features you can read in a dedicated sections of the documentation.
 
-The On-Premises version of the {pluginname} features is an application that can be installed and run on the customer’s in-house servers and computing infrastructure, including a private cloud. It contains all the features of the {pluginname} converters available as SaaS.
 
 A valid license key is needed in order to install {pluginname} On-Premises. link:https://www.tiny.cloud/contact/[Contact us] for a trial license key.
 

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-overview-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-overview-on-premises.adoc
@@ -3,8 +3,6 @@
 
 {pluginname} is a set of two converter services that allow for both exporting a structured HTML content (e.g. created with {productname} WYSIWYG editor) into a `.docx` Microsoft Word file and for importing content from `.docx` and `.dotx` files and converting it into a styled HTML document.
 
-
-
 A valid license key is needed in order to install {pluginname} On-Premises. link:https://www.tiny.cloud/contact/[Contact us] for a trial license key.
 
 The documentation in this section refers to a simplified version of the {pluginname} On-Premises which was designed to be easy to set up and maintain (while preserving all the features). It also lowers the running costs by reducing the number of servers required to run the whole application to the minimum.

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-overview-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-overview-on-premises.adoc
@@ -1,7 +1,7 @@
 [[overview]]
 == Overview
 
-{pluginname} is a set of two converter services that allow for both exporting a structured HTML content (e.g. created with {productname} WYSIWYG editor) into a `.docx` Microsoft Word file and for importing content from `.docx` and `.dotx` files and converting it into a styled HTML document with comments and suggestions attached.
+{pluginname} is a set of two converter services that allow for both exporting a structured HTML content (e.g. created with {productname} WYSIWYG editor) into a `.docx` Microsoft Word file and for importing content from `.docx` and `.dotx` files and converting it into a styled HTML document.
 
 About xref:importword.adoc[Import from Word] and xref:exportword.adoc[Export to Word] features you can read in a dedicated sections of the documentation.
 

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-overview-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-overview-on-premises.adoc
@@ -1,0 +1,16 @@
+[[overview]]
+== Overview
+
+{pluginname} is a set of two converter services that allow for both exporting a structured HTML content (e.g. created with {productname} WYSIWYG editor) into a `.docx` Microsoft Word file and for importing content from `.docx` and `.dotx` files and converting it into a styled HTML document with comments and suggestions attached.
+
+About xref:importword.adoc[Import from Word] and xref:exportword.adoc[Export to Word] features you can read in a dedicated sections of the documentation.
+
+The On-Premises version of the {pluginname} features is an application that can be installed and run on the customer’s in-house servers and computing infrastructure, including a private cloud. It contains all the features of the {pluginname} converters available as SaaS.
+
+A valid license key is needed in order to install {pluginname} On-Premises.
+
+link:https://www.tiny.cloud/contact/[Contact us] for a trial license key.
+
+The documentation in this section refers to a simplified version of the {pluginname} On-Premises which was designed to be easy to set up and maintain (while preserving all the features). It also lowers the running costs by reducing the number of servers required to run the whole application to the minimum.
+
+The only requirement to run {pluginname} On-Premises is a container runtime or orchestration tool e.g. Docker, Kubernetes, Podman.

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-overview-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-overview-on-premises.adoc
@@ -7,9 +7,7 @@ About xref:importword.adoc[Import from Word] and xref:exportword.adoc[Export to 
 
 The On-Premises version of the {pluginname} features is an application that can be installed and run on the customer’s in-house servers and computing infrastructure, including a private cloud. It contains all the features of the {pluginname} converters available as SaaS.
 
-A valid license key is needed in order to install {pluginname} On-Premises.
-
-link:https://www.tiny.cloud/contact/[Contact us] for a trial license key.
+A valid license key is needed in order to install {pluginname} On-Premises. link:https://www.tiny.cloud/contact/[Contact us] for a trial license key.
 
 The documentation in this section refers to a simplified version of the {pluginname} On-Premises which was designed to be easy to set up and maintain (while preserving all the features). It also lowers the running costs by reducing the number of servers required to run the whole application to the minimum.
 

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-overview-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-overview-on-premises.adoc
@@ -3,7 +3,6 @@
 
 {pluginname} is a set of two converter services that allow for both exporting a structured HTML content (e.g. created with {productname} WYSIWYG editor) into a `.docx` Microsoft Word file and for importing content from `.docx` and `.dotx` files and converting it into a styled HTML document.
 
-About xref:importword.adoc[Import from Word] and xref:exportword.adoc[Export to Word] features you can read in a dedicated sections of the documentation.
 
 
 A valid license key is needed in order to install {pluginname} On-Premises. link:https://www.tiny.cloud/contact/[Contact us] for a trial license key.

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-requirements-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-requirements-on-premises.adoc
@@ -1,0 +1,22 @@
+[[requirements]]
+== Requirements
+
+To run {pluginname} On-Premises, a Docker environment is required. Alternatively, use a CaaS available from your cloud provider, such as AWS ECS, Google GKE or Azure ACS.
+
+There are many factors that may affect Export to Word On-Premises performance. The most influential are: the size of exported content, the size of images, and the number of concurrent requests. Also, because your application can prioritize fast response times, or it should handle high load, it is impossible to provide one recommended server specification, that will fit all use cases.
+
+Assuming response time below 10 seconds, one server (2CPU 2GB RAM) with 1 docker container can handle:
+
+* up to 45 concurrent requests with an average content of 1 A4 page (~1k characters)
+* up to 30 concurrent requests with an average content of 5 A4 pages (~7,5k characters)
+* up to 10 concurrent requests with an average content of 20 A4 pages (~30k characters)
+
+> The listed concurrent requests numbers are not a hard limit of a {pluginname} On-Premises instance. It can handle more concurrent requests, but the response time will be longer.
+
+=== High availability
+
+One docker container with {pluginname} On-Premises benefits from additional CPUs on the machine. It is recommended that 2 CPUs are allocated for every docker container. To scale your app on a single machine, increase the number of CPUs and docker containers, however, {productname} recommends scaling on at least three hosts to ensure the reliability of the system.
+
+A load balancer, like HAProxy or NGINX (see the load balancer configuration examples in the SSL communication guide), is required for scaling on several machines. Of course, it is possible to use any cloud provider for scaling, like Amazon ECS, Azure Container Instances or Kubernetes.
+
+link:https://www.tiny.cloud/contact/[Contact us] if you have any questions about server resources needed for your use case of {pluginname} On-Premises.

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-requirements-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-requirements-on-premises.adoc
@@ -11,7 +11,8 @@ Assuming response time below 10 seconds, one server (2CPU 2GB RAM) with 1 docker
 * up to 30 concurrent requests with an average content of 5 A4 pages (~7,5k characters)
 * up to 10 concurrent requests with an average content of 20 A4 pages (~30k characters)
 
-> The listed concurrent requests numbers are not a hard limit of a {pluginname} On-Premises instance. It can handle more concurrent requests, but the response time will be longer.
+[NOTE]
+The listed concurrent requests numbers are not a hard limit of a {pluginname} On-Premises instance. It can handle more concurrent requests, but the response time will be longer.
 
 === High availability
 

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-ssl-communication-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-ssl-communication-on-premises.adoc
@@ -1,0 +1,68 @@
+[[sll-communication]]
+== SSL Communication
+
+Its possible to communicate with {pluginname} On-Premises using secure connections. To achieve this, the load balancer like `NGINX` or `HAProxy` needs to be setup with your SSL certificate.
+
+`HAProxy` and `NGINX` configuration examples below.
+
+=== HAProxy example
+
+Here is a basic `HAProxy` configuration:
+
+[source, nginx]
+----
+global
+  daemon
+  maxconn 256
+  tune.ssl.default-dh-param 2048
+
+defaults
+  mode http
+  timeout connect 5000ms
+  timeout client 50000ms
+  timeout server 50000ms
+
+frontend http-in
+  bind *:80
+  bind *:443 ssl crt /etc/ssl/your_certificate.pem
+  http-request set-header X-Forwarded-Proto https if { ssl_fc }
+  http-request set-header X-Forwarded-Proto http if !{ ssl_fc }
+  redirect scheme https if !{ ssl_fc }
+
+  default_backend servers
+
+backend servers
+  server server1 127.0.0.1:8000 maxconn 32
+----
+
+=== NGINX example
+
+Here is a basic NGINX configuration:
+
+[source, nginx]
+----
+events {
+    worker_connections  1024;
+}
+
+http {
+  server {
+    server_name your.domain.name;
+
+    listen 443;
+    ssl on;
+    ssl_certificate /etc/ssl/your_cert.crt;
+    ssl_certificate_key /etc/ssl/your_cert_key.key;
+
+    location / {
+      proxy_pass http://127.0.0.1:8000;
+
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "Upgrade";
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_http_version 1.1;
+    }
+  }
+}
+----


### PR DESCRIPTION
Ticket: DOC-2352

Site: [DOC-2339_DOC-2352 site](http://docs-hotfix-7-doc-2339doc-2352.staging.tiny.cloud/docs/tinymce/latest/individual-import-from-word-and-export-to-word-on-premises/)

Changes:
* Add On-premises `Import from Word and Export to Word` documentation.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`

Review:
- [x] Documentation Team Lead has reviewed