### PR TITLE
DOC-2373: Update workflow versions and branches

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,12 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "feature/**", "hotfix/**", "tinymce/**" ]
+    branches: [ "feature/**", "hotfix/**", "release/**", "staging/**", "tinymce/**" ]
   pull_request:
     branches: [ "tinymce/**" ]
-## Add schedule if needed
-#  schedule:
-#    - cron: "17 23 * * 5"
 
 jobs:
   analyze:
@@ -25,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/develop_5_docs.yml
+++ b/.github/workflows/develop_5_docs.yml
@@ -6,23 +6,25 @@ on:
     paths:
       - '**'
     branches:
-      - 'feature/5**'
-      - 'hotfix/5**'
+      - 'feature/**'
+      - 'hotfix/**'
+      - 'release/**'
+      - 'staging/**'
 
 jobs:
   build:
     name: Build Docs and Deploy
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
         node-version: [21]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
 
     - name: Use Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         cache: 'yarn'
         node-version: ${{ matrix.node-version }}


### PR DESCRIPTION
Ticket: DOC-2373

Site: [Staging branch](http://docs-feature-5-doc-2373.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* Updated versions in workflows
* Add support for release and staging branches for development builds

Pre-checks:
- [x] Branch prefixed with `feature/5/` or `hotfix/5/`

Review:
- [x] Documentation Team Lead has reviewed