### PR TITLE
DOC-2487: (6 Docs) Replace 'en' with 'en_US' in Spellchecker docs and demo

### DIFF
--- a/modules/ROOT/examples/live-demos/spellcheckerpro/index.js
+++ b/modules/ROOT/examples/live-demos/spellcheckerpro/index.js
@@ -3,7 +3,7 @@ tinymce.init({
   plugins: 'code tinymcespellchecker link',
   toolbar: 'spellchecker language spellcheckdialog',
   height: 500,
-  spellchecker_language: 'en',
+  spellchecker_language: 'en_US',
   content_langs: [
     { title: 'English (US)', code: 'en_US' },
     { title: 'English (US Medical)', code: 'en_US', customCode: 'en_US-medical' },

--- a/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
+++ b/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
@@ -29,7 +29,7 @@ With {cloudname} the server-side spellchecking component is automatically config
 tinymce.init({
   selector: 'textarea',
   plugins: 'tinymcespellchecker',
-  spellchecker_language: 'en'
+  spellchecker_language: 'en_US'
 });
 ----
 
@@ -47,7 +47,7 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'tinymcespellchecker',
   spellchecker_rpc_url: 'localhost/ephox-spelling',
-  spellchecker_language: 'en'
+  spellchecker_language: 'en_US'
 });
 ----
 


### PR DESCRIPTION
Ticket: DOC-2487
7 Docs: https://github.com/tinymce/tinymce-docs/pull/3392

Site: [Spellchecker demo](http://docs-hotfix-6-doc-2487.staging.tiny.cloud/docs/tinymce/6/introduction-to-tiny-spellchecker/#interactive-example) (see JS tab)
Site: [Spellchecker docs](http://docs-hotfix-6-doc-2487.staging.tiny.cloud/docs/tinymce/6/introduction-to-tiny-spellchecker/#cloud-installation)

Search terms used to find any occurences of 'en':
 - `spellchecker_language:`
 - `spellchecker_languages:`
 - `'en'`

Changes:
* Replace 'en' with 'en_US' in Spellchecker docs and demo

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [-] Included a `release note` entry for any `New product features`.
- [-] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed