### PR TITLE
DOC-2466: Long translations of the bottom help text would cause minor graphical issues.

### DIFF
--- a/modules/ROOT/pages/7.2.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.2.1-release-notes.adoc
@@ -26,4 +26,4 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 Previously, resizing the editor caused the statusbar to render the help text incorrectly if it was too long. This was particularly problematic for long translations, as the statusbar did not handle extended text properly, leading to visual misalignment and hiding important elements.
 
-To fix this, the statusbar's CSS was updated to handle overflow text by setting properties like `overflow: hidden;` and adjusting the text height. As a result, the help text now overflows without disrupting the statusbar layout, ensuring a consistent appearance and visibility.
+To fix this, the statusbar's CSS was updated to handle this by retaining the help text on one line and hiding any overflowing text. As a result, the help text now overflows without disrupting the statusbar layout, ensuring a consistent appearance and visibility.

--- a/modules/ROOT/pages/7.2.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.2.1-release-notes.adoc
@@ -21,7 +21,9 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Long translations of the bottom help text would cause minor graphical issues.
+// #TINY-10961
 
-// CCFR here.
+Previously, resizing the editor caused the statusbar to render the help text incorrectly if it was too long. This was particularly problematic for long translations, as the statusbar did not handle extended text properly, leading to visual misalignment and hiding important elements.
+
+To fix this, the statusbar's CSS was updated to handle overflow text by setting properties like `overflow: hidden;` and adjusting the text height. As a result, the help text now overflows without disrupting the statusbar layout, ensuring a consistent appearance and visibility.


### PR DESCRIPTION
Ticket: DOC-2466

Site: [Staging branch](http://docs-feature-721-doc-2466tiny-10961.staging.tiny.cloud/docs/tinymce/latest/7.2.1-release-notes/#long-translations-of-the-bottom-help-text-would-cause-minor-graphical-issues)

Changes:
* add fix documentation for TINY-10961

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed