### PR TITLE
DOC-2456: Docs 7 - Update DOMPurify version in security guide

### DIFF
--- a/modules/ROOT/partials/security/sanitizing-html-input-and-protecting-against-xss-attacks-dom-parser-and-dom-purify.adoc
+++ b/modules/ROOT/partials/security/sanitizing-html-input-and-protecting-against-xss-attacks-dom-parser-and-dom-purify.adoc
@@ -5,18 +5,18 @@ Previously, before HTML content was passed to {productname} 5.x, it was parsed u
 
 The `SaxParser` API was developed in the then-absence of alternatives.
 
-When this API’s validate setting was enabled — `validate: true` — `SaxParser` removed elements and attributes that did not fit the declared schema.
+When this API's validate setting was enabled — `validate: true` — `SaxParser` removed elements and attributes that did not fit the declared schema.
 
 And, over its lifetime, `SaxParser` was extended. For example, as of {productname} 5.9, the `SaxParser` API marked attributes with certain names or IDs as unsafe, because some names or IDs can cause the host browser to overwrite existing properties or functions.
 
-For {productname} 6.0, however, this basic parser was removed and replaced with two significantly more thorough alternatives:
+Since {productname} 6.0, this basic parser was removed and replaced with two significantly more thorough alternatives:
 
 . the https://developer.mozilla.org/en-US/docs/Web/API/DOMParser[native browser API], `DOMParser()`; and
 . the Free and Open Source _https://github.com/cure53/DOMPurify[XSS sanitizer for HTML, MathML and SVG]_, DOMPurify.
 
-NOTE: {productname} uses DOMPurify 2.x, which was current at the time version 6 was developed.
+NOTE: {productname} uses DOMPurify 3.x, which was current at the time {productname} {productmajorversion} was developed.
 
-Before HTML (or XML) content is passed to {productname} 6.x, the `DOMParser` API parses the HTML (or XML) string into a https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model[DOM object]. As part of this process, `DOMParser` attempts to correct malformed HTML.
+Before HTML (or XML) content is passed to {productname} {productmajorversion}, the `DOMParser` API parses the HTML (or XML) string into a https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model[DOM object]. As part of this process, `DOMParser` attempts to correct malformed HTML.
 
 For example, the following string:
 


### PR DESCRIPTION
Ticket: DOC-2456

Site: [Staging branch](http://docs-hotfix-7-doc-2456.staging.tiny.cloud/docs/tinymce/latest/security/#sanitizing-html-input-to-protect-against-xss-attacks)

**The version of DOMPurify used in TinyMCE was updated to 3.x in [this commit](https://github.com/tinymce/tinymce/pull/9020/files) which was released with TinyMCE 6.8.0, however, the documentation was never updated to match this.**

Changes:
* Update DOMPurify version in security guide
* Update some TinyMCE 6 references with TinyMCE 7

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [-] Files has been included where required `(if applicable)`
- [-] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [-] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed