### PR TITLE
DOC-2363: Included `itemprop`, `itemscope`, `itemtype` as valid HTML5 attributes in the core schema.

### DIFF
--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -133,7 +133,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Included itemprop, itemscope, itemtype as valid HTML5 attributes in the core schema.
 // #TINY-9932
 
-Previously, using `itemprop`, `itemscope` and `itemtype` as valid HTML5 attributes within the editor was not supported as they were not included in the update in v6.
+Previously, using `itemprop`, `itemscope` and `itemtype` as valid HTML5 attributes within the editor was not supported.
 
 As a consequence, users faced difficulties in effectively working with content that used these attributes resulting in compatibility issues or data misrepresentation.
 

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -121,7 +121,7 @@ Previously, using `itemprop`, `itemscope` and `itemtype` as valid HTML5 attribut
 
 As a consequence, users faced difficulties in effectively working with content that used these attributes resulting in compatibility issues or data misrepresentation.
 
-{productname} {product-version} addresses this issue, now, the missed attributes have been added to the HTML5 schema, ensuring that users can now use content containing these attributes such as;
+{productname} {release-version} addresses this issue, now, the missed attributes have been added to the HTML5 schema, ensuring that users can now use content containing these attributes such as;
 
 [source, html]
 ----

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -114,6 +114,25 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Included itemprop, itemscope, itemtype as valid HTML5 attributes in the core schema.
+// #TINY-9932
+
+Previously, using `itemprop`, `itemscope` and `itemtype` as valid HTML5 attributes within the editor was not supported as they were not included in the update in v6.
+
+As a consequence, users faced difficulties in effectively working with content that used these attributes resulting in compatibility issues or data misrepresentation.
+
+{productname} {product-version} addresses this issue, now, the missed attributes have been added to the HTML5 schema, ensuring that users can now use content containing these attributes such as;
+
+[source, html]
+----
+<div itemscope="" itemtype="http://schema.org/Movie">
+  <h1 itemprop="name">Avatar</h1>
+  Director: <span itemprop="director">James Cameron</span> (born August 16, 1954) <span itemprop="genre">Science fiction</span> <a itemprop="trailer" href="movies/avatar-theatrical-trailer.html"> Trailer </a>
+</div>
+----
+
+As a result, `itemprop`, `itemscope` and `itemtype` are now considered valid HTML5 attributes within {productname}.
+
 
 [[additions]]
 == Additions


### PR DESCRIPTION
Ticket: DOC-2363

Site: [Staging branch](http://docs-feature-71-doc-2363tiny-9932.staging.tiny.cloud/docs/tinymce/latest/7.1-release-notes/#included-itemprop-itemscope-itemtype-as-valid-html5-attributes-in-the-core-schema)

Changes:
* Added improvement documentation for: Included `itemprop`, `itemscope`, `itemtype` as valid HTML5 attributes in the core schema.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed