### PR TITLE
DOC-2363: Custom block elements with colon characters would throw errors.

### DIFF
--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -156,7 +156,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Custom block elements with colon characters would throw errors.
 // #TINY-10813
 
-Previously, when using custom elements containing characters like colons, and that element has an anchor element nested within an error would be thrown in the dev-console as the corresponding CSS selector was invalid due to the unescaped colon character.
+Previously, when using `custom_elements` containing characters like colons, and that element has an anchor element nested within an error would be thrown in the dev-console as the corresponding CSS selector was invalid due to the unescaped colon character.
 
 {productname} {release-version} addresses this issue, now, the CSS selector properly escapes special characters like colons, ensuring its validity.
 

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -156,7 +156,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Custom block elements with colon characters would throw errors.
 // #TINY-10813
 
-Previously, when using `custom_elements` containing characters like colons, and that element has an anchor element nested within an error would be thrown in the dev-console as the corresponding CSS selector was invalid due to the unescaped colon character.
+Previously, when `custom_elements` contained special characters such as colons, and these elements included a nested anchor element, an error would be thrown in the dev-console as the corresponding CSS selector was invalid due to the unescaped colon character.
 
 {productname} {release-version} addresses this issue, now, the CSS selector properly escapes special characters like colons, ensuring its validity.
 

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -153,10 +153,14 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} 7.1 also includes the following bug fix<es>:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Custom block elements with colon characters would throw errors.
+// #TINY-10813
 
-// CCFR here.
+Previously, when using custom elements containing characters like colons, and that element has an anchor element nested within an error would be thrown in the dev-console as the corresponding CSS selector was invalid due to the unescaped colon character.
+
+{productname} {release-version} addresses this issue, now, the CSS selector properly escapes special characters like colons, ensuring its validity.
+
+As a result, the error in the console is no longer displayed.
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-2363

Site: [Staging branch](http://docs-feature-71-doc-2363tiny-10813.staging.tiny.cloud/docs/tinymce/latest/7.1-release-notes/#custom-block-elements-with-colon-characters-would-throw-errors)

Changes:
* add `Custom block elements with colon characters would throw errors.` to TinyMCE 7.1 release notes.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed