### PR TITLE
DOC-2513: New option  to opt-in to keep math annotations with specific encodings.

### DIFF
--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -145,8 +145,6 @@ tinymce.init({
 
 For more information on the `allow_mathml_annotation_encodings` option, see xref:content-filtering.adoc#allow-mathml-annotation-encodings[allow_mathml_annotation_encodings].
 
-[NOTE]
-To enable this option, the xref:math.adoc[Math] plugin must be enabled in the editor initialization configuration.
 
 [[changes]]
 == Changes

--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -127,6 +127,24 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== New option `allow_mathml_annotation_encodings` to opt-in to keep math annotations with specific encodings.
+// TINY-11166
+
+In previous versions of {productname}, MathML annotation elements were inadvertently stripped during content processing. This caused compatibility issues with tools like Wiris that rely on these annotations.
+
+{productname} {release-version} introduces a new option, `allow_mathml_annotation_encodings`, to address this problem. This option accepts an array of strings, allowing users to specify which annotation encodings should be preserved. By configuring this option, users can ensure proper functionality of MathML-dependent tools while maintaining control over which annotations are retained.
+
+.Example
+[source, js]
+----
+tinymce.init({
+  selector: "textarea",
+  allow_mathml_annotation_encodings: [ 'wiris', 'application/x-tex' ]
+});
+----
+
+[NOTE]
+To enable this option, the xref:math.adoc[Math] plugin must be enabled in the editor initialization configuration.
 
 [[changes]]
 == Changes

--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -143,6 +143,8 @@ tinymce.init({
 });
 ----
 
+For more information on the `allow_mathml_annotation_encodings` option, see xref:content-filtering.adoc#allow-mathml-annotation-encodings[allow_mathml_annotation_encodings].
+
 [NOTE]
 To enable this option, the xref:math.adoc[Math] plugin must be enabled in the editor initialization configuration.
 

--- a/modules/ROOT/pages/content-filtering.adoc
+++ b/modules/ROOT/pages/content-filtering.adoc
@@ -7,6 +7,8 @@ include::partial$configuration/allow_conditional_comments.adoc[]
 
 include::partial$configuration/allow_html_in_named_anchor.adoc[]
 
+include::partial$configuration/allow_mathml_annotation_encodings.adoc[]
+
 include::partial$configuration/allow_unsafe_link_target.adoc[]
 
 include::partial$configuration/br_in_pre.adoc[]

--- a/modules/ROOT/partials/configuration/allow_mathml_annotation_encodings.adoc
+++ b/modules/ROOT/partials/configuration/allow_mathml_annotation_encodings.adoc
@@ -1,0 +1,18 @@
+[[allow-mathml-annotation-encodings]]
+== `+allow_mathml_annotation_encodings+`
+
+This option allows a specific list of valid MathML annotation encodings to be used in the editor.
+
+*Type:* `+Array+` of `+Strings+`
+
+*Default value:* `+[]+` (empty array)
+
+=== Example: using `+allow_mathml_annotation_encodings+`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  allow_mathml_annotation_encodings: [ 'wiris', 'application/x-tex' ]
+});
+----


### PR DESCRIPTION
Ticket: DOC-2513

Site: [Staging branch](http://docs-feature-74-doc-2513tiny-11166.staging.tiny.cloud/docs/tinymce/latest/7.4-release-notes/#new-option-allow_mathml_annotation_encodings-to-opt-in-to-keep-math-annotations-with-specific-encodings)

Site: [content-filtering/#allow-mathml-annotation-encoding](http://docs-feature-74-doc-2513tiny-11166.staging.tiny.cloud/docs/tinymce/latest/content-filtering/#allow-mathml-annotation-encodings)

Changes:
* add addition entry for TINY-11166
* add new option to custom filtering `partials/configuration/allow_mathml_annotation_encodings.adoc`

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed