### PR TITLE
DOC-2457: TinyMCE 6.8.4 Security Patch.

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -407,6 +407,9 @@
 ** xref:tinymce-and-cors.adoc[Cross-Origin Resource Sharing (CORS)]
 * Release information
 ** xref:release-notes.adoc[Release notes for {productname} 6]
+*** {productname} 6.8.4
+**** xref:6.8.4-release-notes.adoc#overview[Overview]
+**** xref:6.8.4-release-notes.adoc#security-fix[Security fix]
 *** {productname} 6.8.3
 **** xref:6.8.3-release-notes.adoc#overview[Overview]
 **** xref:6.8.3-release-notes.adoc#accompanying-premium-self-hosted-server-side-component-changes[Accompanying Premium self-hosted server-side component changes]

--- a/modules/ROOT/pages/6.8.4-release-notes.adoc
+++ b/modules/ROOT/pages/6.8.4-release-notes.adoc
@@ -1,0 +1,45 @@
+= TinyMCE {release-version}
+:release-version: 6.8.4
+:navtitle: TinyMCE {release-version}
+:description: Release notes for TinyMCE {release-version}
+:keywords: releasenotes, new, changes, bugfixes
+:page-toclevels: 1
+
+include::partial$misc/admon-releasenotes-for-stable.adoc[]
+
+[[overview]]
+== Overview
+
+{productname} {release-version} was released for {enterpriseversion} and {cloudname} on Wednesday, June 19^th^, 2024. These release notes provide an overview of the changes for {productname} {release-version}, including:
+
+* xref:security-fixes[Security fixes]
+
+
+[[security-fixes]]
+== Security fixes
+
+{productname} 6.8.4 includes two fixes for the following security issues:
+
+=== HTML entities that were double decoded in `noscript` elements caused an XSS vulnerability.
+// #TINY-11019
+
+A https://owasp.org/www-community/attacks/xss/[cross-site scripting] (XSS) vulnerability was discovered in {productname}'s content parsing code. This allowed specially crafted `noscript` elements containing malicious code to be executed when that content was loaded into the editor.
+
+This vulnerability has been patched in {productname} 7.2.0, {productname} {release-version} and {productname} 5.11.0 LTS by ensuring that content within `noscript` elements are properly parsed.
+
+GHSA: link:https://github.com/tinymce/tinymce/security/advisories/GHSA-w9jx-4g6g-rp7x[GitHub Advisory].
+
+CVE: Pending.
+
+NOTE: Tiny Technologies would like to thank link:https://malavkhatri.com/[Malav Khatri (devilbugbounty)] and another reported for discovering this vulnerability.
+
+=== It was possible to inject XSS HTML that was not matching the regexp when using the `noneditable_regexp` option.
+// #TINY-11022
+
+A https://owasp.org/www-community/attacks/xss/[cross-site scripting] (XSS) vulnerability was discovered in {productname}'s content extraction code. When using the `noneditable_regexp` option, specially crafted HTML attributes containing malicious code were able to be executed when content was extracted from the editor.
+
+This vulnerability has been patched in {productname} 7.2.0, {productname} {release-version} and {productname} 5.11.0 LTS by ensuring that, when using the `noneditable_regexp` option, any content within an attribute is properly verified to match the configured regular expression before being added.
+
+GHSA: link:https://github.com/tinymce/tinymce/security/advisories/GHSA-9hcv-j9pv-qmph[GitHub Advisory].
+
+CVE: Pending.

--- a/modules/ROOT/pages/6.8.4-release-notes.adoc
+++ b/modules/ROOT/pages/6.8.4-release-notes.adoc
@@ -31,7 +31,7 @@ GHSA: link:https://github.com/tinymce/tinymce/security/advisories/GHSA-w9jx-4g6g
 
 CVE: Pending.
 
-NOTE: Tiny Technologies would like to thank link:https://malavkhatri.com/[Malav Khatri (devilbugbounty)] and another reported for discovering this vulnerability.
+NOTE: Tiny Technologies would like to thank link:https://malavkhatri.com/[Malav Khatri (devilbugbounty)] and another reporter for discovering this vulnerability.
 
 === It was possible to inject XSS HTML that was not matching the regexp when using the `noneditable_regexp` option.
 // #TINY-11022

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -4,6 +4,12 @@
 
 NOTE: This is the {productname} Community version changelog. For information about the latest {cloudname} or {enterpriseversion} Release, see: xref:release-notes.adoc[{productname} Release Notes].
 
+## 6.8.4 - 2024-06-19
+
+=== Fixed
+* HTML entities that were double decoded in `noscript` elements caused an XSS vulnerability.
+* It was possible to inject XSS HTML that was not matching the regexp when using the `noneditable_regexp` option.
+
 == 6.8.3 - 2024-02-08
 
 === Changed

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -11,6 +11,12 @@ This section lists the releases for {productname} 6 and the changes made in each
 
 a|
 [.lead]
+xref:6.8.4-release-notes.adoc#overview[{productname} 6.8.4]
+
+Release notes for {productname} 6.8.4
+
+a|
+[.lead]
 xref:6.8.3-release-notes.adoc#overview[{productname} 6.8.3]
 
 Release notes for {productname} 6.8.3


### PR DESCRIPTION
Ticket: DOC-2457

Site: [Staging branch](http://docs-hotfix-684-doc-2457.staging.tiny.cloud/docs/tinymce/6/6.8.4-release-notes/#overview)
Site: [Staging branch](http://docs-hotfix-684-doc-2457.staging.tiny.cloud/docs/tinymce/6/changelog/#6-8-4-2024-06-19)

Changes:
* TinyMCE Cross-Site Scripting (XSS) vulnerability using `noneditable_regexp` option
* TinyMCE Cross-Site Scripting (XSS) vulnerability using `noscript` elements

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed