### PR TITLE
DOC-2411: Iframes in dialogs were not rendering rounded borders correctly.

### DIFF
--- a/modules/ROOT/pages/7.1.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.1-release-notes.adoc
@@ -173,7 +173,7 @@ For more information about these changes, see xref:emoticons.adoc#emoticons_imag
 
 Previously, when opening a dialog with an `iframe` element that had a different background color than the dialog, the corners of the dialog did not round off as expected as the border radius was applied to the dialog and not the iframe.
 
-{productname} {release-version} addresses this issue by applying the border radius to the `iframe` itself, ensuring that it renders correctly.
+{productname} {release-version} addresses this issue by additionally applying the border radius to the `iframe` itself, ensuring that it renders correctly.
 
 As a result, borders now render properly, and the background of the `iframe` is no longer visible through to the parent dialog.
 

--- a/modules/ROOT/pages/7.1.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.1-release-notes.adoc
@@ -171,7 +171,7 @@ For more information about these changes, see xref:emoticons.adoc#emoticons_imag
 ==== Iframes in dialogs were not rendering rounded borders correctly.
 // #TINY-10901
 
-Previously, when opening a dialog with an `iframe` element that had a different background color than the dialog, the corners of the dialog did not round off as expected as the border radius was applied to the dialog and not the iframe.
+Previously, when opening a dialog with an `iframe` element that had a different background color than the dialog, the corners of the dialog did not round off as expected as the border radius was applied to the `iframe` parent element and not the `iframe`.
 
 {productname} {release-version} addresses this issue by additionally applying the border radius to the `iframe` itself, ensuring that it renders correctly.
 

--- a/modules/ROOT/pages/7.1.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.1-release-notes.adoc
@@ -168,6 +168,15 @@ As a result, emoji's now render in all occasion without redirecting.
 
 For more information about these changes, see xref:emoticons.adoc#emoticons_images_url[Emoticons#emoticons_images_url].
 
+==== Iframes in dialogs were not rendering rounded borders correctly.
+// #TINY-10901
+
+Previously, when opening a dialog with an `iframe` element that had a different background color than the dialog, the corners of the dialog did not round off as expected as the border radius was applied to the dialog and not the iframe.
+
+{productname} {release-version} addresses this issue by applying the border radius to the `iframe` itself, ensuring that it renders correctly.
+
+As a result, borders now render properly, and the background of the `iframe` is no longer visible through to the parent dialog.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-2411

Site: [Staging branch](http://docs-feature-711-doc-2411tiny-10901.staging.tiny.cloud/docs/tinymce/latest/7.1.1-release-notes/#iframes-in-dialogs-were-not-rendering-rounded-borders-correctly)

Changes:
* added fix documentation for TINY-10901 to the release notes.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed