### PR TITLE
DOC-2450: Restructure editor-plugin-version.adoc

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -123,7 +123,7 @@
 ** xref:cloud-deployment-guide.adoc[Cloud deployment guide]
 *** xref:editor-and-features.adoc[Cloud deployment of editor & plugins]
 *** xref:features-only.adoc[Cloud deployment of plugins Only]
-*** xref:editor-plugin-version.adoc[Specify editor & plugins]
+*** xref:editor-plugin-version.adoc[Specify editor version & plugins]
 *** xref:plugin-editor-version-compatibility.adoc[Version compatibility reference]
 *** xref:cloud-troubleshooting.adoc[Cloud Troubleshooting]
 ** Premium server-side services guide

--- a/modules/ROOT/pages/editor-plugin-version.adoc
+++ b/modules/ROOT/pages/editor-plugin-version.adoc
@@ -6,14 +6,12 @@
 [[specifying-the-tinymce-editor-version-deployed-from-cloud]]
 == Specifying the {productname} Editor Version from the Cloud
 
-To set the {productname} version when deploying from {cloudname}, use the following URL:
+The example below shows the default way to load {productname} {productmajorversion} from {cloudname}. This URL ensures the most recent and verified version of {productname} is used.
 
 [source,html,subs="attributes+"]
 ----
 <script src="{cdnurl}" referrerpolicy="origin"></script>
 ----
-
-The example above shows the default way to load {productname} {productmajorversion} from {cloudname}. This URL ensures the most recent and verified version of {productname} is used.
 
 For loading a specific version of {productname} {productmajorversion} other than the latest release, replace the `7` in the URL with the desired version. For example, to load a minor version such as {productname} `7.1`, use the following URL:
 
@@ -22,7 +20,7 @@ For loading a specific version of {productname} {productmajorversion} other than
 <script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/7.1/tinymce.min.js" referrerpolicy="origin"></script>
 ----
 
-To load a specific patch version, replace the `7` in the URL with the desired version. For example, to load {productname} `7.1.1`, use the following URL:
+To load a specific patch version, replace the `7` in the URL with the desired patch version. For example, to load {productname} `7.1.1`, use the following URL:
 
 [source,html,subs="attributes+"]
 ----
@@ -39,8 +37,8 @@ Replace 'no-api-key' with your own API key.
 ====
 All {cloudname} channels are based on the {enterpriseversion} version.
 
-* For complete information on the latest version of the {cloudname} `{productmajorversion}` release channel including premium changes, see: xref:release-notes.adoc[{productname} Release Notes].
-* For a summarised list of only the changes that affect the open-source version of {productname}, see: xref:changelog.adoc[{productname} Changelog].
+* For complete information on the latest version of the {cloudname} `{productmajorversion}` Release Channel including premium changes, see: xref:release-notes.adoc[{productname} Release Notes].
+* For a summarized list of only the changes that affect the open-source version of {productname}, see: xref:changelog.adoc[{productname} Changelog].
 ====
 
 Choose from the `{productmajorversion}`, `{productmajorversion}-testing`, or `{productmajorversion}-dev` release channels to load the latest version of {productname} from {cloudname}.
@@ -108,7 +106,7 @@ The `plugins.min.js` script loads every premium plugin the API key is entitled t
 
 [source,html,subs="attributes+"]
 ----
-<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/7/plugins.min.js" referrerpolicy="origin"></script>
+<script src="https://cdn.tiny.cloud/1/api-key/tinymce/7/plugins.min.js" referrerpolicy="origin"></script>
 ----
 
 === `plugins.min.js` with Exclusions for Specific Plugins.
@@ -117,7 +115,7 @@ To exclude specific premium plugins from `plugins.min.js` because you are self-h
 
 [source,html,subs="attributes+"]
 ----
-<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/7/plugins.min.js?mentions=sdk&powerpaste=sdk" referrerpolicy="origin"></script>
+<script src="https://cdn.tiny.cloud/1/api-key/tinymce/7/plugins.min.js?mentions=sdk&powerpaste=sdk" referrerpolicy="origin"></script>
 ----
 
 [NOTE]
@@ -133,7 +131,7 @@ The `cloud-plugins.min.js` script allows loading of specific premium plugins fro
 
 [source,html,subs="attributes+"]
 ----
-<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/7/cloud-plugins.min.js?mentions&powerpaste&advcode" referrerpolicy="origin"></script>
+<script src="https://cdn.tiny.cloud/1/api-key/tinymce/7/cloud-plugins.min.js?mentions&powerpaste&advcode" referrerpolicy="origin"></script>
 ----
 
 [NOTE]

--- a/modules/ROOT/pages/editor-plugin-version.adoc
+++ b/modules/ROOT/pages/editor-plugin-version.adoc
@@ -1,7 +1,7 @@
 = Specify editor version & plugins
 :description_short: Specifying editor version and plugins for {cloudname} deployments.
 :description: Instructions on setting the {productname} editor version and plugins for {cloudname} deployments.
-:keywords: tinymce, cloud, script, textarea, apiKey, hybrid
+:keywords: tinymce, cloud, script, textarea, apiKey, hybrid, dev, testing, production
 
 [[specifying-the-tinymce-editor-version-deployed-from-cloud]]
 == Specifying the {productname} Editor Version from the Cloud
@@ -15,8 +15,81 @@ To set the {productname} version when deploying from {cloudname}, use the follow
 
 The example above shows the default way to load {productname} {productmajorversion} from {cloudname}. This URL ensures the most recent and verified version of {productname} is used.
 
+For loading a specific version of {productname} {productmajorversion} other than the latest release, replace the `7` in the URL with the desired version. For example, to load a minor version such as {productname} `7.1`, use the following URL:
+
+[source,html,subs="attributes+"]
+----
+<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/7.1/tinymce.min.js" referrerpolicy="origin"></script>
+----
+
+To load a specific patch version, replace the `7` in the URL with the desired version. For example, to load {productname} `7.1.1`, use the following URL:
+
+[source,html,subs="attributes+"]
+----
+<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/7.1.1/tinymce.min.js" referrerpolicy="origin"></script>
+----
+
 [TIP]
 Replace 'no-api-key' with your own API key.
+
+[#{productmajorversion}-{productmajorversion}-testing-and-{productmajorversion}-dev-release-channels]
+=== Difference between using {productname} {productmajorversion}, {productmajorversion}-Testing, and {productmajorversion}-Dev release channels
+
+[IMPORTANT]
+====
+All {cloudname} channels are based on the {enterpriseversion} version.
+
+* For complete information on the latest version of the {cloudname} `{productmajorversion}` release channel including premium changes, see: xref:release-notes.adoc[{productname} Release Notes].
+* For a summarised list of only the changes that affect the open-source version of {productname}, see: xref:changelog.adoc[{productname} Changelog].
+====
+
+Choose from the `{productmajorversion}`, `{productmajorversion}-testing`, or `{productmajorversion}-dev` release channels to load the latest version of {productname} from {cloudname}.
+
+These channels are updated automatically and provide the latest {productname} version based on the following criteria:
+
+[#{productmajorversion}-release-channel]
+==== {productmajorversion} Release Channel
+
+This channel deploys the latest release of {productname} that has passed our quality assurance process. The current version of {productname} available through the `/{productmajorversion}` channel can be found on the https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}/version.txt[{cloudname} {productname} {productmajorversion} version page]. The {productname} {productmajorversion} channel can be loaded from `{cdnurl}`.
+
+[#example-using-the-{productmajorversion}-release-channel]
+===== Example: using the `{productmajorversion}` release channel
+
+[source,html,subs="attributes+"]
+----
+<script src="{cdnurl}" referrerpolicy="origin"></script>
+----
+
+[#{productmajorversion}-testing-release-channel]
+==== {productmajorversion}-Testing Release Channel
+
+This channel deploys the current *release candidate* for the `{productmajorversion}` channel. The {productname} release candidate is undergoing quality assurance. The current version of {productname} available through the `{productmajorversion}-testing` channel can be found on the https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}-testing/version.txt[{cloudname} {productname} {productmajorversion}-testing version page].
+
+[#example-using-the-{productmajorversion}-testing-release-channel]
+===== Example: Using the `{productmajorversion}-testing` Release Channel
+
+[source,html,subs="attributes+"]
+----
+<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}-testing/tinymce.min.js" referrerpolicy="origin"></script>
+----
+
+[#{productmajorversion}-dev-release-channel]
+==== {productmajorversion}-Dev Release Channel
+
+This channel deploys nightly builds of {productname}, which includes **unreleased changes** from the link:https://github.com/tinymce/tinymce/tree/main[{productname} repository^]. 
+
+The current version of {productname} is available on the `{productmajorversion}-dev` channel can be found on the link:https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}-dev/version.txt[{cloudname} {productname} {productmajorversion}-dev version page^].
+
+[NOTE]
+{productname} now uses `main` branch for nightly builds instead of `develop` as of {productname} `7.0.0`.
+
+[#example-using-the-{productmajorversion}-dev-release-channel]
+===== Example: Using the `{productmajorversion}-dev` Release Channel
+
+[source,html,subs="attributes+"]
+----
+<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}-dev/tinymce.min.js" referrerpolicy="origin"></script>
+----
 
 For more details, check out the xref:editor-and-features.adoc[{productname} editor via {cloudname}].
 
@@ -67,64 +140,3 @@ The `cloud-plugins.min.js` script allows loading of specific premium plugins fro
 This approach is intended for edge cases where you self-host most premium plugins on your own servers and only need one or two from {companyname} Cloud.
 
 '''
-
-=== Selecting Specific Editor Versions
-
-[IMPORTANT]
-====
-All {cloudname} channels are based on the {enterpriseversion} version.
-
-* For information on the latest version of the {cloudname} `{productmajorversion}` release channel, see: xref:release-notes.adoc[{productname} Release Notes].
-* For a list of changes that *may* be present in the {cloudname} testing channel, see: xref:changelog.adoc[{productname} Changelog].
-====
-
-[#{productmajorversion}-{productmajorversion}-testing-and-{productmajorversion}-dev-release-channels]
-=== Difference between using {productname} {productmajorversion}, {productmajorversion}-Testing, and {productmajorversion}-Dev release channels
-
-Choose from the `{productmajorversion}`, `{productmajorversion}-testing`, or `{productmajorversion}-dev` release channels to load the latest version of {productname} from {cloudname}.
-
-These channels are updated automatically and provide the latest {productname} version based on the following criteria:
-
-[#{productmajorversion}-release-channel]
-==== {productmajorversion} Release Channel
-
-This channel deploys the latest release of {productname} that has passed our quality assurance process. The current version of {productname} available through the `/{productmajorversion}` channel can be found on the https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}/version.txt[{cloudname} {productname} {productmajorversion} version page]. The {productname} {productmajorversion} channel can be loaded from `{cdnurl}`.
-
-[#example-using-the-{productmajorversion}-release-channel]
-===== Example: using the `{productmajorversion}` release channel
-
-[source,html,subs="attributes+"]
-----
-<script src="{cdnurl}" referrerpolicy="origin"></script>
-----
-
-[#{productmajorversion}-testing-release-channel]
-==== {productmajorversion}-Testing Release Channel
-
-This channel deploys the current *release candidate* for the `{productmajorversion}` channel. The {productname} release candidate is undergoing quality assurance. The current version of {productname} available through the `{productmajorversion}-testing` channel can be found on the https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}-testing/version.txt[{cloudname} {productname} {productmajorversion}-testing version page].
-
-[#example-using-the-{productmajorversion}-testing-release-channel]
-===== Example: Using the `{productmajorversion}-testing` Release Channel
-
-[source,html,subs="attributes+"]
-----
-<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}-testing/tinymce.min.js" referrerpolicy="origin"></script>
-----
-
-[#{productmajorversion}-dev-release-channel]
-==== {productmajorversion}-Dev Release Channel
-
-This channel deploys nightly builds of {productname}, which includes **unreleased changes** from the link:https://github.com/tinymce/tinymce/tree/main[{productname} repository^]. 
-
-The current version of {productname} is available on the `{productmajorversion}-dev` channel can be found on the link:https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}-dev/version.txt[{cloudname} {productname} {productmajorversion}-dev version page^].
-
-[NOTE]
-{productname} now uses `main` branch for nightly builds instead of `develop` as of {productname} `7.0.0`.
-
-[#example-using-the-{productmajorversion}-dev-release-channel]
-===== Example: Using the `{productmajorversion}-dev` Release Channel
-
-[source,html,subs="attributes+"]
-----
-<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}-dev/tinymce.min.js" referrerpolicy="origin"></script>
-----

--- a/modules/ROOT/pages/editor-plugin-version.adoc
+++ b/modules/ROOT/pages/editor-plugin-version.adoc
@@ -48,7 +48,7 @@ These channels are updated automatically and provide the latest {productname} ve
 [#{productmajorversion}-release-channel]
 ==== {productmajorversion} Release Channel
 
-This channel deploys the latest release of {productname} that has passed our quality assurance process. The current version of {productname} available through the `/{productmajorversion}` channel can be found on the https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}/version.txt[{cloudname} {productname} {productmajorversion} version page]. The {productname} {productmajorversion} channel can be loaded from `{cdnurl}`.
+This channel deploys the latest release of {productname} that has passed our quality assurance process. The current version of {productname} available through the `{productmajorversion}` channel can be found on the https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}/version.txt[{cloudname} {productname} {productmajorversion} version page].
 
 [#example-using-the-{productmajorversion}-release-channel]
 ===== Example: using the `{productmajorversion}` release channel

--- a/modules/ROOT/pages/editor-plugin-version.adoc
+++ b/modules/ROOT/pages/editor-plugin-version.adoc
@@ -108,7 +108,7 @@ The `plugins.min.js` script loads every premium plugin the API key is entitled t
 
 [source,html,subs="attributes+"]
 ----
-<script src="https://cdn.tiny.cloud/1/api-key/tinymce/7/plugins.min.js" referrerpolicy="origin"></script>
+<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/7/plugins.min.js" referrerpolicy="origin"></script>
 ----
 
 === `plugins.min.js` with Exclusions for Specific Plugins.
@@ -117,7 +117,7 @@ To exclude specific premium plugins from `plugins.min.js` because you are self-h
 
 [source,html,subs="attributes+"]
 ----
-<script src="https://cdn.tiny.cloud/1/api-key/tinymce/7/plugins.min.js?mentions=sdk&powerpaste=sdk" referrerpolicy="origin"></script>
+<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/7/plugins.min.js?mentions=sdk&powerpaste=sdk" referrerpolicy="origin"></script>
 ----
 
 [NOTE]
@@ -133,7 +133,7 @@ The `cloud-plugins.min.js` script allows loading of specific premium plugins fro
 
 [source,html,subs="attributes+"]
 ----
-<script src="https://cdn.tiny.cloud/1/api-key/tinymce/7/cloud-plugins.min.js?mentions&powerpaste&advcode" referrerpolicy="origin"></script>
+<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/7/cloud-plugins.min.js?mentions&powerpaste&advcode" referrerpolicy="origin"></script>
 ----
 
 [NOTE]

--- a/modules/ROOT/pages/editor-plugin-version.adoc
+++ b/modules/ROOT/pages/editor-plugin-version.adoc
@@ -4,7 +4,7 @@
 :keywords: tinymce, cloud, script, textarea, apiKey, hybrid, dev, testing, production
 
 [[specifying-the-tinymce-editor-version-deployed-from-cloud]]
-== Specifying the {productname} Editor Version from the Cloud
+== Specifying the {productname} Editor Version from {cloudname}
 
 The example below shows the default way to load {productname} {productmajorversion} from {cloudname}. This URL ensures the most recent and verified version of {productname} is used.
 
@@ -13,18 +13,18 @@ The example below shows the default way to load {productname} {productmajorversi
 <script src="{cdnurl}" referrerpolicy="origin"></script>
 ----
 
-To load a specific version of {productname} {productmajorversion} other than the latest release, replace the `7` in the URL with the desired version. For example, to load a minor version such as {productname} `7.1`, use the following URL:
+To load a specific version of {productname} {productmajorversion} other than the latest release, replace the `{productmajorversion}` in the URL with the desired version. For example, to load a minor version such as {productname} `{productmajorversion}.1`, use the following URL:
 
 [source,html,subs="attributes+"]
 ----
-<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/7.1/tinymce.min.js" referrerpolicy="origin"></script>
+<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}.1/tinymce.min.js" referrerpolicy="origin"></script>
 ----
 
-To load a specific patch version, replace the `7` in the URL with the desired patch version. For example, to load {productname} `7.1.1`, use the following URL:
+To load a specific patch version, replace the `{productmajorversion}` in the URL with the desired patch version. For example, to load {productname} `{productmajorversion}.1.2`, use the following URL:
 
 [source,html,subs="attributes+"]
 ----
-<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/7.1.1/tinymce.min.js" referrerpolicy="origin"></script>
+<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}.1.2/tinymce.min.js" referrerpolicy="origin"></script>
 ----
 
 [TIP]
@@ -106,7 +106,7 @@ The `plugins.min.js` script loads every premium plugin the API key is entitled t
 
 [source,html,subs="attributes+"]
 ----
-<script src="https://cdn.tiny.cloud/1/api-key/tinymce/7/plugins.min.js" referrerpolicy="origin"></script>
+<script src="https://cdn.tiny.cloud/1/api-key/tinymce/{productmajorversion}/plugins.min.js" referrerpolicy="origin"></script>
 ----
 
 === `plugins.min.js` with Exclusions for Specific Plugins
@@ -115,7 +115,7 @@ To exclude specific premium plugins from `plugins.min.js` because you are self-h
 
 [source,html,subs="attributes+"]
 ----
-<script src="https://cdn.tiny.cloud/1/api-key/tinymce/7/plugins.min.js?mentions=sdk&powerpaste=sdk" referrerpolicy="origin"></script>
+<script src="https://cdn.tiny.cloud/1/api-key/tinymce/{productmajorversion}/plugins.min.js?mentions=sdk&powerpaste=sdk" referrerpolicy="origin"></script>
 ----
 
 [NOTE]
@@ -131,7 +131,7 @@ The `cloud-plugins.min.js` script allows loading of specific premium plugins fro
 
 [source,html,subs="attributes+"]
 ----
-<script src="https://cdn.tiny.cloud/1/api-key/tinymce/7/cloud-plugins.min.js?mentions&powerpaste&advcode" referrerpolicy="origin"></script>
+<script src="https://cdn.tiny.cloud/1/api-key/tinymce/{productmajorversion}/cloud-plugins.min.js?mentions&powerpaste&advcode" referrerpolicy="origin"></script>
 ----
 
 [NOTE]

--- a/modules/ROOT/pages/editor-plugin-version.adoc
+++ b/modules/ROOT/pages/editor-plugin-version.adoc
@@ -1,4 +1,4 @@
-= Specify editor version & plugins
+= Specify Editor Version & Plugins
 :description_short: Specifying editor version and plugins for {cloudname} deployments.
 :description: Instructions on setting the {productname} editor version and plugins for {cloudname} deployments.
 :keywords: tinymce, cloud, script, textarea, apiKey, hybrid, dev, testing, production
@@ -13,7 +13,7 @@ The example below shows the default way to load {productname} {productmajorversi
 <script src="{cdnurl}" referrerpolicy="origin"></script>
 ----
 
-For loading a specific version of {productname} {productmajorversion} other than the latest release, replace the `7` in the URL with the desired version. For example, to load a minor version such as {productname} `7.1`, use the following URL:
+To load a specific version of {productname} {productmajorversion} other than the latest release, replace the `7` in the URL with the desired version. For example, to load a minor version such as {productname} `7.1`, use the following URL:
 
 [source,html,subs="attributes+"]
 ----
@@ -31,7 +31,7 @@ To load a specific patch version, replace the `7` in the URL with the desired pa
 Replace 'no-api-key' with your own API key.
 
 [#{productmajorversion}-{productmajorversion}-testing-and-{productmajorversion}-dev-release-channels]
-=== Difference between using {productname} {productmajorversion}, {productmajorversion}-Testing, and {productmajorversion}-Dev release channels
+=== Difference between using {productname} {productmajorversion}, {productmajorversion}-Testing, and {productmajorversion}-Dev Release Channels
 
 [IMPORTANT]
 ====
@@ -48,10 +48,10 @@ These channels are updated automatically and provide the latest {productname} ve
 [#{productmajorversion}-release-channel]
 ==== {productmajorversion} Release Channel
 
-This channel deploys the latest release of {productname} that has passed our quality assurance process. The current version of {productname} available through the `{productmajorversion}` channel can be found on the https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}/version.txt[{cloudname} {productname} {productmajorversion} version page].
+This channel deploys the latest release of {productname} that has passed our quality assurance process. The current version of {productname} available through the `{productmajorversion}` channel can be found on the link:https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}/version.txt[{cloudname} {productname} {productmajorversion} version page].
 
 [#example-using-the-{productmajorversion}-release-channel]
-===== Example: using the `{productmajorversion}` release channel
+===== Example: Using the `{productmajorversion}` Release Channel
 
 [source,html,subs="attributes+"]
 ----
@@ -61,7 +61,7 @@ This channel deploys the latest release of {productname} that has passed our qua
 [#{productmajorversion}-testing-release-channel]
 ==== {productmajorversion}-Testing Release Channel
 
-This channel deploys the current *release candidate* for the `{productmajorversion}` channel. The {productname} release candidate is undergoing quality assurance. The current version of {productname} available through the `{productmajorversion}-testing` channel can be found on the https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}-testing/version.txt[{cloudname} {productname} {productmajorversion}-testing version page].
+This channel deploys the current *release candidate* for the `{productmajorversion}` channel. The {productname} release candidate is undergoing quality assurance. The current version of {productname} available through the `{productmajorversion}-testing` channel can be found on the link:https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}-testing/version.txt[{cloudname} {productname} {productmajorversion}-testing version page].
 
 [#example-using-the-{productmajorversion}-testing-release-channel]
 ===== Example: Using the `{productmajorversion}-testing` Release Channel
@@ -76,7 +76,7 @@ This channel deploys the current *release candidate* for the `{productmajorversi
 
 This channel deploys nightly builds of {productname}, which includes **unreleased changes** from the link:https://github.com/tinymce/tinymce/tree/main[{productname} repository^]. 
 
-The current version of {productname} is available on the `{productmajorversion}-dev` channel can be found on the link:https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}-dev/version.txt[{cloudname} {productname} {productmajorversion}-dev version page^].
+The current version of {productname} available on the `{productmajorversion}-dev` channel can be found on the link:https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}-dev/version.txt[{cloudname} {productname} {productmajorversion}-dev version page^].
 
 [NOTE]
 {productname} now uses `main` branch for nightly builds instead of `develop` as of {productname} `7.0.0`.
@@ -100,7 +100,7 @@ include::partial$misc/admon-script-tag-placement.adoc[]
 
 {companyname} offers the following configuration scripts to assist:
 
-=== `plugin.min.js` Standalone with No Exclusions.
+=== `plugin.min.js` Standalone with No Exclusions
 
 The `plugins.min.js` script loads every premium plugin the API key is entitled to from the CDN.
 
@@ -109,7 +109,7 @@ The `plugins.min.js` script loads every premium plugin the API key is entitled t
 <script src="https://cdn.tiny.cloud/1/api-key/tinymce/7/plugins.min.js" referrerpolicy="origin"></script>
 ----
 
-=== `plugins.min.js` with Exclusions for Specific Plugins.
+=== `plugins.min.js` with Exclusions for Specific Plugins
 
 To exclude specific premium plugins from `plugins.min.js` because you are self-hosting them, add the excluded plugins to the script query parameters as shown below:
 
@@ -122,10 +122,10 @@ To exclude specific premium plugins from `plugins.min.js` because you are self-h
 ====
 Ensure that the excluded plugins' names are appended with `=sdk`, such as `mentions=sdk`.
 
-When {companyname} Cloud releases a new premium plugin, if you wish to self-host it this script tag will need to be updated to exclude it.
+When {companyname} Cloud releases a new premium plugin, if you wish to self-host it, this script tag will need to be updated to exclude it.
 ====
 
-=== `cloud-plugins.min.js` for Specific Premium Plugins from {companyname} Cloud.
+=== `cloud-plugins.min.js` for Specific Premium Plugins from {companyname} Cloud
 
 The `cloud-plugins.min.js` script allows loading of specific premium plugins from {companyname} Cloud.
 
@@ -136,5 +136,3 @@ The `cloud-plugins.min.js` script allows loading of specific premium plugins fro
 
 [NOTE]
 This approach is intended for edge cases where you self-host most premium plugins on your own servers and only need one or two from {companyname} Cloud.
-
-'''


### PR DESCRIPTION
Ticket: DOC-2450

Site: [Staging branch](http://docs-hotfix-7-doc-2450.staging.tiny.cloud/docs/tinymce/latest/editor-plugin-version)

**HOTFIX**

Changes:
* Add examples of specifying minor and patch versions
* Move the "Difference between using TinyMCE 7, 7-Testing, and 7-Dev release channels" section to the top of the document so that information about specifying editor version is all in one place.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [-] Files has been included where required `(if applicable)`
- [-] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [-] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed