### PR TITLE
DOC-2513: Caret would unexpectedly shift to the `non-editable` table row above when pressing Enter.

### DIFF
--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -160,6 +160,14 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Caret would unexpectedly go to a not editable table row above when user pressed enter.
+// #TINY-11077
+
+Previously, an issue where pressing Enter in a table cell caused the selection to shift incorrectly when the row above was set to `contenteditable="false"`. This problem affected table editing functionality, leading to unexpected cursor placement and content modifications.
+
+{productname} {release-version} addresses this issue. Now, this fix ensures that the selection remains stable when adding new lines within editable cells, regardless of the content editable state of adjacent rows.
+
+As a result, users can now reliably edit table contents without experiencing unintended cursor movements.
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -160,7 +160,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
-=== Caret would unexpectedly go to a not editable table row above when user pressed enter.
+=== Caret would unexpectedly shift to the non-editable table row above when pressing Enter.
 // #TINY-11077
 
 Previously, an issue where pressing Enter in a table cell caused the selection to shift incorrectly when the row above was set to `contenteditable="false"`. This problem affected table editing functionality, leading to unexpected cursor placement and content modifications.


### PR DESCRIPTION
Ticket: DOC-2513

Site: [Staging branch](http://docs-feature-74-doc-2513tiny-11077.staging.tiny.cloud/docs/tinymce/latest/7.4-release-notes/#caret-would-unexpectedly-shift-to-the-non-editable-table-row-above-when-pressing-enter)

Changes:
* bug fix documentation for TINY-11077

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed