### PR TITLE
DOC-2510: Temporarily remove api-ref link from `importword` plugin documentation.

### DIFF
--- a/modules/ROOT/pages/importword.adoc
+++ b/modules/ROOT/pages/importword.adoc
@@ -54,7 +54,3 @@ include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 The {pluginname} plugin provides the following {productname} commands.
 
 include::partial$commands/{plugincode}-cmds.adoc[]
-
-== API Reference
-
-> Explore the comprehensive API documentation for the {pluginname} Premium plugin at link:https://importdocx.converter.tiny.cloud/v2/convert/docs#section/Import-from-Word[Import from Word.^]


### PR DESCRIPTION
Ticket: DOC-2510

Site: [Staging branch](http://docs-hotfix-7-doc-2510.staging.tiny.cloud/docs/tinymce/latest/importword)

Changes:
* Temporarily remove api-ref link from `importword` plugin documentation until the configuration option is implemented.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed