### PR TITLE
DOC-2411: Clearing the formula input and then saving didn't remove the element

### DIFF
--- a/modules/ROOT/pages/7.1.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.1-release-notes.adoc
@@ -63,7 +63,7 @@ The following premium plugin updates were released alongside {productname} {rele
 
 The {productname} {release-version} release includes an accompanying release of the **Math** premium plugin.
 
-**Premium plugin Math**, includes the following fix.
+The **Math** premium plugin includes the following fix:
 
 ==== Clearing the formula input and then saving didn't remove the element.
 

--- a/modules/ROOT/pages/7.1.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.1-release-notes.adoc
@@ -71,7 +71,7 @@ In the initial release of the Math Plugin, {productname} did nothing when the us
 
 As a consequence, when the user cleared the formula and then clicked "save", {productname} did not remove the element from the document.
 
-{productname} {release-version} addresses this issue. Now, when a user has a formula selected, clears it, and then clicks "save", the selected formula and element is removed from the editor.
+{productname} {release-version} addresses this issue. Now, when a user has a formula selected, clears it, and clicks "save", the selected formula and element are properly removed from the editor.
 
 For information on the **Math** plugin, see: xref:math.adoc[Math].
 

--- a/modules/ROOT/pages/7.1.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.1-release-notes.adoc
@@ -69,7 +69,7 @@ The **Math** premium plugin includes the following fix:
 
 In the initial release of the Math Plugin, {productname} did nothing when the user saved an empty formula, even if a formula was selected.
 
-As a consequence, when the user cleared the formula and then clicked "save", {productname} did not remove the element from the document.
+As a consequence, when the user cleared the formula and clicked "save", the selected formula and element remained in the editor.
 
 {productname} {release-version} addresses this issue. Now, when a user has a formula selected, clears it, and clicks "save", the selected formula and element are properly removed from the editor.
 

--- a/modules/ROOT/pages/7.1.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.1-release-notes.adoc
@@ -1,0 +1,199 @@
+= {productname} {release-version}
+:release-version: 7.1.1
+:navtitle: {productname} {release-version}
+:description: Release notes for {productname} {release-version}
+:keywords: releasenotes, new, changes, bugfixes
+:page-toclevels: 1
+
+include::partial$misc/admon-releasenotes-for-stable.adoc[]
+
+
+[[overview]]
+== Overview
+
+{productname} {release-version} was released for {enterpriseversion} and {cloudname} on <weekday>, <month> <DD>^<st|nd|rd|th>^, <YYYY>. These release notes provide an overview of the changes for {productname} {release-version}, including:
+
+// Remove sections and section boilerplates as necessary.
+// Pluralise as necessary or remove the placeholder plural marker.
+* xref:new-premium-plugin<s>[New Premium plugin<s>]
+* xref:new-open-source-plugin<s>[New Open Source plugin<s>]
+* xref:accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
+* xref:accompanying-premium-plugin-end-of-life-announcement[Accompanying Premium plugin end-of-life announcement]
+* xref:accompanying-open-source-plugin-end-of-life-announcement[Accompanying open source plugin end-of-life-announcement]
+* xref:accompanying-enhanced-skins-and-icon-packs-changes[Accompanying Enhanced Skins & Icon Packs changes]
+* xref:improvements[Improvements]
+* xref:additions[Additions]
+* xref:changes[Changes]
+* xref:bug-fixes[Bug fixes]
+* xref:security-fixes[Security fixes]
+* xref:deprecated[Deprecated]
+* xref:known-issues[Known issues]
+
+
+[[new-premium-plugin<s>]]
+New Premium plugin<s>
+
+The following new Premium plugin was released alongside {productname} {release-version}.
+
+=== <Premium plugin name>
+
+The new Premium plugin, **<Premium plugin name>** // description here.
+
+For information on the **<Premium plugin name>** plugin, see xref:<plugincode>.adoc[<Premium plugin name>].
+
+
+[[new-open-source-plugin]]
+== New Open Source plugin
+
+The following new Open Source plugin was released alongside {productname} {release-version}.
+
+=== <Open source plugin name>
+
+The new open source plugin, **<Open source plugin name>** // description here.
+
+For information on the **<Open source plugin name>** plugin, see xref:<plugincode>.adoc[<Open source plugin name>].
+
+
+[[accompanying-premium-plugin-changes]]
+== Accompanying Premium plugin changes
+
+The following premium plugin updates were released alongside {productname} {release-version}.
+
+=== Math Plugin
+
+The {productname} {release-version} release includes an accompanying release of the **Math** premium plugin.
+
+**Premium plugin Math**, includes the following fix.
+
+==== Clearing the formula input and then saving didn't remove the element.
+
+In the initial release of the Math Plugin, {productname} did nothing when the user saved an empty formula, even if a formula was selected.
+
+As a consequence, when the user cleared the formula and then clicked "save", {productname} did not remove the element from the document.
+
+{productname} {release-version} addresses this issue. Now, when a user has a formula selected, clears it, and then clicks "save", the selected formula and element is removed from the editor.
+
+For information on the **Math** plugin, see: xref:math.adoc[Math].
+
+
+[[accompanying-premium-plugin-end-of-life-announcement]]
+== Accompanying Premium plugin end-of-life announcement
+
+The following Premium plugin has been announced as reaching its end-of-life:
+
+=== <Premium plugin name eol>
+
+{productname}’s xref:<plugincode>.adoc[<Premium plugin name eol>] plugin will be deactivated on <month> <DD>, <YYYY>, and is no longer available for purchase.
+
+
+[[accompanying-open-source-plugin-end-of-life-announcement]]
+== Accompanying open source plugin end-of-life announcement
+
+The following open source plugin has been announced as reaching its end-of-life:
+
+=== <Open source plugin name eol>
+
+{productname}’s xref:<plugincode>.adoc[<Open source plugin name eol>] plugin will be deactivated on <month> <DD>, <YYYY>, and is no longer available for purchase.
+
+
+[[accompanying-enhanced-skins-and-icon-packs-changes]]
+== Accompanying Enhanced Skins & Icon Packs changes
+
+The {productname} {release-version} release includes an accompanying release of the **Enhanced Skins & Icon Packs**.
+
+=== Enhanced Skins & Icon Packs
+
+The **Enhanced Skins & Icon Packs** release includes the following updates:
+
+The **Enhanced Skins & Icon Packs** were rebuilt to pull in the changes also incorporated into the default {productname} {release-version} skin, Oxide.
+
+For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-and-icon-packs.adoc[Enhanced Skins & Icon Packs].
+
+
+[[improvements]]
+== Improvements
+
+{productname} {release-version} also includes the following improvement<s>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[additions]]
+== Additions
+
+{productname} {release-version} also includes the following addition<s>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[changes]]
+== Changes
+
+{productname} {release-version} also includes the following change<s>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[removed]]
+== Removed
+
+{productname} {release-version} also includes the following removal<s>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[bug-fixes]]
+== Bug fixes
+
+{productname} {release-version} also includes the following bug fix<es>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[security-fixes]]
+== Security fixes
+
+{productname} {release-version} includes <a fix | fixes for the following security issue<s>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[deprecated]]
+== Deprecated
+
+{productname} {release-version} includes the following deprecation<s>:
+
+=== The `<plugin>` configuration property, `<name>`, has been deprecated
+
+// placeholder here.
+
+
+[[known-issues]]
+== Known issues
+
+This section describes issues that users of {productname} {release-version} may encounter and possible workarounds for these issues.
+
+There <is one | are <number> known issue<s> in {productname} {release-version}.
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.

--- a/modules/ROOT/pages/7.1.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.1-release-notes.adoc
@@ -67,7 +67,7 @@ The **Math** premium plugin includes the following fix:
 
 ==== Clearing the formula input and then saving didn't remove the element.
 
-In the initial release of the Math Plugin, {productname} did nothing when the user saved an empty formula, even if a formula was selected.
+In the initial release of the Math Plugin, {productname} did not remove the selected formula and element when the user saved an empty formula.
 
 As a consequence, when the user cleared the formula and clicked "save", the selected formula and element remained in the editor.
 


### PR DESCRIPTION
Ticket: DOC-2411

Site: [Staging branch](http://docs-feature-711-doc-2411tiny-10898.staging.tiny.cloud/docs/tinymce/latest/7.1.1-release-notes/#math-plugin)

Changes:
* add fix documentation for TINY-10898 to the release notes.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed