### PR TITLE
DOC-2346: Updated Angular technical reference page to support tinymce-angular v8 changes

### DIFF
--- a/modules/ROOT/partials/integrations/angular-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/angular-tech-ref.adoc
@@ -129,7 +129,7 @@ include::partial$misc/get-an-api-key.adoc[]
 ></editor>
 ----
 
-[[licenseKey]]
+[[licensekey]]
 === `+licenseKey+`
 
 {cloudname} License key.

--- a/modules/ROOT/partials/integrations/angular-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/angular-tech-ref.adoc
@@ -5,7 +5,7 @@
 * xref:using-the-tinymce-angular-integration[Using the TinyMCE Angular integration]
 * xref:configuring-the-editor[Configuring the editor]
 ** xref:apikey[`+apiKey+`]
-** xref:licenseKey[`+licenseKey+`]
+** xref:licensekey[`+licenseKey+`]
 ** xref:cloudchannel[`+cloudChannel+`]
 ** xref:disabled[`+disabled+`]
 ** xref:id[`+id+`]

--- a/modules/ROOT/partials/integrations/angular-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/angular-tech-ref.adoc
@@ -5,6 +5,7 @@
 * xref:using-the-tinymce-angular-integration[Using the TinyMCE Angular integration]
 * xref:configuring-the-editor[Configuring the editor]
 ** xref:apikey[`+apiKey+`]
+** xref:licenseKey[`+licenseKey+`]
 ** xref:cloudchannel[`+cloudChannel+`]
 ** xref:disabled[`+disabled+`]
 ** xref:id[`+id+`]
@@ -124,6 +125,28 @@ include::partial$misc/get-an-api-key.adoc[]
 <editor
   apiKey="your-api-key"
 ></editor>
+----
+
+[[licenseKey]]
+=== `+licenseKey+`
+
+{cloudname} License key.
+
+Use this when self-hosting {productname} instead of loading from {cloudname}. For more information, see: xref:license-key.adoc[License Key].
+
+*Type:* `+String+`
+
+*Default value:* `+undefined+`
+
+*Possible values:* `undefined`, `'gpl'` or a valid {productname} license key
+
+==== Example: using `+licenseKey+`
+
+[source,jsx]
+----
+<Editor
+  licenseKey='your-license-key'
+/>
 ----
 
 [[cloudchannel]]

--- a/modules/ROOT/partials/integrations/angular-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/angular-tech-ref.adoc
@@ -431,6 +431,9 @@ The following events are available:
 * `+onBlur+`
 * `+onClick+`
 * `+onContextMenu+`
+* `+onCompositionEnd+`
+* `+onCompositionStart+`
+* `+onCompositionUpdate+`
 * `+onCopy+`
 * `+onCut+`
 * `+onDblclick+`
@@ -443,6 +446,7 @@ The following events are available:
 * `+onFocus+`
 * `+onFocusIn+`
 * `+onFocusOut+`
+* `+onInput+`
 * `+onKeyDown+`
 * `+onKeyPress+`
 * `+onKeyUp+`

--- a/modules/ROOT/partials/integrations/angular-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/angular-tech-ref.adoc
@@ -33,7 +33,9 @@ The following table shows the supported versions of Angular and the required ver
 [cols="^,^",options="header"]
 |===
 |Angular Version |`+tinymce-angular+` version
-|13+ |5.x or newer
+|16+ |8.x
+|14 or 15 |7.x
+|13 |6.x
 |9 to 12 |4.x
 |5 to 8 |3.x
 |4 or older |Not Supported


### PR DESCRIPTION
Ticket: DOC-2346

Site: [Staging branch](http://docs-feature-7-doc-2346.staging.tiny.cloud/docs/tinymce/7/)

Changes:
- Added `licenseKey` info
- Updated Angular version table to match what is in `tinymce-angular`'s _README.md_
- Updated event list to include the new events in v8

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`
- [x] ~`modules/ROOT/nav.adoc` has been updated `(if applicable)`~
- [x] Files has been included where required `(if applicable)`
- [x] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [x] ~Files added for `New product features`, and included a `release note` entry.~

Review:
- [x] Documentation Team Lead has reviewed