### PR TITLE
DOC-2411: Add TINY-10942 release note entry

### DIFF
--- a/modules/ROOT/pages/7.1.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.1-release-notes.adoc
@@ -155,6 +155,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following bug fix<es>:
 
+=== Autocompleter possible values are no longer capped at a length of 10.
+// #TINY-10942
+
+Previously in {productname}, the Autocompleter option values were constrained to lengths of less than 10. As a consequence, the Autocompleter popover would close after only one value being selected if the selected value was greater than or equal to 10. This created a limitation for users who needed to select multiple values consecutively with lengths greater than 10.
+
+In {productname} {release-version}, this hardcoded limit of 10 has been removed. The Autocompleter now allows selection of multiple options consecutively with values of any length, while keeping the same popover open.
+
 === Resolved an issue where emojis were not loading correctly due to a broken CDN
 // #TINY-10878
 


### PR DESCRIPTION
Ticket: DOC-2411

Site: [Staging branch](http://docs-feature-711-doc-2411tiny-10942.staging.tiny.cloud/docs/tinymce/latest/7.1.1-release-notes/#autocompleter-possible-values-are-no-longer-capped-at-a-length-of-10)

Changes:
* DOC-2411: Add TINY-10942 release note entry

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [-] Files has been included where required `(if applicable)`
- [-] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed