### PR TITLE
DOC-2446: Add TINY-10962 release note entry

### DIFF
--- a/modules/ROOT/pages/7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.2-release-notes.adoc
@@ -70,6 +70,25 @@ In {productname} {release-version}, this issue has been resolved. Now, the slide
 
 For information on the **Image Editing** plugin, see: xref:editimage.adoc[Image Editing].
 
+=== PowerPaste
+
+The {productname} {release-version} release includes an accompanying release of the **PowerPaste** premium plugin.
+
+This release of **PowerPaste** introduces the following addition.
+
+==== New option to disable the auto-linking feature in PowerPaste.
+// #TINY-10962
+
+Previously in {productname}, it was not possible to configure PowerPaste to exclude converting text that resembles a URL into a hyperlink. As a consequence, all text that resembled a URL was automatically converted into a hyperlink when pasting plain text or rich text from HTML.
+
+In {productname} {release-version}, the `powerpaste_autolink_urls` option has been introduced. This option allows users to customize the auto-linking behavior on paste. As a result, users can now disable the auto-linking feature in PowerPaste.
+
+NOTE: This option is enabled by default and does not exhibit any change in behavior when upgrading to {productname} {release-version}.
+
+For more information on the `powerpaste_autolink_urls` option, refer to: xref:powerpaste-options.adoc#powerpaste_autolink_urls[PowerPaste - powerpaste_autolink_urls].
+
+For information on the **PowerPaste** premium plugin, see: xref:introduction-to-powerpaste.adoc[PowerPaste].
+
 === <Premium plugin name 1> <Premium plugin name 1 version>
 
 The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.

--- a/modules/ROOT/pages/powerpaste-options.adoc
+++ b/modules/ROOT/pages/powerpaste-options.adoc
@@ -19,6 +19,8 @@ include::partial$configuration/powerpaste_googledocs_import.adoc[leveloffset=+1]
 
 include::partial$configuration/powerpaste_html_import.adoc[leveloffset=+1]
 
+include::partial$configuration/powerpaste_autolink_urls.adoc[leveloffset=+1]
+
 include::partial$configuration/powerpaste_allow_local_images.adoc[leveloffset=+1]
 
 include::partial$configuration/paste_block_drop.adoc[leveloffset=+1]

--- a/modules/ROOT/partials/configuration/powerpaste_autolink_urls.adoc
+++ b/modules/ROOT/partials/configuration/powerpaste_autolink_urls.adoc
@@ -1,0 +1,23 @@
+[[powerpaste_autolink_urls]]
+== `+powerpaste_autolink_urls+`
+
+This option enables or disables the automatic linking of text that resembles URLs in pasted content.
+
+*Type:* `+Boolean+`
+
+*Default value:* `+true+`
+
+*Possible values:* `+true+`, `+false+`
+
+NOTE: Setting the `+powerpaste_autolink_urls+` option to `+false+` overrides the auto-linking behavior of the xref:smart_paste[`+smart_paste+`] option.
+
+=== Example: Disable auto-linking of URLs
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  plugins: 'powerpaste',
+  powerpaste_autolink_urls: false,
+});
+----

--- a/modules/ROOT/partials/configuration/smart_paste.adoc
+++ b/modules/ROOT/partials/configuration/smart_paste.adoc
@@ -14,6 +14,8 @@ To disable the `+smart_paste+` functionality, set `+smart_paste+` to `+false+`. 
 
 *Possible values:* `+true+`, `+false+`
 
+NOTE: Setting the xref:powerpaste_autolink_urls[`+powerpaste_autolink_urls+`] option to `+false+` overrides the auto-linking feature of the `+smart_paste+` option.
+
 === Example: using `+smart_paste+`
 
 ifdef::plugincode[]


### PR DESCRIPTION
Ticket: DOC-2446

Site: [Staging branch](http://docs-feature-72-doc-2446tiny-10962.staging.tiny.cloud/docs/tinymce/latest/7.2-release-notes/#new-option-to-disable-the-auto-linking-feature-in-powerpaste)
Site: [New powerpaste_autolink_urls  option](http://docs-feature-72-doc-2446tiny-10962.staging.tiny.cloud/docs/tinymce/latest/powerpaste-options/#powerpaste_autolink_urls)

Changes:
* Add TINY-10962 release note entry: New option to disable the auto-linking feature in PowerPaste. **(@kemister85 the heading has been modified form the [original changie title](https://github.com/tinymce/tinymce-premium/pull/214/files#diff-f0abfed8886d754d30efb422a296814751436924a360100cb10a6371a5f96c94))**
* New `powerpaste_autolink_urls.adoc` option page
* Add link to new option in `powerpaste-options.adoc` page
* Add NOTE admonition to `powerpaste_autolink_urls` and `smart_paste` saying that `powerpaste_autolink_urls` overrides `smart_paste`

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [x] Files has been included where required `(if applicable)`
- [-] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed