### PR TITLE
DOC-2441: update ai assistant to use new GPT4o model.

### DIFF
--- a/modules/ROOT/examples/live-demos/ai/example.js
+++ b/modules/ROOT/examples/live-demos/ai/example.js
@@ -42,7 +42,7 @@ const ai_request =  (request, respondWith) => respondWith.stream(async (signal, 
   ];
 
   const requestBody = {
-    model: 'gpt-3.5-turbo',
+    model: 'gpt-4o',
     temperature: 0.7,
     max_tokens: 800,
     messages,

--- a/modules/ROOT/examples/live-demos/ai/index.js
+++ b/modules/ROOT/examples/live-demos/ai/index.js
@@ -38,7 +38,7 @@ const ai_request =  (request, respondWith) => respondWith.stream(async (signal, 
   ];
 
   const requestBody = {
-    model: 'gpt-3.5-turbo',
+    model: 'gpt-4o',
     temperature: 0.7,
     max_tokens: 800,
     messages,

--- a/modules/ROOT/pages/ai-openai.adoc
+++ b/modules/ROOT/pages/ai-openai.adoc
@@ -41,7 +41,7 @@ const ai_request = (request, respondWith) => {
       'Authorization': `Bearer ${api_key}`
     },
     body: JSON.stringify({
-      model: 'gpt-3.5-turbo',
+      model: 'gpt-4o',
       temperature: 0.7,
       max_tokens: 800,
       messages: [{ role: 'user', content: request.prompt }],
@@ -122,7 +122,7 @@ const ai_request = (request, respondWith) => {
     ];
 
     const requestBody = {
-      model: 'gpt-3.5-turbo',
+      model: 'gpt-4o',
       temperature: 0.7,
       max_tokens: 800,
       messages,

--- a/modules/ROOT/partials/configuration/ai_request.adoc
+++ b/modules/ROOT/partials/configuration/ai_request.adoc
@@ -29,7 +29,7 @@ const ai_request = (request, respondWith) => {
       'Authorization': `Bearer ${api_key}`
     },
     body: JSON.stringify({
-      model: 'gpt-3.5-turbo',
+      model: 'gpt-4o',
       temperature: 0.7,
       max_tokens: 800,
       messages: [{ role: 'user', content: request.prompt }],


### PR DESCRIPTION
Ticket: DOC-2441

Site: [Staging branch](http://docs-hotfix-7-doc-2441.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* Change model in config from  “model: "gpt-3.5-turbo"  to “model: 'gpt-4o'“.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`


Review:
- [x] Documentation Team Lead has reviewed