### PR TITLE
DOC-2463: Notifications didn't position and resize properly when resizing the editor or toggling views.

### DIFF
--- a/modules/ROOT/pages/7.3-release-notes.adoc
+++ b/modules/ROOT/pages/7.3-release-notes.adoc
@@ -105,10 +105,16 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Notifications didn't position and resize properly when resizing the editor or toggling views.
+// #TINY-10894
 
-// CCFR here.
+Previously, the function responsible for recalculating the width of notifications only added a width if the notification's width exceeded the boundaries.
+
+As a consequence, when notifications were constrained by boundaries, an additional width was added. However, if the boundaries were later increased, the added width was not adjusted accordingly.
+
+{prouductname} {release-version} addresses this issue. Now, the function now not only adds width when the notification's width exceeds the boundaries but also removes this width when necessary.
+
+As a result, notifications now resize correctly when the boundaries increase, ensuring their width adjusts as expected.
 
 
 [[security-fixes]]

--- a/modules/ROOT/pages/7.3-release-notes.adoc
+++ b/modules/ROOT/pages/7.3-release-notes.adoc
@@ -112,7 +112,7 @@ Previously, the function responsible for recalculating the width of notification
 
 As a consequence, when notifications were constrained by boundaries, an additional width was added. However, if the boundaries were later increased, the added width was not adjusted accordingly.
 
-{prouductname} {release-version} addresses this issue. Now, the function now not only adds width when the notification's width exceeds the boundaries but also removes this width when necessary.
+{prouductname} {release-version} addresses this issue. Now, the function adds width when the notification's width exceeds the boundaries but also removes this width when necessary.
 
 As a result, notifications now resize correctly when the boundaries increase, ensuring their width adjusts as expected.
 


### PR DESCRIPTION
Ticket: DOC-2463

Site: [Staging branch](http://docs-feature-73-doc-2463tiny-10894.staging.tiny.cloud/docs/tinymce/latest/7.3-release-notes/#notifications-didnt-position-and-resize-properly-when-resizing-the-editor-or-toggling-views)

Changes:
* adding fix for TINY-10894

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.
- [x] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed