### PR TITLE
DOC-2463: Added new option `advcode_prettify_getcontent` to Enhanced Code Editor.

### DIFF
--- a/modules/ROOT/pages/7.3-release-notes.adoc
+++ b/modules/ROOT/pages/7.3-release-notes.adoc
@@ -39,7 +39,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 Previously, formatting HTML content within the **Enhanced Code Editor** view or retrieving formatted HTML from the `editor.getContent` API as not possible.
 
-{productname} {release-version} introduces the new `advcode_prettify_getcontent` option, which resolves this issue. When enabled (default is false), calling `editor.getContent` now returns formatted HTML. Additionally, it is now possible to retrieve formatted content by calling `editor.getContent({ prettify: true })`, regardless of the option's status.
+To resolve this issue, {productname} {release-version} introduces a new `advcode_prettify_getcontent` option. When enabled (default: false), `editor.getContent` will return formatted HTML. Additionally, invoking `+editor.getContent({ prettify: true })+` will retrieve formatted HTML content regardless of the option's status.
 
 As a result, It is now possible to obtain formatted content through the editor API.
 

--- a/modules/ROOT/pages/7.3-release-notes.adoc
+++ b/modules/ROOT/pages/7.3-release-notes.adoc
@@ -37,7 +37,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 ==== Added new option `advcode_prettify_getcontent` to Enhanced Code Editor.
 
-Previously, formatting of HTML content was only applied in the **Enhanced Code Editor** view, and as a consequence, it was not possible to obtain formatted HTML content when calling the `editor.getContent` API.
+Previously, formatting HTML content within the **Enhanced Code Editor** view or retrieving formatted HTML from the `editor.getContent` API as not possible.
 
 {productname} {release-version} introduces the new `advcode_prettify_getcontent` option, which resolves this issue. When enabled (default is false), calling `editor.getContent` now returns formatted HTML. Additionally, it is now possible to retrieve formatted content by calling `editor.getContent({ prettify: true })`, regardless of the option's status.
 

--- a/modules/ROOT/pages/7.3-release-notes.adoc
+++ b/modules/ROOT/pages/7.3-release-notes.adoc
@@ -29,17 +29,21 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
-=== <Premium plugin name 1>
+=== Enhanced Code Editor
 
-The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+The {productname} {release-version} release includes an accompanying release of the **Enhanced Code Editor** premium plugin.
 
-**<Premium plugin name 1>** includes the following <fixes, changes, improvements>.
+**Enhanced Code Editor** includes the following improvements.
 
-==== <Premium plugin name 1 change 1>
+==== Added new option `advcode_prettify_getcontent` to Enhanced Code Editor.
 
-// CCFR here.
+Previously, formatting was only applied in the **Enhanced Code Editor** view, and as a consequence users could only obtain raw, unformatted HTML when calling `editor.getContent` via the editor API.
 
-For information on the **<Premium plugin name 1>** premium plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+{productname} {release-version} introduces the new `advcode_prettify_getcontent` option, which resolves this issue. When enabled (default is false), calling `editor.getContent` now returns formatted HTML. Additionally, it is now possible to retrieve formatted content by calling `editor.getContent({ prettify: true })`, regardless of the option's status.
+
+As a result, It is now possible to obtain formatted content through the editor API.
+
+For more information on the **Enhanced Code Editor** premium plugin, see: xref:advcode.adoc[Enhanced Code Editor].
 
 
 [[accompanying-enhanced-skins-and-icon-packs-changes]]

--- a/modules/ROOT/pages/7.3-release-notes.adoc
+++ b/modules/ROOT/pages/7.3-release-notes.adoc
@@ -37,7 +37,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 ==== Added new option `advcode_prettify_getcontent` to Enhanced Code Editor.
 
-Previously, formatting was only applied in the **Enhanced Code Editor** view, and as a consequence users could only obtain raw, unformatted HTML when calling `editor.getContent` via the editor API.
+Previously, formatting of HTML content was only applied in the **Enhanced Code Editor** view, and as a consequence, it was not possible to obtain formatted HTML content when calling the `editor.getContent` API.
 
 {productname} {release-version} introduces the new `advcode_prettify_getcontent` option, which resolves this issue. When enabled (default is false), calling `editor.getContent` now returns formatted HTML. Additionally, it is now possible to retrieve formatted content by calling `editor.getContent({ prettify: true })`, regardless of the option's status.
 

--- a/modules/ROOT/partials/configuration/advcode.adoc
+++ b/modules/ROOT/partials/configuration/advcode.adoc
@@ -52,7 +52,6 @@ tinymce.init({
 
 [IMPORTANT]
 If existing HTML content in the database is not well-formatted or has inconsistent indentation, enabling this option may **change the formatting** of previously saved content which may be undesirable in some cases.
-=======
 
 [[advcode_prettify_editor]]
 == `+advcode_prettify_editor+`

--- a/modules/ROOT/partials/configuration/advcode.adoc
+++ b/modules/ROOT/partials/configuration/advcode.adoc
@@ -32,9 +32,11 @@ When this option is set to `true` it will format the HTML code when `editor.getC
 
 This is equivalent to retrieving formatted content by calling `+tinymce.activeEditor.getContent({ prettify: true })+`, regardless of the option's status.
 
-Type : `boolean`,
+*Type:* `+Boolean+`
 
-Default: false
+*Default value:* `+false+`
+
+*Possible values:* `+true+`, `+false+`
 
 == Example: basic setup
 

--- a/modules/ROOT/partials/configuration/advcode.adoc
+++ b/modules/ROOT/partials/configuration/advcode.adoc
@@ -28,9 +28,9 @@ include::partial$misc/admon-requires-7.3v.adoc[]
 
 As part of the {productname} 7.3 release, the {pluginname} plugin includes a new option, `advcode_prettify_getcontent`, which is set to `false` by default.
 
-When this option is set to `true` if will format the HTML code when `editor.getContent` is called.
+When this option is set to `true` it will format the HTML code when `editor.getContent` is called.
 
-This is equivalent when retrieving formatted content by calling `+tinymce.activeEditor.getContent({ prettify: true })+`, regardless of the option's status.
+This is equivalent to retrieving formatted content by calling `+tinymce.activeEditor.getContent({ prettify: true })+`, regardless of the option's status.
 
 Type : `boolean`,
 

--- a/modules/ROOT/partials/configuration/advcode.adoc
+++ b/modules/ROOT/partials/configuration/advcode.adoc
@@ -20,3 +20,33 @@ tinymce.init({
   toolbar: 'code',
 });
 ----
+
+[[advcode_prettify_getcontent]]
+== `+advcode_prettify_getcontent+`
+
+include::partial$misc/admon-requires-7.3v.adoc[]
+
+As part of the {productname} 7.3 release, the {pluginname} plugin includes a new option, `advcode_prettify_getcontent`, which is set to `false` by default.
+
+When this option is set to `true` if will format the HTML code when `editor.getContent` is called.
+
+This is equivalent when retrieving formatted content by calling `+tinymce.activeEditor.getContent({ prettify: true })+`, regardless of the option's status.
+
+Type : `boolean`,
+
+Default: false
+
+== Example: basic setup
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea', // change this value according to your HTML
+  plugins: 'advcode',
+  advcode_prettify_getcontent: false,
+  toolbar: 'code',
+});
+----
+
+[IMPORTANT]
+If existing HTML code in the database is not well-formatted or has inconsistent indentation, enabling this option could result in a uniform appearance of the HTML content, but it might also **change the formatting** of previously saved content which maybe undesirable based on specific use case.

--- a/modules/ROOT/partials/configuration/advcode.adoc
+++ b/modules/ROOT/partials/configuration/advcode.adoc
@@ -49,4 +49,4 @@ tinymce.init({
 ----
 
 [IMPORTANT]
-If existing HTML code in the database is not well-formatted or has inconsistent indentation, enabling this option could result in a uniform appearance of the HTML content, but it might also **change the formatting** of previously saved content which maybe undesirable based on specific use case.
+If existing HTML content in the database is not well-formatted or has inconsistent indentation, enabling this option may **change the formatting** of previously saved content which may be undesirable in some cases.

--- a/modules/ROOT/partials/configuration/advcode.adoc
+++ b/modules/ROOT/partials/configuration/advcode.adoc
@@ -43,7 +43,7 @@ Default: false
 tinymce.init({
   selector: 'textarea', // change this value according to your HTML
   plugins: 'advcode',
-  advcode_prettify_getcontent: false,
+  advcode_prettify_getcontent: true,
   toolbar: 'code',
 });
 ----

--- a/modules/ROOT/partials/misc/admon-requires-7.3v.adoc
+++ b/modules/ROOT/partials/misc/admon-requires-7.3v.adoc
@@ -1,0 +1,1 @@
+NOTE: This feature is only available for {productname} 7.3 and later.


### PR DESCRIPTION
Ticket: DOC-2463

Site: [Staging branch- release notes](http://docs-feature-73-doc-2463tiny-11054.staging.tiny.cloud/docs/tinymce/latest/7.3-release-notes/#added-new-option-advcode_prettify_getcontent-to-enhanced-code-editor)
[Staging branch- new option](http://docs-feature-73-doc-2463tiny-11054.staging.tiny.cloud/docs/tinymce/latest/advcode/#advcode_prettify_getcontent)

Changes:
* added new option for TINY-11054

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] Included a `release note` entry for any `New product features`.

Review:
- [x] Documentation Team Lead has reviewed