### PR TITLE
DOC-2513: Mouse hover on partially visible dialog collection elements no longer scrolls.

### DIFF
--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -163,9 +163,9 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Mouse hover on partially visible dialog collection elements no longer scrolls
 // #TINY-9915
 
-Previously, an issue caused partially visible collection elements to automatically scroll into view when hovered.
+Previously, an issue caused partially visible collection elements, such as in the Character Map or Emojis dialog, to automatically scroll into view when hovered over.
 
-{productname} {release-version} addresses this issue by preventing scrolling on hover. This ensures that content remains stable and does not unexpectedly move into view.
+{productname} {release-version} addresses this issue by preventing scrolling on hover. This ensures that the dialog remains in place and does not scroll when partially visible elements are hovered over.
 
 
 [[security-fixes]]

--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -163,7 +163,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Mouse hover on partially visible dialog collection elements no longer scrolls
 // #TINY-9915
 
-Previously, an issue caused partially visible collection elements, such as in the Character Map or Emojis dialog, to automatically scroll into view when hovered over.
+Previously, an issue caused partially visible collection elements, such as those in the Character Map or Emojis dialog, to unexpectedly scroll into view with abrupt and unintended movement when hovered over, resulting in a disruptive user experience.
 
 {productname} {release-version} addresses this issue by preventing scrolling on hover. This ensures that the dialog remains in place and does not scroll when partially visible elements are hovered over.
 

--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -160,6 +160,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Mouse hover on partially visible dialog collection elements no longer scrolls
+// #TINY-9915
+
+Previously, an issue caused partially visible collection elements to automatically scroll into view when hovered.
+
+{productname} {release-version} addresses this issue by preventing scrolling on hover. This ensures that content remains stable and does not unexpectedly move into view.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-2513

Site: [Staging branch](http://docs-feature-74-doc-2513tiny-9915.staging.tiny.cloud/docs/tinymce/latest/7.4-release-notes/#mouse-hover-on-partially-visible-dialog-collection-elements-no-longer-scrolls)

Changes:
* bug fix documentation for TINY-9915

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed