### PR TITLE
DOC-2411: Add TINY-10885 release note entry

### DIFF
--- a/modules/ROOT/pages/7.1.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.1-release-notes.adoc
@@ -163,9 +163,9 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Insert/Edit image dialog lost focus after the image upload completed.
 // #TINY-10885
 
-Previously, when using the TinyMCE editor's `Insert/Edit image` dialog and uploading an image from the 'Upload' tab, the focus would move outside of the dialog after the image was successfully uploaded. As a consequence, users were unable to navigate within the dialog using the tab key.
+Previously, when using the {productname} editor's `Insert/Edit Image` dialog and uploading an image from the 'Upload' tab, the focus would move outside of the dialog after the image was successfully uploaded. As a consequence, users were unable to navigate within the dialog using the tab key.
 
-In {productname} {release-version}, this issue has been fixed. Now, the focus remains inside the `Insert/Edit image` dialog after uploading an image, allowing users to navigate within the dialog using the keyboard as expected.
+In {productname} {release-version}, this issue has been addressed. Now, the focus remains inside the `Insert/Edit Image` dialog after uploading an image, allowing users to navigate within the dialog using the keyboard as expected.
 
 
 [[security-fixes]]

--- a/modules/ROOT/pages/7.1.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.1-release-notes.adoc
@@ -160,6 +160,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Insert/Edit image dialog lost focus after the image upload completed.
+// #TINY-10885
+
+Previously, when using the TinyMCE editor's `Insert/Edit image` dialog and uploading an image from the 'Upload' tab, the focus would move outside of the dialog after the image was successfully uploaded. As a consequence, users were unable to navigate within the dialog using the tab key.
+
+In {productname} {release-version}, this issue has been fixed. Now, the focus remains inside the `Insert/Edit image` dialog after uploading an image, allowing users to navigate within the dialog using the keyboard as expected.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-2411

Site: [Staging branch](http://docs-feature-711-doc-2411tiny-10885.staging.tiny.cloud/docs/tinymce/latest/7.1.1-release-notes/#insertedit-image-dialog-lost-focus-after-the-image-upload-completed)

Changes:
* DOC-2411: Add TINY-10885 release note entry

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [-] Files has been included where required `(if applicable)`
- [-] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed