### PR TITLE
DOC-2513: Dialog list dropdown menus now close when the browser window resizes.

### DIFF
--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -116,6 +116,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Dialog list dropdown menus now close when the browser window resizes.
+// #TINY-11123
+  
+In previous versions of {productname} any listbox with a fixed-width dropdown would remain open when resizing the browser window, creating a visual discrepancy as other UI elements adjusted to the new window size.
+
+{productname} {release-version} addresses this issue. Now, dropdowns will now automatically close when a window resize event is triggered, preventing the need for resizing the dropdown list itself.
 
 [[additions]]
 == Additions


### PR DESCRIPTION
Ticket: DOC-2513

Site: [Staging branch](http://docs-feature-74-doc-2513tiny-11123.staging.tiny.cloud/docs/tinymce/latest/7.4-release-notes/#dialog-list-dropdown-menus-now-close-when-the-browser-window-resizes)

Changes:
* added fix documentation for TINY-11123

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed