### PR TITLE
DOC-2446: Add `for` attribute to label component in `dialog-components.adoc`.

### DIFF
--- a/modules/ROOT/pages/dialog-components.adoc
+++ b/modules/ROOT/pages/dialog-components.adoc
@@ -162,6 +162,7 @@ A *label* is a layout component that wraps other components and adds a label abo
 {
   type: 'label', // component type
   label: 'Caption', // text for the group label
+  for: 'findtext', // identifier of the dialog label component
   items: [ ... ] // array of panel components
 }
 ----


### PR DESCRIPTION
Ticket: DOC-2446

Site: [Staging branch](http://docs-feature-72-doc-2446tiny-10971.staging.tiny.cloud/docs/tinymce/latest/dialog-components/#label)

Changes:
* Add `for` attribute to label component in `dialog-components.adoc` to support TINY-10971

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed