### PR TITLE
DOC-2466: `Open Link` button was disabled when selection partially covered a link or when multiple links were selected.

### DIFF
--- a/modules/ROOT/pages/7.2.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.2.1-release-notes.adoc
@@ -26,4 +26,4 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 Previously, the “Open link” toolbar button and menu item were disabled when a link was partially selected or when the selection included multiple links.
 
-{productname} {release-version} addresses this issue. Now, the "Open link" toolbar button and menu item are enabled when any part of a link or multiple links are within the selection, even when the selection is not perfectly confined to a single link.
+{productname} {release-version} addresses this issue. Now, the "Open link" toolbar button and menu item are enabled when any part of a link or multiple links are within the selection.

--- a/modules/ROOT/pages/7.2.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.2.1-release-notes.adoc
@@ -21,7 +21,9 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Open Link button was disabled when selection partially covered a link or when multiple links were selected.
+// #TINY-11009
 
-// CCFR here.
+Previously, the “Open link” toolbar button and menu item were disabled when a link was partially selected or when the selection included multiple links.
+
+{productname} {release-version} addresses this issue. Now, the "Open link" toolbar button and menu item are enabled when any part of a link or multiple links are within the selection, even when the selection is not perfectly confined to a single link.


### PR DESCRIPTION
Ticket: DOC-2466

Site: [Staging branch](http://docs-feature-721-doc-2466tiny-11009.staging.tiny.cloud/docs/tinymce/latest/7.2.1-release-notes/#open-link-button-was-disabled-when-selection-partially-covered-a-link-or-when-multiple-links-were-selected)

Changes:
* added fix documentation for TINY-11009

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`

Review:
- [x] Documentation Team Lead has reviewed