### PR TITLE
DOC-2463: Markdown will now respect the `Paste as Text` menu option.

### DIFF
--- a/modules/ROOT/pages/7.3-release-notes.adoc
+++ b/modules/ROOT/pages/7.3-release-notes.adoc
@@ -55,6 +55,21 @@ As a result, code within the Enhanced Code Editor is now more readable.
 
 For more information on the **Enhanced Code Editor** premium plugin, see: xref:advcode.adoc[Enhanced Code Editor].
 
+=== Markdown
+
+The {productname} {release-version} release includes an accompanying release of the **Markdown** premium plugin.
+
+This **Markdown** premium plugin release includes the following improvement:
+
+==== Markdown will now respect the 'Paste as Text' menu option.
+// #TINY-10939
+
+In previous versions of the Markdown plugin, pasting text would always modify the content, even if the "Paste as Text" option was active. This caused HTML documents to be altered during paste operations, affecting elements like newlines.
+
+{productname} {release-version} resolves this issue. Now, pasting Markdown does not trigger conversion when the "Paste as Text" button is active.
+
+For information on the **Markdown** plugin, see xref:markdown.adoc[Markdown].
+
 === Math Plugin
 
 The {productname} {release-version} release includes an accompanying release of the **Math** premium plugin.


### PR DESCRIPTION
Ticket: DOC-2463

Site: [Staging branch](http://docs-feature-73-doc-2463tiny-10939.staging.tiny.cloud/docs/tinymce/latest/7.3-release-notes/#markdown-will-now-respect-the-paste-as-text-menu-option)

Changes:
* added `improvement` for TINY-10939

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.
- [x] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed
- [x] Waiting on feedback on Question regarding test.