### PR TITLE
DOC-2363: Video and audio elements could not be played on Safari.

### DIFF
--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -153,10 +153,14 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} 7.1 also includes the following bug fix<es>:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Video and audio elements could not be played on Safari.
+// #TINY-10774
 
-// CCFR here.
+In earlier versions of {productname}, a problem occurred when users inserted a video or media element into a {productname} document while using Safari as the host browser. The issue caused media files to be unplayable in Safari.
+
+{productname} {release-version} resolves this problem by preventing events from bubbling out of the video element, which previously caused the playback issue.
+
+With this fix, users can now play video and audio elements on Safari without any issues.
 
 
 [[security-fixes]]

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -158,7 +158,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 In earlier versions of {productname}, a problem occurred when users inserted a video or media element into a {productname} document while using Safari as the host browser. The issue caused media files to be unplayable in Safari.
 
-{productname} {release-version} resolves this problem by preventing events from bubbling out of the video element, which previously caused the playback issue.
+{productname} {release-version} resolves this problem by preventing events from propagating outside of the video element, which previously caused the playback issue.
 
 With this fix, users can now play video and audio elements on Safari without any issues.
 


### PR DESCRIPTION
Ticket: DOC-2363

Site: [Staging branch](http://docs-feature-71-doc-2363tiny-10774.staging.tiny.cloud/docs/tinymce/latest/7.1-release-notes/#video-and-audio-elements-could-not-be-played-on-safari)

Changes:
* added `Video and audio elements could not be played on Safari` to TinyMCE 7.1 release notes.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed