### PR TITLE
DOC-2513: Formatting indent size would be different than CodeMirror indent size.

### DIFF
--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -80,7 +80,11 @@ The {productname} {release-version} release includes an accompanying release of 
 === Formatting indent size would be different than CodeMirror indent size.
 // #TINY-11150
 
-Previously, the indent sizes between CodeMirror and js-beautify (formatter) were inconsistent due to the use of default options for both. As a result, the formatted code did not match the indent settings in CodeMirror, causing discrepancies in code appearance. To resolve this, the formatter's indent settings were adjusted to **2 spaces** to align with CodeMirror, ensuring consistent indent sizes and uniform code presentation.
+Previously, the indent sizes between CodeMirror and js-beautify (formatter) were inconsistent due to the use of default options for both.
+
+As a result, the formatted code did not match the indent settings in CodeMirror, causing discrepancies in code appearance.
+
+{productname} {release-version} addresses this issue. Now, the formatter's indent settings have been adjusted to "2" indent spaces to align with CodeMirror, ensuring consistent indent sizes and uniform code presentation.
 
 For information on the Enhanced Code Editor plugin, see: xref:advcode.adoc[Enhanced Code Editor].
 

--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -71,6 +71,18 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Enhanced Code Editor
+
+The {productname} {release-version} release includes an accompanying release of the **Enhanced Code Editor** premium plugin.
+
+**Enhanced Code Editor** includes the following fixes, additions, and improvements.
+
+=== Formatting indent size would be different than CodeMirror indent size.
+// #TINY-11150
+
+Previously, the indent sizes between CodeMirror and js-beautify (formatter) were inconsistent due to the use of default options for both. As a result, the formatted code did not match the indent settings in CodeMirror, causing discrepancies in code appearance. To resolve this, the formatter's indent settings were adjusted to **2 spaces** to align with CodeMirror, ensuring consistent indent sizes and uniform code presentation.
+
+For information on the Enhanced Code Editor plugin, see: xref:advcode.adoc[Enhanced Code Editor].
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement

--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -80,7 +80,7 @@ The {productname} {release-version} release includes an accompanying release of 
 === Formatting indent size would be different than CodeMirror indent size.
 // #TINY-11150
 
-Previously, the indent sizes between CodeMirror and js-beautify (formatter) were inconsistent due to the use of default options for both.
+Previously, the indent sizes between CodeMirror and the formatter were inconsistent due to the use of default options for both.
 
 As a result, the formatted code did not match the indent settings in CodeMirror, causing discrepancies in code appearance.
 


### PR DESCRIPTION
Ticket: DOC-2513

Site: [Staging branch](http://docs-feature-74-doc-2513tiny-11150.staging.tiny.cloud/docs/tinymce/latest/7.4-release-notes/#formatting-indent-size-would-be-different-than-codemirror-indent-size)

Changes:
* add fix documentation for TINY-11150

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed