### PR TITLE
DOC-2388: Documenting notification keyboard navigation

### DIFF
--- a/modules/ROOT/pages/keyboard-shortcuts.adoc
+++ b/modules/ROOT/pages/keyboard-shortcuts.adoc
@@ -30,6 +30,7 @@ This is a list of available keyboard shortcuts within the editor body.
 |Focus to menu bar |Alt+F9 |⌥+F9 |core
 |Focus to toolbar |Alt+F10 |⌥+F10 |core
 |Focus to element path |Alt+F11 |⌥+F11 |core
+|Focus to notification |Alt+F12 |⌥+F12 |core
 |Focus to contextual toolbar |Ctrl+F9 |Ctrl+F9 |core
 |Print |Ctrl+P |⌘+P |core
 |Open the {productname} Help dialog |Alt+0 |⌥+0 |xref:help.adoc[help]
@@ -59,6 +60,7 @@ This is a list of available keyboard shortcuts within the editor user interface.
 |Close submenu |Left Arrow / Esc |Left Arrow / Esc
 |Close dialog |Esc |Esc
 |Close menu |Esc |Esc
+|Close notification |Esc |Esc
 |Move focus back to editor body |Esc |Esc
 |===
 

--- a/modules/ROOT/pages/tinymce-and-screenreaders.adoc
+++ b/modules/ROOT/pages/tinymce-and-screenreaders.adoc
@@ -16,6 +16,7 @@ The following *Alt+key* and *Option+key* shortcuts can only be used when the con
 |Focus/jump to menu bar |Alt+F9 |⌥+F9
 |Focus/jump to toolbar |Alt+F10 |⌥+F10
 |Focus/jump to element path |Alt+F11 |⌥+F11
+|Focus/jump to notification |Alt+F12 |⌥+F12
 |Close menu/submenu/dialog |Esc |Esc
 |Return to the editor content area |Esc |Esc
 |Navigate left/right through menu/toolbar |Tab and the Arrow Keys |Tab and the Arrow Keys
@@ -45,6 +46,10 @@ To open submenus or grid selections on toolbar buttons, use the *Enter*, *Return
 === Navigating dialogs
 
 Dialogs such as *Insert/Edit Image* are opened from either a menu item or a toolbar button. Some dialogs contain multiple tabs or pages of options. To change tabs or pages, use the arrow keys; the highlighted tab will become active immediately. Use the *Tab* key to navigate between the dialog options on the selected dialog tab. The *Save* dialog button stores the changes, and the *Cancel* dialog button or the *Esc* key discards changes.
+
+=== Navigating notifications
+
+To focus on the editor notifications, press *Alt+F12* (or *⌥+F12*); which moves the keyboard focus to the first notification. To move the focus _between_ notifications and other focusable elements (e.g. links or buttons) within a notification, use the *Tab* key. Use *Shift+Tab* key to navigate backward. When you reach the end of the elements within a notification using *Tab* key, it will either cycle to the next notification in the list or cycle back to the first one if you're already on the last. To close the currently focused notification, press the *Esc* key.
 
 == Accessibility options
 


### PR DESCRIPTION
Ticket: DOC-2388

Site: [Staging branch](http://docs-feature-71-doc-2388.staging.tiny.cloud/docs/tinymce/latest/tinymce-and-screenreaders/)
[Staging branch](http://docs-feature-71-doc-2388.staging.tiny.cloud/docs/tinymce/latest/keyboard-shortcuts/)

Changes:
* Added documentation for shortcut to navigate to notifications and across multiple notifications

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [x] Files has been included where required `(if applicable)`
- [x] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed