### PR TITLE
Rearrange advtemplate_list docs to make the example clearer

### DIFF
--- a/modules/ROOT/partials/configuration/advtemplate_list.adoc
+++ b/modules/ROOT/partials/configuration/advtemplate_list.adoc
@@ -10,7 +10,32 @@ None
 
 *Return data:* `+Array+`
 
-=== Example of `advtemplate_list` response
+=== Example: using `advtemplate_list`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea#advtemplate',  // change this value according to your html
+  plugins: ["advtemplate"],
+  advtemplate_list: () =>
+    fetch('/categories', {
+      method: 'GET',
+    })
+    .then((response) => response.json())
+    .then((data) => data)
+    .catch((error) => console.log('Failed to get template list\n' + error)),
+});
+----
+
+The data returned by `advtemplate_list` must adhere to the following requirements:
+
+. Each list item must have a unique `id` value.
+. Each list item must have a non-empty `title` value.
+. Each category item is required to include an `items` sublist, which can be empty.
+. Category items must not contain nested subcategories.
+. Template item is not required to include a `content` value.
+
+=== Sample `advtemplate_list` response
 
 [source,js]
 ----
@@ -32,29 +57,4 @@ None
     ]
   }
 ]
-----
-
-The data returned by `advtemplate_list` must adhere to the following requirements:
-
-. Each list item must have a unique `id` value.
-. Each list item must have a non-empty `title` value.
-. Each category item is required to include an `items` sublist, which can be empty.
-. Category items must not contain nested subcategories.
-. Template item is not required to include a `content` value.
-
-=== Example: using `advtemplate_list`
-
-[source,js]
-----
-tinymce.init({
-  selector: 'textarea#advtemplate',  // change this value according to your html
-  plugins: ["advtemplate"],
-  advtemplate_list: () =>
-    fetch('/categories', {
-      method: 'GET',
-    })
-    .then((response) => response.json())
-    .then((data) => data)
-    .catch((error) => console.log('Failed to get template list\n' + error)),
-});
 ----


### PR DESCRIPTION
Site: [Staging branch](http://docs-hotfix-7-template-wording.staging.tiny.cloud/docs/tinymce/latest/advanced-templates/#advtemplate_list)

Changes:
* [Previously](https://www.tiny.cloud/docs/tinymce/latest/advanced-templates/#advtemplate_list) it could appear at first glance like the value of the config was an array - arguably a bit misleading.
* I rearranged the section to put the code example first, then a description of the response, then the response block.
* I renamed the response block to a _sample_, rather than an _example_.
* No other content changes were made.

I suspect we might need a wider effort to change the statement that "return value is array" - it's really a promise containing an array - but that's happened on every section of the template docs so I don't want to do that without a ticket.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`
- [x] ~`modules/ROOT/nav.adoc` has been updated `(if applicable)`~
- [x] ~Files has been included where required `(if applicable)`~
- [x] ~Files removed have been deleted, not just excluded from the build `(if applicable)`~
- [x] ~Files added for `New product features`, and included a `release note` entry.~

Review:
- [x] Documentation Team Lead has reviewed