### PR TITLE
DOC-2513: Formatter would not remove empty lines.

### DIFF
--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -80,9 +80,9 @@ The {productname} {release-version} release includes an accompanying release of 
 === Formatter would not remove empty lines.
 // #TINY-11146
 
-In previous versions of Enhanced Code Editor, the HTML formatting function used the js-beautify library's default setting of `+preserve_newlines: true+`. This configuration maintained all existing line breaks, including unnecessary ones.
+In previous versions of Enhanced Code Editor, the HTML formatting function retained all line breaks, including unnecessary empty lines, resulting in more spaced-out code than desired.
 
-{productname} {release-version} improves HTML output by explicitly setting `+preserve_newlines: false+` when calling the HTML formatting function. This change removes empty lines during formatting, resulting in cleaner and more compact HTML.
+With {productname} {release-version}, the HTML formatting has been optimized to automatically remove empty lines during the formatting process. This results in cleaner, more compact HTML output.
 
 For information on the Enhanced Code Editor plugin, see: xref:advcode.adoc[Enhanced Code Editor].
 

--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -71,6 +71,24 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Enhanced Code Editor
+
+The {productname} {release-version} release includes an accompanying release of the **Enhanced Code Editor** premium plugin.
+
+**Enhanced Code Editor** includes the following fixes, additions, and improvements.
+
+=== Formatter would not remove empty lines.
+// #TINY-11146
+
+In previous versions of Enhanced Code Editor, the `preserve_newlines` property in the js-beautify library was set to its default value of `+true+` while running the HTML formatting function. "_This configuration keeps unnecessary new lines intact_".
+
+As a consequence, since `preserve_newlines` was **not** disabled, the formatting process retained unwanted empty lines, leading to less optimal HTML output.
+
+{productname} {release-version} addresses this. Now, the `preserve_newlines` property has been explicitly set to `+false+` when invoking the HTML formatting function. This ensures that empty lines are removed during the formatting process.
+
+As a result, unnecessary new lines are no longer preserved, resulting in cleaner and more efficient HTML formatting.
+
+For information on the Enhanced Code Editor plugin, see: xref:advcode.adoc[Enhanced Code Editor].
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement

--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -80,13 +80,9 @@ The {productname} {release-version} release includes an accompanying release of 
 === Formatter would not remove empty lines.
 // #TINY-11146
 
-In previous versions of Enhanced Code Editor, the `preserve_newlines` property in the js-beautify library was set to its default value of `+true+` while running the HTML formatting function. "_This configuration keeps unnecessary new lines intact_".
+In previous versions of Enhanced Code Editor, the HTML formatting function used the js-beautify library's default setting of `+preserve_newlines: true+`. This configuration maintained all existing line breaks, including unnecessary ones.
 
-As a consequence, since `preserve_newlines` was **not** disabled, the formatting process retained unwanted empty lines, leading to less optimal HTML output.
-
-{productname} {release-version} addresses this. Now, the `preserve_newlines` property has been explicitly set to `+false+` when invoking the HTML formatting function. This ensures that empty lines are removed during the formatting process.
-
-As a result, unnecessary new lines are no longer preserved, resulting in cleaner and more efficient HTML formatting.
+{productname} {release-version} improves HTML output by explicitly setting `+preserve_newlines: false+` when calling the HTML formatting function. This change removes empty lines during formatting, resulting in cleaner and more compact HTML.
 
 For information on the Enhanced Code Editor plugin, see: xref:advcode.adoc[Enhanced Code Editor].
 


### PR DESCRIPTION
Ticket: DOC-2513

Site: [Staging branch](http://docs-feature-74-doc-2513tiny-11146.staging.tiny.cloud/docs/tinymce/latest/7.4-release-notes/#formatter-would-not-remove-empty-lines)

Changes:
* ass fix documentation for TINY-11146

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed