### PR TITLE
DOC-2363: Notification accessibility improvements: added tooltips, keyboard navigation and shortcut to focus on notifications.

### DIFF
--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -122,7 +122,7 @@ As a consequence, users who rely on keyboard navigation or screen readers could 
 
 {productname} {release-version} addressed this issue with the following changes: 
 
-* Keyboard Shortcut: keyboard shortcut `+(ALT+F12)+` was added, that allows users to now focus on notifications, providing a way for keyboard-only users to access and interact with them.
+* Keyboard Shortcut: keyboard shortcut *Alt+F12* (or *⌥+F12*) was added, that allows users to now focus on notifications, providing a way for keyboard-only users to access and interact with them.
 * Keyboard Navigation: allows keyboard navigation within the focusable elements in a notification, such as links and buttons, with *Tab* or *Shift+Tab*.
 * Tooltip: added a tooltip to the `close` button of the notification, providing additional context for users who may need it.
 * Link Styles: improved the styles of links within notifications, including `hover`, `focus`, `active`, and `focus-visible` states, to ensure that they are easily distinguishable and navigable.

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -123,7 +123,7 @@ As a consequence, users who rely on keyboard navigation or screen readers could 
 {productname} {release-version} addressed this issue with the following changes: 
 
 * Keyboard Shortcut: keyboard shortcut `+(ALT+F12)+` was added, that allows users to now focus on notifications, providing a way for keyboard-only users to access and interact with them.
-* Keyboard Navigation: allows keyboard navigation within the focusable elements in a notification, such as links and buttons, with `+tab+` or `+shift-tab+`.
+* Keyboard Navigation: allows keyboard navigation within the focusable elements in a notification, such as links and buttons, with *Tab* or *Shift+Tab*.
 * Tooltip: added a tooltip to the `close` button of the notification, providing additional context for users who may need it.
 * Link Styles: improved the styles of links within notifications, including `hover`, `focus`, `active`, and `focus-visible` states, to ensure that they are easily distinguishable and navigable.
 * Screen Reader Announcement: content of a notification is announced by screen readers, making it easier for visually impaired users to access and understand the information.

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -114,6 +114,22 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Notification accessibility improvements: added tooltips, keyboard navigation and shortcut to focus on notifications.
+
+In previous versions of {productname}, an accessibility issue was identified that affected keyboard-only, specifically when a user receives a notification and they where unable to close it using the keyboard.
+
+As a consequence, users who rely on keyboard navigation or screen readers could only close the notifications via mouse "Click".
+
+{productname} {release-version} addressed this issue with the following changes: 
+
+* Keyboard Shortcut: keyboard shortcut `+(ALT+F12)+` was added, that allows users to now focus on notifications, providing a way for keyboard-only users to access and interact with them.
+* Keyboard Navigation: allows keyboard navigation within the focusable elements in a notification, such as links and buttons, with `+tab+` or `+shift-tab+`.
+* Tooltip: added a tooltip to the `close` button of the notification, providing additional context for users who may need it.
+* Link Styles: improved the styles of links within notifications, including `hover`, `focus`, `active`, and `focus-visible` states, to ensure that they are easily distinguishable and navigable.
+* Screen Reader Announcement: content of a notification is announced by screen readers, making it easier for visually impaired users to access and understand the information.
+
+As a result of these changes notifications now more accessible for all users.
+
 === New `index.js` file that includes all plugin resources.
 // #TINY-10778
 


### PR DESCRIPTION
Ticket: DOC-2363

Site: [Staging branch](http://docs-feature-71-doc-2363tiny-6925.staging.tiny.cloud/docs/tinymce/latest/7.1-release-notes/#notification-accessibility-improvements-added-tooltips-keyboard-navigation-and-shortcut-to-focus-on-notifications)

Changes:
* added `Notification accessibility improvements: added tooltips, keyboard navigation and shortcut to focus on notifications` to the release notes.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`


Review:
- [x] Documentation Team Lead has reviewed