### PR TITLE
DOC-2446: Improved `Search & Replace` dialog accessibility by changing placeholders to labels.

### DIFF
--- a/modules/ROOT/pages/7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.2-release-notes.adoc
@@ -134,7 +134,7 @@ In previous versions of {productname}, the Search & Replace dialog inputs were i
 
 As a consequence, the dialog was less accessible because the input placeholders were hidden once the user started typing. This posed difficulties for users who rely on consistent visual cues for context.
 
-{productname} {release-version} addresses this issue. Now, placeholders have been replaced by input labels.
+{productname} {release-version} addresses this issue. Now, placeholders have been replaced by input labels located above the input fields.
 
 As a result, dialog is now more accessible and the labels remain visible at all times.
 

--- a/modules/ROOT/pages/7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.2-release-notes.adoc
@@ -130,7 +130,7 @@ Previously in {productname}, the `referrerpolicy` attribute was not considered a
 === Improved Search & Replace dialog accessibility by changing placeholders to labels.
 // #TINY-10871
 
-In previous versions of {productname}, the Find & Replace dialog inputs were initially implemented with placeholders.
+In previous versions of {productname}, the Search & Replace dialog inputs were initially implemented with placeholders.
 
 As a consequence, the dialog was less accessible because the placeholders are removed once the user starts typing. This posed difficulties for people with cognitive disabilities who rely on constant visual cues for context.
 

--- a/modules/ROOT/pages/7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.2-release-notes.adoc
@@ -127,6 +127,17 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 Previously in {productname}, the `referrerpolicy` attribute was not considered as valid for iframe elements. In {productname} {release-version}, this attribute has been added to the schema, allowing users to include the `referrerpolicy` attribute in iframes.
 
+=== Improved Find & Replace dialog accessibility by changing placeholders to labels.
+// #TINY-10871
+
+In previous versions of {productname}, the Find & Replace dialog inputs were initially implemented with placeholders.
+
+As a consequence, the dialog was less accessible because the placeholders are removed once the user starts typing. This posed difficulties for people with cognitive disabilities who rely on constant visual cues for context.
+
+{productname} {release-version} addresses this issue. Now, placeholders have been replaced by input labels.
+
+As a result, dialog is now more accessible and the labels remain visible at all times.
+
 
 [[additions]]
 == Additions

--- a/modules/ROOT/pages/7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.2-release-notes.adoc
@@ -127,7 +127,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 Previously in {productname}, the `referrerpolicy` attribute was not considered as valid for iframe elements. In {productname} {release-version}, this attribute has been added to the schema, allowing users to include the `referrerpolicy` attribute in iframes.
 
-=== Improved Find & Replace dialog accessibility by changing placeholders to labels.
+=== Improved Search & Replace dialog accessibility by changing placeholders to labels.
 // #TINY-10871
 
 In previous versions of {productname}, the Find & Replace dialog inputs were initially implemented with placeholders.

--- a/modules/ROOT/pages/7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.2-release-notes.adoc
@@ -132,7 +132,7 @@ Previously in {productname}, the `referrerpolicy` attribute was not considered a
 
 In previous versions of {productname}, the Search & Replace dialog inputs were initially implemented with placeholders.
 
-As a consequence, the dialog was less accessible because the placeholders are removed once the user starts typing. This posed difficulties for people with cognitive disabilities who rely on constant visual cues for context.
+As a consequence, the dialog was less accessible because the input placeholders were hidden once the user started typing. This posed difficulties for users who rely on consistent visual cues for context.
 
 {productname} {release-version} addresses this issue. Now, placeholders have been replaced by input labels.
 

--- a/modules/ROOT/pages/7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.2-release-notes.adoc
@@ -136,7 +136,7 @@ As a consequence, the dialog was less accessible because the input placeholders 
 
 {productname} {release-version} addresses this issue. Now, placeholders have been replaced by input labels located above the input fields.
 
-As a result, dialog is now more accessible and the labels remain visible at all times.
+As a result, the Search & Replace dialog is now more accessible and there are input labels that remain visible at all times.
 
 
 [[additions]]


### PR DESCRIPTION
Ticket: DOC-2446

Site: [Staging branch](http://docs-feature-72-doc-2446tiny-10871.staging.tiny.cloud/docs/tinymce/latest/7.2-release-notes/#improved-find-replace-dialog-accessibility-by-changing-placeholders-to-labels)

Changes:
* add improvement fix for TINY-10871

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed