### PR TITLE
DOC-2363: New `index.js` file that includes all plugin resources.

### DIFF
--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -114,6 +114,26 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== New `index.js` file that includes all plugin resources.
+// #TINY-10778
+
+Previously, integrating {productname} and its premium plugins necessitated the separate inclusion of the `plugin.js` file along with the corresponding resource API-loaded CSS files. This approach often led to complications due to inconsistent naming conventions for our CSS files, making bundling a cumbersome process.
+
+To address this, {productname} {release-version} has included `index.js` files to each premium plugin, which will consolidate all necessary resources.
+
+As a result, when bundling from a distribution bundle or `.zip` build, by including all the {productname} imports for each plugin such as in a `all.js` file for example;
+
+[source, js]
+----
+import './plugins/a11ychecker';
+import './plugins/advcode';
+import './plugins/advtable';
+import './plugins/advtemplate';
+----
+and using a module bundler such as link:https://esbuild.github.io/[esbuild], will now load all the specific plugins from the `all.js` file, without the need to load any additional resources.
+
+For information on the **Bundling plugins**, see: xref:bundling-plugins.adoc[Bunding plugins].
+
 
 [[additions]]
 == Additions

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -130,7 +130,9 @@ import './plugins/advcode';
 import './plugins/advtable';
 import './plugins/advtemplate';
 ----
-and using a module bundler such as link:https://esbuild.github.io/[esbuild], will now load all the specific plugins from the `all.js` file, without the need to load any additional resources.
+all the specific plugins will load without the need of any additional resources.
+
+For more information on bundling with {productname}, see xref:bundling-plugins.adoc[bundling plugins]
 
 For information on the **Bundling plugins**, see: xref:bundling-plugins.adoc[Bunding plugins].
 

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -134,8 +134,6 @@ all the specific plugins will load without the need of any additional resources.
 
 For more information on bundling with {productname}, see xref:bundling-plugins.adoc[bundling plugins]
 
-For information on the **Bundling plugins**, see: xref:bundling-plugins.adoc[Bunding plugins].
-
 
 [[additions]]
 == Additions


### PR DESCRIPTION
Ticket: DOC-2363

Site: [Staging branch](http://docs-feature-71-doc-2363tiny-10778.staging.tiny.cloud/docs/tinymce/latest/7.1-release-notes/#new-index-js-file-that-includes-all-plugin-resources)

Changes:
* New `index.js` file that includes all plugin resources.
* include link back to the newly update bundling page.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed