### PR TITLE
DOC-2383: Update Svelte Integration's Technical Reference page for TinyMCE V7 release.

### DIFF
--- a/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
@@ -43,6 +43,28 @@ The `+tinymce-svelte+` `+Editor+` component accepts the following properties:
 />
 ----
 
+[[licenseKey]]
+=== `+licenseKey+`
+
+{cloudname} License key.
+
+Use this when self-hosting {productname} instead of loading from {cloudname}. For more information, see: xref:license-key.adoc[License Key].
+
+*Type:* `+String+`
+
+*Default value:* `+undefined+`
+
+*Possible values:* `undefined`, `'gpl'` or a valid {productname} license key
+
+==== Example: using `+licenseKey+`
+
+[source,jsx]
+----
+<Editor
+  licenseKey="your-license-key"
+/>
+----
+
 [[channel]]
 === `+channel+`
 
@@ -229,6 +251,10 @@ The following events are available:
 * `+change+`
 * `+clearundos+`
 * `+click+`
+* `+CommentChange+`
+* `+CompositionEnd+`
+* `+CompositionStart+`
+* `+CompositionUpdate+`
 * `+contextmenu+`
 * `+copy+`
 * `+cut+`
@@ -248,6 +274,7 @@ The following events are available:
 * `+getcontent+`
 * `+hide+`
 * `+init+`
+* `+input+`
 * `+keydown+`
 * `+keypress+`
 * `+keyup+`

--- a/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
@@ -1,6 +1,14 @@
 Covered in this section:
 
 * xref:configuring-the-tinymce-svelte-integration[Configuring the TinyMCE Svelte integration]
+** xref:api-key[apikey]
+** xref:licensekey[licenseKey]
+** xref:channel[channel]
+** xref:id[id]
+** xref:inline[inline]
+** xref:disabled[disabled]
+** xref:scriptsrc[scriptsrc]
+** xref:conf[conf]
 * xref:component-binding[Component binding]
 * xref:event-binding[Event binding]
 

--- a/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
@@ -1,7 +1,7 @@
 Covered in this section:
 
 * xref:configuring-the-tinymce-svelte-integration[Configuring the TinyMCE Svelte integration]
-** xref:api-key[apikey]
+** xref:apikey[apiKey]
 ** xref:licensekey[licenseKey]
 ** xref:channel[channel]
 ** xref:id[id]


### PR DESCRIPTION
Ticket: DOC-2383

Site: [Staging branch](http://docs-hotfix-7-doc-2383.staging.tiny.cloud/docs/tinymce/latest/svelte-ref/)

Changes:
* Added `licenseKey` info
* Updated Svelte version table to match what is in `tinymce-svelte README.md`
* Updated event list to include the new events in `v7`.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed