### PR TITLE
DOC-2513: Copying tables to the clipboard did not correctly separate cells and rows for the "text/plain" MIME type.

### DIFF
--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -165,7 +165,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 Previously, when copying rows from tables, the newline character `+\n+` was not returned correctly, causing cell and row data to be improperly formatted. However, using the "Select All" function before copying preserved the newline characters.
 
-{productname} {release-version} resolves this issue by enhancing the `getTextContent` function in the clipboard handling module. These updates ensure better text extraction from table elements, particularly for complex structures. The updated function now sets a temporary offscreen element to accurately render and retrieve formatted text, resolving problems with detached table elements.
+{productname} {release-version} resolves this issue by enhancing the clipboard handling for text extraction from table elements, particularly for complex structures.
 
 These improvements ensure more consistent and correctly formatted text output when copying table content within the editor.
 

--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -160,6 +160,14 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Copying tables to the clipboard did not correctly separate cells and rows for the "text/plain" MIME type.
+// #TINY-10847
+
+Previously, when copying rows from tables, the newline character `+\n+` was not returned correctly, causing cell and row data to be improperly formatted. However, using the "Select All" function before copying preserved the newline characters.
+
+{productname} {release-version} resolves this issue by enhancing the `getTextContent` function in the clipboard handling module. These updates ensure better text extraction from table elements, particularly for complex structures. The updated function now sets a temporary offscreen element to accurately render and retrieve formatted text, resolving problems with detached table elements.
+
+These improvements ensure more consistent and correctly formatted text output when copying table content within the editor.
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-2513

Site: [Staging branch](http://docs-feature-74-doc-2513tiny-10847.staging.tiny.cloud/docs/tinymce/latest/7.4-release-notes/#copying-tables-to-the-clipboard-did-not-correctly-separate-cells-and-rows-for-the-textplain-mime-type)

Changes:
* add fix documentation for TINY-10847

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed