### PR TITLE
DOC-2446: Add TINY-10891 release note entry

### DIFF
--- a/modules/ROOT/pages/7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.2-release-notes.adoc
@@ -159,11 +159,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Accessibility for element path buttons, added tooltip to describe the button and removed incorrect `aria-level` attribute.
 // #TINY-10891
 
-Previously in {productname}, an issue was identified where the element path buttons in the status bar did not provide any aria description of their functionality. Without any description for the element path buttons in the status bar, screen reader users were unable to describe the purpose of these buttons to visually impaired users.
+In previous versions of {productname}, Axe-DevTools (web accessibility testing extension) identified that the element path buttons contained an invalid `aria-level` attribute that is not permitted on `role="button"` elements. As a consequence, screen readers were unable to describe the purpose of these buttons to visually impaired users.
 
-To address this issue in {productname} {release-version}, tooltips have been added to the buttons in the element path. These tooltips provide a description of the button's functionality. Additionally, the `aria-describedby` attribute has been added when the tooltip is focused, allowing screen readers to announce and describe the purpose of the button. Now, a tooltip appears when hovering over an element path button with the mouse or focusing on it using the keyboard, and the description is announced by screen readers if the button is focused. This improvement ensures that visually impaired users receive the same information as other users.
+{productname} {release-version} addresses this issue by adding tooltips to the buttons in the element path which now provides a description of the button's functionality. In addition, the `aria-describedby` attribute has been added when the tooltip is focused, allowing screen readers to announce and describe the purpose of the button when in-focus. Now, a tooltip appears when hovering over an element path button with the mouse or focusing on it using the keyboard.
 
-Another part of the change is the removal of the incorrect `aria-level` attribute that was added to these buttons. This change was made to ensure that the editor complies with the "Elements must only use supported ARIA attributes" rule in WCAG 2.x (A).
+[NOTE]
+With this change {productname} also removed of the incorrect `aria-level` attribute that was added to these buttons previously. This change ensures that the editor complies with the "Elements must only use supported ARIA attributes" rule.
 
 
 [[security-fixes]]

--- a/modules/ROOT/pages/7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.2-release-notes.adoc
@@ -156,6 +156,15 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Accessibility for element path buttons, added tooltip to describe the button and removed incorrect `aria-level` attribute.
+// #TINY-10891
+
+Previously in {productname}, an issue was identified where the element path buttons in the status bar did not provide any aria description of their functionality. Without any description for the element path buttons in the status bar, screen reader users were unable to describe the purpose of these buttons to visually impaired users.
+
+To address this issue in {productname} {release-version}, tooltips have been added to the buttons in the element path. These tooltips provide a description of the button's functionality. Additionally, the `aria-describedby` attribute has been added when the tooltip is focused, allowing screen readers to announce and describe the purpose of the button. Now, a tooltip appears when hovering over an element path button with the mouse or focusing on it using the keyboard, and the description is announced by screen readers if the button is focused. This improvement ensures that visually impaired users receive the same information as other users.
+
+Another part of the change is the removal of the incorrect `aria-level` attribute that was added to these buttons. This change was made to ensure that the editor complies with the "Elements must only use supported ARIA attributes" rule in WCAG 2.x (A).
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-2446

Site: [Staging branch](http://docs-feature-72-doc-2446tiny-10891.staging.tiny.cloud/docs/tinymce/latest/7.2-release-notes/#accessibility-for-element-path-buttons-added-tooltip-to-describe-the-button-and-removed-incorrect-aria-level-attribute)

Changes:
* Add TINY-10891 release note entry: Accessibility for element path buttons, added tooltip to describe the button and removed incorrect `aria-level` attribute.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [-] Files has been included where required `(if applicable)`
- [-] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed