### PR TITLE
DOC-2446: Add TINY-10374 release note entry

### DIFF
--- a/modules/ROOT/pages/7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.2-release-notes.adoc
@@ -105,12 +105,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 [[improvements]]
 == Improvements
 
-{productname} {release-version} also includes the following improvement<s>:
+{productname} {release-version} also includes the following improvements:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Added `referrerpolicy` as a valid attribute for an iframe element.
+// #TINY-10374
 
-// CCFR here.
+Previously in {productname}, the `referrerpolicy` attribute was not a valid attribute for an iframe element. In {productname} {release-version}, the `referrerpolicy` attribute has been added to the schema as a valid attribute for an iframe element. This allows users to add an iframe with a `referrerpolicy` attribute.
 
 
 [[additions]]

--- a/modules/ROOT/pages/7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.2-release-notes.adoc
@@ -110,7 +110,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Added `referrerpolicy` as a valid attribute for an iframe element.
 // #TINY-10374
 
-Previously in {productname}, the `referrerpolicy` attribute was not a valid attribute for an iframe element. In {productname} {release-version}, the `referrerpolicy` attribute has been added to the schema as a valid attribute for an iframe element. This allows users to add an iframe with a `referrerpolicy` attribute.
+Previously in {productname}, the `referrerpolicy` attribute was not considered as valid for iframe elements. In {productname} {release-version}, this attribute has been added to the schema, allowing users to include the `referrerpolicy` attribute in iframes.
 
 
 [[additions]]


### PR DESCRIPTION
Ticket: DOC-2446

Site: [Staging branch](http://docs-feature-72-doc-2446tiny-10374.staging.tiny.cloud/docs/tinymce/latest/7.2-release-notes/#added-referrerpolicy-as-a-valid-attribute-for-an-iframe-element)

Changes:
* DOC-2446: Add TINY-10374 release note entry

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [-] Files has been included where required `(if applicable)`
- [-] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed