### PR TITLE
DOC-2419: CSS color values set to `transparent` were incorrectly converted to `#000000`.

### DIFF
--- a/modules/ROOT/pages/7.1.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.2-release-notes.adoc
@@ -156,6 +156,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== CSS color values set to `transparent` were incorrectly converted to `+#000000+`.
+
+Previously, transparent color values were converted to `+#00000000+`, which would be correct if {productname} included the alpha when rendering hex color. However, {productname} does not export the last two digits of the hex string, so the alpha value is lost, causing transparent to be converted to `+#000000+`.
+
+{productname} {release-version} addresses this issue by, removing the if statement that handles transparent since it is no longer needed. As a result, the transparent property will be retained as a transparent string instead of converting to other values. This change is consistent with the behavior in {productname} v5, v6.
+
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/pages/7.1.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.2-release-notes.adoc
@@ -158,7 +158,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 === CSS color values set to `transparent` were incorrectly converted to `+#000000+`.
 
-Previously, transparent color values were converted to `+#00000000+`, which would be correct if {productname} included the alpha when rendering hex color. However, {productname} does not export the last two digits of the hex string, so the alpha value is lost, causing transparent to be converted to `+#000000+`.
+Previously, transparent color values were incorrectly converted to `+#00000000+`, deviating from the behavior observed in earlier major versions.  Additionally, {productname} does not export the last two digits of the hex string, so the alpha value is lost, causing transparent to be converted to `+#000000+`.
 
 {productname} {release-version} addresses this issue by, removing the if statement that handles transparent since it is no longer needed. As a result, the transparent property will be retained as a transparent string instead of converting to other values. This change is consistent with the behavior in {productname} v5, v6.
 

--- a/modules/ROOT/pages/7.1.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.2-release-notes.adoc
@@ -157,6 +157,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 // CCFR here.
 
 === CSS color values set to `transparent` were incorrectly converted to `+#000000+`.
+// #TINY-10916
 
 Previously, transparent color values were incorrectly converted to `+#00000000+`, deviating from the behavior observed in earlier major versions.  Additionally, {productname} does not export the last two digits of the hex string, so the alpha value is lost, causing transparent to be converted to `+#000000+`.
 

--- a/modules/ROOT/pages/7.1.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.2-release-notes.adoc
@@ -159,7 +159,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === CSS color values set to `transparent` were incorrectly converted to `+#000000+`.
 // #TINY-10916
 
-Previously, transparent color values were incorrectly converted to `+#00000000+`, deviating from the behavior observed in earlier major versions.  Additionally, {productname} does not export the last two digits of the hex string, so the alpha value is lost, causing transparent to be converted to `+#000000+`.
+Previously, transparent color values were incorrectly converted to `+#000000+`, deviating from the behavior observed in earlier major versions.  Additionally, {productname} does not export the last two digits of the hex string, so the alpha value is lost, causing transparent to be converted to `+#000000+`.
 
 {productname} {release-version} addresses this issue by, removing the if statement that handles transparent since it is no longer needed. As a result, the transparent property will be retained as a transparent string instead of converting to other values. This change is consistent with the behavior in {productname} v5, v6.
 


### PR DESCRIPTION
Ticket: DOC-2419

Site: [Staging branch](http://docs-feature-712-doc-2419tiny-10916.staging.tiny.cloud/docs/tinymce/latest/7.1.2-release-notes/#css-color-values-set-to-transparent-were-incorrectly-converted-to-000000)

Changes:
* add fix documentation for TINY-10916.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed