### PR TITLE
DOC-2492: Remove IMPORTANT mention regarding prefix and suffix cannot match in editor config.

### DIFF
--- a/modules/ROOT/pages/mergetags.adoc
+++ b/modules/ROOT/pages/mergetags.adoc
@@ -66,13 +66,13 @@ For example, a merge tag can be set to any available typeface, type-size, foregr
 +
 A selected merge tag can be changed to any other merge tag by using the {pluginname} toolbar menu button.
 
-. Text that matches an existing merge tag will be recognised as a merge tag when it is pasted or otherwise inserted into a {productname} document.
+. Text that matches an existing merge tag will be recognized as a merge tag when it is pasted or otherwise inserted into a {productname} document.
 +
-Content containing the specified prefix and suffix, and matching a specified merge tag, will be inserted as a merge tag when pasted into the editor. For example, if `Sender.Firstname` is a merge tag value, and the merge tag prefix and suffix have their default values, adding the string, `{{Sender.FirstName}}`, to a {productname} document will result in the string automatically being recognised as a merge tag.
+Content containing the specified prefix and suffix, and matching a specified merge tag, will be inserted as a merge tag when pasted into the editor. For example, if `Sender.Firstname` is a merge tag value, and the merge tag prefix and suffix have their default values, adding the string, `{{Sender.FirstName}}`, to a {productname} document will result in the string automatically being recognized as a merge tag.
 
 . {pluginname} can be nested within the `+mergetags_list+` option.
 +
-The `+mergetags_list+` option allows for the specification of a nested menu item within the {pluginname} toolbar menu button. This option allows any number of nested menus and items for merge tag categorisation.
+The `+mergetags_list+` option allows for the specification of a nested menu item within the {pluginname} toolbar menu button. This option allows any number of nested menus and items for merge tag categorization.
 
 == Styling Merge Tags
 

--- a/modules/ROOT/partials/configuration/mergetags_prefix.adoc
+++ b/modules/ROOT/partials/configuration/mergetags_prefix.adoc
@@ -20,5 +20,3 @@ tinymce.init({
   mergetags_prefix: '{{'
 });
 ----
-
-IMPORTANT: Whatever character or characters are set as the Merge Tags prefix, it or they must be different to the characters set as the Merge Tags suffix. For example, if the Merge Tags prefix is set to `%`, the Merge Tags suffix cannot also be `%`.

--- a/modules/ROOT/partials/configuration/mergetags_suffix.adoc
+++ b/modules/ROOT/partials/configuration/mergetags_suffix.adoc
@@ -18,5 +18,3 @@ tinymce.init({
   mergetags_suffix: '}}'
 });
 ----
-
-IMPORTANT: Whatever character or characters are set as the Merge Tags suffix, it or they must be different to the characters set as the Merge Tags prefix. For example, if the Merge Tags suffix is set to `%`, the Merge Tags prefix cannot also be `%`.


### PR DESCRIPTION
Ticket: DOC-2492

Site: [Staging branch](http://docs-hotfix-7-doc-2492.staging.tiny.cloud/docs/tinymce/latest/mergetags/#mergetags_prefix)

Changes:
* hotfix to remove mention that the prefix and suffix cannot match, to support issue `25402`.
* fix spelling errors.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.
- [x] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed