### PR TITLE
DOC-2513: Pasting a table now places the cursor after the table instead of into the last table cell.

### DIFF
--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -160,6 +160,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Pasting a table now places the cursor after the table instead of into the last table cell.
+// #TINY-11082
+
+Previously, when users copied and pasted a table, the cursor would remain in the last cell of the table, which differed from the behavior in popular word processing applications like Google Docs and Microsoft Word.
+
+{productname} {release-version} addresses this behavior. Now, after pasting a table, the cursor is automatically placed on a new line immediately following the table inside a '+<p>&nbsp;</p>+' tag.
+
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -116,6 +116,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Pasting a table now places the cursor after the table instead of into the last table cell.
+// #TINY-11082
+
+Previously, when users copied and pasted a table, the cursor would remain in the last cell of the table, which differed from the behavior in popular word processing applications like Google Docs and Microsoft Word.
+
+{productname} {release-version} addresses this behavior. Now, after pasting a table, the cursor is automatically placed on a new line immediately following the table inside a '+<p>&nbsp;</p>+' tag.
 
 [[additions]]
 == Additions
@@ -160,12 +166,6 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
-=== Pasting a table now places the cursor after the table instead of into the last table cell.
-// #TINY-11082
-
-Previously, when users copied and pasted a table, the cursor would remain in the last cell of the table, which differed from the behavior in popular word processing applications like Google Docs and Microsoft Word.
-
-{productname} {release-version} addresses this behavior. Now, after pasting a table, the cursor is automatically placed on a new line immediately following the table inside a '+<p>&nbsp;</p>+' tag.
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-2513

Site: [Staging branch](http://docs-feature-74-doc-2513tiny-11082.staging.tiny.cloud/docs/tinymce/latest/7.4-release-notes/#pasting-a-table-now-places-the-cursor-after-the-table-instead-of-into-the-last-table-cell)

Changes:
* add improvements change for TINY-11082

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed