### PR TITLE
DOC-2438: `Docx to HTML` and `HTML to Docx` converter api documentation.

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -313,14 +313,12 @@
 *** Export to PDF
 **** xref:exportpdf.adoc[Export to PDF]
 **** xref:export-to-pdf-standalone-service.adoc[Export to PDF standalone service]
-*** Export to Word
-**** xref:exportword.adoc[Export to Word]
-**** xref:export-to-word-standalone-service.adoc[Export to Word standalone service]
+*** xref:exportword.adoc[Export to Word]
+**** xref:html-to-docx-converter-api.adoc[HTML to DOCX Converter API]
 *** xref:footnotes.adoc[Footnotes]
 *** xref:formatpainter.adoc[Format Painter]
-*** Import from Word
-**** xref:importword.adoc[Import from Word]
-**** xref:import-from-word-standalone-service.adoc[Import from Word standalone service]
+*** xref:importword.adoc[Import from Word]
+**** xref:docx-to-html-converter-api.adoc[DOCX to HTML Converter API]
 *** xref:editimage.adoc[Image Editing]
 *** xref:inline-css.adoc[Inline CSS]
 *** xref:linkchecker.adoc[Link Checker]

--- a/modules/ROOT/pages/docx-to-html-converter-api.adoc
+++ b/modules/ROOT/pages/docx-to-html-converter-api.adoc
@@ -1,0 +1,67 @@
+= Docx to HTML Converter API
+:navtitle: Docx to HTML Converter API
+:description: The DOCX to HTML converter provides an API for converting Microsoft Word .docx and .dotx files to HTML, allowing users to import content from Word documents directly into their web applications.
+:description_short: The DOCX to HTML converter provides an API for converting Microsoft Word .docx and .dotx files to HTML.
+:keywords: service, exportword, export to docx, export to word, html to docx converter api
+:pluginname: Import from Word
+:servicename: Docx to HTML Converter API
+
+[NOTE]
+This is a premium feature. link:https://www.tiny.cloud/contact/[Contact us] to purchase a license or to learn more about our tailored offers. Note that any documents generated without authentication will be watermarked.
+
+== Overview
+
+The {servicename} provides an API for converting Microsoft Word `.docx` and `.dotx` files to HTML, allowing users to import content from Word documents directly into their web applications. This feature ensures that the imported content retains its original formatting, making it an essential tool for users who require high fidelity in document conversion.
+
+== Key Features
+
+* **High Fidelity Conversion**: Ensures that the content from Word documents is imported with accurate formatting, including styles, lists, tables, images, and hyperlinks.
+* **Seamless Integration**: Easily integrates with a WYSIWYG editor, allowing users to convert Word documents directly within their existing content management workflows.
+* **API Accessibility**: Accessible via a simple REST API, making it easy to incorporate into various applications and services.
+* **Support for Complex Documents**: Handles complex Word documents with multiple sections, headers, footers, and different page layouts.
+* **Customization Options**: Provides options to customize the conversion process to meet specific needs, such as excluding certain elements or converting only specific parts of a document.
+
+[[options]]
+== Flexible Configuration Options
+
+=== Exclude Specific Elements
+
+* **Exclude Images**: Option to exclude images during the conversion process.
+* **Exclude Tables**: Ability to exclude tables, simplifying the resulting content.
+* **Exclude Headers and Footers**: Choose to omit headers and footers from the import.
+
+=== Selective Import
+
+* **Page Range**: Import only specific pages from the Word document.
+* **Section Import**: Select and import specific sections or elements from the document.
+
+=== Formatting Customization
+
+* **Style Mapping**: Map Word document styles to corresponding TinyMCE styles.
+* **Custom CSS**: Apply custom CSS to the converted content for consistent styling.
+
+=== Content Adjustments
+
+* **Replace Text**: Automatically replace specific text or phrases during import.
+* **Content Filtering**: Filter out unwanted content based on predefined rules.
+
+=== Output Options
+
+* **Output Format**: Choose the output format (HTML, JSON) for the converted content.
+* **Preserve Line Breaks**: Option to maintain or adjust line breaks from the original document.
+
+These configuration options enhance the flexibility and control users have over the import process, making it adaptable to various needs and use cases.
+
+[[ideal-use-cases]]
+== Ideal for Various Use Cases
+
+* **Corporate Documentation**: Organizations can seamlessly import Word documents into their web-based content management systems, preserving formatting and styles.
+* **Academic Publishing**: Researchers and educators can easily convert and publish their Word documents on educational platforms or academic journals' websites.
+* **Legal Document Management**: Law firms can streamline the review and editing of Word documents while preserving essential formatting elements.
+* **Content Creation and Blogging**: Bloggers can import their drafts directly into their blogging platform, saving time on reformatting.
+* **Online Learning Platforms**: Instructors can import educational materials directly from Word, improving the learning experience for students.
+* **Government and Public Services**: Government agencies can import documents into their web platforms, ensuring they are accessible in a consistent and professional manner.
+
+== Docx to HTML Converter API Reference
+
+> Explore the comprehensive API documentation at link:https://exportdocx.converter.tiny.cloud/docs#section/Import-from-Word[Docx to HTML Converter API Reference documentation.^]

--- a/modules/ROOT/pages/html-to-docx-converter-api.adoc
+++ b/modules/ROOT/pages/html-to-docx-converter-api.adoc
@@ -1,0 +1,43 @@
+= HTML to Docx Converter API
+:navtitle: Export to Word Standalone Service
+:description: The Export to Microsoft Word feature collects the HTML generated with the tinymce.editor.getContent() method and combines it with the default editor content styles along with the styles provided in the configuration. 
+:description_short: Generate a .docx file directly from any application.
+:keywords: service, exportword, export to docx, export to word, html to docx converter api
+:pluginname: Export to Word
+:servicename: HTML to Docx Converter API
+
+[NOTE]
+This is a premium feature. link:https://www.tiny.cloud/contact/[Contact us] to purchase a license or to learn more about our tailored offers. Note that any documents generated without authentication will be watermarked.
+
+== Overview
+
+The {servicename} allows developers to convert HTML content into DOCX files seamlessly. It is designed to integrate effortlessly into your applications, providing high-quality document conversions with ease.
+
+== Key Features
+
+- **HTML to DOCX Conversion**: Transform HTML content into DOCX files with precision, maintaining the structure and styling.
+- **Customizable Outputs**: Tailor the DOCX output to match your requirements, including custom headers, footers, and styles.
+- **High Performance**: Engineered for efficiency, ensuring fast and reliable document conversions.
+- **Ease of Integration**: Simple RESTful API interface that can be integrated into any application or workflow.
+
+[[options]]
+== Flexible Configuration Options
+
+You can customize the DOCX output by specifying various options in your request:
+
+- **Headers and Footers**: Add custom headers and footers to your DOCX documents.
+- **Styles**: Define custom styles for different HTML elements to ensure your documents look exactly as desired.
+
+== Ideal for Various Use Cases
+
+Examples on how you can use the API to convert an HTML document with custom styles and a header and footer.
+
+* **Legal Document Automation**: Automate the generation of legal documents by converting pre-defined HTML templates into standardized DOCX files, complete with custom headers, footers, and styling.
+* **Dynamic Report Generation**: Generate dynamic reports from HTML data, allowing for consistent formatting and styling across all generated documents.
+* **Educational Material Distribution**: Convert HTML-based educational content into DOCX files for easy distribution and offline access by students.
+* **Newsletter Archiving**: Archive HTML newsletters as DOCX files, preserving the layout and design for future reference.
+
+
+== HTML to Docx Converter API Reference
+
+> Explore the comprehensive API documentation at link:https://exportdocx.converter.tiny.cloud/docs[HTML to Docx Converter API Reference documentation.^]


### PR DESCRIPTION
Ticket: DOC-2438

Site: [HTML to DOCX (Export to Word)](http://docs-feature-7-doc-2438.staging.tiny.cloud/docs/tinymce/latest/html-to-docx-converter-api/)
Site: [DOCX to HTML (Import from Word)](http://docs-feature-7-doc-2438.staging.tiny.cloud/docs/tinymce/latest/docx-to-html-converter-api/)

Changes:
* Add new `Docx to HTML Converter API` docs page to documentation suite.
* Add new  `HTML to Docx Converter API` page to documentation suite.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`
- [x] Files has been included where required `(if applicable)`

Review:
- [ ] Documentation Team Lead has reviewed