### PR TITLE
DOC-2446: Added support for querying the state of the `mceTogglePlainTextPaste` command.

### DIFF
--- a/modules/ROOT/pages/7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.2-release-notes.adoc
@@ -281,6 +281,18 @@ The above code will log the following to the console:
 
 Previously in {productname}, the `referrerpolicy` attribute was not considered as valid for iframe elements. In {productname} {release-version}, this attribute has been added to the schema, allowing users to include the `referrerpolicy` attribute in iframes.
 
+=== Added support for querying the state of the `mceTogglePlainTextPaste` command.
+// #TINY-10938
+
+In {productname} {release-version}, the `mceTogglePlainTextPaste` command has been updated to support querying its state. This allows users to determine whether the paste-as-text mode is currently active.
+
+The `mceTogglePlainTextPaste` command can be queried using the following API:
+
+[source,js]
+----
+tinymce.activeEditor.queryCommandState('mceTogglePlainTextPaste');
+----
+
 
 [[changes]]
 == Changes

--- a/modules/ROOT/pages/editor-command-identifiers.adoc
+++ b/modules/ROOT/pages/editor-command-identifiers.adoc
@@ -601,6 +601,7 @@ The following command states can be queried using the xref:apis/tinymce.editor.a
 |JustifyLeft |Returns `+true+` if the content is formatted using the same markup as the {productname} `+JustifyLeft+` command.
 |JustifyRight |Returns `+true+` if the content is formatted using the same markup as the {productname} `+JustifyRight+` command.
 |mceBlockQuote |Returns `+true+` if the content is formatted using the same markup as the {productname} `+mceBlockQuote+` command.
+|mceTogglePlainTextPaste |Returns `+true+` if the {productname} `+mceTogglePlainTextPaste+` command is active.
 |Outdent |Returns `+true+` if the content is formatted using the same markup as the {productname} `+Outdent+` command.
 |Strikethrough |Returns `+true+` if the content is formatted using the same markup as the {productname} `+Strikethrough+` command.
 |Subscript |Returns `+true+` if the content is formatted using the same markup as the {productname} `+Subscript+` command.
@@ -622,6 +623,7 @@ tinymce.activeEditor.queryCommandState('JustifyFull');
 tinymce.activeEditor.queryCommandState('JustifyLeft');
 tinymce.activeEditor.queryCommandState('JustifyRight');
 tinymce.activeEditor.queryCommandState('mceBlockQuote');
+tinymce.activeEditor.queryCommandState('mceTogglePlainTextPaste');
 tinymce.activeEditor.queryCommandState('Outdent');
 tinymce.activeEditor.queryCommandState('Strikethrough');
 tinymce.activeEditor.queryCommandState('Subscript');


### PR DESCRIPTION
Ticket: DOC-2446

Site: [Staging branch](http://docs-feature-72-doc-2446tiny-tiny-10938.staging.tiny.cloud/docs/tinymce/latest/7.2-release-notes/#added-support-for-querying-the-state-of-the-mcetoggleplaintextpaste-command)

Changes:
* TINY-10938 Release Note Entry: Added support for querying the state of the `mceTogglePlainTextPaste` command.
* Add `mceTogglePlainTextPaste` command to `editor-command-identifiers.adoc`

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [-] Files has been included where required `(if applicable)`
- [-] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [ ] Documentation Team Lead has reviewed