### PR TITLE
DOC-2399: Update Basic Setup section in AI Assistant plugin page

### DIFF
--- a/modules/ROOT/pages/ai.adoc
+++ b/modules/ROOT/pages/ai.adoc
@@ -31,50 +31,13 @@ liveDemo::ai[]
 
 To add the {pluginname} plugin to the editor, add both `{plugincode}` to the `plugins` option in the editor configuration and the `ai_request` function to the editor configuration.
 
-For example, interfacing with the OpenAI Completions API:
-
-include::partial$misc/admon-ai-proxy.adoc[]
-
 [source,js]
 ----
-// Providing access credentials within the integration is not recommended for production use.
-// We recommend setting up a proxy server to authenticate requests and provide access.
-const api_key = '<INSERT_API_KEY_HERE>';
-
 tinymce.init({
-  selector: 'textarea',  // Change this value according to your HTML
+  selector: 'textarea',  // change this value according to your HTML
   plugins: 'ai',
   toolbar: 'aidialog aishortcuts',
-  ai_request: (request, respondWith) => {
-    const openAiOptions = {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${api_key}`
-      },
-      body: JSON.stringify({
-        model: 'gpt-3.5-turbo',
-        temperature: 0.7,
-        max_tokens: 800,
-        messages: [{ role: 'user', content: request.prompt }],
-      })
-    };
-    respondWith.string((signal) => window.fetch('https://api.openai.com/v1/chat/completions', { signal, ...openAiOptions })
-      .then(async (response) => {
-        if (response) {
-          const data = await response.json();
-          if (data.error) {
-            throw new Error(`${data.error.type}: ${data.error.message}`);
-          } else if (response.ok) {
-            // Extract the response content from the data returned by the API
-            return data?.choices[0]?.message?.content?.trim();
-          }
-        } else {
-          throw new Error('Failed to communicate with the ChatGPT API');
-        }
-      })
-    );
-  }
+  ai_request: <AI_REQUEST_FUNCTION>,
 });
 ----
 

--- a/modules/ROOT/pages/ai.adoc
+++ b/modules/ROOT/pages/ai.adoc
@@ -29,7 +29,12 @@ liveDemo::ai[]
 
 == Basic setup
 
-To add the {pluginname} plugin to the editor, add both `{plugincode}` to the `plugins` option in the editor configuration and the `ai_request` function to the editor configuration.
+To add the {pluginname} plugin to the editor, follow these steps:
+
+- Add `{plugincode}` to the `plugins` option in the editor configuration.
+- Add the `ai_request` function to the editor configuration.
+
+For example:
 
 [source,js]
 ----


### PR DESCRIPTION
Ticket: DOC-2399

Site: [Staging branch](http://docs-hotfix-7-doc-23992.staging.tiny.cloud/docs/tinymce/latest/ai/#basic-setup)

Hotfix - I forgot to update the "Basic setup" section with the initial pull request.

Changes:
* DOC-2399: Update Basic Setup section in AI Assistant plugin page

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [-] Files has been included where required `(if applicable)`
- [-] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [-] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed