### PR TITLE
DOC-2471: Update inline-demo to support `toolbar_sticky_offset`, to correct visual UI issue.

### DIFF
--- a/modules/ROOT/examples/live-demos/inline/index.js
+++ b/modules/ROOT/examples/live-demos/inline/index.js
@@ -2,6 +2,8 @@ const emailHeaderConfig = {
   selector: '.tinymce-heading',
   menubar: false,
   inline: true,
+  toolbar_sticky: true,
+  toolbar_sticky_offset: 110,
   plugins: [
     'lists',
     'powerpaste',
@@ -20,6 +22,8 @@ const emailBodyConfig = {
   selector: '.tinymce-body',
   menubar: false,
   inline: true,
+  toolbar_sticky: true,
+  toolbar_sticky_offset: 110,
   plugins: [
     'link', 'lists', 'powerpaste',
     'autolink', 'tinymcespellchecker'


### PR DESCRIPTION
Ticket: DOC-2471

Site: [Staging branch](http://docs-hotfix-7-doc-2471.staging.tiny.cloud/docs/tinymce/latest/inline-demo/)

Changes:
* Add `toolbar_sticky_offset`, to correct visual UI issue with inline-demos in docs.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed