### PR TITLE
DOC-2406: Update default emoticons_images_url

### DIFF
--- a/modules/ROOT/partials/configuration/emoticons_images_url.adoc
+++ b/modules/ROOT/partials/configuration/emoticons_images_url.adoc
@@ -7,7 +7,7 @@ By default, this option loads the required image _assets_ from the Twemoji CDN. 
 
 *Type:* `+String+`
 
-*Default value:* `+'https://twemoji.maxcdn.com/v/13.0.1/72x72/'+`
+*Default value:* `+'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/'+`
 
 === Example: using `+emoticons_images_url+`
 


### PR DESCRIPTION
Ticket: DOC-<num>

Site: [Staging branch](http://docs-feature-71-doc-2406.staging.tiny.cloud/docs/tinymce/latest/emoticons/#emoticons_images_url)

Changes:
* DOC-2406: Update default emoticons_images_url

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [-] Files has been included where required `(if applicable)`
- [-] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [-] Files added for `New product features`, and included a `release note` entry.

Review:
- [ ] Documentation Team Lead has reviewed