### PR TITLE
DOC-2354: Add TINY-10784 release note entry

### DIFF
--- a/modules/ROOT/pages/7.0.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.0.1-release-notes.adoc
@@ -69,9 +69,9 @@ This **Enhanced Code Editor** release includes the following fixes.
 ==== Text inside code editor was not properly rendered when using a dark {productname} skin.
 // #TINY-10784
 
-With the release of {productname} 7.0, a bug was introduced when using the Enhanced Code Editor with a dark skin, such as `oxide-dark`. The code editor inherited its background color from the {productname} skin, resulting in dark text on a dark background.
+In previous versions of the **Enhanced Code Editor**, the text color of the code editor was inherited from the {productname} skin. This caused the light theme of the code editor to display white text on a white background when using a dark skin, such as `oxide-dark`.
 
-In {productname} {release-version}, this issue has been addressed. Now, the light theme of the Enhanced Code Editor will always use a light background color, regardless of the skin being used. As a result, the light mode will render correctly and be legible when using a dark skin.
+In {productname} {release-version}, this issue has been resolved. Now, the light theme of the Enhanced Code Editor will always use a dark text color, regardless of the skin being used. As a result, the light mode will render correctly and be easily readable when using a dark skin.
 
 ==== Light mode background with `advcode_inline: true` had the wrong color when {productname} was used with a dark skin.
 // #TINY-10760

--- a/modules/ROOT/pages/7.0.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.0.1-release-notes.adoc
@@ -60,6 +60,13 @@ For information on the **<Open source plugin name>** plugin, see xref:<plugincod
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
+==== Text inside code editor was not properly rendered when using a dark {productname} skin.
+// #TINY-10784
+
+With the release of {productname} 7.0, a bug was introduced when using the Enhanced Code Editor with a dark skin, such as `oxide-dark`. The code editor inherited its background color from the {productname} skin, resulting in dark text on a dark background.
+
+In {productname} {release-version}, this issue has been addressed. Now, the light theme of the Enhanced Code Editor will always use a light background color, regardless of the skin being used. As a result, the light mode will render correctly and be legible when using a dark skin.
+
 === <Premium plugin name 1> <Premium plugin name 1 version>
 
 The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.


### PR DESCRIPTION
Ticket: DOC-2354
Entry: TINY-10784

Site: [Staging branch](http://docs-feature-7-doc-2354tiny-10784.staging.tiny.cloud/docs/tinymce/latest/7.0.1-release-notes/#text-inside-code-editor-was-not-properly-rendered-when-using-a-dark-tinymce-skin)

Changes:
* DOC-2354: Add TINY-10784 release note entry

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed