### PR TITLE
DOC-2363: In the custom view, the scrollbar of the container were not visible if its height was greater than the editor.

### DIFF
--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -112,7 +112,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === In the custom view, the scrollbar of the container were not visible if its height was greater than the editor.
 // #TINY-10741
 
-Previously, when opening a custom view on small screens or mobile devices, like the revision history view, some header buttons and UI components were not completely visible, and in some cases, they were not accessible. For example, users might not have been able to close the view because the Close button was obscured on smaller screens.
+Previously, when opening a custom view on small screens or mobile devices, like the Revision History view, some header buttons and UI components were not completely visible, and in some cases, they were not accessible. For example, users might not have been able to close the view because the Close button was obscured on smaller screens.
 
 {productname} {release-version} addresses this issue by improving the layout's responsiveness to maximize usability.
 

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -109,10 +109,14 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} 7.1 also includes the following improvement<s>:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== In the custom view, the scrollbar of the container were not visible if its height was greater than the editor.
+// #TINY-10741
 
-// CCFR here.
+Previously, when opening a custom view on small screens or mobile devices, like the revision history view, some header buttons and UI components were not completely visible, and in some cases, they were not accessible. For example, users might not have been able to close the view because the Close button was obscured on smaller screens.
+
+{productname} {release-version} addresses this issue by improving the layout's responsiveness to maximize usability.
+
+As a result, header buttons and UI components are more accessible and visible on small screens and mobile devices, ensuring that users can interact with the custom view without issues.
 
 === Notification accessibility improvements: added tooltips, keyboard navigation and shortcut to focus on notifications.
 

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -109,7 +109,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} 7.1 also includes the following improvement<s>:
 
-=== Improved the responsiveness of the Custom view on small screens
+=== Improved the responsiveness of the custom view on small screens
 // #TINY-10741
 
 Previously, when opening a custom view on small screens or mobile devices, like the Revision History view, some header buttons and UI components were not completely visible, and in some cases, they were not accessible. For example, users might not have been able to close the view because the Close button was obscured on smaller screens.

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -109,7 +109,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} 7.1 also includes the following improvement<s>:
 
-=== In the custom view, the scrollbar of the container were not visible if its height was greater than the editor.
+=== Improved the responsiveness of the Custom view on small screens
 // #TINY-10741
 
 Previously, when opening a custom view on small screens or mobile devices, like the Revision History view, some header buttons and UI components were not completely visible, and in some cases, they were not accessible. For example, users might not have been able to close the view because the Close button was obscured on smaller screens.

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -118,6 +118,8 @@ Previously, when opening a custom view on small screens or mobile devices, like 
 
 As a result, header buttons and UI components are more accessible and visible on small screens and mobile devices, ensuring that users can interact with the custom view without issues.
 
+For more information, see the xref:custom-view.adoc[Custom views] documentation.
+
 === Notification accessibility improvements: added tooltips, keyboard navigation and shortcut to focus on notifications.
 
 In previous versions of {productname}, an accessibility issue was identified that affected keyboard-only, specifically when a user receives a notification and they where unable to close it using the keyboard.


### PR DESCRIPTION
Ticket: DOC-2363

Site: [Staging branch](http://docs-feature-71-doc-2363tiny-10741.staging.tiny.cloud/docs/tinymce/latest/7.1-release-notes/#in-the-custom-view-the-scrollbar-of-the-container-were-not-visible-if-its-height-was-greater-than-the-editor)

Changes:
* added improvement docs for `In the custom view, the scrollbar of the container were not visible if its height was greater than the editor.`

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed