### PR TITLE
DOC-2363: Notification width was not constrained to the width of the editor.

### DIFF
--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -192,9 +192,9 @@ For more information on bundling with {productname}, see xref:bundling-plugins.a
 === Notification width was not constrained to the width of the editor.
 // #TINY-10886
 
-Previously, opening a notification or when one is display in the editor would cause it to exceed the editor's fixed width if it contained a large amount of text.
+Previously, when opening a notification containing a large amount of text or when one was displayed by the editor, the notification was not constrained to the width of the editor.
 
-As a consequence, the notification became wider than the editor.
+As a consequence, the notification popup would exceed the fixed width of the editor window.
 
 In {productname} {release-version}, this issue is resolved by ensuring that notifications do not exceed the width of the editor.
 

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -189,6 +189,15 @@ For more information on bundling with {productname}, see xref:bundling-plugins.a
 
 {productname} {release-version} also includes the following bug fixes:
 
+=== Notification width was not constrained to the width of the editor.
+// #TINY-10886
+
+Previously, opening a notification or when one is display in the editor would cause it to exceed the editor's fixed width if it contained a large amount of text.
+
+As a consequence, the notification became wider than the editor.
+
+In {productname} {release-version}, this issue is resolved by ensuring that notifications do not exceed the width of the editor.
+
 === Dialog title markup changed to use an `h1` element instead of `div`.
 // #TINY-10800
 


### PR DESCRIPTION
Ticket: DOC-2363

Site: [Staging branch](http://docs-feature-71-doc-2363tiny-10886.staging.tiny.cloud/docs/tinymce/latest/7.1-release-notes/#notification-width-was-not-constrained-to-the-width-of-the-editor)

Changes:
* added fix documentation for `Notification width was not constrained to the width of the editor.`

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed