### PR TITLE
DOC-2419: Math icon state was not set to `active` on math element selection.

### DIFF
--- a/modules/ROOT/pages/7.1.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.2-release-notes.adoc
@@ -62,6 +62,7 @@ The {productname} {release-version} release includes an accompanying release of 
 This **Math** premium plugin release includes the following fix:
 
 ==== Math icon state was not set to active on math element selection.
+// #TINY-10931
 
 Previously, the Math icon was not set to active when a math element was selected within the editor.
 

--- a/modules/ROOT/pages/7.1.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.2-release-notes.adoc
@@ -55,17 +55,21 @@ For information on the **<Open source plugin name>** plugin, see xref:<plugincod
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
-=== <Premium plugin name 1> <Premium plugin name 1 version>
+=== Math Plugin
 
-The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+The {productname} {release-version} release includes an accompanying release of the **Math** premium plugin.
 
-**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+This **Math** premium plugin release includes the following fix:
 
-==== <Premium plugin name 1 change 1>
+==== Math icon state was not set to active on math element selection.
 
-// CCFR here.
+Previously, the Math icon was not set to active when a math element was selected within the editor.
 
-For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+As a consequence, users had no visual indication that a math element was selected or that it could be edited by selecting it and then clicking the toolbar button.
+
+{productname} {release-version} addresses this issue. Now, when a tiny-math-inline or tiny-math-block HTML element is selected, the button's active state is triggered.
+
+For information on the **Math** plugin, see: xref:math.adoc[Math].
 
 
 [[accompanying-premium-plugin-end-of-life-announcement]]

--- a/modules/ROOT/pages/7.1.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.2-release-notes.adoc
@@ -68,7 +68,7 @@ Previously, the Math icon was not set to active when a math element was selected
 
 As a consequence, users had no visual indication that a math element was selected or that it could be edited by selecting it and then clicking the toolbar button.
 
-{productname} {release-version} addresses this issue. Now, when a tiny-math-inline or tiny-math-block HTML element is selected, the button's active state is triggered.
+{productname} {release-version} addresses this issue. Now, when any Math element is selected, the button's active state is triggered.
 
 For information on the **Math** plugin, see: xref:math.adoc[Math].
 


### PR DESCRIPTION
Ticket: DOC-2419

Site: [Staging branch](http://docs-feature-712-doc-2419tiny-10931.staging.tiny.cloud/docs/tinymce/latest/7.1.2-release-notes/#math-icon-state-was-not-set-to-active-on-math-element-selection)

Changes:
* Add fix documentation for TINY-10931

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed