### PR TITLE
By default, code is now formatted automatically when the Enhanced Code Editor view is opened.

### DIFF
--- a/modules/ROOT/pages/7.3-release-notes.adoc
+++ b/modules/ROOT/pages/7.3-release-notes.adoc
@@ -41,7 +41,7 @@ Previously, the Enhanced Code Editor plugin did not automatically format code wi
 
 With {productname} {release-version}, the new `advcode_prettify_editor` option has been introduced. By default, this option is set to `true`, ensuring that HTML content is automatically formatted upon opening the Enhanced Code Editor view.
 
-Additionally, users can manually format pasted HTML code in the Enhanced Code Editor with a single click using the new "Format Code" button.
+Additionally, users can now format either all content within the Enhanced Code Editor or a specific context selection when clicking on the "Format Code" button.
 
 As a result, code within the Enhanced Code Editor is now more readable.
 

--- a/modules/ROOT/pages/7.3-release-notes.adoc
+++ b/modules/ROOT/pages/7.3-release-notes.adoc
@@ -29,17 +29,23 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
-=== <Premium plugin name 1>
+=== Enhanced Code Editor
 
-The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+The {productname} {release-version} release includes an accompanying release of the **Enhanced Code Editor** premium plugin.
 
-**<Premium plugin name 1>** includes the following <fixes, changes, improvements>.
+**Enhanced Code Editor** includes the following improvements.
 
-==== <Premium plugin name 1 change 1>
+==== By default, code is now formatted automatically when the Enhanced Code Editor view is opened.
 
-// CCFR here.
+Previously, the Enhanced Code Editor plugin did not automatically format code with indentation, resulting in less readable source code for users.
 
-For information on the **<Premium plugin name 1>** premium plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+With {productname} {release-version}, the new `advcode_prettify_editor` option has been introduced. By default, this option is set to `true`, ensuring that code indentation is automatically formatted upon opening the Enhanced Code Editor view.
+
+Additionally, users can manually format pasted HTML code in the Enhanced Code Editor with a single click using the new "Format Code" button.
+
+As a result, code within the Enhanced Code Editor is now more readable.
+
+For more information on the **Enhanced Code Editor** premium plugin, see: xref:advcode.adoc[Enhanced Code Editor].
 
 
 [[accompanying-enhanced-skins-and-icon-packs-changes]]

--- a/modules/ROOT/pages/7.3-release-notes.adoc
+++ b/modules/ROOT/pages/7.3-release-notes.adoc
@@ -39,7 +39,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 Previously, the Enhanced Code Editor plugin did not automatically format code with indentation, resulting in less readable source code for users.
 
-With {productname} {release-version}, the new `advcode_prettify_editor` option has been introduced. By default, this option is set to `true`, ensuring that code indentation is automatically formatted upon opening the Enhanced Code Editor view.
+With {productname} {release-version}, the new `advcode_prettify_editor` option has been introduced. By default, this option is set to `true`, ensuring that HTML content is automatically formatted upon opening the Enhanced Code Editor view.
 
 Additionally, users can manually format pasted HTML code in the Enhanced Code Editor with a single click using the new "Format Code" button.
 

--- a/modules/ROOT/partials/configuration/advcode.adoc
+++ b/modules/ROOT/partials/configuration/advcode.adoc
@@ -20,3 +20,31 @@ tinymce.init({
   toolbar: 'code',
 });
 ----
+
+[[advcode_prettify_editor]]
+== `+advcode_prettify_editor+`
+
+include::partial$misc/admon-requires-7.3v.adoc[]
+
+As part of the {productname} 7.3 release, the {pluginname} plugin includes a new option, `advcode_prettify_editor`, which is set to `true` by default.  
+
+By default, any code rendered inside **Enhanced Coded Editor** will be formatted with correct indentation.
+
+Type : `boolean`,
+
+Default: false
+
+== Example: basic setup
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea', // change this value according to your HTML
+  plugins: 'advcode',
+  advcode_prettify_editor: true, // default value
+  toolbar: 'code',
+});
+----
+
+[NOTE]
+To disable this default behavior, set the `advcode_prettify_editor` option to `false`.


### PR DESCRIPTION
Ticket: DOC-2463

Site: [Staging branch- release notes](http://docs-feature-73-doc-2463tiny-11018.staging.tiny.cloud/docs/tinymce/latest/7.3-release-notes/#by-default-code-is-now-formatted-automatically-when-the-enhanced-code-editor-view-is-opened)
Site: [Staging branch- new option](http://docs-feature-73-doc-2463tiny-11018.staging.tiny.cloud/docs/tinymce/latest/advcode/#advcode_prettify_editor)

Changes:
* add new option to support TINY-11018

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] Included a `release note` entry for any `New product features`.

Review:
- [x] Documentation Team Lead has reviewed