### PR TITLE
DOC-2411: Resolved an issue where emojis were not loading correctly due to a broken CDN

### DIFF
--- a/modules/ROOT/pages/7.1.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.1-release-notes.adoc
@@ -155,10 +155,18 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Resolved an issue where emojis were not loading correctly due to a broken CDN
+// #TINY-10878
 
-// CCFR here.
+Recently, the original CDN url {productname} used for the twitter emoji database was discontinued. 
+
+As a consequence, all emoji's would not render, however this issue was resolved by the CDN owner by a redirect to an active link
+
+{productname} {release-version} addresses this issue. Now, {producname} has set the default CDN link to the actively maintained one.
+
+As a result, emoji's now render in all occasion without redirecting.
+
+For more information about these changes, see xref:emoticons.adoc#emoticons_images_url[Emoticons#emoticons_images_url].
 
 
 [[security-fixes]]

--- a/modules/ROOT/partials/configuration/emoticons_images_url.adoc
+++ b/modules/ROOT/partials/configuration/emoticons_images_url.adoc
@@ -3,11 +3,11 @@
 
 This option sets the base URL for the images used to represent emojis when using the `+emojiimages+` database.
 
-By default, this option loads the required image _assets_ from the Twemoji CDN. To use self-hosted emoji images, download the image _assets_ from the https://github.com/twitter/twemoji/#download[Twitter Emoji (twemoji) GitHub repository].
+By default, this option loads the required image _assets_ from the Twemoji CDN. To use self-hosted emoji images, download the image _assets_ from the https://github.com/jdecked/twemoji/#download[Twitter Emoji (Twemoji) GitHub repository].
 
 *Type:* `+String+`
 
-*Default value:* `+'https://twemoji.maxcdn.com/v/13.0.1/72x72/'+`
+*Default value:* `+'https://cdnjs.cloudflare.com/ajax/libs/twemoji/15.1.0/72x72/'+`
 
 === Example: using `+emoticons_images_url+`
 


### PR DESCRIPTION
Ticket: DOC-2411

Site: [Staging branch: release notes entry](http://docs-feature-711-doc-2411tiny-10878.staging.tiny.cloud/docs/tinymce/latest/7.1.1-release-notes/#resolved-an-issue-where-emojis-were-not-loading-correctly-due-to-a-broken-cdn)

Site: [Staging branch: emoticons_images_url](http://docs-feature-711-doc-2411tiny-10878.staging.tiny.cloud/docs/tinymce/latest/emoticons/#emoticons_images_url)

Changes:
* Added fix for TINY-10878 and included changes to `emoticons#emoticons_images_url` for DOC-2406.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed