### PR TITLE
DOC-2499: 7x Remove UI Bundle Cache

### DIFF
--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -13,6 +13,7 @@ urls:
 ui:
   bundle:
     url: https://tiny-cloud-docs-antora-themes-staging.s3.amazonaws.com/ui-bundle.zip
+    snapshot: true
 asciidoc:
   extensions:
     - '@tinymce/antora-extension-livedemos'

--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -12,7 +12,7 @@ urls:
   latest_version_segment: latest
 ui:
   bundle:
-    url: https://tiny-cloud-docs-antora-themes-staging.s3.amazonaws.com/ui-bundle.zip
+    url: https://tiny-cloud-docs-antora-themes-production.s3.amazonaws.com/ui-bundle.zip
     snapshot: true
 asciidoc:
   extensions:

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -15,6 +15,7 @@ urls:
 ui:
   bundle:
     url: https://tiny-cloud-docs-antora-themes-staging.s3.amazonaws.com/ui-bundle.zip
+    snapshot: true
 asciidoc:
   extensions:
     - '@tinymce/antora-extension-livedemos'

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -14,7 +14,7 @@ urls:
   latest_version_segment: latest
 ui:
   bundle:
-    url: https://tiny-cloud-docs-antora-themes-staging.s3.amazonaws.com/ui-bundle.zip
+    url: https://tiny-cloud-docs-antora-themes-production.s3.amazonaws.com/ui-bundle.zip
     snapshot: true
 asciidoc:
   extensions:


### PR DESCRIPTION
Ticket: DOC-2499

Site: [Staging branch](http://docs-feature-7-doc-2499.staging.tiny.cloud/docs/tinymce/7/)

Changes:
* Always fetch new UI Bundle

Pre-checks:
- [X] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [X] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [X] Included a `release note` entry for any `New product features`.
- [X] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed