### PR TITLE
DOC-2461_2: Add CVE's for TinyMCE 7.2 release notes.

### DIFF
--- a/modules/ROOT/pages/7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.2-release-notes.adoc
@@ -370,7 +370,7 @@ This vulnerability has been patched in {productname} {release-version}, {product
 
 GHSA: link:https://github.com/tinymce/tinymce/security/advisories/GHSA-w9jx-4g6g-rp7x[GitHub Advisory].
 
-CVE: Pending.
+CVE: link:https://www.cve.org/CVERecord?id=CVE-2024-38357[CVE-2024-38357].
 
 NOTE: Tiny Technologies would like to thank link:https://malavkhatri.com/[Malav Khatri (devilbugbounty)] and another reporter for discovering this vulnerability.
 
@@ -383,4 +383,4 @@ This vulnerability has been patched in {productname} {release-version}, {product
 
 GHSA: link:https://github.com/tinymce/tinymce/security/advisories/GHSA-9hcv-j9pv-qmph[GitHub Advisory].
 
-CVE: Pending.
+CVE: link:https://www.cve.org/CVERecord?id=CVE-2024-38356[CVE-2024-38356].


### PR DESCRIPTION
Ticket: DOC-2461

Site: [Staging branch](http://docs-hotfix-72-doc-24612.staging.tiny.cloud/docs/tinymce/latest/7.2-release-notes/#security-fixes)

Changes:
* add CVE for: HTML entities that were double decoded in noscript elements caused an XSS vulnerability.0
* add CVE for: It was possible to inject XSS HTML that was not matching the regexp when using the noneditable_regexp option.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed