### PR TITLE
DOC-2392: Re-write of `editor-plugin-version.adoc` page.

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -123,7 +123,7 @@
 ** xref:cloud-deployment-guide.adoc[Cloud deployment guide]
 *** xref:editor-and-features.adoc[Cloud deployment of editor & plugins]
 *** xref:features-only.adoc[Cloud deployment of plugins Only]
-*** xref:editor-plugin-version.adoc[Specify editor & plugin versions]
+*** xref:editor-plugin-version.adoc[Specify editor & plugins]
 *** xref:plugin-editor-version-compatibility.adoc[Version compatibility reference]
 *** xref:cloud-troubleshooting.adoc[Cloud Troubleshooting]
 ** Premium server-side services guide

--- a/modules/ROOT/pages/cloud-deployment-guide.adoc
+++ b/modules/ROOT/pages/cloud-deployment-guide.adoc
@@ -21,9 +21,9 @@ Connect to Tiny Cloud within a hybrid deployment.
 
 |
 [.lead]
-xref:editor-plugin-version.adoc[Specify editor & plugin versions]
+xref:editor-plugin-version.adoc[Specify editor & plugins]
 
-Specifying editor and plugin versions for Tiny Cloud deployments.
+Specifying editor and plugins for Tiny Cloud deployments.
 
 |
 [.lead]

--- a/modules/ROOT/pages/editor-plugin-version.adoc
+++ b/modules/ROOT/pages/editor-plugin-version.adoc
@@ -23,7 +23,7 @@ For more details, check out the xref:editor-and-features.adoc[{productname} edit
 [[specifying-the-cloud-deployment-of-plugins]]
 == Specifying the Cloud Deployment of Plugins
 
-When deploying {productname}, integrators have the choice to **self-host** premium plugins or load them from {companyname} Cloud (a.k.a. hybrid mode). Depending on your requirements, you can use a combination of both approaches.
+When self-hosting {productname}, integrators have the choice to host premium plugins or load them from {companyname} Cloud (a.k.a. hybrid mode). Depending on your requirements, you can use a combination of both approaches.
 
 include::partial$misc/admon-script-tag-placement.adoc[]
 

--- a/modules/ROOT/pages/editor-plugin-version.adoc
+++ b/modules/ROOT/pages/editor-plugin-version.adoc
@@ -48,7 +48,9 @@ To exclude specific premium plugins from `plugins.min.js` because you are self-h
 ----
 
 [NOTE]
-When excluding specific plugins from the CDN, ensure that the excluded plugins' names are appended with `=sdk`, such as `mentions=sdk`. Note that when {companyname} Cloud releases a new plugin, you will need to update your script tag to accommodate it.
+Ensure that the excluded plugins' names are appended with `=sdk`, such as `mentions=sdk`.
+
+When {companyname} Cloud releases a new premium plugin, if you wish to self-host it this script tag will need to be updated to exclude it.
 
 === `cloud-plugins.min.js` for Specific Premium Plugins from {companyname} Cloud.
 

--- a/modules/ROOT/pages/editor-plugin-version.adoc
+++ b/modules/ROOT/pages/editor-plugin-version.adoc
@@ -37,30 +37,33 @@ In most cases, using `plugins.min.js` is the correct choice. It provides the mos
 .Example
 [source,html]
 ----
-<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/7/plugins.min.js?mentions=3.0&powerpaste=6.0" referrerpolicy="origin"></script>
+<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/7/plugins.min.js?mentions=3.0&powerpaste=6.0&advcode=sdk" referrerpolicy="origin"></script>
 ----
 
-In this example, {productname} will attempt to load all premium plugins from {companyname} Cloud, with specified versions for the "mentions" and "powerpaste" plugins. The only disadvantage of `+plugins.min.js+`: to load only one plugin from the {cloudname} and the rest from a self-hosted deployment, *ALL* other plugins need to be added as query parameter with the version as `+sdk+`. When {cloudname} releases a new plugin, this will need to be updated.
+In this example, {productname} will try to load all premium plugins from {companyname} Cloud, including specified versions for the "mentions" and "powerpaste" plugins. The disadvantage of using `plugins.min.js` is that if you want to load only one plugin from {companyname} Cloud while the rest are self-hosted, you have to add all other plugins as query parameters with their versions specified as "sdk." When {companyname} Cloud releases a new plugin, you'll need to update the list.
 
+include::partial$misc/admon-script-tag-placement.adoc[]
 
 ==== Using `cloud-plugins.min.js`
 
-Use `cloud-plugins.min.js` **only** if you have a specific reason to self-host some premium plugins while loading others from Tiny Cloud. This approach is more complex and requires you to specify which plugins to load from {companyname} Cloud.
+{companyname} recommends only using `cloud-plugins.min.js` if you have a specific reason to self-host some premium plugins while loading others from Tiny Cloud. This approach is more complex and requires you to specify which plugins to load from {companyname} Cloud.
 
 .Example
 [source,html]
 ----
-<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/7/cloud-plugins.min.js?mentions=3.0&powerpaste=6.0" referrerpolicy="origin"></script>
+<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/7/cloud-plugins.min.js?mentions=3.0&powerpaste=6.0&advcode" referrerpolicy="origin"></script>
 ----
 
-This example loads specific premium plugins from Tiny Cloud, with the rest assumed to be self-hosted. Unlike `plugins.min.js`, there is no need to specify a special version (like "sdk") for self-hosted plugins.
+In this example, {productname} loads specific premium plugins from {companyname} Cloud, with the rest assumed to be self-hosted. Unlike `plugins.min.js`, there is no need to specify a special version (like "sdk") for self-hosted plugins.
+
+include::partial$misc/admon-script-tag-placement.adoc[]
 
 [TIP]
-Specifying plugin versions is generally **not recommended**. {companyname} recommends using the latest versions to ensure compatibility and security. As the disadvantage of `+cloud-plugins.min.js+`: every plugin to be loaded from {cloudname} must be added to the query parameter.
+Specifying plugin versions is generally **not recommended**. {companyname} recommends using the latest versions to ensure compatibility and security. As the disadvantage of using `+cloud-plugins.min.js+` is that every plugin loaded from {cloudname} must be added to the query parameter.
 
-== Premium plugin versions available from Tiny Cloud
+== Premium plugin versions available from {companyname} Cloud
 
-While it is not recommended, but it is possible to specify different versions of each premium plugin to use with {productname}. Using the URL query parameters mentioned above, this can by used to specify the version of each premium plugin to load. This approach works with both the xref:editor-and-features.adoc[{productname} editor and premium plugins deployment via {cloudname}] or just the xref:features-only.adoc[premium plugins deployment from {cloudname}].
+While it is not recommended, it is possible to specify different versions of each premium plugin to use with {productname}. Using the URL query parameters mentioned above, this can by used to specify the version of each premium plugin to load. This approach works with both the xref:editor-and-features.adoc[{productname} editor and premium plugins deployment via {cloudname}] or just the xref:features-only.adoc[premium plugins deployment from {cloudname}].
 
 The `+identifier+` of the plugin is used as a query parameter. This table summarises the possible options.
 
@@ -101,11 +104,16 @@ The `+identifier+` of the plugin is used as a query parameter. This table summar
 
 === Understanding and selecting specific version numbers
 
-IMPORTANT
-All {cloudname} channels are based on the {enterpriseversion} version. For information on the latest version of the {cloudname} `{productmajorversion}` release channel, see: xref:release-notes.adoc[{productname} Release Notes]. For a list of changes that *may* be present in the {cloudname} testing channel, see: xref:changelog.adoc[{productname} Changelog].
+[IMPORTANT]
+====
+All {cloudname} channels are based on the {enterpriseversion} version.
+
+* For information on the latest version of the {cloudname} `{productmajorversion}` release channel, see: xref:release-notes.adoc[{productname} Release Notes].
+* For a list of changes that *may* be present in the {cloudname} testing channel, see: xref:changelog.adoc[{productname} Changelog].
+====
 
 [#{productmajorversion}-{productmajorversion}-testing-and-{productmajorversion}-dev-release-channels]
-=== {productmajorversion}, {productmajorversion}-testing, and {productmajorversion}-dev release channels
+=== Difference between using {productname} {productmajorversion}, {productmajorversion}-testing, and {productmajorversion}-dev release channels
 
 Choose from the `{productmajorversion}`, `{productmajorversion}-testing`, or `{productmajorversion}-dev` release channels to load the latest version of {productname} from {cloudname}.
 

--- a/modules/ROOT/pages/editor-plugin-version.adoc
+++ b/modules/ROOT/pages/editor-plugin-version.adoc
@@ -1,4 +1,4 @@
-= Specify editor & plugins
+= Specify editor version & plugins
 :description_short: Specifying editor version and plugins for {cloudname} deployments.
 :description: Instructions on setting the {productname} editor version and plugins for {cloudname} deployments.
 :keywords: tinymce, cloud, script, textarea, apiKey, hybrid

--- a/modules/ROOT/pages/editor-plugin-version.adoc
+++ b/modules/ROOT/pages/editor-plugin-version.adoc
@@ -112,7 +112,12 @@ This channel deploys the current *release candidate* for the `{productmajorversi
 [#{productmajorversion}-dev-release-channel]
 ==== {productmajorversion}-Dev Release Channel
 
-This channel deploys nightly builds of {productname}, which includes unreleased changes documented in the https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/CHANGELOG.md[{productname} changelog]. The current version of {productname} available through the `{productmajorversion}-dev` channel can be found on the https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}-dev/version.txt[{cloudname} {productname} {productmajorversion}-dev version page].
+This channel deploys nightly builds of {productname}, which includes **unreleased changes** from the link:https://github.com/tinymce/tinymce/tree/main[{productname} repository^]. 
+
+The current version of {productname} is available on the `{productmajorversion}-dev` channel can be found on the link:https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}-dev/version.txt[{cloudname} {productname} {productmajorversion}-dev version page^].
+
+[NOTE]
+{productname} now uses `main` branch for nightly builds instead of `develop` as of {productname} `7.0.0`.
 
 [#example-using-the-{productmajorversion}-dev-release-channel]
 ===== Example: Using the `{productmajorversion}-dev` Release Channel

--- a/modules/ROOT/pages/editor-plugin-version.adoc
+++ b/modules/ROOT/pages/editor-plugin-version.adoc
@@ -26,7 +26,7 @@ For more details, check out the xref:editor-and-features.adoc[{productname} edit
 When deploying {productname}, integrators have the choice to **self-host** premium plugins or load them from {companyname} Cloud which is referred to as Hybrid mode. Depending on your setup, a combination of both approaches can be used. For simplifying this process, {companyname} offers two configuration scripts:
 
 * `plugins.min.js`: This script configures {productname} to load all premium plugins from {companyname} Cloud, **defaulting** to the `latest` version in the selected cloud channel. You can specify different plugin versions if necessary, but it's generally best to use the latest versions for optimal performance and security.
-* `cloud-plugins.min.js`: This script allows loading of specific premium plugins from {companyname} Cloud, while self-hosting the rest. This approach is intended for edge cases, such as when you have custom plugins on your own servers and only need a few from {companyname} Cloud.
+* `cloud-plugins.min.js`: This script allows loading of specific premium plugins from {companyname} Cloud. This approach is intended for edge cases, when you self-host most premium plugins on your own servers and only need one or two from {companyname} Cloud.
 
 === Which Script Should You Use?
 

--- a/modules/ROOT/pages/editor-plugin-version.adoc
+++ b/modules/ROOT/pages/editor-plugin-version.adoc
@@ -1,108 +1,70 @@
-= Specify editor & plugin versions
-:description_short: Specifying editor and plugin versions for Tiny Cloud deployments.
-:description: Specifying editor and plugin versions for Tiny Cloud deployments.
+= Specify editor & plugins
+:description_short: Specifying editor version and plugins for Tiny Cloud deployments.
+:description: Instructions on setting the TinyMCE editor version and plugins for Tiny Cloud deployments.
 :keywords: tinymce, cloud, script, textarea, apiKey, hybrid
 
 [[specifying-the-tinymce-editor-version-deployed-from-cloud]]
 == Specifying the {productname} Editor Version from the Cloud
 
-To set the {productname} version when deploying from {cloudname}, use the following URL.
+To set the {productname} version when deploying from {cloudname}, use the following URL:
 
 [source,html,subs="attributes+"]
 ----
 <script src="{cdnurl}" referrerpolicy="origin"></script>
 ----
 
-The example above shows the default way to load {productname} {productmajorversion} from {cloudname}.
+The example above shows the default way to load {productname} {productmajorversion} from {cloudname}. This URL ensures the most recent and verified version of {productname} is used.
 
 [TIP]
-Replace 'no-api-key' with your own API key. This URL ensures the most recent and verified version of {productname} is used.
+Replace 'no-api-key' with your own API key.
 
 For more details, check out the xref:editor-and-features.adoc[{productname} editor via {cloudname}].
 
 [[specifying-the-cloud-deployment-of-plugins]]
-== Specifying the Cloud Deployment of plugins
+== Specifying the Cloud Deployment of Plugins
 
-When deploying {productname}, integrators have the choice to **self-host** premium plugins or load them from {companyname} Cloud which is referred to as Hybrid mode. Depending on your setup, a combination of both approaches can be used. For simplifying this process, {companyname} offers two configuration scripts:
-
-* `plugins.min.js`: This script configures {productname} to load all premium plugins from {companyname} Cloud, **defaulting** to the `latest` version in the selected cloud channel. You can specify different plugin versions if necessary, but it's generally best to use the latest versions for optimal performance and security.
-* `cloud-plugins.min.js`: This script allows loading of specific premium plugins from {companyname} Cloud. This approach is intended for edge cases, when you self-host most premium plugins on your own servers and only need one or two from {companyname} Cloud.
-
-=== Which Script Should You Use?
-
-==== Using `plugins.min.js`
-
-In most cases, using `plugins.min.js` is the correct choice. It provides the most flexibility and simplicity by ensuring all plugins are loaded from {companyname} Cloud. If you need to specify individual plugin versions, you can do so via query parameters.
-
-.Example
-[source,html]
-----
-<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/7/plugins.min.js?mentions=3.0&powerpaste=6.0&advcode=sdk" referrerpolicy="origin"></script>
-----
-
-In this example, {productname} will try to load all premium plugins from {companyname} Cloud, including specified versions for the "mentions" and "powerpaste" plugins. The disadvantage of using `plugins.min.js` is that if you want to load only one plugin from {companyname} Cloud while the rest are self-hosted, you have to add all other plugins as query parameters with their versions specified as "sdk." When {companyname} Cloud releases a new plugin, you'll need to update the list.
+When deploying {productname}, integrators have the choice to **self-host** premium plugins or load them from {companyname} Cloud (a.k.a. hybrid mode). Depending on your requirements, you can use a combination of both approaches.
 
 include::partial$misc/admon-script-tag-placement.adoc[]
 
-==== Using `cloud-plugins.min.js`
+{companyname} offers the following configuration scripts to assist:
 
-{companyname} recommends only using `cloud-plugins.min.js` if you have a specific reason to self-host some premium plugins while loading others from Tiny Cloud. This approach is more complex and requires you to specify which plugins to load from {companyname} Cloud.
+=== `plugin.min.js` Standalone with No Exclusions.
 
-.Example
-[source,html]
+The `plugins.min.js` script loads every plugin the API key is entitled to from the CDN.
+
+[source,html,subs="attributes+"]
 ----
-<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/7/cloud-plugins.min.js?mentions=3.0&powerpaste=6.0&advcode" referrerpolicy="origin"></script>
+<script src="https://cdn.tiny.cloud/1/api-key/tinymce/7/plugins.min.js" referrerpolicy="origin"></script>
 ----
 
-In this example, {productname} loads specific premium plugins from {companyname} Cloud, with the rest assumed to be self-hosted. Unlike `plugins.min.js`, there is no need to specify a special version (like "sdk") for self-hosted plugins.
+=== `plugins.min.js` with Exclusions for Specific Plugins.
 
-include::partial$misc/admon-script-tag-placement.adoc[]
+To exclude specific premium plugins from `plugins.min.js` because you are self-hosting them, add the excluded plugins to the script query parameters as shown below:
 
-[TIP]
-Specifying plugin versions is generally **not recommended**. {companyname} recommends using the latest versions to ensure compatibility and security. As the disadvantage of using `+cloud-plugins.min.js+` is that every plugin loaded from {cloudname} must be added to the query parameter.
+[source,html,subs="attributes+"]
+----
+<script src="https://cdn.tiny.cloud/1/api-key/tinymce/7/plugins.min.js?mentions=sdk&powerpaste=sdk" referrerpolicy="origin"></script>
+----
 
-== Premium plugin versions available from {companyname} Cloud
+[NOTE]
+When excluding specific plugins from the CDN, ensure that the excluded plugins' names are appended with `=sdk`, such as `mentions=sdk`. Note that when {companyname} Cloud releases a new plugin, you will need to update your script tag to accommodate it.
 
-While it is not recommended, it is possible to specify different versions of each premium plugin to use with {productname}. Using the URL query parameters mentioned above, this can by used to specify the version of each premium plugin to load. This approach works with both the xref:editor-and-features.adoc[{productname} editor and premium plugins deployment via {cloudname}] or just the xref:features-only.adoc[premium plugins deployment from {cloudname}].
+=== `cloud-plugins.min.js` for Specific Premium Plugins from {companyname} Cloud.
 
-The `+identifier+` of the plugin is used as a query parameter. This table summarises the possible options.
+The `cloud-plugins.min.js` script allows loading of specific premium plugins from {companyname} Cloud.
 
-[cols=",,",options="header"]
-|===
-|Plugin |Identifier |Supported Versions
-|xref:a11ychecker.adoc[Accessibility Checker] | `+a11ychecker+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/a11ychecker/available-versions[Versions]
-|xref:advanced-typography.adoc[Advanced Typography] | `+advtable+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/advtable/available-versions[Versions]
-|xref:ai.adoc[AI Assistant] | `+ai+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/ai/available-versions[Versions]
-|xref:casechange.adoc[Case Change] | `+casechange+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/casechange/available-versions[Versions]
-|xref:checklist.adoc[Checklist] | `+checklist+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/checklist/available-versions[Versions]
-|xref:introduction-to-tiny-comments.adoc[Comments] | `+tinycomments+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/tinycomments/available-versions[Versions]
-|xref:advcode.adoc[Enhanced Code Editor] | `+advcode+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/advcode/available-versions[Versions]
-|xref:introduction-to-mediaembed.adoc[Enhanced Media Embed] | `+mediaembed+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/mediaembed/available-versions[Versions]
-|xref:advtable.adoc[Enhanced Tables] | `+advtable+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/advtable/available-versions[Versions]
-|xref:exportword.adoc[Export to Word] | `+exportword+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/exportword/available-versions[Versions]
-|xref:exportpdf.adoc[Export to PDF] | `+exportpdf+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/exportpdf/available-versions[Versions]
-|xref:footnotes.adoc[Footnotes] | `+footnotes+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/footnotes/available-versions[Versions]
-|xref:formatpainter.adoc[Format Painter] | `+formatpainter+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/formatpainter/available-versions[Versions]
-|xref:inline-css.adoc[Inline CSS] | `+inlinecss+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/inline-css/available-versions[Versions]
-|xref:importword.adoc[Import from Word] | `+importword+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/importword/available-versions[Versions]
-|xref:editimage.adoc[Image Editing] | `+editimage+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/editimage/available-versions[Versions]
-|xref:linkchecker.adoc[Link Checker] | `+linkchecker+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/linkchecker/available-versions[Versions]
-|xref:markdown.adoc[Markdown] | `+markdown+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/markdown/available-versions[Versions]
-|xref:mentions.adoc[Mentions] | `+mentions+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/mentions/available-versions[Versions]
-|xref:mergetags.adoc[Merge Tags] | `+mergetags+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/mergetags/available-versions[Versions]
-|xref:moxiemanager.adoc[MoxieManager] | `+moxiemanager+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/moxiemanager/available-versions[Versions]
-|xref:pageembed.adoc[Page Embed] | `+pageembed+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/pageembed/available-versions[Versions]
-|xref:permanentpen.adoc[Permanent Pen] | `+permanentpen+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/permanentpen/available-versions[Versions]
-|xref:introduction-to-powerpaste.adoc[PowerPaste] | `+powerpaste+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/powerpaste/available-versions[Versions]
-|xref:revisionhistory.adoc[Revision History] | `+revisionhistory+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/revisionhistory/available-versions[Versions]
-|xref:introduction-to-tiny-spellchecker.adoc[Spell Checker] | `+tinymcespellchecker+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/tinymcespellchecker/available-versions[Versions]
-|xref:autocorrect.adoc[Spelling Autocorrect] | `+autocorrect+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/autocorrect/available-versions[Versions]
-|xref:advanced-templates.adoc[Templates] | `+templates+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/advanced-templates/available-versions[Versions]
-|xref:tableofcontents.adoc[Table of Contents] | `+tableofcontents+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/tableofcontents/available-versions[Versions]
-|xref:tinydrive-introduction.adoc[Tiny Drive] | `+tinydrive+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/tinydrive/available-versions[Versions]
-|===
+[source,html,subs="attributes+"]
+----
+<script src="https://cdn.tiny.cloud/1/api-key/tinymce/7/cloud-plugins.min.js?mentions&powerpaste&advcode" referrerpolicy="origin"></script>
+----
 
-=== Understanding and selecting specific version numbers
+[NOTE]
+This approach is intended for edge cases where you self-host most premium plugins on your own servers and only need one or two from {companyname} Cloud.
+
+'''
+
+=== Selecting Specific Editor Versions
 
 [IMPORTANT]
 ====
@@ -113,14 +75,14 @@ All {cloudname} channels are based on the {enterpriseversion} version.
 ====
 
 [#{productmajorversion}-{productmajorversion}-testing-and-{productmajorversion}-dev-release-channels]
-=== Difference between using {productname} {productmajorversion}, {productmajorversion}-testing, and {productmajorversion}-dev release channels
+=== Difference between using {productname} {productmajorversion}, {productmajorversion}-Testing, and {productmajorversion}-Dev release channels
 
 Choose from the `{productmajorversion}`, `{productmajorversion}-testing`, or `{productmajorversion}-dev` release channels to load the latest version of {productname} from {cloudname}.
 
-These channels are updated automatically and provide the latest {productname} version that matches the criteria below.
+These channels are updated automatically and provide the latest {productname} version based on the follow criteria:
 
 [#{productmajorversion}-release-channel]
-==== {productmajorversion} release channel
+==== {productmajorversion} Release Channel
 
 This channel deploys the latest release of {productname} that has passed our quality assurance process. The current version of {productname} available through the `/{productmajorversion}` channel can be found on the https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}/version.txt[{cloudname} {productname} {productmajorversion} version page]. The {productname} {productmajorversion} channel can be loaded from `{cdnurl}`.
 
@@ -133,12 +95,12 @@ This channel deploys the latest release of {productname} that has passed our qua
 ----
 
 [#{productmajorversion}-testing-release-channel]
-==== {productmajorversion}-testing release channel
+==== {productmajorversion}-Testing Release Channel
 
 This channel deploys the current *release candidate* for the `{productmajorversion}` channel. The {productname} release candidate is undergoing quality assurance. The current version of {productname} available through the `{productmajorversion}-testing` channel can be found on the https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}-testing/version.txt[{cloudname} {productname} {productmajorversion}-testing version page].
 
 [#example-using-the-{productmajorversion}-testing-release-channel]
-===== Example: using the `{productmajorversion}-testing` release channel
+===== Example: Using the `{productmajorversion}-testing` Release Channel
 
 [source,html,subs="attributes+"]
 ----
@@ -146,12 +108,12 @@ This channel deploys the current *release candidate* for the `{productmajorversi
 ----
 
 [#{productmajorversion}-dev-release-channel]
-==== {productmajorversion}-dev release channel
+==== {productmajorversion}-Dev Release Channel
 
-This channel deploys nightly builds of {productname}. This channel includes the unreleased changes documented in the https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/CHANGELOG.md[{productname} changelog]. The current version of {productname} available through the `{productmajorversion}-dev` channel can be found on the https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}-dev/version.txt[{cloudname} {productname} {productmajorversion}-dev version page].
+This channel deploys nightly builds of {productname}, which includes unreleased changes documented in the https://github.com/tinymce/tinymce/blob/develop/modules/tinymce/CHANGELOG.md[{productname} changelog]. The current version of {productname} available through the `{productmajorversion}-dev` channel can be found on the https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}-dev/version.txt[{cloudname} {productname} {productmajorversion}-dev version page].
 
 [#example-using-the-{productmajorversion}-dev-release-channel]
-===== Example: using the `{productmajorversion}-dev` release channel
+===== Example: Using the `{productmajorversion}-dev` Release Channel
 
 [source,html,subs="attributes+"]
 ----

--- a/modules/ROOT/pages/editor-plugin-version.adoc
+++ b/modules/ROOT/pages/editor-plugin-version.adoc
@@ -4,22 +4,105 @@
 :keywords: tinymce, cloud, script, textarea, apiKey, hybrid
 
 [[specifying-the-tinymce-editor-version-deployed-from-cloud]]
-== Specifying the TinyMCE editor version deployed from Cloud
+== Specifying the {productname} Editor Version from the Cloud
 
-Use the URL provided to specify the {productname} version when deploying via {cloudname}. Refer to the xref:editor-and-features.adoc[{productname} editor via the {cloudname}] for more information.
-
-The following example is the default for loading {productname} {productmajorversion} via {cloudname}. Substitute 'no-api-key' with your api key in the examples below.
+To set the {productname} version when deploying from {cloudname}, use the following URL.
 
 [source,html,subs="attributes+"]
 ----
 <script src="{cdnurl}" referrerpolicy="origin"></script>
 ----
 
-This URL specifies the latest and quality assured release of {productname}.
+The example above shows the default way to load {productname} {productmajorversion} from {cloudname}.
 
-=== Selecting specific version numbers
+[TIP]
+Replace 'no-api-key' with your own API key. This URL ensures the most recent and verified version of {productname} is used.
 
-NOTE: All {cloudname} channels are based on the {enterpriseversion} version. For information on the latest version of the {cloudname} `{productmajorversion}` release channel, see: xref:release-notes.adoc[{productname} Release Notes]. For a list of changes that *may* be present in the {cloudname} testing channel, see: xref:changelog.adoc[{productname} Changelog].
+For more details, check out the xref:editor-and-features.adoc[{productname} editor via {cloudname}].
+
+[[specifying-a-self-hosted-deployment-of-plugins]]
+== Specifying a Self-Hosted Deployment of plugins
+
+When deploying {productname}, integrators have the choice to **self-host** premium plugins or load them from {companyname} Cloud which is referred to as Hybrid mode. Depending on your setup, a combination of both approaches can be used. For simplifying this process, {companyname} offers two configuration scripts:
+
+* `plugins.min.js`: This script configures {productname} to load all premium plugins from {companyname} Cloud, **defaulting** to the `latest` version in the selected cloud channel. You can specify different plugin versions if necessary, but it's generally best to use the latest versions for optimal performance and security.
+* `cloud-plugins.min.js`: This script allows loading of specific premium plugins from {companyname} Cloud, while self-hosting the rest. This approach is intended for edge cases, such as when you have custom plugins on your own servers and only need a few from {companyname} Cloud.
+
+=== Which Script Should You Use?
+
+==== Using `plugins.min.js`
+
+In most cases, using `plugins.min.js` is the correct choice. It provides the most flexibility and simplicity by ensuring all plugins are loaded from {companyname} Cloud. If you need to specify individual plugin versions, you can do so via query parameters.
+
+.Example
+[source,html]
+----
+<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/7/plugins.min.js?mentions=3.0&powerpaste=6.0" referrerpolicy="origin"></script>
+----
+
+In this example, {productname} will attempt to load all premium plugins from {companyname} Cloud, with specified versions for the "mentions" and "powerpaste" plugins. The only disadvantage of `+plugins.min.js+`: to load only one plugin from the {cloudname} and the rest from a self-hosted deployment, *ALL* other plugins need to be added as query parameter with the version as `+sdk+`. When {cloudname} releases a new plugin, this will need to be updated.
+
+
+==== Using `cloud-plugins.min.js`
+
+Use `cloud-plugins.min.js` **only** if you have a specific reason to self-host some premium plugins while loading others from Tiny Cloud. This approach is more complex and requires you to specify which plugins to load from {companyname} Cloud.
+
+.Example
+[source,html]
+----
+<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/7/cloud-plugins.min.js?mentions=3.0&powerpaste=6.0" referrerpolicy="origin"></script>
+----
+
+This example loads specific premium plugins from Tiny Cloud, with the rest assumed to be self-hosted. Unlike `plugins.min.js`, there is no need to specify a special version (like "sdk") for self-hosted plugins.
+
+[TIP]
+Specifying plugin versions is generally **not recommended**. {companyname} recommends using the latest versions to ensure compatibility and security. As the disadvantage of `+cloud-plugins.min.js+`: every plugin to be loaded from {cloudname} must be added to the query parameter.
+
+== Premium plugin versions available from Tiny Cloud
+
+While it is not recommended, but it is possible to specify different versions of each premium plugin to use with {productname}. Using the URL query parameters mentioned above, this can by used to specify the version of each premium plugin to load. This approach works with both the xref:editor-and-features.adoc[{productname} editor and premium plugins deployment via {cloudname}] or just the xref:features-only.adoc[premium plugins deployment from {cloudname}].
+
+The `+identifier+` of the plugin is used as a query parameter. This table summarises the possible options.
+
+[cols=",,",options="header"]
+|===
+|Plugin |Identifier |Supported Versions
+|xref:a11ychecker.adoc[Accessibility Checker] | `+a11ychecker+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/a11ychecker/available-versions[Versions]
+|xref:advanced-typography.adoc[Advanced Typography] | `+advtable+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/advtable/available-versions[Versions]
+|xref:ai.adoc[AI Assistant] | `+ai+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/ai/available-versions[Versions]
+|xref:casechange.adoc[Case Change] | `+casechange+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/casechange/available-versions[Versions]
+|xref:checklist.adoc[Checklist] | `+checklist+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/checklist/available-versions[Versions]
+|xref:introduction-to-tiny-comments.adoc[Comments] | `+tinycomments+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/tinycomments/available-versions[Versions]
+|xref:advcode.adoc[Enhanced Code Editor] | `+advcode+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/advcode/available-versions[Versions]
+|xref:introduction-to-mediaembed.adoc[Enhanced Media Embed] | `+mediaembed+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/mediaembed/available-versions[Versions]
+|xref:advtable.adoc[Enhanced Tables] | `+advtable+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/advtable/available-versions[Versions]
+|xref:exportword.adoc[Export to Word] | `+exportword+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/exportword/available-versions[Versions]
+|xref:exportpdf.adoc[Export to PDF] | `+exportpdf+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/exportpdf/available-versions[Versions]
+|xref:footnotes.adoc[Footnotes] | `+footnotes+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/footnotes/available-versions[Versions]
+|xref:formatpainter.adoc[Format Painter] | `+formatpainter+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/formatpainter/available-versions[Versions]
+|xref:inline-css.adoc[Inline CSS] | `+inlinecss+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/inline-css/available-versions[Versions]
+|xref:importword.adoc[Import from Word] | `+importword+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/importword/available-versions[Versions]
+|xref:editimage.adoc[Image Editing] | `+editimage+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/editimage/available-versions[Versions]
+|xref:linkchecker.adoc[Link Checker] | `+linkchecker+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/linkchecker/available-versions[Versions]
+|xref:markdown.adoc[Markdown] | `+markdown+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/markdown/available-versions[Versions]
+|xref:mentions.adoc[Mentions] | `+mentions+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/mentions/available-versions[Versions]
+|xref:mergetags.adoc[Merge Tags] | `+mergetags+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/mergetags/available-versions[Versions]
+|xref:moxiemanager.adoc[MoxieManager] | `+moxiemanager+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/moxiemanager/available-versions[Versions]
+|xref:pageembed.adoc[Page Embed] | `+pageembed+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/pageembed/available-versions[Versions]
+|xref:permanentpen.adoc[Permanent Pen] | `+permanentpen+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/permanentpen/available-versions[Versions]
+|xref:introduction-to-powerpaste.adoc[PowerPaste] | `+powerpaste+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/powerpaste/available-versions[Versions]
+|xref:revisionhistory.adoc[Revision History] | `+revisionhistory+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/revisionhistory/available-versions[Versions]
+|xref:introduction-to-tiny-spellchecker.adoc[Spell Checker] | `+tinymcespellchecker+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/tinymcespellchecker/available-versions[Versions]
+|xref:autocorrect.adoc[Spelling Autocorrect] | `+autocorrect+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/autocorrect/available-versions[Versions]
+|xref:advanced-templates.adoc[Templates] | `+templates+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/advanced-templates/available-versions[Versions]
+|xref:tableofcontents.adoc[Table of Contents] | `+tableofcontents+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/tableofcontents/available-versions[Versions]
+|xref:tinydrive-introduction.adoc[Tiny Drive] | `+tinydrive+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/tinydrive/available-versions[Versions]
+|===
+
+=== Understanding and selecting specific version numbers
+
+IMPORTANT
+All {cloudname} channels are based on the {enterpriseversion} version. For information on the latest version of the {cloudname} `{productmajorversion}` release channel, see: xref:release-notes.adoc[{productname} Release Notes]. For a list of changes that *may* be present in the {cloudname} testing channel, see: xref:changelog.adoc[{productname} Changelog].
 
 [#{productmajorversion}-{productmajorversion}-testing-and-{productmajorversion}-dev-release-channels]
 === {productmajorversion}, {productmajorversion}-testing, and {productmajorversion}-dev release channels
@@ -66,95 +149,3 @@ This channel deploys nightly builds of {productname}. This channel includes the 
 ----
 <script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}-dev/tinymce.min.js" referrerpolicy="origin"></script>
 ----
-
-== Specifying the version of premium plugins deployed from Tiny Cloud
-
-Each {productname} version is bundled with a set of premium plugins, but it is possible to specify different versions of each premium plugin to use with {productname}. Use the URL query parameters to specify the version of each premium plugin to load. This approach works with both the xref:editor-and-features.adoc[{productname} editor and premium plugins deployment via {cloudname}] or just the xref:features-only.adoc[premium plugins deployment from {cloudname}].
-
-The `+identifier+` of the plugin is used as a query parameter. This table summarises the possible options.
-
-[cols=",,",options="header"]
-|===
-|Plugin |Identifier |Supported Versions
-|xref:a11ychecker.adoc[Accessibility Checker] |`+a11ychecker+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/a11ychecker/available-versions[Versions]
-|xref:advtable.adoc[Enhanced Tables] |`+advtable+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/advtable/available-versions[Versions]
-|xref:advanced-typography.adoc[Advanced Typography] |`+typography+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/advtable/available-versions[Versions]
-|xref:casechange.adoc[Case Change] |`+casechange+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/casechange/available-versions[Versions]
-|xref:checklist.adoc[Checklist] |`+checklist+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/checklist/available-versions[Versions]
-|xref:introduction-to-tiny-comments.adoc[Comments] |`+comments+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/tinycomments/available-versions[Versions]
-|xref:advcode.adoc[Enhanced Code Editor] |`+advcode+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/advcode/available-versions[Versions]
-|xref:introduction-to-mediaembed.adoc[Enhanced Media Embed] |`+mediaembed+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/mediaembed/available-versions[Versions]
-|xref:footnotes.adoc[Footnotes] |`+footnotes+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/footnotes/available-versions[Versions]
-|xref:formatpainter.adoc[Format Painter] |`+formatpainter+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/formatpainter/available-versions[Versions]
-|xref:inline-css.adoc[Inline CSS] |`+inlinecss+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/formatpainter/available-versions[Versions]
-|xref:editimage.adoc[Image Editing] |`+editimage+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/editimage/available-versions[Versions]
-|xref:linkchecker.adoc[Link Checker] |`+linkchecker+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/linkchecker/available-versions[Versions]
-|xref:mentions.adoc[Mentions] |`+mentions+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/mentions/available-versions[Versions]
-|xref:mergetags.adoc[Merge Tags] |`+mergetags+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/mergetags/available-versions[Versions]
-|xref:pageembed.adoc[Page Embed] |`+pageembed+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/pageembed/available-versions[Versions]
-|xref:permanentpen.adoc[Permanent Pen] |`+permanentpen+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/permanentpen/available-versions[Versions]
-|xref:introduction-to-powerpaste.adoc[PowerPaste] |`+powerpaste+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/powerpaste/available-versions[Versions]
-|xref:introduction-to-tiny-spellchecker.adoc[Spell Checker] |`+tinymcespellchecker+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/tinymcespellchecker/available-versions[Versions]
-|xref:autocorrect.adoc[Spelling Autocorrect] |`+autocorrect+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/autocorrect/available-versions[Versions]
-|xref:tableofcontents.adoc[Table of Contents] |`+tableofcontents+`|http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/tableofcontents/available-versions[Versions]
-|xref:tinydrive-introduction.adoc[Tiny Drive] |`+tinydrive+` |http://cdn.tiny.cloud/1/no-api-key/tinymce-plugins/tinydrive/available-versions[Versions]
-|===
-
-=== Specifying versions for the editor and premium plugin deployment
-
-When deploying xref:editor-and-features.adoc[both the editor and premium plugins from {cloudname}], {productname} will load the premium plugins bundled with that version of the editor. To load a different version of a premium plugin, append the name of the plugin and the version to load as query parameters. The version must match one of the versions listed in the `+Supported Versions+` link for the relevant plugin.
-
-Combine multiple plugin specifications using `+&+` in your query string. For example, to load:
-
-* mentions v3.0
-* powerpaste v6.0
-* all other premium plugins from those bundled with `{productmajorversion}`
-
-Append `+?mentions=3.0&powerpaste=6.0+`, such as:
-
-[source,html,subs="attributes+"]
-----
-<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}/tinymce.min.js?mentions=3.0&powerpaste=6.0" referrerpolicy="origin"></script>
-----
-
-=== Specifying a self-hosted deployment of features/plugins
-
-When deploying xref:features-only.adoc[only premium plugins from {cloudname}], some features are served from {cloudname} and some features served from a self-hosted installation. There are two ways to achieve this: `+plugins.min.js+` and `+cloud-plugins.min.js+`.
-
-==== plugins.min.js
-
-Instead of loading `+tinymce.min.js+` from {cloudname}, serve {productname} from a self-hosted server, and load `+plugins.min.js+` from {cloudname}. {productname} which will attempt to load every *premium* plugin from {cloudname}, unless the version of the plugin is specified as the special version `+sdk+`. The query string for `+plugins.min.js+` works the same way as `+tinymce.min.js+`, except for the addition of `+sdk+`. For example, this script tag:
-
-The following example:
-
-* Assumes {productname} has already been loaded by another script on the page.
-* Attempts to load `+mentions+` `+v3.0+` and `+powerpaste+` `+v6.0+` from {cloudname}.
-* Attempts to load `+advcode+` from the self-hosted installation.
-* Attempts to load all other premium plugins from those bundled with version `{productmajorversion}` of {productname}.
-
-[source,html,subs="attributes+"]
-----
-<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}/plugins.min.js?mentions=3.0&powerpaste=6.0&advcode=sdk" referrerpolicy="origin"></script>
-----
-
-The disadvantage of `+plugins.min.js+`: to load only one plugin from the {cloudname} and the rest from a self-hosted deployment, *ALL* other plugins need to be added as query parameter with the version as `+sdk+`. When {cloudname} releases a new plugin, this will need to be updated. In situations where most premium plugins need to be loaded from a self-hosted deployment, use `+cloud-plugins.min.js+`.
-
-==== cloud-plugins.min.js
-
-Instead of loading `+tinymce.min.js+` from {cloudname}, serve {productname} from a self-hosted server, and load `+cloud-plugins.min.js+` from {cloudname}. Unlike `+plugins.min.js+`, `+cloud-plugins.min.js+` defaults to loading every *premium* plugin from the *self-hosted {productname} installation*, not {cloudname}. However, plugins can be loaded from {cloudname} by specifying them as query parameters.
-
-With `+cloud-plugins.min.js+`, the plugins listed in the query strings do not require a version. If there is no version specified, {productname} uses the version bundled with the {productname} version requested. There is also no need to specify `+sdk+` as the version for any plugin, as that is the default.
-
-The following example:
-
-* Assumes {productname} has already been loaded by another script on the page.
-* Attempts to load `+mentions+` `+v3.0+` and `+powerpaste+` `+v6.0+` from {cloudname}.
-* Attempts to load `+advcode+` from the version bundled with version `{productmajorversion}` of {productname} because it doesn't specify a version.
-* Attempts to load all other premium plugins from the self-hosted installation.
-
-[source,html,subs="attributes+"]
-----
-<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}/cloud-plugins.min.js?mentions=3.0&powerpaste=6.0&advcode" referrerpolicy="origin"></script>
-----
-
-The disadvantage of `+cloud-plugins.min.js+`: every plugin to be loaded from {cloudname} must be added to the query parameter. When {cloudname} releases a new plugin, this will need to be updated. In situations where most premium plugins need to be loaded from {cloudname}, use `+plugins.min.js+`.

--- a/modules/ROOT/pages/editor-plugin-version.adoc
+++ b/modules/ROOT/pages/editor-plugin-version.adoc
@@ -1,6 +1,6 @@
 = Specify editor & plugins
-:description_short: Specifying editor version and plugins for Tiny Cloud deployments.
-:description: Instructions on setting the TinyMCE editor version and plugins for Tiny Cloud deployments.
+:description_short: Specifying editor version and plugins for {cloudname} deployments.
+:description: Instructions on setting the {productname} editor version and plugins for {cloudname} deployments.
 :keywords: tinymce, cloud, script, textarea, apiKey, hybrid
 
 [[specifying-the-tinymce-editor-version-deployed-from-cloud]]

--- a/modules/ROOT/pages/editor-plugin-version.adoc
+++ b/modules/ROOT/pages/editor-plugin-version.adoc
@@ -20,8 +20,8 @@ Replace 'no-api-key' with your own API key. This URL ensures the most recent and
 
 For more details, check out the xref:editor-and-features.adoc[{productname} editor via {cloudname}].
 
-[[specifying-a-self-hosted-deployment-of-plugins]]
-== Specifying a Self-Hosted Deployment of plugins
+[[specifying-the-cloud-deployment-of-plugins]]
+== Specifying the Cloud Deployment of plugins
 
 When deploying {productname}, integrators have the choice to **self-host** premium plugins or load them from {companyname} Cloud which is referred to as Hybrid mode. Depending on your setup, a combination of both approaches can be used. For simplifying this process, {companyname} offers two configuration scripts:
 

--- a/modules/ROOT/pages/editor-plugin-version.adoc
+++ b/modules/ROOT/pages/editor-plugin-version.adoc
@@ -81,7 +81,7 @@ All {cloudname} channels are based on the {enterpriseversion} version.
 
 Choose from the `{productmajorversion}`, `{productmajorversion}-testing`, or `{productmajorversion}-dev` release channels to load the latest version of {productname} from {cloudname}.
 
-These channels are updated automatically and provide the latest {productname} version based on the follow criteria:
+These channels are updated automatically and provide the latest {productname} version based on the following criteria:
 
 [#{productmajorversion}-release-channel]
 ==== {productmajorversion} Release Channel

--- a/modules/ROOT/pages/editor-plugin-version.adoc
+++ b/modules/ROOT/pages/editor-plugin-version.adoc
@@ -48,9 +48,11 @@ To exclude specific premium plugins from `plugins.min.js` because you are self-h
 ----
 
 [NOTE]
+====
 Ensure that the excluded plugins' names are appended with `=sdk`, such as `mentions=sdk`.
 
 When {companyname} Cloud releases a new premium plugin, if you wish to self-host it this script tag will need to be updated to exclude it.
+====
 
 === `cloud-plugins.min.js` for Specific Premium Plugins from {companyname} Cloud.
 

--- a/modules/ROOT/pages/editor-plugin-version.adoc
+++ b/modules/ROOT/pages/editor-plugin-version.adoc
@@ -31,7 +31,7 @@ include::partial$misc/admon-script-tag-placement.adoc[]
 
 === `plugin.min.js` Standalone with No Exclusions.
 
-The `plugins.min.js` script loads every plugin the API key is entitled to from the CDN.
+The `plugins.min.js` script loads every premium plugin the API key is entitled to from the CDN.
 
 [source,html,subs="attributes+"]
 ----

--- a/modules/ROOT/partials/misc/admon-script-tag-placement.adoc
+++ b/modules/ROOT/partials/misc/admon-script-tag-placement.adoc
@@ -1,2 +1,2 @@
 [IMPORTANT]
-The plugin script tag must be positioned between the {productname} script tag and the `tinymce.init()` call. For applications that bundle {productname}, delay the `tinymce.init()` call until the plugin script tag has fully loaded. This ensures that the plugin is available when the editor is initialized.
+The cloud plugin script tag must be positioned between the {productname} script tag and the `tinymce.init()` call. For applications that bundle {productname}, delay the `tinymce.init()` call until after the cloud plugin script tag has loaded. This ensures that the cloud plugins are available when the editor is initialized.

--- a/modules/ROOT/partials/misc/admon-script-tag-placement.adoc
+++ b/modules/ROOT/partials/misc/admon-script-tag-placement.adoc
@@ -1,0 +1,2 @@
+[IMPORTANT]
+The plugin script tag must be positioned between the {productname} script tag and the `tinymce.init()` call. For applications that bundle {productname}, delay the `tinymce.init()` call until the plugin script tag has fully loaded. This ensures that the plugin is available when the editor is initialized.


### PR DESCRIPTION
Ticket: DOC-2392

Site: [Staging branch](http://docs-hotfix-7-doc-2392.staging.tiny.cloud/docs/tinymce/latest/editor-plugin-version/)

Changes:
* Remove list of plugins versions from document.
* Remove mention of the ability to specify plugin versions when loading from Cloud.
* Added new `admon` for `important` message for placement of script tags.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`
- [x] ~`modules/ROOT/nav.adoc` has been updated `(if applicable)`~
- [x] ~Files has been included where required `(if applicable)`~
- [x] ~Files removed have been deleted, not just excluded from the build `(if applicable)`~
- [x] ~Files added for `New product features`, and included a `release note` entry.~

Review:
- [x] Documentation Team Lead has reviewed