### PR TITLE
DOC-2513: Markdown will now respect the 'Paste as Text' menu option.

### DIFF
--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-api-usage-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-api-usage-on-premises.adoc
@@ -13,3 +13,6 @@ The REST API documentation is available at `+http://localhost:[port]/v2/convert/
 Alternatively you can check specification in our public resources for link:https://importdocx.converter.tiny.cloud/v2/convert/docs#section/Import-from-Word[Import from Word^] and the link:https://exportdocx.converter.tiny.cloud/v2/convert/docs#section/Export-to-Word[Export to Word^] plugins.
 
 If you have the authorization for the API enabled, you should provide an authorization token. More instructions you can find in the authorization section.
+
+
+test-automation


### PR DESCRIPTION
Ticket: DOC-2513

Site: [Staging branch](http://docs-feature-74-doc-2513bug-1.staging.tiny.cloud/docs/tinymce/latest/7.4-release-notes/#tiny-vwxyz-1-changelog-entry-2)

Changes:
* fix doc for TINY-1111

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.


Review:
- [x] Documentation Team Lead has reviewed