### PR TITLE
DOC-2354: Add TINY-10747 release note entry

### DIFF
--- a/modules/ROOT/pages/7.0.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.0.1-release-notes.adoc
@@ -28,13 +28,6 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
-==== Pasting markdown then pressing undo resulted in incorrect text layout.
-// #TINY-10747
-
-Previously in **Markdown**, the markdown paste feature performed a direct content insertion for creating the intermediary undo level between the raw pasted content and the markdown conversion. As a consequence, the editor would lose the newline formatting of the original text when pasting markdown and then pressing undo.
-
-In {productname} {release-version}, the markdown paste feature has been updated to use the clipboard insert command for creating the undo level. This ensures that the editor retains the newline formatting of the original text when pasting markdown and then pressing undo.
-
 === Enhanced Code Editor
 
 The {productname} {release-version} release includes an accompanying release of the **Enhanced Code Editor** premium plugin.
@@ -104,19 +97,14 @@ Previously in the **Markdown** plugin, the "markdown-on-paste" feature used the 
 
 NOTE: This fix addresses xref:7.0-release-notes.adoc#non-breaking-spaces-nbsp-may-be-inadvertently-inserted-around-content-during-markdown-conversion[a known issue] in the xref:markdown.adoc[Markdown premium plugin].
 
+==== Pasting markdown then pressing undo resulted in incorrect text layout.
+// #TINY-10747
+
+Previously in **Markdown**, the markdown paste feature performed a direct content insertion for creating the intermediary undo level between the raw pasted content and the markdown conversion. As a consequence, the editor would lose the newline formatting of the original text when pasting markdown and then pressing undo.
+
+In {productname} {release-version}, the markdown paste feature has been updated to use the clipboard insert command for creating the undo level. This ensures that the editor retains the newline formatting of the original text when pasting markdown and then pressing undo.
+
 For information on the **Markdown** plugin, see: xref:markdown.adoc[Markdown].
-
-=== <Premium plugin name 1> <Premium plugin name 1 version>
-
-The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
-
-**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
-
-==== <Premium plugin name 1 change 1>
-
-// CCFR here.
-
-For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
 === Table of Contents
 
@@ -198,7 +186,6 @@ For information on the **Table of Contents** plugin, see: xref:tableofcontents.a
 == Bug fixes
 
 {productname} {release-version} also includes the following bug fixes:
-
 
 === The status bar was invisible when the editor's height was set to the minimum.
 // #TINY-10705

--- a/modules/ROOT/pages/7.0.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.0.1-release-notes.adoc
@@ -28,6 +28,13 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
+==== Pasting markdown then pressing undo resulted in incorrect text layout.
+// #TINY-10747
+
+Previously in **Markdown**, the markdown paste feature performed a direct content insertion for creating the intermediary undo level between the raw pasted content and the markdown conversion. As a consequence, the editor would lose the newline formatting of the original text when pasting markdown and then pressing undo.
+
+In {productname} {release-version}, the markdown paste feature has been updated to use the clipboard insert command for creating the undo level. This ensures that the editor retains the newline formatting of the original text when pasting markdown and then pressing undo.
+
 === Enhanced Code Editor
 
 The {productname} {release-version} release includes an accompanying release of the **Enhanced Code Editor** premium plugin.


### PR DESCRIPTION
Ticket: DOC-2354
Entry: TINY-10747

Site: [Staging branch](http://docs-feature-7-doc-2354tiny-10747.staging.tiny.cloud/docs/tinymce/latest/7.0.1-release-notes/#pasting-markdown-then-pressing-undo-resulted-in-incorrect-text-layout)

Changes:
* DOC-2354: Add TINY-10747 release note entry

Pre-checks:
- [x] Branch prefixed with `feature/7/` or `hotfix/7/`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed