### PR TITLE
DOC-2363: Firefox not announcing the iframe title when `iframe_aria_text` was set.

### DIFF
--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -189,6 +189,17 @@ For more information on bundling with {productname}, see xref:bundling-plugins.a
 
 {productname} {release-version} also includes the following bug fixes:
 
+=== Firefox not announcing the iframe title when `iframe_aria_text` was set.
+// #TINY-10718
+
+Previously, there was inconsistencies across browsers in announcing the `aria-label` for the editor body when the host browser was Firefox.
+
+As a consequence, the aria-label of the editor body was not announced. It was intended to be conveyed by the `iframe_aria_text` option but in this case, it was not being announced, while Chrome and Safari functioned correctly.
+
+{productname} {release-version} addresses this issue. Now, the `iframe_aria_text` option is set to the **title** of the iframe specifically in Firefox, to ensure screen readers announce the option across all browsers.
+
+As a result, when navigating into the editor, screen readers in all supported browsers will now announce the correct label for the editor body.
+
 === Dialog title markup changed to use an `h1` element instead of `div`.
 // #TINY-10800
 

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -194,7 +194,7 @@ For more information on bundling with {productname}, see xref:bundling-plugins.a
 
 Previously, there was inconsistencies across browsers in announcing the `aria-label` for the editor body when the host browser was Firefox.
 
-As a consequence, the aria-label of the editor body was not announced. It was intended to be conveyed by the `iframe_aria_text` option but in this case, it was not being announced, while Chrome and Safari functioned correctly.
+As a consequence, the `aria-label` of the editor body was not announced. It was intended to be conveyed by the `iframe_aria_text` option but in this case, it was not being announced, while Chrome and Safari functioned correctly.
 
 {productname} {release-version} addresses this issue. Now, the `iframe_aria_text` option is set to the **title** of the iframe specifically in Firefox, to ensure screen readers announce the option across all browsers.
 

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -194,7 +194,7 @@ For more information on bundling with {productname}, see xref:bundling-plugins.a
 
 Previously, there was inconsistencies across browsers in announcing the `aria-label` for the editor body when the host browser was Firefox.
 
-As a consequence, the `aria-label` of the editor body was not announced. It was intended to be conveyed by the `iframe_aria_text` option but in this case, it was not being announced, while Chrome and Safari functioned correctly.
+As a consequence, the `aria-label` of the editor body was not announced. It was intended to be conveyed by the `iframe_aria_text` option but in this case, it was not being announced in Firefox, while Chrome and Safari functioned correctly.
 
 {productname} {release-version} addresses this issue. Now, the `iframe_aria_text` option is set to the **title** of the iframe specifically in Firefox, to ensure screen readers announce the option across all browsers.
 


### PR DESCRIPTION
Ticket: DOC-2363

Site: [Staging branch](http://docs-feature-71-doc-2363tiny-10718.staging.tiny.cloud/docs/tinymce/latest/7.1-release-notes/#firefox-not-announcing-the-iframe-title-when-iframe_aria_text-was-set)

Changes:
* added fix documentation for Firefox not announcing the iframe title when `iframe_aria_text` was set.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed