### PR TITLE
DOC-2466: Cursor would shift to the start of the editor body when focus was shifted to a noneditable cell of a table.

### DIFF
--- a/modules/ROOT/pages/7.2.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.2.1-release-notes.adoc
@@ -19,9 +19,20 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 [[bug-fixes]]
 == Bug fixes
 
-{productname} {release-version} also includes the following bug fix<es>:
+{productname} {release-version} also includes the following bug fixes:
 
 === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1
 
 // CCFR here.
+
+=== Cursor would shift to the start of the editor body when focus was shifted to a noneditable cell of a table.
+// #TINY-10127
+
+Previously in {productname}, when the editor did not have focus and a non-editable cell of a table was clicked, the selection was set to the non-editable cell of the table instead of the offscreen element.
+
+As a consequence, placing the selection on the non-editable cell caused the cursor to be incorrectly placed in the editor body and unexpectedly scroll to the top of the editor.
+
+In {productname} {release-version}, the selection handling logic has been updated. Now, the selection is maintained on the offscreen div when necessary to prevent the selection from being changed.
+
+As a result, the selection correctly shifts to the offscreen element when required, maintaining the cursor position and no longer causing the editor to scroll unexpectedly.


### PR DESCRIPTION
Site: [Staging branch](http://docs-feature-721-doc-2466tiny-10127.staging.tiny.cloud/docs/tinymce/latest/7.2.1-release-notes/#cursor-would-shift-to-the-start-of-the-editor-body-when-focus-was-shifted-to-a-noneditable-cell-of-a-table)

Changes:
* DOC-2466: Add TINY-10127 release note entry

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [-] Files has been included where required `(if applicable)`
- [-] Files removed have been deleted, not just excluded from the build `(if applicable)`
- [x] Files added for `New product features`, and included a `release note` entry.

Review:
- [x] Documentation Team Lead has reviewed