### PR TITLE
DOC-2461: Add CVE's to the TinyMCE 6.8.4 release notes.

### DIFF
--- a/modules/ROOT/pages/6.8.4-release-notes.adoc
+++ b/modules/ROOT/pages/6.8.4-release-notes.adoc
@@ -29,7 +29,7 @@ This vulnerability has been patched in {productname} 7.2.0, {productname} {relea
 
 GHSA: link:https://github.com/tinymce/tinymce/security/advisories/GHSA-w9jx-4g6g-rp7x[GitHub Advisory].
 
-CVE: Pending.
+CVE: link:https://www.cve.org/CVERecord?id=CVE-2024-38357[CVE-2024-38357]
 
 NOTE: Tiny Technologies would like to thank link:https://malavkhatri.com/[Malav Khatri (devilbugbounty)] and another reporter for discovering this vulnerability.
 
@@ -42,4 +42,4 @@ This vulnerability has been patched in {productname} 7.2.0, {productname} {relea
 
 GHSA: link:https://github.com/tinymce/tinymce/security/advisories/GHSA-9hcv-j9pv-qmph[GitHub Advisory].
 
-CVE: Pending.
+CVE: link:https://www.cve.org/CVERecord?id=CVE-2024-38356[CVE-2024-38356].


### PR DESCRIPTION
Ticket: DOC-2461

Site: [Staging branch](http://docs-hotfix-684-doc-2461.staging.tiny.cloud/docs/tinymce/6/6.8.4-release-notes/#security-fixes)

Changes:
* add CVE for: HTML entities that were double decoded in `noscript` elements caused an XSS vulnerability. 
* add CVE for: It was possible to inject XSS HTML that was not matching the regexp when using the `noneditable_regexp` option.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed