### PR TITLE
DOC-2324: Add workflows for development on 5 docs branch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,16 @@
-Related Ticket: 
+Ticket: DOC-<num>
 
-Description of Changes:
-* Placeholder text
+Site: [DOC-<num> site](http://docs-<hotfix/feature>-5-doc-<num>.staging.tiny.cloud/docs/tinymce/5/)
+
+Changes:
+* <placeholder-text>
 
 Pre-checks:
-- [ ] Branch prefixed with `feature/` or `hotfix/`
-- [ ] `_data/nav.yml` has been updated (if applicable)
-- [ ] Files has been included where required (if applicable)
-- [ ] Files removed have been deleted, not just excluded from the build (if applicable)
-- [ ] (New product features only) Release Note added
+- [ ] Branch prefixed with `feature/5/` or `hotfix/5/`
+- [ ] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
+- [ ] Files has been included where required `(if applicable)`
+- [ ] Files removed have been deleted, not just excluded from the build `(if applicable)`
+- [ ] Files added for `New product features`, and included a `release note` entry.
 
 Review:
 - [ ] Documentation Team Lead has reviewed
-- [ ] Product Manager has reviewed

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "feature/**", "hotfix/**", "tinymce/**" ]
+  pull_request:
+    branches: [ "tinymce/**" ]
+## Add schedule if needed
+#  schedule:
+#    - cron: "17 23 * * 5"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ javascript ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/develop_5_docs.yml
+++ b/.github/workflows/develop_5_docs.yml
@@ -1,0 +1,63 @@
+name: Develop 5 Docs
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '**'
+    branches:
+      - 'feature/5**'
+      - 'hotfix/5**'
+
+jobs:
+  build:
+    name: Build Docs and Deploy
+    runs-on: ubuntu-22.04
+
+    strategy:
+      matrix:
+        node-version: [21]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Use Node.js
+      uses: actions/setup-node@v2
+      with:
+        cache: 'yarn'
+        node-version: ${{ matrix.node-version }}
+
+    - name: (Develop 5 Docs) Install dependencies
+      run: yarn install
+
+    - name: (Develop 5 Docs) Build API References
+      run: yarn build
+
+    - name: (Develop 5 Docs) Build Website
+      run: yarn antora ./antora-playbook.yml
+
+    - name: (deploy) Prepare for branch deployments
+      shell: bash
+      run: |
+        printf "User-agent: * \nDisallow: /\n" > ./build/site/robots.txt
+        S3_BUCKET=$(node -e 'console.log(`s3://docs-${process.env.GITHUB_REF.replace("refs/heads/","").replace(/[/\s]/g, "-").replace(/[^0-9a-zA-Z-]/g, "").replace(/-$/g, "").toLowerCase()}.staging.tiny.cloud`)')
+        printf "S3_BUCKET: ${S3_BUCKET} (${#S3_BUCKET})\n"
+
+        if [ ${#S3_BUCKET} -lt 3 ]
+        then
+          echo "WARNING! S3_BUCKET name is too short"
+        fi
+
+        if [ ${#S3_BUCKET} -gt 63 ]
+        then
+          echo "WARNING! S3_BUCKET name is too long"
+        fi
+
+        echo $S3_BUCKET > S3_BUCKET
+
+    - name: (deploy) Upload website to S3
+      run: aws s3 sync --acl=public-read --delete ./build/site $(cat S3_BUCKET)/docs
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+        AWS_EC2_METADATA_DISABLED: true


### PR DESCRIPTION
Ticket: DOC-2324

Site: [Staging branch](http://docs-feature-5-doc-2324.staging.tiny.cloud/docs/tinymce/5/)

Changes:
* Added development and codeql workflows which apply to branches and PRs against tinymce/5 branch

Pre-checks:
- [x] Branch prefixed with `feature/5/` or `hotfix/5/`

Review:
- [x] Documentation Team Lead has reviewed