### PR TITLE
DOC-2354: Add TINY-10789 release note entry

### DIFF
--- a/modules/ROOT/pages/7.0.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.0.1-release-notes.adoc
@@ -154,13 +154,14 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 [[bug-fixes]]
 == Bug fixes
 
-{productname} {release-version} also includes the following bug fix<es>:
+{productname} {release-version} also includes the following bug fixes:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Encode header title for literal display in table of contents.
+// #TINY-10789
 
-// CCFR here.
+Previously in {productname}, during Table of Contents (ToC) generation, heading elements containing HTML tags such as `<i>` for italics were incorrectly rendered within the ToC itself.
 
+{productname} {release-version} addresses this issue by encoding the heading element during ToC generation. This ensures that any HTML tags present within the heading element are treated as plain text and displayed literally.
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/pages/7.0.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.0.1-release-notes.adoc
@@ -72,6 +72,21 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Table of Contents
+
+The {productname} {release-version} release includes an accompanying release of the **Table of Contents** premium plugin.
+
+This **Table of Contents** release includes the following fixes.
+
+==== Encode header title for literal display in table of contents.
+// #TINY-10789
+
+Previously in {productname}, during Table of Contents (ToC) generation, heading elements containing HTML tags such as `<i>` for italics were incorrectly rendered within the ToC itself.
+
+{productname} {release-version} addresses this issue by encoding the heading element during ToC generation. This ensures that any HTML tags present within the heading element are treated as plain text and displayed literally.
+
+For information on the **Table of Contents** plugin, see: xref:tableofcontents.adoc[Table of Contents].
+
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement
@@ -154,14 +169,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 [[bug-fixes]]
 == Bug fixes
 
-{productname} {release-version} also includes the following bug fixes:
+{productname} {release-version} also includes the following bug fix<es>:
 
-=== Encode header title for literal display in table of contents.
-// #TINY-10789
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
 
-Previously in {productname}, during Table of Contents (ToC) generation, heading elements containing HTML tags such as `<i>` for italics were incorrectly rendered within the ToC itself.
+// CCFR here.
 
-{productname} {release-version} addresses this issue by encoding the heading element during ToC generation. This ensures that any HTML tags present within the heading element are treated as plain text and displayed literally.
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-2354
Entry: TINY-10789

Site: [Staging branch](http://docs-feature-7-doc-2354tiny-10789.staging.tiny.cloud/docs/tinymce/latest/7.0.1-release-notes/#table-of-contents)

Changes:
* DOC-2354: Add TINY-10789 release note entry

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed