### PR TITLE
DOC-2446: Add TINY-10869 release note entry

### DIFF
--- a/modules/ROOT/pages/7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.2-release-notes.adoc
@@ -112,6 +112,18 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Improve merging of inserted inline elements by removing nodes with redundant inheritable styles.
+// #TINY-10869
+
+In previous versions of {productname}, when inserting inline elements into existing inline elements, the editor would only attempt to merge identical inline elements when the pasted elements were not nested within other non-identical inline elements. As a consequence, the pasted inline elements would contain redundant inheritable styles that were not removed.
+
+In {productname} {release-version}, this behavior has been improved. Now, when inserting inline elements inside other inline elements, any inserted inline element that contains no non-inheritable styles and has no more than one child element is automatically stripped if it also meets one of the following conditions:
+
+* Contains no styles that are inherited by a child element, or
+* Is identical to a parent of the element inserted into and doesn't conflict with a parent element within the inserted content.
+
+As a result, many redundant inline elements are automatically stripped when inserted into the editor, while maintaining their appearance and overall element structure.
+
 
 [[additions]]
 == Additions

--- a/modules/ROOT/pages/7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.2-release-notes.adoc
@@ -115,12 +115,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Improve merging of inserted inline elements by removing nodes with redundant inheritable styles.
 // #TINY-10869
 
-In previous versions of {productname}, when inserting inline elements into existing inline elements, the editor would only attempt to merge identical inline elements when the pasted elements were not nested within other non-identical inline elements. As a consequence, the pasted inline elements would contain redundant inheritable styles that were not removed.
+In previous versions of {productname}, when inserting inline elements into existing inline elements, the editor would attempt to merge the contents of identical inline elements. Inserted inline elements would only be removed if they were identical to inline parents of the element being inserted into, and this check would only occur until it found a non-inheritable style or a conflict.
 
-In {productname} {release-version}, this behavior has been improved. Now, when inserting inline elements inside other inline elements, any inserted inline element that contains no non-inheritable styles and has no more than one child element is automatically stripped if it also meets one of the following conditions:
+In {productname} {release-version}, this behavior has been improved. Now, inserted inline elements are removed when they contain no non-inheritable styles, have only one child element, and either:
 
-* Contains no styles that are inherited by a child element, or
-* Is identical to a parent of the element inserted into and doesn't conflict with a parent element within the inserted content.
+* Contain no styles which are inherited in a child element, or
+* Are identical to any inline parent of the selected element and don't contain any styles which conflict with another inserted parent's styles.
 
 As a result, many redundant inline elements are automatically stripped when inserted into the editor, while maintaining their appearance and overall element structure.
 


### PR DESCRIPTION
Ticket: DOC-2446

Site: [Staging branch](http://docs-feature-72-doc-2446tiny-10869.staging.tiny.cloud/docs/tinymce/latest/7.2-release-notes/#improve-merging-of-inserted-inline-elements-by-removing-nodes-with-redundant-inheritable-styles)

Changes:
* Add TINY-10869 release note entry: Improve merging of inserted inline elements by removing nodes with redundant inheritable styles.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [-] Files has been included where required `(if applicable)`
- [-] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed