### PR TITLE
DOC-2363 TinyMCE 7.1 Release notes & community changelog

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -398,6 +398,22 @@
 ** xref:tinymce-and-cors.adoc[Cross-Origin Resource Sharing (CORS)]
 * Release information
 ** xref:release-notes.adoc[Release notes for TinyMCE 7]
+*** TinyMCE 7.1
+**** xref:7.1-release-notes.adoc#overview[Overview]
+**** xref:7.1-release-notes.adoc#new-premium-plugin<s>[New Premium Plugin<s>]
+**** xref:7.1-release-notes.adoc#new-open-source-plugin<s>[New Open Source Plugin<s>]
+**** xref:7.1-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]
+**** xref:7.1-release-notes.adoc#accompanying-premium-plugin-end-of-life-announcement[Accompanying Premium Plugin end-of-life announcement]
+**** xref:7.1-release-notes.adoc#accompanying-open-source-plugin-end-of-life-announcement[Accompanying Open Source Plugin end-of-life announcement]
+**** xref:7.1-release-notes.adoc#accompanying-enhanced-skins-and-icon-packs-changes[Accompanying Enhanced Skins & Icon Packs changes]
+**** xref:7.1-release-notes.adoc#improvements[Improvements]
+**** xref:7.1-release-notes.adoc#additions[Additions]
+**** xref:7.1-release-notes.adoc#changes[Changes]
+**** xref:7.1-release-notes.adoc#removed[Removed]
+**** xref:7.1-release-notes.adoc#bug-fixes[Bug fixes]
+**** xref:7.1-release-notes.adoc#security-fixes[Security fixes]
+**** xref:7.1-release-notes.adoc#deprecated[Deprecated]
+**** xref:7.1-release-notes.adoc#known-issues[Known issues]
 *** TinyMCE 7.0
 **** xref:7.0-release-notes.adoc#overview[Overview]
 **** xref:7.0-release-notes.adoc#new-premium-plugins[New Premium plugins]

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -1,0 +1,196 @@
+= {productname} {release-version}
+:release-version: 7.1
+:navtitle: {productname} {release-version}
+:description: Release notes for {productname} {release-version}
+:keywords: releasenotes, new, changes, bugfixes
+:page-toclevels: 1
+
+include::partial$misc/admon-releasenotes-for-stable.adoc[]
+
+
+[[overview]]
+== Overview
+
+{productname} {release-version} was released for {enterpriseversion} and {cloudname} on <weekday>, <month> <DD>^<st|nd|rd|th>^, <YYYY>. These release notes provide an overview of the changes for {productname} {release-version}, including:
+
+// Remove sections and section boilerplates as necessary.
+// Pluralise as necessary or remove the placeholder plural marker.
+* xref:new-premium-plugin<s>[New Premium plugin<s>]
+* xref:new-open-source-plugin<s>[New Open Source plugin<s>]
+* xref:accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
+* xref:accompanying-premium-plugin-end-of-life-announcement[Accompanying Premium plugin end-of-life announcement]
+* xref:accompanying-open-source-plugin-end-of-life-announcement[Accompanying open source plugin end-of-life-announcement]
+* xref:accompanying-enhanced-skins-and-icon-packs-changes[Accompanying Enhanced Skins & Icon Packs changes]
+* xref:improvements[Improvements]
+* xref:additions[Additions]
+* xref:changes[Changes]
+* xref:removed[Removed]
+* xref:bug-fixes[Bug fixes]
+* xref:security-fixes[Security fixes]
+* xref:deprecated[Deprecated]
+* xref:known-issues[Known issues]
+
+
+[[new-premium-plugin<s>]]
+New Premium plugin<s>
+
+The following new Premium plugin was released alongside {productname} {release-version}.
+
+=== <Premium plugin name>
+
+The new Premium plugin, **<Premium plugin name>** // description here.
+
+For information on the **<Premium plugin name>** plugin, see xref:<plugincode>.adoc[<Premium plugin name>].
+
+
+[[new-open-source-plugin]]
+== New Open Source plugin
+
+The following new Open Source plugin was released alongside {productname} {release-version}.
+
+=== <Open source plugin name>
+
+The new open source plugin, **<Open source plugin name>** // description here.
+
+For information on the **<Open source plugin name>** plugin, see xref:<plugincode>.adoc[<Open source plugin name>].
+
+
+[[accompanying-premium-plugin-changes]]
+== Accompanying Premium plugin changes
+
+The following premium plugin updates were released alongside {productname} {release-version}.
+
+=== <Premium plugin name 1> <Premium plugin name 1 version>
+
+The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+
+**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+
+==== <Premium plugin name 1 change 1>
+
+// CCFR here.
+
+For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+
+
+[[accompanying-premium-plugin-end-of-life-announcement]]
+== Accompanying Premium plugin end-of-life announcement
+
+The following Premium plugin has been announced as reaching its end-of-life:
+
+=== <Premium plugin name eol>
+
+{productname}’s xref:<plugincode>.adoc[<Premium plugin name eol>] plugin will be deactivated on <month> <DD>, <YYYY>, and is no longer available for purchase.
+
+
+[[accompanying-open-source-plugin-end-of-life-announcement]]
+== Accompanying open source plugin end-of-life announcement
+
+The following open source plugin has been announced as reaching its end-of-life:
+
+=== <Open source plugin name eol>
+
+{productname}’s xref:<plugincode>.adoc[<Open source plugin name eol>] plugin will be deactivated on <month> <DD>, <YYYY>, and is no longer available for purchase.
+
+
+[[accompanying-enhanced-skins-and-icon-packs-changes]]
+== Accompanying Enhanced Skins & Icon Packs changes
+
+The {productname} {release-version} release includes an accompanying release of the **Enhanced Skins & Icon Packs**.
+
+=== Enhanced Skins & Icon Packs
+
+The **Enhanced Skins & Icon Packs** release includes the following updates:
+
+The **Enhanced Skins & Icon Packs** were rebuilt to pull in the changes also incorporated into the default {productname} {release-version} skin, Oxide.
+
+For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-and-icon-packs.adoc[Enhanced Skins & Icon Packs].
+
+
+[[improvements]]
+== Improvements
+
+{productname} {release-version} also includes the following improvement<s>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[additions]]
+== Additions
+
+{productname} {release-version} also includes the following addition<s>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[changes]]
+== Changes
+
+{productname} {release-version} also includes the following change<s>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[removed]]
+== Removed
+
+{productname} {release-version} also includes the following removal<s>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[bug-fixes]]
+== Bug fixes
+
+{productname} {release-version} also includes the following bug fix<es>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[security-fixes]]
+== Security fixes
+
+{productname} {release-version} includes <a fix | fixes for the following security issue<s>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[deprecated]]
+== Deprecated
+
+{productname} {release-version} includes the following deprecation<s>:
+
+=== The `<plugin>` configuration property, `<name>`, has been deprecated
+
+// placeholder here.
+
+
+[[known-issues]]
+== Known issues
+
+This section describes issues that users of {productname} {release-version} may encounter and possible workarounds for these issues.
+
+There <is one | are <number> known issue<s> in {productname} {release-version}.
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -4,10 +4,16 @@
 
 include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
-This section lists the releases for {productname} 7 and the changes made in each release.
+This section lists the releases for {productname} {productmajorversion} and the changes made in each release.
 
 [cols="1,1"]
 |===
+
+a|
+[.lead]
+xref:7.1-release-notes.adoc#overview[{productname} 7.1]
+
+Release notes for {productname} 7.1
 
 a|
 [.lead]


### PR DESCRIPTION
Ticket: DOC-2363

Site: [7.1 Release Notes](http://docs-feature-7-doc-2363.staging.tiny.cloud/docs/tinymce/latest/7.1-release-notes/#overview)
Site: [7.1 Changelog](http://docs-feature-7-doc-2363.staging.tiny.cloud/docs/tinymce/latest/changelog)

Changes:
* Add 7.1 staging template to `staging/docs-7` for Community and GA Docs Release.

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [x] Files has been included where required `(if applicable)`
- [ ] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [x] Files added for `New product features`, and included a `release note` entry.
- [ ] Bump `api-version` to `7.1`
- [ ] Update `supported-versions.adoc` with TinyMCE 7.1 row
- [ ] Add/remove dummy cell in `release-notes.adoc` if necessary

Review:
- [ ] Documentation Team Lead has reviewed