### PR TITLE
DOC-2372: Rename and populate index files to match latest

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -1,5 +1,5 @@
 * xref:quick-start.adoc[Quick start]
-* xref:general-configuration-guide.adoc[Introduction & getting started]
+* xref:getting-started.adoc[Introduction & getting started]
 ** xref:basic-setup.adoc[Basic setup]
 ** xref:use-tinymce-classic.adoc[Classic editing mode]
 ** xref:use-tinymce-inline.adoc[Inline editing mode]
@@ -48,7 +48,7 @@
 ** xref:file-picker.adoc[Basic local file picker]
 ** xref:local-upload.adoc[Local file upload]
 * xref:tinymce-for-mobile.adoc[Mobile]
-* xref:configure[Configuration reference]
+* xref:configure.adoc[Configuration reference]
 ** xref:integration-and-setup.adoc[Integration options]
 ** xref:editor-appearance.adoc[User interface options]
 ** xref:content-appearance.adoc[Content appearance options]
@@ -182,7 +182,7 @@
 ** xref:enterprise-export.adoc[Export]
 ** xref:support.adoc[Professional support]
 ** xref:enterprise-system-requirements.adoc[Supported Premium Versions and Platforms]
-* xref:tinydrive.adoc[Tiny Drive]
+* Tiny Drive
 ** xref:tinydrive-introduction.adoc[Introduction]
 ** xref:tinydrive-getting-started.adoc[Getting started]
 ** xref:tinydrive-jwt-authentication.adoc[JWT Authentication]
@@ -195,7 +195,7 @@
 ** xref:tinydrive-integrations.adoc[Integrations]
 *** xref:tinydrive-dropbox-integration.adoc[Dropbox]
 *** xref:tinydrive-dropbox-and-google-drive.adoc[Google Drive]
-** xref:tinydrive-api.adoc[API]
+** API
 *** xref:standalone.adoc[Standalone API]
 *** xref:introduction-to-tinydrive-apis.adoc[Plugin API]
 ** xref:tinydrive-changelog.adoc[Changelog]

--- a/modules/ROOT/pages/cloud-deployment-guide.adoc
+++ b/modules/ROOT/pages/cloud-deployment-guide.adoc
@@ -1,5 +1,43 @@
-= Cloud deployment guide
-:description: Start here for Tiny Cloud.
-:title_nav: Cloud deployment guide
+= Cloud Deployment Guide
+:description: Start here for Tiny Cloud
+:title_nav: Cloud Deployment Guide
 :type: folder
 
+// 2 Columns, both asciidoc
+[cols=2*a]
+|===
+
+|
+[.lead]
+xref:editor-and-features.adoc[Cloud deployment of editor & plugins]
+
+Learn how to set up the {productname} editor via the Cloud or migrate from a self-hosted environment.
+
+|
+[.lead]
+xref:features-only.adoc[Cloud deployment of plugins Only]
+
+Connect to Tiny Cloud within a hybrid deployment.
+
+|
+[.lead]
+xref:editor-plugin-version.adoc[Specify editor & plugin versions]
+
+Specifying editor and plugin versions for Tiny Cloud deployments.
+
+|
+[.lead]
+xref:plugin-editor-version-compatibility.adoc[Version compatibility reference]
+
+Matrix of compatibility between TinyMCE editor versions and premium plugins.
+
+|
+[.lead]
+xref:cloud-troubleshooting.adoc[Cloud Troubleshooting]
+
+Troubleshooting errors shown by the Tiny Cloud.
+
+// Empty cell to even out rows
+| 
+
+|===

--- a/modules/ROOT/pages/demo-tinydrive.adoc
+++ b/modules/ROOT/pages/demo-tinydrive.adoc
@@ -6,6 +6,6 @@
 
 == Interactive example
 
-This example shows you how to use {cloudfilemanager} for your file and image management. For more information on {cloudfilemanager}, see the xref:tinydrive.adoc[docs].
+This example shows you how to use {cloudfilemanager} for your file and image management. For more information on {cloudfilemanager}, see the xref:tinydrive-introduction.adoc[docs].
 
 liveDemo::drive-demo[]

--- a/modules/ROOT/pages/editor-and-features.adoc
+++ b/modules/ROOT/pages/editor-and-features.adoc
@@ -5,7 +5,7 @@
 
 {cloudname} is the easiest way to integrate {productname} and upgrade to premium plugins.
 
-{cloudname} can be used without an API key. Refer to the xref:general-configuration-guide.adoc[Introduction & getting started] guide for more information. Sign up for an API key and update the script tag to use premium plugins or avoid the in-editor developer warning.
+{cloudname} can be used without an API key. Refer to the xref:getting-started.adoc[Introduction & getting started] guide for more information. Sign up for an API key and update the script tag to use premium plugins or avoid the in-editor developer warning.
 
 All {cloudname} accounts include a free, pre-configured {cloudname} image proxy service. This setup uses the xref:editimage.adoc[Image tools] plugin.
 

--- a/modules/ROOT/pages/enterprise-tinydrive.adoc
+++ b/modules/ROOT/pages/enterprise-tinydrive.adoc
@@ -9,7 +9,7 @@
 
 == Configuring the editor for Tiny Drive
 
-Once you have the API key, or if you are a current {cloudname} user who already has an API key, then you have access to {cloudfilemanager}. In order to get the service up and running, you'll need to complete a few more steps. See our xref:tinydrive.adoc[documentation] for more information.
+Once you have the API key, or if you are a current {cloudname} user who already has an API key, then you have access to {cloudfilemanager}. In order to get the service up and running, you'll need to complete a few more steps. See our xref:tinydrive-introduction.adoc[documentation] for more information.
 
 == Security & performance
 
@@ -25,5 +25,5 @@ liveDemo::drive-demo[]
 
 :pluginname: Tiny Drive
 :pluginminimumplan: tierone
-:plugindocspage: tinydrive.adoc
+:plugindocspage: tinydrive-introduction.adoc
 include::partial$misc/purchase-premium-plugins.adoc[]

--- a/modules/ROOT/pages/examples.adoc
+++ b/modules/ROOT/pages/examples.adoc
@@ -1,6 +1,152 @@
-= Examples & demos
+= Examples & Demos
 :description: Working examples of TinyMCE's popular functionality.
 :redirect_from: ["/example/", "/examples/", "/tutorial/", "/tutorials/", "/example-tutorial/", "/try-tinymce/"]
 :title_nav: Examples
 :type: folder
 
+// 2 Columns, both asciidoc
+[cols=2*a]
+|===
+
+|
+[.lead]
+xref:basic-example.adoc[Basic example]
+
+Basic example
+
+|
+[.lead]
+xref:full-featured.adoc[Full featured]
+
+Full featured demo
+
+|
+[.lead]
+xref:demo-casechange.adoc[Case Change]
+
+Case Change demo
+
+|
+[.lead]
+xref:comments-demo.adoc[Comments]
+
+Comments demo
+
+|
+[.lead]
+xref:demo-checklist.adoc[Checklist]
+
+Checklist demo
+
+|
+[.lead]
+xref:demo-pageembed.adoc[Page Embed]
+
+Page Embed demo
+
+|
+[.lead]
+xref:demo-permanentpen.adoc[Permanent Pen]
+
+Permanent Pen demo
+
+|
+[.lead]
+xref:demo-formatpainter.adoc[Format Painter]
+
+Format Painter demo
+
+|
+[.lead]
+xref:demo-tinydrive.adoc[Tiny Drive]
+
+Tiny Drive demo
+
+|
+[.lead]
+xref:distraction-free-demo.adoc[Distraction-free editor]
+
+Distraction-free editor demo
+
+|
+[.lead]
+xref:inline.adoc[Inline editor]
+
+Inline editor demo
+
+|
+[.lead]
+xref:classic-demo.adoc[Classic editor mode]
+
+Classic editor mode demo
+
+|
+[.lead]
+xref:image-tools.adoc[Image tools]
+
+Image tools demo
+
+|
+[.lead]
+xref:format-custom.adoc[Custom formats]
+
+Custom formats demo
+
+|
+[.lead]
+xref:format-html5.adoc[HTML5 formats]
+
+HTML5 formats demo
+
+|
+[.lead]
+xref:url-conversion.adoc[URL conversion]
+
+URL conversion demo
+
+|
+[.lead]
+xref:valid-elements.adoc[Valid elements]
+
+Valid elements demo
+
+|
+[.lead]
+xref:custom-basic-toolbar-button.adoc[Custom toolbar button]
+
+Custom toolbar button demo
+
+|
+[.lead]
+xref:custom-menu-toolbar-button.adoc[Custom toolbar menu button]
+
+Custom toolbar menu button demo
+
+|
+[.lead]
+xref:custom-split-toolbar-button.adoc[Custom toolbar split button]
+
+Custom toolbar split button demo
+
+|
+[.lead]
+xref:custom-basic-menu-items.adoc[Custom menu item]
+
+Custom menu item demo
+
+|
+[.lead]
+xref:file-picker.adoc[Basic local file picker]
+
+Basic local file picker demo
+
+|
+[.lead]
+xref:local-upload.adoc[Local file upload]
+
+Local file upload demo
+
+// Empty cell to even out rows
+| 
+
+|===

--- a/modules/ROOT/pages/general-configuration-guide.adoc
+++ b/modules/ROOT/pages/general-configuration-guide.adoc
@@ -1,5 +1,0 @@
-= Introduction & getting started
-:description: New to self-hosting TinyMCE? Start here.
-:title_nav: Introduction &amp; getting started
-:type: folder
-

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -1,0 +1,115 @@
+= Introduction & getting started
+:description: New to self-hosting {productname}? Start here.
+:title_nav: Introduction &amp; getting started
+:type: folder
+
+// 2 Columns, both asciidoc
+[cols=2*a]
+|===
+
+|
+[.lead]
+xref:basic-setup.adoc[Basic setup]
+
+How to get up and running with {productname}
+
+|
+[.lead]
+xref:use-tinymce-classic.adoc[Classic editing mode]
+
+The Theme that renders iframe or inline modes using the {productname} core UI framework.
+
+|
+[.lead]
+xref:use-tinymce-inline.adoc[Inline editing mode]
+
+Learn about forms-based editing v. inline editing.
+
+|
+[.lead]
+xref:use-tinymce-distraction-free.adoc[Distraction-free editing mode]
+
+Mode that renders a lightweight UI for inline editing.
+
+|
+[.lead]
+xref:multiple-editors.adoc[Multiple editors in a page]
+
+Use multiple {productname} instances in a single page
+
+|
+[.lead]
+xref:installation.adoc[Options for installing {productname}]
+
+Learn how to install {productname} via {cloudname}, package manager options, Self-hosted, jQuery and custom build options.
+
+|
+[.lead]
+xref:upgrading.adoc[Upgrading {productname}]
+
+How to upgrade {productname} via {cloudname}, package manager options, Self-hosted, and custom build options.
+
+|
+[.lead]
+xref:work-with-plugins.adoc[Using plugins to extend {productname}]
+
+Learn about {productname}'s plugin functionality and discover our Top 10 plugins.
+
+|
+[.lead]
+xref:customize-ui.adoc[Customizing the UI]
+
+Learn how to change the appearance of {productname}.
+
+|
+[.lead]
+xref:editor-content-css.adoc[Boilerplate content CSS]
+
+Learn how to set up CSS for your site to integrate {productname}.
+
+|
+[.lead]
+xref:upload-images.adoc[Image uploads]
+
+How to manage asynchronous image uploads.
+
+|
+[.lead]
+xref:spell-checking.adoc[Spell checking]
+
+Check spelling in {productname}
+
+|
+[.lead]
+xref:filter-content.adoc[Content filtering]
+
+Learn how to create clean, maintainable and readable content.
+
+|
+[.lead]
+xref:localize-your-language.adoc[Localization]
+
+Localize {productname} with global language capabilities.
+
+|
+[.lead]
+xref:attribution-requirements.adoc[Logo attribution]
+
+{productname} Terms of Service.
+
+|
+[.lead]
+xref:system-requirements.adoc[Supported Versions and Platforms]
+
+Supported versions and platforms for {productname}.
+
+|
+[.lead]
+xref:get-support.adoc[Support & FAQ]
+
+Community and pro-grade support options.
+
+// Empty cell to even out rows
+| 
+
+|===

--- a/modules/ROOT/pages/release-notes504.adoc
+++ b/modules/ROOT/pages/release-notes504.adoc
@@ -16,7 +16,7 @@ The new Tiny Drive comes with significant changes to the previous versions. Impr
 
 To try out *Tiny Drive* start with this https://www.tiny.cloud/drive/[dedicated product page] or check out the https://www.tiny.cloud/pricing[pricing page] to see all the flexible pricing options.
 
-For more information on *Tiny Drive* refer to the full xref:tinydrive.adoc[documentation].
+For more information on *Tiny Drive* refer to the full xref:tinydrive-introduction.adoc[documentation].
 
 There is also a demo provided to explore the *Tiny Drive* capabilities xref:tinydrive-introduction.adoc#demo[here].
 

--- a/modules/ROOT/pages/release-notes505.adoc
+++ b/modules/ROOT/pages/release-notes505.adoc
@@ -34,7 +34,7 @@ The new TinyMCE 5.0.5 editor comes with significant changes to the previous vers
 
 To try out *Tiny Drive* start with this https://www.tiny.cloud/drive/[dedicated product page] or check out the https://www.tiny.cloud/pricing[pricing page] to see all the flexible pricing options.
 
-For more information on *Tiny Drive* refer to the full xref:tinydrive.adoc[documentation].
+For more information on *Tiny Drive* refer to the full xref:tinydrive-introduction.adoc[documentation].
 
 There is also a demo provided to explore the *Tiny Drive* capabilities xref:tinydrive-introduction.adoc#demo[here].
 

--- a/modules/ROOT/pages/release-notes507.adoc
+++ b/modules/ROOT/pages/release-notes507.adoc
@@ -44,7 +44,7 @@ For more information and demos on the new *Premium Skins and Icon Packs* refer t
 
 To try out *Tiny Drive* start with this https://www.tiny.cloud/drive/[dedicated product page] or check out the https://www.tiny.cloud/pricing[pricing page] to see all the flexible pricing options.
 
-For more information on *Tiny Drive* refer to the full xref:tinydrive.adoc[documentation].
+For more information on *Tiny Drive* refer to the full xref:tinydrive-introduction.adoc[documentation].
 
 There is also a demo provided to explore the *Tiny Drive* capabilities xref:tinydrive-introduction.adoc#demo[here].
 

--- a/modules/ROOT/pages/release-notes58.adoc
+++ b/modules/ROOT/pages/release-notes58.adoc
@@ -172,7 +172,7 @@ The {productname} 5.8 release includes an accompanying release of *Tiny Drive*.
 * Fixed a bug where specifying 'audio' for the `filetype` setting would not list the files in the grid view.
 * Fixed a bug where tabbing though the user interface could throw an error.
 
-For information on Tiny Drive, see: xref:tinydrive.adoc[Tiny Drive].
+For information on Tiny Drive, see: xref:tinydrive-introduction.adoc[Tiny Drive].
 
 [[accompanyingpremiumskinsandiconpackschanges]]
 == Accompanying Premium Skins and Icon Packs changes

--- a/modules/ROOT/pages/release-notes581.adoc
+++ b/modules/ROOT/pages/release-notes581.adoc
@@ -41,7 +41,7 @@ The {productname} 5.8.1 release includes an accompanying release of *Tiny Drive*
 
 *Tiny Drive* 1.4.1 fixes an issue where the `skin` setting wasn't working in standalone-mode.
 
-For information on Tiny Drive, see: xref:tinydrive.adoc[Tiny Drive].
+For information on Tiny Drive, see: xref:tinydrive-introduction.adoc[Tiny Drive].
 
 [[general-bug-fixes]]
 == General bug fixes

--- a/modules/ROOT/pages/tinydrive-api.adoc
+++ b/modules/ROOT/pages/tinydrive-api.adoc
@@ -1,5 +1,0 @@
-= Tiny Drive API
-:description: Tiny Drive API.
-:keywords: tinydrive api
-:title_nav: API
-:type: folder

--- a/modules/ROOT/pages/tinydrive.adoc
+++ b/modules/ROOT/pages/tinydrive.adoc
@@ -1,4 +1,0 @@
-= Tiny Drive
-:description: Tiny Drive
-:title_nav: Tiny Drive
-:type: folder

--- a/modules/ROOT/partials/misc/plugin-menu-item-id-boilerplate.adoc
+++ b/modules/ROOT/partials/misc/plugin-menu-item-id-boilerplate.adoc
@@ -40,7 +40,13 @@ For information on the {pluginname} plugin, see: xref:editimage.adoc[Plugins - T
 endif::[]
 
 ifeval::["{plugincode}" != "imagetools"]
+ifeval::["{plugincode}" == "tinydrive"]
+For information on the {pluginname} plugin, see: xref:tinydrive-introduction.adoc[Plugins - The {pluginname} plugin]
+endif::[]
+
+ifeval::["{plugincode}" != "tinydrive"]
 For information on the {pluginname} plugin, see: xref:{plugincode}.adoc[Plugins - The {pluginname} plugin]
+endif::[]
 endif::[]
 endif::[]
 endif::[]

--- a/modules/ROOT/partials/misc/plugin-toolbar-button-id-boilerplate.adoc
+++ b/modules/ROOT/partials/misc/plugin-toolbar-button-id-boilerplate.adoc
@@ -39,11 +39,12 @@ For information on the {pluginname} plugin, see: xref:editimage.adoc[Plugins - T
 endif::[]
 
 ifeval::["{plugincode}" != "imagetools"]
+ifeval::["{plugincode}" == "tinydrive"]
+For information on the {pluginname} plugin, see: xref:tinydrive-introduction.adoc[Plugins - The {pluginname} plugin]
+endif::[]
+
+ifeval::["{plugincode}" != "tinydrive"]
 For information on the {pluginname} plugin, see: xref:{plugincode}.adoc[Plugins - The {pluginname} plugin]
-endif::[]
-endif::[]
-endif::[]
-endif::[]
 endif::[]
 
 endif::[]


### PR DESCRIPTION
Ticket: DOC-2372

Site: [Staging branch](http://docs-feature-doc-2372.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* Renamed some index files to match 6/7 docs
* Populated some index files
* Removed links of unnecessary index files

Pre-checks:
- [X] Branch prefixed with `feature/7/` or `hotfix/7/`
- [X] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [X] Files has been included where required `(if applicable)`
- [X] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [X] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed