### PR TITLE
DOC-2418: Copy edits to `migration-from-6x.adoc`, and replaced version (num) with variable.

### DIFF
--- a/modules/ROOT/pages/migration-from-6x.adoc
+++ b/modules/ROOT/pages/migration-from-6x.adoc
@@ -1,14 +1,14 @@
-= Migrating from TinyMCE 6 to TinyMCE 7
+= Migrating from {productname} 6 to {productname} 7
 :navtitle: Migrating from TinyMCE 6
 :description: Guidance for migrating from TinyMCE 6 to TinyMCE 7
 :keywords: migration, considerations, premigration, pre-migration
+:release-version: 7.0
 
-The process for setting up a basic {productname} 7 instance is the same as {productname} 6.
+The process for setting up a basic {productname} {release-version} instance is the same as {productname} 6.
 
-Most configuration changes in {productname} 7.0 only affect complex use cases, such as custom plugins and customized user interface components.
+Most configuration changes in {productname} {release-version} only affect complex use cases, such as custom plugins and customized user interface components.
 
-
-It set outs the {productname} 7.0 changes that customers using {productname} 6 should be aware of as part of upgrading.
+This documentation details the changes in {productname} {release-version} that integrators using {productname} 6 should consider when upgrading.
 
 NOTE: For support related to migration, please contact https://support.tiny.cloud/hc/en-us/requests/new[Tiny Support].  +
 Open Source users: please report issues in the https://github.com/tinymce/tinymce/[TinyMCE GitHub Repository].
@@ -25,7 +25,7 @@ Open Source users: please report issues in the https://github.com/tinymce/tinymc
 [[tinymce-70-core-changes]]
 == {productname} {productmajorversion} core changes.
 
-For additional details on {productname} 7.0 changes, see xref:7.0-release-notes.adoc[{productname} 7.0 release notes].
+For additional details on {productname} {release-version} changes, see xref:7.0-release-notes.adoc[{productname} {release-version} release notes].
 
 
 [[commands-and-apis]]
@@ -63,10 +63,10 @@ The `remove_trailing_brs` setting was removed from the xref:apis/tinymce.html.do
 
 Applying basic formats such as headings, lists, bold and italic from typing them out in Markdown syntax is considered a must-have for WYSIWYG Editor's. In previous versions, {productname} would only apply these formats once the user presses the `Enter` key.
 
-{productname} 7 updates the default behavior of the `text-patterns` option to apply these formats when the user presses the `Space` key.
+{productname} {release-version} updates the default behavior of the `text-patterns` option to apply these formats when the user presses the `Space` key.
 
 [NOTE]
-The previous default `text_patterns` behavior, applying the format on an `Enter` key press, can be configured by replacing the `trigger` property with the value `'space'`. Learn more about how you can configure `text_patterns` in the xref:7.0-release-notes.adoc#a-new-trigger-property-for-block-text-pattern-configurations-allowing-pattern-activation-with-either-space-or-enter-keys[7.0 Release notes]
+The previous default `text_patterns` behavior, applying the format on an `Enter` key press, can be configured by replacing the `trigger` property with the value `'space'`. Learn more about how you can configure `text_patterns` in the xref:7.0-release-notes.adoc#a-new-trigger-property-for-block-text-pattern-configurations-allowing-pattern-activation-with-either-space-or-enter-keys[{release-version} Release notes]
 
 .Updated default text patterns
 [source, ts]
@@ -111,7 +111,7 @@ For more information, visit the updated xref:autocompleter.adoc[Autocompleter] d
 [[highlight-on-focus]]
 ==== `highlight_on_focus`
 
-Previously, the default value for the editor configuration option `highlight_on_focus` was set to `false` by default. In {productname} 7.0 this option is now by default set to `true`.
+Previously, the default value for the editor configuration option `highlight_on_focus` was set to `false` by default. In {productname} {release-version} this option is now by default set to `true`.
 
 As a result, the focus outline for the editor will by default be displayed when the focus is on the editor.
 
@@ -198,7 +198,7 @@ For more information on using `+media_url_resolver+`, see xref:media.adoc#media_
 [[removed-plugins]]
 === Removed Plugins
 
-In {productname} 7.0 the below plugin has been removed.
+In {productname} {release-version} the below plugin has been removed.
 
 [[removed-plugins-template-plugin]]
 ==== Removed open-source `Template` plugin
@@ -228,13 +228,13 @@ Removed **Template** options:
 
 Previously, {productname} added numerous `height` styles when resizing table rows such as on the `table` element, `tr` elements, and `td` elements. This resulted in unnecessarily verbose HTML output.
 
-{productname} 7.0 addresses this by making a couple of changes:
+{productname} {release-version} addresses this by making a couple of changes:
 
 * The height input field has been removed from the "Cell Properties" dialog. Now, the "Row Properties" dialog is the only way to update row heights. 
 * When a table is resized using the resize handles or the "Row properties" dialog, existing `height` styles will be stripped from `td/th` elements where applicable and only applied to the `table` element and `tr` elements.
 
 [NOTE]
-{productname} 7.0 does not provide any fallback to revert to the old behavior.
+{productname} {release-version} does not provide any fallback to revert to the old behavior.
 
 === Removed
 


### PR DESCRIPTION
Ticket: DOC-2418

Site: [Staging branch](http://docs-hotfix-7-doc-2418.staging.tiny.cloud/docs/tinymce/latest/migration-from-6x/#:~:text=This%20documentation%20details%20the%20changes%20in%20TinyMCE%207.0%20that%20integrators%20using%20TinyMCE%206%20should%20consider%20when%20upgrading.)

Changes:
* Copy edits to `migration-from-6x.adoc`
* Replaced version (num) with variable.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed