### PR TITLE
DOC-2488: Remove reference of `Cloud Service` from various plugin pages.

### DIFF
--- a/modules/ROOT/pages/exportpdf.adoc
+++ b/modules/ROOT/pages/exportpdf.adoc
@@ -12,7 +12,7 @@ include::partial$misc/admon-export-pdf-paid-addon-pricing.adoc[]
 
 include::partial$misc/admon-requires-7.0v.adoc[]
 
-The {pluginname} functionality gathers the HTML produced using the `editor.getcontent()` method and the default editor content styles, along with the styles specified in the configuration options for the plugin. This data is transmitted to the {productname} Cloud Services HTML to PDF converter service. The service processes this information to create a PDF file, which is then sent back to the user's browser for saving to their local disk.
+The {pluginname} functionality gathers the HTML produced using the `editor.getcontent()` method and the default editor content styles, along with the styles specified in the configuration options for the plugin. This data is transmitted to the {productname} HTML to PDF converter service. The service processes this information to create a PDF file, which is then sent back to the user's browser for saving to their local disk.
 
 == Interactive example
 

--- a/modules/ROOT/pages/exportpdf.adoc
+++ b/modules/ROOT/pages/exportpdf.adoc
@@ -12,7 +12,7 @@ include::partial$misc/admon-export-pdf-paid-addon-pricing.adoc[]
 
 include::partial$misc/admon-requires-7.0v.adoc[]
 
-The {pluginname} functionality gathers the HTML produced using the `editor.getcontent()` method and the default editor content styles, along with the styles specified in the configuration options for the plugin. This data is transmitted to the {productname} HTML to PDF converter service. The service processes this information to create a PDF file, which is then sent back to the user's browser for saving to their local disk.
+The {pluginname} functionality gathers the HTML produced using the `editor.getcontent()` method and the default editor content styles, along with the styles specified in the configuration options for the plugin. This data is transmitted to the HTML to PDF converter service. The service processes this information to create a PDF file, which is then sent back to the user's browser for saving to their local disk.
 
 == Interactive example
 

--- a/modules/ROOT/pages/exportword.adoc
+++ b/modules/ROOT/pages/exportword.adoc
@@ -11,7 +11,7 @@ include::partial$misc/admon-export-word-paid-addon-pricing.adoc[]
 
 include::partial$misc/admon-requires-7.0v.adoc[]
 
-The export to Microsoft Word feature collects the HTML generated with the `tinymce.editor.getContent()` method and combines it with the default editor content styles along with the styles provided in the configuration. The combined content and styles are then transmitted to the {productname} Cloud Services HTML to DOCX converter service. Following this, the service generates a Word file, which is subsequently returned to the user’s browser, enabling them to save it in the Word format onto their disk.
+The export to Microsoft Word feature collects the HTML generated with the `tinymce.editor.getContent()` method and combines it with the default editor content styles along with the styles provided in the configuration. The combined content and styles are then transmitted to the {productname} HTML to DOCX converter service. Following this, the service generates a Word file, which is subsequently returned to the user’s browser, enabling them to save it in the Word format onto their disk.
 
 == Interactive example
 

--- a/modules/ROOT/pages/exportword.adoc
+++ b/modules/ROOT/pages/exportword.adoc
@@ -11,7 +11,7 @@ include::partial$misc/admon-export-word-paid-addon-pricing.adoc[]
 
 include::partial$misc/admon-requires-7.0v.adoc[]
 
-The export to Microsoft Word feature collects the HTML generated with the `tinymce.editor.getContent()` method and combines it with the default editor content styles along with the styles provided in the configuration. The combined content and styles are then transmitted to the {productname} HTML to DOCX converter service. Following this, the service generates a Word file, which is subsequently returned to the user’s browser, enabling them to save it in the Word format onto their disk.
+The export to Microsoft Word feature collects the HTML generated with the `tinymce.editor.getContent()` method and combines it with the default editor content styles along with the styles provided in the configuration. The combined content and styles are then transmitted to the HTML to DOCX converter service. Following this, the service generates a Word file, which is subsequently returned to the user’s browser, enabling them to save it in the Word format onto their disk.
 
 == Interactive example
 

--- a/modules/ROOT/partials/configuration/exportpdf.adoc
+++ b/modules/ROOT/partials/configuration/exportpdf.adoc
@@ -1,7 +1,7 @@
 [[exportpdf-service-url]]
 == `exportpdf_service_url`
 
-The {pluginname} uses the {productname} HTML to PDF converter service to generate the `document-name.pdf` files.
+The {pluginname} uses the HTML to PDF converter service to generate the `document-name.pdf` files.
 
 NOTE: The {pluginname} feature is currently only available `on-premise` and requires the `exportpdf_service_url` option to be configured. https://www.tiny.cloud/contact/[Contact us] if you require this feature.
 

--- a/modules/ROOT/partials/configuration/exportpdf.adoc
+++ b/modules/ROOT/partials/configuration/exportpdf.adoc
@@ -3,7 +3,7 @@
 
 The {pluginname} uses the HTML to PDF converter service to generate the `document-name.pdf` files.
 
-The {pluginname} feature is currently only available exclusively for `on-premise` setups, requiring a self-hosted HTML to PDF converter service and the `exportpdf_service_url` option to be properly configured. If you require access to this feature, please link:https://www.tiny.cloud/contact/[contact us]. Refer to our xref:individual-export-to-pdf-on-premises.adoc[on-premises documentation] for detailed instructions on deploying the {productname} {pluginname} service server-side component using Docker.
+The {pluginname} feature is currently only available exclusively for `on-premise` setups, requiring a self-hosted HTML to PDF converter service and the `exportpdf_service_url` option to be properly configured. If you require access to this feature, please link:https://www.tiny.cloud/contact/[contact us]. Refer to our xref:individual-export-to-pdf-on-premises.adoc[on-premises documentation] for detailed instructions on deploying the {pluginname} service server-side component using Docker.
 
 [TIP]
 Update the `exportpdf_service_url` configuration in your {productname} setup to point to your host. For instance, if your host is `mycustomhost.com`, the URL will be `https://mycustomhost.com/v1/convert`.

--- a/modules/ROOT/partials/configuration/exportpdf.adoc
+++ b/modules/ROOT/partials/configuration/exportpdf.adoc
@@ -1,7 +1,7 @@
 [[exportpdf-service-url]]
 == `exportpdf_service_url`
 
-The {pluginname} uses the {productname} Cloud Services HTML to PDF converter service to generate the `document-name.pdf` files.
+The {pluginname} uses the {productname} HTML to PDF converter service to generate the `document-name.pdf` files.
 
 NOTE: The {pluginname} feature is currently only available `on-premise` and requires the `exportpdf_service_url` option to be configured. https://www.tiny.cloud/contact/[Contact us] if you require this feature.
 

--- a/modules/ROOT/partials/configuration/exportpdf.adoc
+++ b/modules/ROOT/partials/configuration/exportpdf.adoc
@@ -3,7 +3,10 @@
 
 The {pluginname} uses the HTML to PDF converter service to generate the `document-name.pdf` files.
 
-NOTE: The {pluginname} feature is currently only available `on-premise` and requires the `exportpdf_service_url` option to be configured. https://www.tiny.cloud/contact/[Contact us] if you require this feature.
+The {pluginname} feature is currently only available exclusively for `on-premise` setups, requiring a self-hosted HTML to PDF converter service and the `exportpdf_service_url` option to be properly configured. If you require access to this feature, please link:https://www.tiny.cloud/contact/[contact us]. Refer to our xref:individual-export-to-pdf-on-premises.adoc[on-premises documentation] for detailed instructions on deploying the {productname} {pluginname} service server-side component using Docker.
+
+[TIP]
+Update the `exportpdf_service_url` configuration in your {productname} setup to point to your host. For instance, if your host is `mycustomhost.com`, the URL will be `https://mycustomhost.com/v1/convert`.
 
 *Type:* `+String+`
 

--- a/modules/ROOT/partials/configuration/exportword.adoc
+++ b/modules/ROOT/partials/configuration/exportword.adoc
@@ -3,7 +3,10 @@
 
 The {pluginname} uses the HTML to DOCX converter service to generate the Word files.
 
-NOTE: The {pluginname} feature is currently only available `on-premise` and requires the `exportword_service_url` option to be configured. https://www.tiny.cloud/contact/[Contact us] if you require this feature.
+The {pluginname} feature is currently only available exclusively for `on-premise` setups, requiring a self-hosted HTML to DOCX converter service and the `exportword_service_url` option to be properly configured. If you require access to this feature, please link:https://www.tiny.cloud/contact/[contact us]. Refer to our xref:individual-import-from-word-and-export-to-word-on-premises.adoc[on-premises documentation] for detailed instructions on deploying the {productname} {pluginname} service server-side component using Docker.
+
+[TIP]
+Update the `exportword_service_url` configuration in your {productname} setup to point to your host. For instance, if your host is `mycustomhost.com`, the URL will be `https://mycustomhost.com/v1/convert`.
 
 *Type:* `+String+`
 

--- a/modules/ROOT/partials/configuration/exportword.adoc
+++ b/modules/ROOT/partials/configuration/exportword.adoc
@@ -1,7 +1,7 @@
 [[exportword-service-url]]
 == `exportword_service_url`
 
-The {pluginname} uses the {productname} HTML to DOCX converter service to generate the Word files.
+The {pluginname} uses the HTML to DOCX converter service to generate the Word files.
 
 NOTE: The {pluginname} feature is currently only available `on-premise` and requires the `exportword_service_url` option to be configured. https://www.tiny.cloud/contact/[Contact us] if you require this feature.
 

--- a/modules/ROOT/partials/configuration/exportword.adoc
+++ b/modules/ROOT/partials/configuration/exportword.adoc
@@ -3,7 +3,7 @@
 
 The {pluginname} uses the HTML to DOCX converter service to generate the Word files.
 
-The {pluginname} feature is currently only available exclusively for `on-premise` setups, requiring a self-hosted HTML to DOCX converter service and the `exportword_service_url` option to be properly configured. If you require access to this feature, please link:https://www.tiny.cloud/contact/[contact us]. Refer to our xref:individual-import-from-word-and-export-to-word-on-premises.adoc[on-premises documentation] for detailed instructions on deploying the {productname} {pluginname} service server-side component using Docker.
+The {pluginname} feature is currently only available exclusively for `on-premise` setups, requiring a self-hosted HTML to DOCX converter service and the `exportword_service_url` option to be properly configured. If you require access to this feature, please link:https://www.tiny.cloud/contact/[contact us]. Refer to our xref:individual-import-from-word-and-export-to-word-on-premises.adoc[on-premises documentation] for detailed instructions on deploying the {pluginname} service server-side component using Docker.
 
 [TIP]
 Update the `exportword_service_url` configuration in your {productname} setup to point to your host. For instance, if your host is `mycustomhost.com`, the URL will be `https://mycustomhost.com/v1/convert`.

--- a/modules/ROOT/partials/configuration/exportword.adoc
+++ b/modules/ROOT/partials/configuration/exportword.adoc
@@ -1,7 +1,7 @@
 [[exportword-service-url]]
 == `exportword_service_url`
 
-The {pluginname} uses the {productname} Cloud Services HTML to DOCX converter service to generate the Word files.
+The {pluginname} uses the {productname} HTML to DOCX converter service to generate the Word files.
 
 NOTE: The {pluginname} feature is currently only available `on-premise` and requires the `exportword_service_url` option to be configured. https://www.tiny.cloud/contact/[Contact us] if you require this feature.
 

--- a/modules/ROOT/partials/configuration/importword.adoc
+++ b/modules/ROOT/partials/configuration/importword.adoc
@@ -3,7 +3,7 @@
 
 This option is used for setting the URL endpoint for the DOCX to HTML conversion service.
 
-The {pluginname} feature is currently only available exclusively for `on-premise` setups, requiring a self-hosted version of the DOCX to HTML conversion service and the `importword_service_url` option to be properly configured. If you require access to this feature, please link:https://www.tiny.cloud/contact/[contact us]. Refer to our xref:individual-import-from-word-and-export-to-word-on-premises.adoc[on-premises documentation] for detailed instructions on deploying the {productname} {pluginname} service server-side component using Docker.
+The {pluginname} feature is currently only available exclusively for `on-premise` setups, requiring a self-hosted version of the DOCX to HTML conversion service and the `importword_service_url` option to be properly configured. If you require access to this feature, please link:https://www.tiny.cloud/contact/[contact us]. Refer to our xref:individual-import-from-word-and-export-to-word-on-premises.adoc[on-premises documentation] for detailed instructions on deploying the {pluginname} service server-side component using Docker.
 
 [TIP]
 Update the `importword_service_url` configuration in your {productname} setup to point to your host. For instance, if your host is `mycustomhost.com`, the URL will be `https://mycustomhost.com/v1/convert`.

--- a/modules/ROOT/partials/configuration/importword.adoc
+++ b/modules/ROOT/partials/configuration/importword.adoc
@@ -1,5 +1,5 @@
-[[importword-service-url-option]]
-== `importword_service_url` option
+[[importword-service-url]]
+== `importword_service_url`
 
 This option is used for setting the URL endpoint for the conversion service.
 

--- a/modules/ROOT/partials/configuration/importword.adoc
+++ b/modules/ROOT/partials/configuration/importword.adoc
@@ -1,11 +1,12 @@
 [[importword-service-url]]
 == `importword_service_url`
 
-This option is used for setting the URL endpoint for the conversion service.
+This option is used for setting the URL endpoint for the DOCX to HTML conversion service.
 
-[IMPORTANT]
-If this string value is **not configured** it will return a console.error:
-_The {pluginname} plugin requires the `importword_service_url` to be configured_. If the editor detects an `invalid_URL`, it will return a console.error: _The value provided in `importword_service_url` is not a valid URL_.
+The {pluginname} feature is currently only available exclusively for `on-premise` setups, requiring a self-hosted version of the DOCX to HTML conversion service and the `importword_service_url` option to be properly configured. If you require access to this feature, please link:https://www.tiny.cloud/contact/[contact us]. Refer to our xref:individual-import-from-word-and-export-to-word-on-premises.adoc[on-premises documentation] for detailed instructions on deploying the {productname} {pluginname} service server-side component using Docker.
+
+[TIP]
+Update the `importword_service_url` configuration in your {productname} setup to point to your host. For instance, if your host is `mycustomhost.com`, the URL will be `https://mycustomhost.com/v1/convert`.
 
 *Type:* `+String+`
 
@@ -15,8 +16,12 @@ _The {pluginname} plugin requires the `importword_service_url` to be configured_
 ----
 tinymce.init({
   selector: 'textarea',
-  plugins: 'code importword',
-  toolbar: 'importword code',
+  plugins: 'importword',
+  toolbar: 'importword',
   importword_service_url: '<service-URL>'
 });
 ----
+
+[IMPORTANT]
+If this string value is **not configured** it will return a console.error:
+_The {pluginname} plugin requires the `importword_service_url` to be configured_. If the editor detects an `invalid_URL`, it will return a console.error: _The value provided in `importword_service_url` is not a valid URL_.


### PR DESCRIPTION
Ticket: DOC-2488

Site: [ExportPDF](http://docs-hotfix-7-doc-2488.staging.tiny.cloud/docs/tinymce/latest/exportpdf/#:~:text=The%20Export%20to%20PDF%20uses%20the%20TinyMCE%20HTML%20to%20PDF%20converter%20service%20to%20generate%20the%20document%2Dname.pdf%20files.)

Site: [ExportPDF#intro](http://docs-hotfix-7-doc-2488.staging.tiny.cloud/docs/tinymce/latest/exportpdf/#:~:text=This%20data%20is%20transmitted%20to%20the%20TinyMCE%20HTML%20to%20PDF%20converter%20service.)

Site: [ExportWord](http://docs-hotfix-7-doc-2488.staging.tiny.cloud/docs/tinymce/latest/exportword/#:~:text=The%20Export%20to%20Word%20uses%20the%20TinyMCE%20HTML%20to%20DOCX%20converter%20service%20to%20generate%20the%20Word%20files.)

Site: [ExportWord#intro](http://docs-hotfix-7-doc-2488.staging.tiny.cloud/docs/tinymce/latest/exportword/#:~:text=transmitted%20to%20the%20TinyMCE%20HTML%20to%20DOCX%20converter%20service)

Changes:
* Remove ref of `Cloud Service` from various locations, until the plugin is hosted on the Cloud.
* Remove `option` from `importword_service_url` option header.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed