### PR TITLE
DOC-2363: Add TINY-10800 release note entry

### DIFF
--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -151,7 +151,14 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 [[bug-fixes]]
 == Bug fixes
 
-{productname} 7.1 also includes the following bug fix<es>:
+{productname} {release-version} also includes the following bug fixes:
+
+=== Dialog title markup changed to use an `h1` element instead of `div`.
+// #TINY-10800
+
+Previously, the dialog component's title was wrapped in a `<div>` element, visually appearing as a heading and functioning as the main heading for the dialog. However, without the title being semantically marked up as a heading element, screen reader users may struggle to understand the purpose of the dialog box and navigate its content.
+
+{productname} {release-version} addresses this issue by updating the dialog title markup to use an `<h1>` element, ensuring that the title is semantically identified as a heading. This improves the accessibility experience for users by helping screen readers and other assistive technologies understand the structure of the page and navigate its content more easily.
 
 === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1


### PR DESCRIPTION
Ticket: DOC-2363

Site: [Staging branch](http://docs-feature-71-doc-2363tiny-10800.staging.tiny.cloud/docs/tinymce/latest/7.1-release-notes/#dialog-title-markup-changed-to-use-an-h1-element-instead-of-div)

Changes:
* DOC-2363: Add TINY-10800 release note entry

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [-] Files has been included where required `(if applicable)`
- [-] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed