### PR TITLE
DOC-2363: Added new `A11ycheckStart`, `A11ycheckStop`, `A11ycheckIgnore`, `A11ycheckRepair` and `A11ycheckShowDetails` events..

### DIFF
--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -57,11 +57,33 @@ For information on the **<Open source plugin name>** plugin, see xref:<plugincod
 
 The following premium plugin updates were released alongside {productname} 7.1.
 
-=== <Premium plugin name 1> <Premium plugin name 1 version>
+=== Accessibility Checker
 
-The {productname} 7.1 release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+The {productname} 7.1 release includes an accompanying release of the **Accessibility Checker** premium plugin.
 
-**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+**Accessibility Checker** includes the following improvement.
+
+==== Added new `A11ycheckStart`, `A11ycheckStop`, `A11ycheckIgnore`, `A11ycheckRepair` and `A11ycheckShowDetails` events.
+// #TINY-10777
+
+{productname} introduces five new events within the **Accessibility Checker** premium plugin. These events capture usage statistics, offering valuable insights into the tool's internal usage for customers.
+
+The events include:
+
+[cols="1,2",options="header"]
+|===
+|Name |Description
+|A11ycheckStart |Fired when the Accessibility Checker is `opened`
+|A11ycheckStop |Fired when the Accessibility Checker is `closed`
+|A11ycheckIgnore |Fired when the `Ignore` button is toggled
+|A11ycheckRepair |Fired when the `Repair` button is toggled
+|A11ycheckShowDetails |Fired when the `Click for more info` button is toggled
+|===
+
+[NOTE]
+These events will only be visible within the developer console when each `event` is triggered.
+
+For information on the **Accessibility Checker** plugin, see: xref:a11ychecker.adoc[Accessibility Checker].
 
 ==== <Premium plugin name 1 change 1>
 

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -155,10 +155,9 @@ The events include:
 |A11ycheckShowDetails |Fired when the `Click for more info` button is pressed
 |===
 
-[NOTE]
-These events will only be visible within the developer console when each `event` is triggered.
-
 For information on the **Accessibility Checker** plugin, see: xref:a11ychecker.adoc[Accessibility Checker].
+
+For information on handling events in {productname}, see: xref:events.adoc[Events].
 
 ==== <Premium plugin name 1 change 1>
 

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -75,9 +75,9 @@ The events include:
 |Name |Description
 |A11ycheckStart |Fired when the Accessibility Checker is `opened`
 |A11ycheckStop |Fired when the Accessibility Checker is `closed`
-|A11ycheckIgnore |Fired when the `Ignore` button is toggled
-|A11ycheckRepair |Fired when the `Repair` button is toggled
-|A11ycheckShowDetails |Fired when the `Click for more info` button is toggled
+|A11ycheckIgnore |Fired when the `Ignore` button is pressed
+|A11ycheckRepair |Fired when the `Repair` button is pressed
+|A11ycheckShowDetails |Fired when the `Click for more info` button is pressed
 |===
 
 [NOTE]

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -66,7 +66,7 @@ The {productname} 7.1 release includes an accompanying release of the **Accessib
 ==== Added new `A11ycheckStart`, `A11ycheckStop`, `A11ycheckIgnore`, `A11ycheckRepair` and `A11ycheckShowDetails` events.
 // #TINY-10777
 
-{productname} introduces five new events within the **Accessibility Checker** premium plugin. These events capture usage statistics, offering valuable insights into the tool's internal usage for customers.
+{productname} {release-version} introduces five new events within the **Accessibility Checker** premium plugin. These events capture usage statistics, offering valuable insights into the tool's internal usage for customers.
 
 The events include:
 

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -59,7 +59,7 @@ The following premium plugin updates were released alongside {productname} 7.1.
 
 === Accessibility Checker
 
-The {productname} 7.1 release includes an accompanying release of the **Accessibility Checker** premium plugin.
+The {productname} {release-version} release includes an accompanying release of the **Accessibility Checker** premium plugin.
 
 **Accessibility Checker** includes the following improvement.
 

--- a/modules/ROOT/pages/a11ychecker.adoc
+++ b/modules/ROOT/pages/a11ychecker.adoc
@@ -360,6 +360,13 @@ include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
+[[events]]
+== Events
+
+The {pluginname} plugin provides the following events.
+
+include::partial$events/a11ychecker-events.adoc[]
+
 == APIs
 
 The {pluginname} plugin provides the following APIs.

--- a/modules/ROOT/pages/events.adoc
+++ b/modules/ROOT/pages/events.adoc
@@ -180,6 +180,7 @@ The following events are provided by the {productname} editor.
 
 The following plugins provide events.
 
+* xref:a11ychecker-events[Accessibility Checker events]
 * xref:autosave-events[Autosave events]
 * xref:character-map-events[Character Map events]
 * xref:comments-events[Comments events]
@@ -197,6 +198,13 @@ The following plugins provide events.
 * xref:visual-blocks-events[Visual Blocks events]
 * xref:visual-characters-events[Visual Characters events]
 * xref:word-count-events[Word Count events]
+
+[[a11ychecker-events]]
+=== Accessibility Checker events
+
+The following events are provided by the xref:a11ychecker.adoc[Accessibility Checker plugin].
+
+include::partial$events/a11ychecker-events.adoc[]
 
 [[autosave-events]]
 === Autosave events

--- a/modules/ROOT/partials/events/a11ychecker-events.adoc
+++ b/modules/ROOT/partials/events/a11ychecker-events.adoc
@@ -3,7 +3,7 @@
 |Name |Data |Description
 |A11ycheckStart |N/A |Fired when the Accessibility Checker is `opened`
 |A11ycheckStop |N/A |Fired when the Accessibility Checker is `closed`
-|A11ycheckIgnore |N/A |Fired when the `Ignore` button is toggled
-|A11ycheckRepair |N/A |Fired when the `Repair` button is toggled
-|A11ycheckShowDetails |N/A |Fired when the `Click for more info` button is toggled
+|A11ycheckIgnore |N/A |Fired when the `Ignore` button is pressed
+|A11ycheckRepair |N/A |Fired when the `Repair` button is pressed
+|A11ycheckShowDetails |N/A |Fired when the `Click for more info` button is pressed
 |===

--- a/modules/ROOT/partials/events/a11ychecker-events.adoc
+++ b/modules/ROOT/partials/events/a11ychecker-events.adoc
@@ -1,0 +1,9 @@
+[cols="1,1,2",options="header"]
+|===
+|Name |Data |Description
+|A11ycheckStart |N/A |Fired when the Accessibility Checker is `opened`
+|A11ycheckStop |N/A |Fired when the Accessibility Checker is `closed`
+|A11ycheckIgnore |N/A |Fired when the `Ignore` button is toggled
+|A11ycheckRepair |N/A |Fired when the `Repair` button is toggled
+|A11ycheckShowDetails |N/A |Fired when the `Click for more info` button is toggled
+|===


### PR DESCRIPTION
Ticket: DOC-2363

Site: [Staging branch- Release notes](http://docs-feature-71-doc-2363tiny-10777.staging.tiny.cloud/docs/tinymce/latest/7.1-release-notes/#added-new-a11ycheckstart-a11ycheckstop-a11ycheckignore-a11ycheckrepair-and-a11ycheckshowdetails-events)
Site: [Staging branch- Events](http://docs-feature-71-doc-2363tiny-10777.staging.tiny.cloud/docs/tinymce/latest/a11ychecker/#events)

Changes:
* Added new A11ycheckStart, A11ycheckStop, A11ycheckIgnore, A11ycheckRepair and A11ycheckShowDetails events to `a11ychecker.adoc`, and added release notes entry for new added events.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`
- [x] Files has been included where required `(if applicable)`

Review:
- [x] Documentation Team Lead has reviewed