### PR TITLE
DOC-2363: Styles were not retained when toggling a list on and off.

### DIFF
--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -189,6 +189,15 @@ For more information on bundling with {productname}, see xref:bundling-plugins.a
 
 {productname} {release-version} also includes the following bug fixes:
 
+=== Styles were not retained when toggling a list on and off.
+// #TINY-10837
+
+Previously, toggling a list into a paragraph that had a specific alignment style, did not retain the alignment state when the list was converted to the paragraph.
+
+{productname} {release-version} addresses this issue, by ensuring that the style attribute of the list item being transformed into a paragraph is carried over to the new paragraph.
+
+As a result, style attributes are now properly applied to the new paragraph after conversion when toggling lists.
+
 === Dialog title markup changed to use an `h1` element instead of `div`.
 // #TINY-10800
 


### PR DESCRIPTION
Ticket: DOC-2363

Site: [Staging branch](http://docs-feature-71-doc-2363tiny-10837.staging.tiny.cloud/docs/tinymce/latest/7.1-release-notes/#styles-were-not-retained-when-toggling-a-list-on-and-off)

Changes:
* added fix for `Styles were not retained when toggling a list on and off.`

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed