### PR TITLE
DOC-2463: Attempting to use focus commands on an editor where the cursor had last been in certain `contentEditable="true"` elements would fail.

### DIFF
--- a/modules/ROOT/pages/7.3-release-notes.adoc
+++ b/modules/ROOT/pages/7.3-release-notes.adoc
@@ -141,6 +141,15 @@ As a result, non-breaking spaces between different inline elements are now norma
 
 {productname} {release-version} also includes the following bug fix<es>:
 
+=== Attempting to use focus commands on an editor where the cursor had last been in certain `+contentEditable="true"+` elements would fail.
+// #TINY-11085
+
+Previously, when `+contentEditable="true"+` (CET) fields where not wrapped in `+contentEditable="false"+` (CEF) elements, the elements did not respond properly to focus commands. As a consequence, the focus was not given to the editor as expected, leading to disruptions in user interactions.
+
+{productname} {release-version} addresses this issue. Now, when (CET) fields are **not wrapped** in (CEF) elements, the editor directs the focus to the body of the editor first.
+
+As a result, the editor now correctly returns focus as expected, ensuring seamless user interactions.
+
 === Notifications didn't position and resize properly when resizing the editor or toggling views.
 // #TINY-10894
 


### PR DESCRIPTION
Ticket: DOC-2463

Site: [Staging branch](http://docs-feature-73-doc-2463tiny-11085.staging.tiny.cloud/docs/tinymce/latest/7.3-release-notes/#attempting-to-use-focus-commands-on-an-editor-where-the-cursor-had-last-been-in-certain-contenteditabletrue-elements-would-fail)

Changes:
* add fix documentation for TINY-11085

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.
- [x] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed