### PR TITLE
DOC-2363: Fixed accessibility issue by removing duplicate `role="menu"` attribute from color swatches.

### DIFF
--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -173,10 +173,12 @@ For more information on bundling with {productname}, see xref:bundling-plugins.a
 
 {productname} 7.1 also includes the following bug fix<es>:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Fixed accessibility issue by removing duplicate `role="menu"` attribute from color swatches.
+// #TINY-10806
 
-// CCFR here.
+The color swatch menu item, which is accessible via **Format** > **Text color** menu, previously contained nested block elements with the same ARIA role ('menu') in its HTML structure, which violated ARIA standards.
+
+{productname} {release-version} addresses this issue, by removing the duplicated role attribute, ensuring that the structure now aligns with ARIA guidelines and enhances usability for all users.
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-2363

Site: [Staging branch](http://docs-feature-71-doc-2363tiny-10806.staging.tiny.cloud/docs/tinymce/latest/7.1-release-notes/#fixed-accessibility-issue-by-removing-duplicate-rolemenu-attribute-from-color-swatches)

Changes:
* added fix documentation for `Fixed accessibility issue by removing duplicate `role="menu"` attribute from color swatches`.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [ ] Documentation Team Lead has reviewed