### PR TITLE
DOC-2354: Add TINY-10684 release note entry

### DIFF
--- a/modules/ROOT/pages/7.0.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.0.1-release-notes.adoc
@@ -213,6 +213,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following bug fix<es>:
 
+=== An inline editor toolbar now behaves correctly in horizontally scrolled containers.
+// #TINY-10684
+
+Previously in {productname}, when using an inline editor within a horizontally scrollable container, the calculation of the inline toolbar's width was incorrect. This resulted in the toolbar's maximum width being set too small or the toolbar displaying unexpected overflow behavior.
+
+{productname} {release-version} resolves this issue, now, the toolbar's maximum width calculation has been fixed to span the available viewport space. As a result, the inline toolbar will now behave correctly, displaying all items when there's enough space, or hiding them behind the overflow toolbar button when necessary.
+
 === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1
 


### PR DESCRIPTION
Ticket: DOC-2354
Entry: TINY-10684

Site: [Staging branch](http://docs-feature-7-doc-2354tiny-10684.staging.tiny.cloud/docs/tinymce/latest/7.0.1-release-notes/#an-inline-editor-toolbar-now-behaves-correctly-in-horizontally-scrolled-containers)

Changes:
* DOC-2354: Add TINY-10684 release note entry

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed