### PR TITLE
DOC-2411: List with start attribute separated by  tags resulted in wrong numbering of the lists.

### DIFF
--- a/modules/ROOT/pages/7.1.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.1-release-notes.adoc
@@ -65,7 +65,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 **PowerPaste** includes the following fix.
 
-==== List with start attribute separated by `p` tags resulted in wrong numbering of the lists.
+==== A list with the start attribute, separated by `p` tags, resulted in incorrect numbering of lists.
 // TINY-10585
 
 Previously, when content from Microsoft Word contained a list that starts with a number greater than 1, and is pasted into the editor with `powerpaste` enabled, it caused all list items to display the same number.

--- a/modules/ROOT/pages/7.1.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.1-release-notes.adoc
@@ -59,17 +59,29 @@ For information on the **<Open source plugin name>** plugin, see xref:<plugincod
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
-=== <Premium plugin name 1> <Premium plugin name 1 version>
+=== PowerPaste
 
-The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+The {productname} {release-version} release includes an accompanying release of the **PowerPaste** premium plugin.
 
-**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+**PowerPaste** includes the following fix.
 
-==== <Premium plugin name 1 change 1>
+==== List with start attribute separated by `p` tags resulted in wrong numbering of the lists.
+// TINY-10585
 
-// CCFR here.
+Previously, when content from Microsoft Word contained a list that starts with a number grater than 1, and is pasted into the editor with `powerpaste` enabled, it caused all list items to display the same number.
 
-For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+For example, a list might appear as follows:
+
+[source]
+----
+7. Point 1 
+7. Point 2
+7. Point 3
+----
+
+{productname} {release-version} addresses this issue. Now, all lists correctly render with the proper numbering.
+
+For information on the **PowerPaste** plugin, see: xref:introduction-to-powerpaste.adoc[PowerPaste].
 
 
 [[accompanying-premium-plugin-end-of-life-announcement]]

--- a/modules/ROOT/pages/7.1.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.1-release-notes.adoc
@@ -68,7 +68,7 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== List with start attribute separated by `p` tags resulted in wrong numbering of the lists.
 // TINY-10585
 
-Previously, when content from Microsoft Word contained a list that starts with a number grater than 1, and is pasted into the editor with `powerpaste` enabled, it caused all list items to display the same number.
+Previously, when content from Microsoft Word contained a list that starts with a number greater than 1, and is pasted into the editor with `powerpaste` enabled, it caused all list items to display the same number.
 
 For example, a list might appear as follows:
 


### PR DESCRIPTION
Ticket: DOC-2411

Site: [Staging branch](http://docs-feature-711-doc-2411tiny-10585.staging.tiny.cloud/docs/tinymce/latest/7.1.1-release-notes/#powerpaste)

Changes:
* add fix for TINY-10585 to the release notes.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed