### PR TITLE
DOC-2469: Fix release-notes.adoc table

### DIFF
--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -52,6 +52,6 @@ xref:7.0-release-notes.adoc#overview[{productname} 7.0]
 Release notes for {productname} 7.0
 
 // Uncomment this dummy cell when the number of cells above is odd to ensure the table renders correctly.
-// a|
+a|
 
 |===


### PR DESCRIPTION
Ticket: DOC-2469

Site: [Staging branch](http://docs-hotfix-7-doc-24692.staging.tiny.cloud/docs/tinymce/latest/release-notes)

Changes:
* Fix release-notes.adoc table to show to final entry.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [-] Included a `release note` entry for any `New product features`.
- [-] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed