### PR TITLE
DOC-2457: TinyMCE 7.2 Security Patch.

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -413,6 +413,7 @@
 **** xref:7.2-release-notes.adoc#additions[Additions]
 **** xref:7.2-release-notes.adoc#changes[Changes]
 **** xref:7.2-release-notes.adoc#bug-fixes[Bug fixes]
+**** xref:7.2-release-notes.adoc#security-fixes[Security fixes]
 *** {productname} 7.1.2
 **** xref:7.1.2-release-notes.adoc#overview[Overview]
 **** xref:7.1.2-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]

--- a/modules/ROOT/pages/7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.2-release-notes.adoc
@@ -19,6 +19,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 * xref:additions[Additions]
 * xref:changes[Changes]
 * xref:bug-fixes[Bug fixes]
+* xref:security-fix[Security fix]
 
 
 [[accompanying-premium-self-hosted-server-side-component-changes]]
@@ -354,3 +355,32 @@ Previously in {productname}, the `role` attribute on listbox dialog components w
 In {productname} {release-version}, this issue has been addressed by setting the `role` attribute to `combobox` when there are no nested menu items.
 
 As a result, screen readers now announce the listbox as a combobox and the menu it opens as a listbox. This improvement ensures that the currently selected value is announced when tabbing to the select box, and the selected items are announced as a listbox.
+
+[[security-fixes]]
+== Security fixes
+
+{productname} {release-version} includes two fixes for the following security issues:
+
+=== HTML entities that were double decoded in `noscript` elements caused an XSS vulnerability.
+// #TINY-11019
+
+A https://owasp.org/www-community/attacks/xss/[cross-site scripting] (XSS) vulnerability was discovered in {productname}'s content parsing code. This allowed specially crafted `noscript` elements containing malicious code to be executed when that content was loaded into the editor.
+
+This vulnerability has been patched in {productname} {release-version}, {productname} 6.8.4 and {productname} 5.11.0 LTS by ensuring that content within `noscript` elements are properly parsed.
+
+GHSA: link:https://github.com/tinymce/tinymce/security/advisories/GHSA-w9jx-4g6g-rp7x[GitHub Advisory].
+
+CVE: Pending.
+
+NOTE: Tiny Technologies would like to thank link:https://malavkhatri.com/[Malav Khatri (devilbugbounty)] and another reported for discovering this vulnerability.
+
+=== It was possible to inject XSS HTML that was not matching the regexp when using the `noneditable_regexp` option.
+// #TINY-11022
+
+A https://owasp.org/www-community/attacks/xss/[cross-site scripting] (XSS) vulnerability was discovered in {productname}'s content extraction code. When using the `noneditable_regexp` option, specially crafted HTML attributes containing malicious code were able to be executed when content was extracted from the editor.
+
+This vulnerability has been patched in {productname} {release-version}, {productname} 6.8.4 and {productname} 5.11.0 LTS by ensuring that, when using the `noneditable_regexp` option, any content within an attribute is properly verified to match the configured regular expression before being added.
+
+GHSA: link:https://github.com/tinymce/tinymce/security/advisories/GHSA-9hcv-j9pv-qmph[GitHub Advisory].
+
+CVE: Pending.

--- a/modules/ROOT/pages/7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.2-release-notes.adoc
@@ -372,7 +372,7 @@ GHSA: link:https://github.com/tinymce/tinymce/security/advisories/GHSA-w9jx-4g6g
 
 CVE: Pending.
 
-NOTE: Tiny Technologies would like to thank link:https://malavkhatri.com/[Malav Khatri (devilbugbounty)] and another reported for discovering this vulnerability.
+NOTE: Tiny Technologies would like to thank link:https://malavkhatri.com/[Malav Khatri (devilbugbounty)] and another reporter for discovering this vulnerability.
 
 === It was possible to inject XSS HTML that was not matching the regexp when using the `noneditable_regexp` option.
 // #TINY-11022

--- a/modules/ROOT/pages/7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.2-release-notes.adoc
@@ -19,7 +19,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 * xref:additions[Additions]
 * xref:changes[Changes]
 * xref:bug-fixes[Bug fixes]
-* xref:security-fix[Security fix]
+* xref:security-fixes[Security fixes]
 
 
 [[accompanying-premium-self-hosted-server-side-component-changes]]

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -43,6 +43,11 @@ NOTE: This is the {productname} Community version changelog. For information abo
 // #TINY-10820
 * Corrected the `role` attribute on listbox dialog components to `combobox` when there are no nested menu items.
 // #TINY-10807
+* HTML entities that were double decoded in `noscript` elements caused an XSS vulnerability.
+// #TINY-11019
+* It was possible to inject XSS HTML that was not matching the regexp when using the `noneditable_regexp` option.
+// #TINY-11022
+
 
 == 7.1.2 - 2024-06-05
 


### PR DESCRIPTION
Ticket: DOC-2457

Site: [Changelog Update](http://docs-hotfix-72-doc-24572.staging.tiny.cloud/docs/tinymce/latest/changelog/#7-2-0-2024-06-19:~:text=HTML%20entities%20that,the%20noneditable_regexp%20option.)
Site: [Security Fixes](http://docs-hotfix-72-doc-24572.staging.tiny.cloud/docs/tinymce/latest/7.2-release-notes/#security-fixes)

Changes:
* TinyMCE Cross-Site Scripting (XSS) vulnerability using `noneditable_regexp` option
* TinyMCE Cross-Site Scripting (XSS) vulnerability using `noscript` elements

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed