### PR TITLE
DOC-2419: Acronyms were not managed correctly.

### DIFF
--- a/modules/ROOT/pages/7.1.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.2-release-notes.adoc
@@ -55,17 +55,21 @@ For information on the **<Open source plugin name>** plugin, see xref:<plugincod
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
-=== <Premium plugin name 1> <Premium plugin name 1 version>
+=== Spell Checker
+// TINY-10904
 
-The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+The {productname} {release-version} release includes an accompanying release of the **Spell Checker** premium plugin.
 
-**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+**Spell Checker** includes the following fix.
 
-==== <Premium plugin name 1 change 1>
+==== Added test for acronym handling in `tinymcespellchecker`
+// #TINY-10904
 
-// CCFR here.
+{productname} {release-version} includes a fix to {productname} core to address an issue with acronyms not being managed correctly. see xref:7.1.2-release-notes.adoc#acronyms-were-not-managed-correctly[Acronyms were not managed correctly] for more details.
 
-For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+To accompany this change, the Spell Checker tests where added to now handle acronyms correctly, ensuring the last dot is included.
+
+For information on the Spell Checker plugin, see: xref:introduction-to-tiny-spellchecker.adoc[Spell Checker].
 
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
@@ -155,6 +159,18 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 // #TINY-vwxyz1
 
 // CCFR here.
+
+[[acronyms-were-not-managed-correctly]]
+=== Acronyms were not managed correctly.
+// #TINY-10904
+
+Previously, acronyms were not managed correctly which caused false positive results with Spell Checker premium plugin. In this case, the check was separating the words excluding the dot at the end also when we check the acronyms.
+
+As a consequence, Spell Checker Premium plugin would identify acronyms without the last dot, highlighting them as errors.
+
+{productname} {release-version} addresses this issue. Now, If the word is an abbreviation, {productname} includes the next character if it is a period.
+
+As a result, acronyms are now managed correctly, and the Spell Checker retrieves the correct word (with the dot included) and provides accurate results.
 
 
 [[security-fixes]]

--- a/modules/ROOT/pages/7.1.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.1.2-release-notes.adoc
@@ -53,23 +53,7 @@ For information on the **<Open source plugin name>** plugin, see xref:<plugincod
 [[accompanying-premium-plugin-changes]]
 == Accompanying Premium plugin changes
 
-The following premium plugin updates were released alongside {productname} {release-version}.
-
-=== Spell Checker
-// TINY-10904
-
-The {productname} {release-version} release includes an accompanying release of the **Spell Checker** premium plugin.
-
-**Spell Checker** includes the following fix.
-
-==== Added test for acronym handling in `tinymcespellchecker`
-// #TINY-10904
-
-{productname} {release-version} includes a fix to {productname} core to address an issue with acronyms not being managed correctly. see xref:7.1.2-release-notes.adoc#acronyms-were-not-managed-correctly[Acronyms were not managed correctly] for more details.
-
-To accompany this change, the Spell Checker tests where added to now handle acronyms correctly, ensuring the last dot is included.
-
-For information on the Spell Checker plugin, see: xref:introduction-to-tiny-spellchecker.adoc[Spell Checker].
+The following premium plugin updates were released alongside {productname} {release-version}
 
 
 [[accompanying-premium-plugin-end-of-life-announcement]]


### PR DESCRIPTION
Ticket: DOC-2419

Site: [Spell Checker entry](http://docs-feature-712-doc-2419tiny-10904.staging.tiny.cloud/docs/tinymce/latest/7.1.2-release-notes/#spell-checker)
Site: [Core entry](http://docs-feature-712-doc-2419tiny-10904.staging.tiny.cloud/docs/tinymce/latest/7.1.2-release-notes/#acronyms-were-not-managed-correctly)

Changes:
* added fix documentation for TINY-10904
* included both release note entry to support fix for `acronyms` and premium plugin change as we added `new handling` logic for `acronyms`.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed