### PR TITLE
DOC-2363: Open link context menu action was not enabled for links on images.

### DIFF
--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -194,7 +194,7 @@ In earlier versions of {productname}, the `Open link` context menu action did no
 
 With {productname} {release-version}, this issue has been addressed. Now, when you select a block of text that includes a link and choose `Open link` from the context menu, the link will open in a new tab as expected.
 
-=== Open link context menu action was not enabled for links on images.
+=== Open link context menu action was not enabled when an image with a link was selected.
 
 In previous versions of {productname}, the "Open link" context menu action wasn't available for links embedded in images. This limitation prevented users from using the context menu to open links directly from images, disrupting the usual workflow.
 

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -189,6 +189,12 @@ For more information on bundling with {productname}, see xref:bundling-plugins.a
 
 {productname} {release-version} also includes the following bug fixes:
 
+=== Open link context menu action was not enabled for links on images.
+// #TINY-10391
+
+// CCFR here.
+
+
 === Dialog title was not announced in macOS VoiceOver, dialogs now use `aria-label` instead of `aria-labelledby` on macOS.
 // #TINY-10808
 

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -188,17 +188,17 @@ For more information on bundling with {productname}, see xref:bundling-plugins.a
 == Bug fixes
 
 {productname} {release-version} also includes the following bug fixes:
-=== Open link context menu action did not work with selection surrounding a link
-In previous versions of {productname}, nothing happened when selecting `Open link` context menu action on a link inside selection that is expanded to the surrounding content.
+=== Open link context menu action did not work with selection surrounding a link.
 
-In {productname} {release-version}, the issue has been fixed. Selecting `Open link` context menu action opens the targeted link in a new tab.
+In earlier versions of {productname}, the `Open link` context menu action did not work when a link was part of a larger text selection. This meant that selecting a text block containing a link and then choosing `Open link` from the context menu would not result in any action.
+
+With {productname} {release-version}, this issue has been addressed. Now, when you select a block of text that includes a link and choose `Open link` from the context menu, the link will open in a new tab as expected.
 
 === Open link context menu action was not enabled for links on images.
-In previous versions of {productname},`Open link` context menu action was not enabled for links on images.
 
-As a consequence, the users could not trigger opening the link via link context menu, hindering users' work flow.
+In previous versions of {productname}, the "Open link" context menu action wasn't available for links embedded in images. This limitation prevented users from using the context menu to open links directly from images, disrupting the usual workflow.
 
-In {productname} {release-version}, the `Open link` context menu is enabled for links on images.
+With {productname} {release-version}, this issue has been resolved. The "Open link" context menu action is now enabled for links on images, allowing users to easily open them with a right-click.
 
 === Dialog title was not announced in macOS VoiceOver, dialogs now use `aria-label` instead of `aria-labelledby` on macOS.
 // #TINY-10808

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -188,12 +188,17 @@ For more information on bundling with {productname}, see xref:bundling-plugins.a
 == Bug fixes
 
 {productname} {release-version} also includes the following bug fixes:
+=== Open link context menu action did not work with selection surrounding a link
+In previous versions of {productname}, nothing happened when selecting `Open link` context menu action on a link inside selection that is expanded to the surrounding content.
+
+In {productname} {release-version}, the issue has been fixed. Selecting `Open link` context menu action opens the targeted link in a new tab.
 
 === Open link context menu action was not enabled for links on images.
-// #TINY-10391
+In previous versions of {productname},`Open link` context menu action was not enabled for links on images.
 
-// CCFR here.
+As a consequence, the users could not trigger opening the link via link context menu, hindering users' work flow.
 
+In {productname} {release-version}, the `Open link` context menu is enabled for links on images.
 
 === Dialog title was not announced in macOS VoiceOver, dialogs now use `aria-label` instead of `aria-labelledby` on macOS.
 // #TINY-10808


### PR DESCRIPTION
Ticket: DOC-2363

Site: [Staging branch](http://docs-feature-71-doc-2363tiny-10391.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* add fix documentation for `Open link context menu action was not enabled for links on images.`

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed