### PR TITLE
DOC-2355 add "Setting the license" information to quickstart self-hosted documents

### DIFF
--- a/modules/ROOT/pages/bower-projects.adoc
+++ b/modules/ROOT/pages/bower-projects.adoc
@@ -1,6 +1,6 @@
-= Installing TinyMCE with Bower
+= Installing {productname} with Bower
 :navtitle: Bower projects
-:description: Learn how to install TinyMCE using Bower.
+:description: Learn how to install {productname} using Bower.
 :keywords: bower, javascript, install
 :productSource: bower
 

--- a/modules/ROOT/pages/cloud-quick-start.adoc
+++ b/modules/ROOT/pages/cloud-quick-start.adoc
@@ -1,7 +1,7 @@
 = Quick start
 :navtitle: Quick start
-:description_short: Setup a basic TinyMCE 6 editor using the Tiny Cloud.
-:description: Get an instance of TinyMCE 6 up and running using the Tiny Cloud.
+:description_short: Setup a basic {productname} {productmajorversion} editor using the {cloudname}.
+:description: Get an instance of {productname} {productmajorversion} up and running using the {cloudname}.
 :keywords: tinymce, script, textarea
 :productSource: cloud
 

--- a/modules/ROOT/pages/dotnet-projects.adoc
+++ b/modules/ROOT/pages/dotnet-projects.adoc
@@ -1,6 +1,6 @@
-= Installing TinyMCE for .NET
+= Installing {productname} for .NET
 :navtitle: .NET projects
-:description: Learn how to install TinyMCE from NuGet.
+:description: Learn how to install {productname} from NuGet.
 :keywords: nuget .net install
 :productSource: nuget
 

--- a/modules/ROOT/pages/license-key.adoc
+++ b/modules/ROOT/pages/license-key.adoc
@@ -9,28 +9,10 @@
 
 If you are using {productname} in a self-hosted environment, a console log warning message will display if the license key config option is missing or invalid. This message aims to ensure compliance with licensing requirements and provide transparency during the evaluation period.
 
-This message will not be shown when loading {productname} from the Tiny Cloud, as it is already under a commercial license.
+This message will not be shown when loading {productname} from {cloudname}, as it is already under a commercial license.
 ====
 
-== Setting the license
-
-=== Use {productname} with the GPLv2+ license:
-
-If the developer intends to self-host {productname} under the GPL license, they can set the `license_key` config option to 'gpl'. Case sensitivity does not matter.
-
-==== Example
-
-[source,js]
-----
-tinymce.init({
-  selector: 'textarea',  // change this value according to your HTML
-  license_key: 'gpl'
-});
-----
-
-=== Use {productname} with a commercial license:
-
-If the developer intends to self-host {productname} under a commercial license, they must provide a valid license key. Customers who have purchased a self-hosted-eligible license for {productname} will find their license key in the account portal. To purchase a commercial license, see available options on the link:{pricingpage}/[pricing page]. 
+include::partial$misc/setting-the-license.adoc[]
 
 ==== Example
 
@@ -52,7 +34,7 @@ The GPLv2+ license was chosen to provide the best compatibility with existing GP
 
 === What is the difference between a license key and the API key?
 
-The **API key** is used when loading {productname} from the Tiny Cloud. The **license key** is used to declare the license terms when self-hosting {productname}.
+The **API key** is used when loading {productname} from the {cloudname}. The **license key** is used to declare the license terms when self-hosting {productname}.
 
 === Who needs to get a license key?
 
@@ -64,7 +46,7 @@ If {productname} detects that the `license_key` configuration is missing or inva
 
 === Should I be using both an API key and a license key?
 
-No, an API key and a license key should not be used simultaneously. The API key should only be used if {productname} is loaded from the Tiny Cloud. If {productname} is being self-hosted, the license key option should be used instead.
+No, an API key and a license key should not be used simultaneously. The API key should only be used if {productname} is loaded from the {cloudname}. If {productname} is being self-hosted, the license key option should be used instead.
 
 === Will {productname} “phone home” to check the license key?
 

--- a/modules/ROOT/pages/npm-projects.adoc
+++ b/modules/ROOT/pages/npm-projects.adoc
@@ -1,6 +1,6 @@
-= Installing TinyMCE from NPM
+= Installing {productname} from NPM
 :navtitle: NPM projects
-:description: Learn how to install TinyMCE from NPM using npm and Yarn.
+:description: Learn how to install {productname} from NPM using npm and Yarn.
 :keywords: yarn, npm, javascript, install
 :productSource: npm
 

--- a/modules/ROOT/pages/php-projects.adoc
+++ b/modules/ROOT/pages/php-projects.adoc
@@ -1,6 +1,6 @@
-= Installing TinyMCE with Composer
+= Installing {productname} with Composer
 :navtitle: PHP projects
-:description: Learn how to install TinyMCE from Packagist using Composer.
+:description: Learn how to install {productname} from Packagist using Composer.
 :keywords: php, composer, packagist, install
 :productSource: composer
 

--- a/modules/ROOT/pages/zip-install.adoc
+++ b/modules/ROOT/pages/zip-install.adoc
@@ -1,6 +1,6 @@
-= Using TinyMCE from a .zip file
-:navtitle: TinyMCE .zip deployments
-:description: Learn how to use TinyMCE from a .zip archive.
+= Using {productname} from a .zip file
+:navtitle: {productname} .zip deployments
+:description: Learn how to use {productname} from a .zip archive.
 :keywords: zip, archive, unzip, install
 :productSource: zip
 

--- a/modules/ROOT/partials/install/basic-quickstart-base.adoc
+++ b/modules/ROOT/partials/install/basic-quickstart-base.adoc
@@ -30,7 +30,7 @@ ifeval::["{productSource}" != "cloud"]
 :scriptsource: /path/or/uri/to/tinymce.min.js
 endif::[]
 
-== Install TinyMCE using {sourcename}
+== Install {productname} using {sourcename}
 
 {productname} {productmajorversion} is a powerful and flexible rich text editor that can be embedded in web applications. This quick start covers how to add a {productname} editor to a web page using {sourcename}.
 
@@ -91,14 +91,14 @@ To add {productname} to a .NET project, run the following on a command line:
 +
 [source,sh]
 ----
-Install-Package TinyMCE
+Install-Package {productname}
 ----
 
 * Using the `+dotnet+` CLI, run the following:
 +
 [source,sh]
 ----
-dotnet add package TinyMCE
+dotnet add package {productname}
 ----
 
 Ensure the `+tinymce+` directory containing the `+tinymce.min.js+` file is accessible for the target page or application by either:
@@ -123,7 +123,7 @@ The location of the main {productname} script will be: `+/path/to/webserver/publ
 
 endif::[]
 
-== Include the TinyMCE script
+== Include the {productname} script
 
 Include the following line of code in the `+<head>+` of an HTML page.
 
@@ -132,7 +132,7 @@ Include the following line of code in the `+<head>+` of an HTML page.
 <script src="{scriptsource}" referrerpolicy="origin"></script>
 ----
 
-== Initialize TinyMCE as part of a web form
+== Initialize {productname} as part of a web form
 
 Initialize {productname} {productmajorversion} on any element (or elements) on the web page by passing an object containing a `+selector+` value to `+tinymce.init()+`. The `+selector+` value can be any valid https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors[CSS selector].
 
@@ -140,6 +140,7 @@ For example: To replace `+<textarea id="mytextarea">+` with a {productname} {pro
 
 For example:
 
+ifeval::["{productSource}" == "cloud"]
 [source,html,subs="attributes+"]
 ----
 <!DOCTYPE html>
@@ -164,12 +165,41 @@ For example:
   </body>
 </html>
 ----
+endif::[]
 
-Adding this content to an HTML file and opening it in a web browser will load a TinyMCE editor, such as:
+ifeval::["{productSource}" != "cloud"]
+[source,html,subs="attributes+"]
+----
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <script src="{scriptsource}" referrerpolicy="origin"></script>
+    <script>
+      tinymce.init({
+        selector: '#mytextarea',
+        license_key: 'gpl|<your-license-key>'
+      });
+    </script>
+  </head>
+
+  <body>
+    <h1>{productname} Quick Start Guide</h1>
+    <form method="post">
+      <textarea id="mytextarea">Hello, World!</textarea>
+    </form>
+  </body>
+</html>
+----
+endif::[]
+
+Adding this content to an HTML file and opening it in a web browser will load a {productname} editor, such as:
 
 liveDemo::default[]
-ifeval::["{productSource}" == "cloud"]
 
+ifeval::["{productSource}" == "cloud"]
 == Add your API key
 
 To remove the notice:
@@ -179,6 +209,12 @@ To remove the notice:
 Replace `+no-api-key+` in the source script (`+<script src=...+`) with a {cloudname} API key, which is created when signing up to the link:{accountsignup}/[{cloudname}].
 
 Signing up for a {cloudname} API key will also provide a trial of the xref:plugins.adoc#premium-plugins[Premium Plugins].
+endif::[]
+
+ifeval::["{productSource}" != "cloud"]
+include::partial$misc/setting-the-license.adoc[]
+
+For more information on licensing, see the xref:license-key.adoc[License Key] guide.
 endif::[]
 
 == Save the content from the editor

--- a/modules/ROOT/partials/misc/setting-the-license.adoc
+++ b/modules/ROOT/partials/misc/setting-the-license.adoc
@@ -1,0 +1,19 @@
+== Setting the license
+
+=== Use {productname} with the GPLv2+ license:
+
+If the developer intends to self-host {productname} under the GPL license, they can set the `license_key` config option to 'gpl'. Case sensitivity does not matter.
+
+==== Example
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  license_key: 'gpl'
+});
+----
+
+=== Use {productname} with a commercial license:
+
+If the developer intends to self-host {productname} under a commercial license, they must provide a valid license key. Customers who have purchased a self-hosted-eligible license for {productname} will find their license key in the account portal. To purchase a commercial license, see available options on the link:{pricingpage}/[pricing page].

--- a/modules/ROOT/partials/misc/setting-the-license.adoc
+++ b/modules/ROOT/partials/misc/setting-the-license.adoc
@@ -16,4 +16,4 @@ tinymce.init({
 
 === Use {productname} with a commercial license:
 
-If the developer intends to self-host {productname} under a commercial license, they must provide a valid license key. Customers who have purchased a self-hosted-eligible license for {productname} will find their license key in the account portal. To purchase a commercial license, see available options on the link:{pricingpage}/[pricing page].
+If the developer intends to self-host {productname} under a commercial license, a valid license key must be provided. Customers who have purchased a self-hosted-eligible license for {productname} will find their license key in the link:https://www.tiny.cloud/auth/login/[account portal]. To purchase a commercial license, see available options on the link:{pricingpage}/[pricing page].


### PR DESCRIPTION
Ticket: DOC-2355

Site Pages (same file change affects all these pages):
- [DOC-2355 npm site](http://docs-hotfix-7-doc-2355.staging.tiny.cloud/docs/tinymce/latest/npm-projects)
- [DOC-2355 php site](http://docs-hotfix-7-doc-2355.staging.tiny.cloud/docs/tinymce/latest/php-projects)
- [DOC-2355 dotnet site](http://docs-hotfix-7-doc-2355.staging.tiny.cloud/docs/tinymce/latest/dotnet-projects)
- [DOC-2355 bower site](http://docs-hotfix-7-doc-2355.staging.tiny.cloud/docs/tinymce/latest/bower-projects)
- [DOC-2355 zip site](http://docs-hotfix-7-doc-2355.staging.tiny.cloud/docs/tinymce/latest/zip-install)

Changes:
* update quickstart self-hosted pages (the five pages linked above) to include "Setting the license" information
* extract the "Setting the license" section of `license-key.adoc` into a partial for code reuse between `license-key.adoc` and `basic-quickstart-base.adoc`. [cloud-quick-start](http://docs-hotfix-7-doc-2355.staging.tiny.cloud/docs/tinymce/latest/cloud-quick-start) and [license-key](http://docs-hotfix-7-doc-2355.staging.tiny.cloud/docs/tinymce/latest/license-key) are affected indirectly, but there should be no visual change on these pages.
* Replaced some hardcoded values in affected files with Antora attributes (no visual change).

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] Files has been included where required `(if applicable)`

Review:
- [x] Documentation Team Lead has reviewed