### PR TITLE
Update export to  Word config options to support v2 improved flexibility, and plugin descriptions.

### DIFF
--- a/modules/ROOT/pages/exportpdf.adoc
+++ b/modules/ROOT/pages/exportpdf.adoc
@@ -12,7 +12,7 @@ include::partial$misc/admon-export-pdf-paid-addon-pricing.adoc[]
 
 include::partial$misc/admon-requires-7.0v.adoc[]
 
-The {pluginname} functionality gathers the HTML produced using the `editor.getcontent()` method and the default editor content styles, along with the styles specified in the configuration options for the plugin. This data is transmitted to the {productname} Cloud Services HTML to PDF converter service. The service processes this information to create a PDF file, which is then sent back to the user's browser for saving to their local disk.
+The {pluginname} feature collects the HTML generated with the `tinymce.editor.getContent()` method and combines it with the default editor content styles along with the styles provided in the plugin configuration. The combined content and styles are then processed by the included server-side converter service, which can be either self-hosted or cloud-based. Following this processing, a PDF file is generated, which is subsequently returned to the user’s browser, enabling them to save it onto their disk or drive.
 
 == Interactive example
 

--- a/modules/ROOT/pages/exportword.adoc
+++ b/modules/ROOT/pages/exportword.adoc
@@ -11,7 +11,7 @@ include::partial$misc/admon-export-word-paid-addon-pricing.adoc[]
 
 include::partial$misc/admon-requires-7.0v.adoc[]
 
-The export to Microsoft Word feature collects the HTML generated with the `tinymce.editor.getContent()` method and combines it with the default editor content styles along with the styles provided in the configuration. The combined content and styles are then transmitted to the {productname} Cloud Services HTML to DOCX converter service. Following this, the service generates a Word file, which is subsequently returned to the user’s browser, enabling them to save it in the Word format onto their disk.
+The export to Microsoft Word feature collects the HTML generated with the `tinymce.editor.getContent()` method and combines it with the default editor content styles along with the styles provided in the plugin configuration. The combined content and styles are then processed by the included server-side converter service, which can be either self-hosted or cloud-based. Following this processing, a Word file is generated, which is subsequently returned to the user’s browser, enabling them to save it in the Word format onto their disk or drive.
 
 == Interactive example
 

--- a/modules/ROOT/pages/exportword.adoc
+++ b/modules/ROOT/pages/exportword.adoc
@@ -58,4 +58,4 @@ include::partial$commands/{plugincode}-cmds.adoc[][leveloffset=+1]
 
 == API Reference
 
-> Explore the comprehensive API documentation for the {pluginname} Premium plugin at https://exportdocx.converter.tiny.cloud/docs#section/Export-to-Word[Export to Word.^]
+> Explore the comprehensive API documentation for the {pluginname} Premium plugin at link:https://exportdocx.converter.tiny.cloud/v2/convert/docs#section/Export-to-Word[Export to Word.^]

--- a/modules/ROOT/pages/importword.adoc
+++ b/modules/ROOT/pages/importword.adoc
@@ -57,4 +57,4 @@ include::partial$commands/{plugincode}-cmds.adoc[]
 
 == API Reference
 
-> Explore the comprehensive API documentation for the {pluginname} Premium plugin at link:https://exportdocx.converter.tiny.cloud/v2/convert/docs#section/Import-from-Word[Import from Word.^]
+> Explore the comprehensive API documentation for the {pluginname} Premium plugin at link:https://importdocx.converter.tiny.cloud/v2/convert/docs#section/Import-from-Word[Import from Word.^]

--- a/modules/ROOT/pages/importword.adoc
+++ b/modules/ROOT/pages/importword.adoc
@@ -57,4 +57,4 @@ include::partial$commands/{plugincode}-cmds.adoc[]
 
 == API Reference
 
-> Explore the comprehensive API documentation for the {pluginname} Premium plugin at https://importdocx.converter.tiny.cloud/docs#section/Import-from-Word[Import from Word.^]
+> Explore the comprehensive API documentation for the {pluginname} Premium plugin at link:https://exportdocx.converter.tiny.cloud/v2/convert/docs#section/Import-from-Word[Import from Word.^]

--- a/modules/ROOT/partials/configuration/exportword.adoc
+++ b/modules/ROOT/partials/configuration/exportword.adoc
@@ -60,7 +60,7 @@ tinymce.init({
     },
     document: {
       orientation: "landscape",
-      size: "A3",
+      size: "a3",
       margins: {
         top: "10mm",
         bottom: "10mm",
@@ -75,12 +75,12 @@ tinymce.init({
 [NOTE]
 To use this option, the Export to Word plugin requires the `exportword_service_url` option to be configured.
 
-> For comprehensive details regarding the `exportword_converter_options`, please refer to the https://exportdocx.converter.tiny.cloud/docs#section/Export-to-Word[API documentation^] available for the {pluginname} Premium plugin.
+> For comprehensive details regarding the `exportword_converter_options`, please refer to the link:https://exportdocx.converter.tiny.cloud/v2/convert/docs#section/Export-to-Word[API documentation^] available for the {pluginname} Premium plugin.
 
 [[exportword-converter-style]]
 == `exportword_converter_style`
 
-The `exportword_converter_style` option allow for customization of the styles applied to the exported Word document, providing flexibility in controlling its appearance.
+The `exportword_converter_style` option allows for customization of the styles applied to the exported Word document, providing flexibility in controlling its appearance; however, this option does **not affect** the distinct styling of the `header` and `footer`.
 
 *Type:* `+String+`
 

--- a/modules/ROOT/partials/configuration/exportword.adoc
+++ b/modules/ROOT/partials/configuration/exportword.adoc
@@ -60,7 +60,7 @@ tinymce.init({
     },
     document: {
       orientation: "landscape",
-      size: "a3",
+      size: "A3",
       margins: {
         top: "10mm",
         bottom: "10mm",

--- a/modules/ROOT/partials/configuration/exportword.adoc
+++ b/modules/ROOT/partials/configuration/exportword.adoc
@@ -3,7 +3,7 @@
 
 The {pluginname} uses the {productname} Cloud Services HTML to DOCX converter service to generate the Word files.
 
-NOTE: The {pluginname} feature is currently only available `on-premise` and requires the `exportword_service_url` option to be configured. https://www.tiny.cloud/contact/[Contact us] if you require this feature.
+NOTE: The {pluginname} feature is currently only available `on-premise` and requires the `exportword_service_url` option to be configured. link:https://www.tiny.cloud/contact/[Contact us] if you require this feature.
 
 *Type:* `+String+`
 
@@ -38,12 +38,36 @@ tinymce.init({
   toolbar: 'exportword',
   exportword_service_url: '<service_URL>',
   exportword_converter_options: {
-    header: [
-      {
-        html: '<h1>First page header.</h1>', //example
-        css: 'h1 { font-size: 30px; }', //example
+    headers: {
+      first: {
+        html: "<p>My document header</p>",
+        css: "p { color: gray; }"
+      },
+      default: {
+        html: "<p>My default header</p>",
+        css: "p { color: blue; }"
       }
-    ],
+    },
+    footers: {
+      odd: {
+        html: "<p>My odd footer</p>",
+        css: "p { font-size: 10px; }"
+      },
+      even: {
+        html: "<p>My even footer</p>",
+        css: "p { font-size: 12px; }"
+      }
+    },
+    document: {
+      orientation: "landscape",
+      size: "a3",
+      margins: {
+        top: "10mm",
+        bottom: "10mm",
+        left: "20mm",
+        right: "15mm"
+      }
+    },
   },
 });
 ----
@@ -71,14 +95,18 @@ tinymce.init({
   plugins: 'exportword',
   toolbar: 'exportword',
   exportword_service_url: '<service_URL>', // required
-  exportword_converter_options: { // required to support "exportword_converter_style"
-    header: [
-      {
-        html: '<h1>First page header.</h1>', //example
-        css: 'h1 { font-size: 30px; }', //example
+  exportword_converter_options: {
+    headers: {
+      first: {
+        html: "<p>My document header</p>",
+        css: "p { color: gray; }"
+      },
+      default: {
+        html: "<p>My default header</p>",
+        css: "p { color: blue; }"
       }
-    ],
+    },
   },
-  exportword_converter_style: 'p { color: cyan !important }'
+  exportword_converter_style: 'p { color: cyan !important }' // will override the set <p> tag styles
 });
 ----

--- a/modules/ROOT/partials/configuration/exportword.adoc
+++ b/modules/ROOT/partials/configuration/exportword.adoc
@@ -107,6 +107,6 @@ tinymce.init({
       }
     },
   },
-  exportword_converter_style: 'p { color: cyan !important }' // will override the set <p> tag styles
+  exportword_converter_style: 'p { color: cyan !important }' // will override the set <p> tag styles in the HTML content
 });
 ----

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-api-usage-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-api-usage-on-premises.adoc
@@ -9,7 +9,7 @@
 The API is available on `+http://localhost:[port]+` (by default the port is 8080).
 
 [NOTE]
-The REST API documentation is available at `+http://localhost:[port]/docs+`.
-Alternatively you can check specification in our public resources for link:https://importdocx.converter.tiny.cloud/docs#section/Import-from-Word[Import from Word^] and the link:https://exportdocx.converter.tiny.cloud/docs#section/Export-to-Word[Export to Word^] plugins.
+The REST API documentation is available at `+http://localhost:[port]/v2/convert/docs+`.
+Alternatively you can check specification in our public resources for link:https://importdocx.converter.tiny.cloud/v2/convert/docs#section/Import-from-Word[Import from Word^] and the link:https://exportdocx.converter.tiny.cloud/v2/convert/docs#section/Export-to-Word[Export to Word^] plugins.
 
 If you have the authorization for the API enabled, you should provide an authorization token. More instructions you can find in the authorization section.

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-autorization-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-autorization-on-premises.adoc
@@ -53,7 +53,7 @@ const config = {
    responseType: 'arraybuffer',
 };
 
-axios.post( 'http://localhost:8080/v1/convert', data, config )
+axios.post( 'http://localhost:8080/v2/convert/html-docx', data, config )
    .then( response => {
       fs.writeFileSync('./file.docx', response.data, 'binary');
    } ).catch( error => {
@@ -63,7 +63,7 @@ axios.post( 'http://localhost:8080/v1/convert', data, config )
 
 `SECRET_KEY`: This is the key what has been passed to the {pluginname} On-Premises instance.
 
-Please refer to the link:https://importdocx.converter.tiny.cloud/docs#section/Import-from-Word[Import from Word^] and the link:https://exportdocx.converter.tiny.cloud/docs#section/Export-to-Word[Export to Word^] REST API documentation to start using the service.
+Please refer to the link:https://importdocx.converter.tiny.cloud/v2/convert/docs#section/Import-from-Word[Import from Word^] and the link:https://exportdocx.converter.tiny.cloud/v2/convert/docs#section/Export-to-Word[Export to Word^] REST API documentation to start using the service.
 
 [NOTE]
 If API clients like Postman or Insomnia are used, then set the JWT token as an `Authorization` header in the `Headers` tab. Do not use the built-in token authorization as this will generate invalid header with a `Bearer` prefix added to the token.

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
@@ -82,7 +82,7 @@ docker-compose up
 
 === Next steps
 
-Use the link:http://localhost:8080/v1/convert[http://localhost:8080/v1/convert] endpoint to export DOCX files. Check out the xref:individual-import-from-word-and-export-to-word-on-premises.adoc#authorization[authorization] section to learn more about tokens and token endpoints.
+Use the link:http://localhost:8080/v2/convert/html-docx[http://localhost:8080/v2/convert/html-docx] endpoint to export DOCX files. Check out the xref:individual-import-from-word-and-export-to-word-on-premises.adoc#authorization[authorization] section to learn more about tokens and token endpoints.
 
 Use the demo page available on link:http://localhost:8080/demo[http://localhost:8080/demo] to generate an example DOCX file.
 

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-logs-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-logs-on-premises.adoc
@@ -42,7 +42,7 @@ An example log for HTTP transport:
     "transport": "http",
     "statusCode": 200,
     "status": "success",
-    "url": "/v2/convert",
+    "url": "/v2/convert/html-docx",
     "method": "POST"
   },
   "tags": "metrics"

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-logs-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-logs-on-premises.adoc
@@ -42,7 +42,7 @@ An example log for HTTP transport:
     "transport": "http",
     "statusCode": 200,
     "status": "success",
-    "url": "/v1/convert",
+    "url": "/v2/convert",
     "method": "POST"
   },
   "tags": "metrics"


### PR DESCRIPTION
Ticket: DOC-2482

Site: [Staging branch](http://docs-feature-73-doc-2482.staging.tiny.cloud/docs/tinymce/latest/exportword/)
Site: [Staging branch](http://docs-feature-73-doc-2482.staging.tiny.cloud/docs/tinymce/latest/exportpdf/#:~:text=The%20Export%20to,disk%20or%20drive.)
Site: [Docker changes to support v2](http://docs-feature-73-doc-2482.staging.tiny.cloud/docs/tinymce/latest/individual-import-from-word-and-export-to-word-on-premises/)

Changes:
* Preparation for updating `tinymce/exportword` plugin documentation for incoming changes for `v2`.
* update includes, improving `code` block examples for `exportword_converter_options` and `exportword_converter_style` due to `option` name changes.
* In addition updates to `exportword` plugin description and `improved` wording to `exportPDF` description.
* update links and Import from Word and Export to Word service server-side component using Docker sub-section config changes to support v2

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] Update `SLUG` to new `v2` documentation URL.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.
- [x] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed