### PR TITLE
DOC-2446: Add TINY-11001 release note entry

### DIFF
--- a/modules/ROOT/pages/7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.2-release-notes.adoc
@@ -105,12 +105,14 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 [[improvements]]
 == Improvements
 
-{productname} {release-version} also includes the following improvement<s>:
+{productname} {release-version} also includes the following improvements:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Replaced tiny branding logo with `Build with TinyMCE` text and logo.
+// #TINY-11001
 
-// CCFR here.
+Previously, the branding logo in the {productname} status bar was set to the Tiny logo.
+
+Now, the branding logo in the {productname} status bar is set to `Build with` and the {productname} logo.
 
 
 [[additions]]

--- a/modules/ROOT/pages/7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.2-release-notes.adoc
@@ -107,10 +107,10 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following improvements:
 
-=== Replaced tiny branding logo with `Build with TinyMCE` text and logo.
+=== Replaced {companyname} branding logo with `Build with TinyMCE` text and logo.
 // #TINY-11001
 
-Previously, the branding logo in the {productname} status bar was set to the Tiny logo.
+Previously, the branding logo in the {productname} status bar was set to the {companyname} logo.
 
 Now, the branding logo in the {productname} status bar is set to `Build with` and the {productname} logo.
 


### PR DESCRIPTION
Ticket: DOC-2446

Site: [Staging branch](http://docs-feature-72-doc-2446tiny-11001.staging.tiny.cloud/docs/tinymce/latest/7.2-release-notes/#replaced-tiny-branding-logo-with-build-with-tinymce-text-and-logo)

Changes:
* DOC-2446: Add TINY-11001 release note entry: Replaced tiny branding logo with `Build with TinyMCE` text and logo.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [-] Files has been included where required `(if applicable)`
- [-] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed