### PR TITLE
DOC-2363: Add TINY-10780 release note entry

### DIFF
--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -57,6 +57,21 @@ For information on the **<Open source plugin name>** plugin, see xref:<plugincod
 
 The following premium plugin updates were released alongside {productname} 7.1.
 
+=== Enhanced Code Editor
+
+The {productname} {release-version} release includes an accompanying release of the **Enhanced Code Editor** premium plugin.
+
+The **Enhanced Code Editor** includes the following fix:
+
+==== Inline mode didn't have tab navigation.
+// #TINY-10780
+
+Previously in {productname} 7.0, the **Enhanced Code Editor** was updated to codemirror 6, but the tab navigation was not implemented for the code editor view when `advcode_inline` was set. As a result, users who rely on keyboard navigation found it difficult to navigate the UI elements in the code editor view.
+
+In {productname} {release-version}, this issue has been fixed. Now, the tab navigation is implemented for the code editor view when `advcode_inline` is set. As a result, the code editor view UI elements can be navigated using the `tab` and `shift+tab` keys.
+
+For information on the **Enhanced Code Editor** plugin, see: xref:advcode.adoc[Enhanced Code Editor].
+
 === <Premium plugin name 1> <Premium plugin name 1 version>
 
 The {productname} 7.1 release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.


### PR DESCRIPTION
Ticket: DOC-2363

Site: [Staging branch](http://docs-feature-71-doc-2363tiny-10780.staging.tiny.cloud/docs/tinymce/latest/7.1-release-notes/#enhanced-code-editor)

Changes:
* DOC-2363: Add TINY-10780 release note entry

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [-] Files has been included where required `(if applicable)`
- [-] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed