### PR TITLE
DOC-2471_2: Revert toolbar_sticky_offset fix.

### DIFF
--- a/modules/ROOT/examples/live-demos/inline/index.js
+++ b/modules/ROOT/examples/live-demos/inline/index.js
@@ -2,8 +2,6 @@ const emailHeaderConfig = {
   selector: '.tinymce-heading',
   menubar: false,
   inline: true,
-  toolbar_sticky: true,
-  toolbar_sticky_offset: 110,
   plugins: [
     'lists',
     'powerpaste',
@@ -22,8 +20,6 @@ const emailBodyConfig = {
   selector: '.tinymce-body',
   menubar: false,
   inline: true,
-  toolbar_sticky: true,
-  toolbar_sticky_offset: 110,
   plugins: [
     'link', 'lists', 'powerpaste',
     'autolink', 'tinymcespellchecker'


### PR DESCRIPTION
Ticket: DOC-2471

Site: [Staging branch](http://docs-hotfix-7-doc-24712.staging.tiny.cloud/docs/tinymce/latest/inline-demo/)

Changes:
* Revert `toolbar_sticky_offset` fix until TINY-11071 is fixed.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [ ] Documentation Team Lead has reviewed