### PR TITLE
DOC-2513: Format button would lose focus after action while navigating through keyboard.

### DIFF
--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -71,6 +71,23 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Enhanced Code Editor
+// TINY-10561
+
+The {productname} {release-version} release includes an accompanying release of the **Enhanced Code Editor** premium plugin.
+
+**Enhanced Code Editor** includes the following fixes, additions, and improvements.
+
+==== Format button would lose focus after action while navigating through keyboard.
+// #TINY-11122
+
+Previously, after using the **Format code** button to format code, the focus would shift to the code editor wrapper instead of remaining on the **Format code** button.
+
+{productname} {release-version} implemented a fix that explicitly refocuses the **Format code** button after the formatting action.
+
+As a result, when pressing the **Format code** button, the focus now remains on the button as intended.
+
+For information on the Enhanced Code Editor plugin, see: xref:advcode.adoc[Enhanced Code Editor].
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement
@@ -160,6 +177,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Added focus function to view button api.
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -81,11 +81,9 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== Format button would lose focus after action while navigating through keyboard.
 // #TINY-11122
 
-Previously, after using the **Format code** button to format code, the focus would shift to the code editor wrapper instead of remaining on the **Format code** button.
+Previously, after using the **Format code** button to format code, the focus would shift to the code editor wrapper instead of remaining on the **Format code** button. This behavior was inconsistent for users who prefer to navigate through the keyboard.
 
-{productname} {release-version} implemented a fix that explicitly refocuses the **Format code** button after the formatting action.
-
-As a result, when pressing the **Format code** button, the focus now remains on the button as intended.
+{productname} {release-version} implemented a fix that explicitly refocuses the **Format code** button after the formatting action. As a result, when pressing the **Format code** button, the focus now remains on the button as intended.
 
 For information on the Enhanced Code Editor plugin, see: xref:advcode.adoc[Enhanced Code Editor].
 

--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -72,7 +72,6 @@ The {productname} {release-version} release includes an accompanying release of 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
 === Enhanced Code Editor
-// TINY-10561
 
 The {productname} {release-version} release includes an accompanying release of the **Enhanced Code Editor** premium plugin.
 


### PR DESCRIPTION
Ticket: DOC-2513

Site: [Staging branch](http://docs-feature-74-doc-2513tiny-11122.staging.tiny.cloud/docs/tinymce/latest/7.4-release-notes/#format-button-would-lose-focus-after-action-while-navigating-through-keyboard)

Changes:
* added fix documentation for TINY-11122

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed