### PR TITLE
DOC-2432: Update mention text of `radio` buttons to read `checkbox` instead.

### DIFF
--- a/modules/ROOT/pages/pageembed.adoc
+++ b/modules/ROOT/pages/pageembed.adoc
@@ -58,8 +58,8 @@ NOTE: The *Responsive* option has pre-defined width and height values. The *Widt
 . In the *Advanced* tab, provide a name and title for the iframe in the *Name* and *Title* fields.
 . The *Long description URL* field can be used to describe an iframe by including text in a separate resource when a short text alternative does not adequately convey the function or information provided in the iframe.
 * Click on the image:icons/browse.svg[Source](*Long description URL*) icon to upload a description file.
-. Click on the *Show iframe border* radio button to display iframe borders.
-. Click on the *Scrollbar* radio button to add scrollbars to the iframe.
+. Click on the *Show iframe border* checkbox button to display iframe borders.
+. Click on the *Scrollbar* checkbox button to add scrollbars to the iframe.
 . Click *Save* to save and exit or *Cancel* to dismiss and exit.
 
 *Result*: An iframe of the configured size is inserted in the desired location within the content.

--- a/modules/ROOT/pages/pageembed.adoc
+++ b/modules/ROOT/pages/pageembed.adoc
@@ -58,7 +58,7 @@ NOTE: The *Responsive* option has pre-defined width and height values. The *Widt
 . In the *Advanced* tab, provide a name and title for the iframe in the *Name* and *Title* fields.
 . The *Long description URL* field can be used to describe an iframe by including text in a separate resource when a short text alternative does not adequately convey the function or information provided in the iframe.
 * Click on the image:icons/browse.svg[Source](*Long description URL*) icon to upload a description file.
-. Click on the *Show iframe border* checkbox button to display iframe borders.
+. Click on the *Show iframe border* checkbox to display iframe borders.
 . Click on the *Scrollbar* checkbox button to add scrollbars to the iframe.
 . Click *Save* to save and exit or *Cancel* to dismiss and exit.
 

--- a/modules/ROOT/pages/permanentpen.adoc
+++ b/modules/ROOT/pages/permanentpen.adoc
@@ -87,7 +87,7 @@ NOTE: The Permanent Pen has to be enabled to access the *Permanent Pen Propertie
 
 . Open the *Permanent Pen Properties* dialog box using any of the above methods. image:permanent-pen-props.png[Permanent pen properties]
 . Select the desired settings from the *Font* and *Size* drop-down menus.
-. To select the desired *Styles*, click on the radio button next to *Bold*, *Italic*, *Strikethrough*, or *Underline*.
+. To select the desired *Styles*, click on the checkbox button next to *Bold*, *Italic*, *Strikethrough*, or *Underline*.
 . Choose the desired *Text color*.
 . Select the desired *Background color*
 . Press *Ok* to save or *Cancel* to dismiss.

--- a/modules/ROOT/pages/tinydrive-dropbox-integration.adoc
+++ b/modules/ROOT/pages/tinydrive-dropbox-integration.adoc
@@ -51,7 +51,7 @@ For information on other {cloudfilemanager} config options refer to the xref:tin
 
 . From the {productname} user interface, click on the image:insertimage.png[Insert/edit image] button to access the {cloudfilemanager} user interface.
 . Click on the image:upload.png[Upload/Create] button to select Dropbox from the list of storages.
-. Select the file to upload/import from Dropbox by clicking on the radio button next to it and click the *Choose* button to upload or *Cancel* to abort the operation.
+. Select the file to upload/import from Dropbox by clicking on the checkbox button next to it and click the *Choose* button to upload or *Cancel* to abort the operation.
 . Alternatively, files from your local browser can be uploaded to the Dropbox by clicking on the *Upload files* option and selecting the files to upload.
 
 *Result:* You should be able to view the selected files in your {cloudfilemanager} storage.

--- a/modules/ROOT/pages/tinydrive-googledrive-integration.adoc
+++ b/modules/ROOT/pages/tinydrive-googledrive-integration.adoc
@@ -74,7 +74,7 @@ For information on other {cloudfilemanager} config options refer to the xref:tin
 
 . From the {productname} user interface, click on the image:insertimage.png[Insert/edit image] button to access the {cloudfilemanager} user interface.
 . Click on the image:upload.png[Upload/Create] button to select Google Drive from the list of storages.
-. Select the file to upload/import from Google Drive by clicking on the radio button next to it. Alternatively, to directly insert the file into the editor, double-click on it.
+. Select the file to upload/import from Google Drive by clicking on the checkbox button next to it. Alternatively, to directly insert the file into the editor, double-click on it.
 . Choose *Save* to upload/import the selected file/files to {cloudfilemanager}.
 
 *Result:* You should be able to view the selected files in your {cloudfilemanager} storage.


### PR DESCRIPTION
Ticket: DOC-2432

- Site: [permanentpen/#using-the-ui](http://docs-hotfix-7-doc-2432.staging.tiny.cloud/docs/tinymce/latest/permanentpen/#using-the-ui)
- Site: [pageembed/#using-page-embed](http://docs-hotfix-7-doc-2432.staging.tiny.cloud/docs/tinymce/latest/pageembed/#using-page-embed)

Changes:
* replace mentions of `radio` buttons to render `checkbox` in all documentation pages.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed