### PR TITLE
DOC-2475: Remove old link to Tiny Blog - How to use TinyMCE premium plugins in WordPress 5.

### DIFF
--- a/modules/ROOT/pages/wordpress.adoc
+++ b/modules/ROOT/pages/wordpress.adoc
@@ -21,4 +21,3 @@ https://wordpress.org/plugins/tinymce-advanced/[Advanced Editor Tools] is a Word
 For details, visit:
 
 * https://wordpress.org/plugins/tinymce-advanced/[WordPress.org Plugins - Advanced Editor Tools].
-* link:{blogurl}/how-to-use-tinymce-premium-plugins-in-wordpress-5[{companyname} Blog - How to use TinyMCE premium plugins in WordPress 5].


### PR DESCRIPTION
Ticket: DOC-2475

Site: [Staging branch](http://docs-hotfix-7-doc-2475.staging.tiny.cloud/docs/tinymce/latest/wordpress/)

Changes:
* Remove old blog link to `How to use TinyMCE premium plugins in WordPress 5.` in 7x docs.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed