### PR TITLE
DOC-2486: Add requires 7.1v admon to Revision History Diff API

### DIFF
--- a/modules/ROOT/partials/plugin-apis/revisionhistory-apis.adoc
+++ b/modules/ROOT/partials/plugin-apis/revisionhistory-apis.adoc
@@ -9,6 +9,8 @@ interface PluginAPI {
 === `diff`
 Returns a HTML string with annotations indicating the changes in `originalHTML` relative to `changedHTML`. The styling of annotations can be customized via xref:revisionhistory_diff_classes[`+revisionhistory_diff_classes+`] option.
 
+include::partial$misc/admon-requires-7.1v.adoc[]
+
 == Example
 [source,js]
 ----


### PR DESCRIPTION
Ticket: DOC-2486

Site: [Staging branch](http://docs-hotfix-7-doc-2486.staging.tiny.cloud/docs/tinymce/latest/revisionhistory/#diff)

Changes:
* Add requires 7.1v admon to Revision History Diff API

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [-] Included a `release note` entry for any `New product features`.
- [-] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed