### PR TITLE
DOC-2463: The listbox component had a fixed width and was not a responsive ui element.

### DIFF
--- a/modules/ROOT/pages/7.3-release-notes.adoc
+++ b/modules/ROOT/pages/7.3-release-notes.adoc
@@ -108,7 +108,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === The listbox component had a fixed width and was not a responsive ui element.
 // #TINY-10884
 
-Previously, the listbox component was not responsive as a ui element, due to a fixed width being applied in the `CommonDropdown` component during dialog initialization. This issue has been resolved in {productname} {release-version} by removing the fixed width setting, allowing the listbox component to function as a responsive UI element.
+Previously, the listbox component was not responsive as a UI element, due to a fixed width being applied in the `CommonDropdown` component during dialog initialization. This issue has been resolved in {productname} {release-version} by removing the fixed width setting, allowing the listbox component to function as a responsive UI element.
 
 
 [[security-fixes]]

--- a/modules/ROOT/pages/7.3-release-notes.adoc
+++ b/modules/ROOT/pages/7.3-release-notes.adoc
@@ -105,10 +105,10 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== The listbox component had a fixed width and was not a responsive ui element.
+// #TINY-10884
 
-// CCFR here.
+Previously, the listbox component was not responsive as a ui element, due to a fixed width being applied in the `CommonDropdown` component during dialog initialization. This issue has been resolved in {productname} {release-version} by removing the fixed width setting, allowing the listbox component to function as a responsive UI element.
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-2463

Site: [Staging branch](http://docs-feature-73-doc-2463tiny-10884.staging.tiny.cloud/docs/tinymce/latest/7.3-release-notes/#the-listbox-component-had-a-fixed-width-and-was-not-a-responsive-ui-element)

Changes:
* fix documentation for TINY-10884

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.
- [x] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed