### PR TITLE
DOC-2463: Double-clicking on a math element now opens the `Math` dialog.

### DIFF
--- a/modules/ROOT/pages/7.3-release-notes.adoc
+++ b/modules/ROOT/pages/7.3-release-notes.adoc
@@ -29,17 +29,22 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
-=== <Premium plugin name 1>
+=== Math Plugin
 
-The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+The {productname} {release-version} release includes an accompanying release of the **Math** premium plugin.
 
-**<Premium plugin name 1>** includes the following <fixes, changes, improvements>.
+This **Math** premium plugin release includes the following improvement:
 
-==== <Premium plugin name 1 change 1>
+==== Double-clicking on a `math` element now opens the Edit Math dialog.
+// #TINY-10964
 
-// CCFR here.
+In earlier versions of the Math plugin, the double-click handler was not implemented, preventing users from opening the Math dialog by double-clicking on a math element within the editor. This behavior was inconsistent with other plugins, such as the code sample dialog.
 
-For information on the **<Premium plugin name 1>** premium plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+To address this inconsistency, {productname} {release-version} introduced a double-click handler for the Math dialog.
+
+Now, users can open the Math dialog by double-clicking on a math element, aligning with the functionality of other plugins.
+
+For more information on the **Math** plugin, see: xref:math.adoc[Math].
 
 
 [[accompanying-enhanced-skins-and-icon-packs-changes]]


### PR DESCRIPTION
Ticket: DOC-2463

Site: [Staging branch](http://docs-feature-73-doc-2463tiny-10964.staging.tiny.cloud/docs/tinymce/latest/7.3-release-notes/#double-clicking-on-a-math-element-now-opens-the-edit-math-dialog)

Changes:
* add fix for TINY-10964

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.
- [x] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed