### PR TITLE
DOC-2446: Add TINY-10820 release note entry

### DIFF
--- a/modules/ROOT/pages/7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.2-release-notes.adoc
@@ -161,7 +161,9 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 Previously in {productname}, there was an issue where focusing on `contenteditable="true"` elements, such as media elements, while using `editable_root: false` and inline mode would cause the selection to be shifted. When saving the media dialog, the focus would first shift to the editor to ensure the changes are inserted into the editor. However, this caused the selection to change, leading to a duplicated element being inserted into the editor.
 
-This issue has been resolved in {productname} {release-version}. Now, after focusing on the `contenteditable="true"` root, the editor bookmark is restored, ensuring that the selection remains at the correct location when saving the media. As a result, when focusing on `contenteditable="true"` elements in inline mode with `editable_root: false`, the selection will remain correct after saving the media dialog. This prevents the duplication of elements and ensures that the changes are inserted at the intended location within the editor.
+This issue has been resolved in {productname} {release-version}. Now, after focusing on the `contenteditable="true"` root, the editor bookmark is restored, ensuring that the selection remains at the correct location when saving the media.
+
+As a result, when focusing on `contenteditable="true"` elements in inline mode with `editable_root: false`, the selection will remain correct after saving the media dialog. This prevents the duplication of elements and ensures that the changes are inserted at the intended location within the editor.
 
 
 [[security-fixes]]

--- a/modules/ROOT/pages/7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.2-release-notes.adoc
@@ -156,6 +156,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Focusing on `contenteditable="true"` element when using `editable_root: false` and inline mode causing selection to be shifted.
+// #TINY-10820
+
+Previously in {productname}, there was an issue where focusing on `contenteditable="true"` elements, such as media elements, while using `editable_root: false` and inline mode would cause the selection to be shifted. When saving the media dialog, the focus would first shift to the editor to ensure the changes are inserted into the editor. However, this caused the selection to change, leading to a duplicated element being inserted into the editor.
+
+This issue has been resolved in {productname} {release-version}. Now, after focusing on the `contenteditable="true"` root, the editor bookmark is restored, ensuring that the selection remains at the correct location when saving the media. As a result, when focusing on `contenteditable="true"` elements in inline mode with `editable_root: false`, the selection will remain correct after saving the media dialog. This prevents the duplication of elements and ensures that the changes are inserted at the intended location within the editor.
+
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/pages/7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.2-release-notes.adoc
@@ -156,7 +156,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
-=== Focusing on `contenteditable="true"` element when using `editable_root: false` and inline mode causing selection to be shifted.
+=== Focusing on `contenteditable="true"` element when using `editable_root: false` and inline mode caused selection to be shifted.
 // #TINY-10820
 
 Previously in {productname}, there was an issue where focusing on `contenteditable="true"` elements, such as media elements, while using `editable_root: false` and inline mode would cause the selection to be shifted. When saving the media dialog, the focus would first shift to the editor to ensure the changes are inserted into the editor. However, this caused the selection to change, leading to a duplicated element being inserted into the editor.


### PR DESCRIPTION
Ticket: DOC-2446

Site: [Staging branch](http://docs-feature-72-doc-2446tiny-10820.staging.tiny.cloud/docs/tinymce/latest/7.2-release-notes/#focusing-on-contenteditabletrue-element-when-using-editable_root-false-and-inline-mode-caused-selection-to-be-shifted)

Changes:
* Add TINY-10820 release note entry: Focusing on `contenteditable="true"` element when using `editable_root: false` and inline mode caused selection to be shifted.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [-] Files has been included where required `(if applicable)`
- [-] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed