### PR TITLE
DOC-2534: Update the example for lazy loading a revision

### DIFF
--- a/modules/ROOT/examples/live-demos/full-featured/example.js
+++ b/modules/ROOT/examples/live-demos/full-featured/example.js
@@ -146,12 +146,140 @@ tinymce.init({
       title: 'Salutation'
     }
   ],
-  revisionhistory_fetch: () => { // Implement the fetch function for the revision history plugin
+  // For revision history plugin
+  revisionhistory_fetch: () => {
     return Promise.resolve([
       {
-        revisionId: '1',
+        revisionId: '3',
         createdAt: '2023-11-24T22:26:21.578Z',
-        content: '<p>Initial content</p>'
+        author: {
+          id: 'husky',
+          name: 'A Tiny Husky',
+          avatar: '{{imagesdir}}/tiny-husky.jpg'
+        },
+        content: `
+          <p><img style="display: block; margin-left: auto; margin-right: auto;" title="Tiny Logo" src="https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128"></p>
+          <h2 style="text-align: center;">Welcome to the TinyMCE editor demo!</h2>
+          <h2>A simple table to play with</h2>
+          <table style="border-collapse: collapse; width: 100%;" border="1">
+          <thead>
+          <tr>
+          <th>Product</th>
+          <th>Cost</th>
+          <th>Really?</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+          <td>TinyMCE</td>
+          <td>Free</td>
+          <td>YES!</td>
+          </tr>
+          <tr>
+          <td>Plupload</td>
+          <td>Free</td>
+          <td>YES!</td>
+          </tr>
+          </tbody>
+          </table>
+          <h2>Found a bug?</h2>
+          <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
+          <h2>Finally ...</h2>
+          <p><s>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank" rel="noopener">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</s></p>
+          <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
+        `,
+      },
+      {
+        revisionId: '2',
+        createdAt: '2023-11-25T08:30:21.578Z',
+        author: {
+          id: 'tiny.user',
+          name: 'A Tiny User',
+          avatar: '{{imagesdir}}/logos/android-chrome-192x192.png'
+        },
+        content: `
+          <p><img style="display: block; margin-left: auto; margin-right: auto;" title="Tiny Logo" src="https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128"></p>
+          <h2 style="text-align: center;">Welcome to the TinyMCE editor demo!</h2>
+          <h2>Got questions or need help?</span></h2>
+          <ol>
+          <li>Our <a href="../">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+          <li>Have a specific question? Try the <a href="https://stackoverflow.com/questions/tagged/tinymce" target="_blank" rel="noopener"><code>tinymce</code> tag at Stack Overflow</a>.</li>
+          <li>We also offer enterprise grade support as part of <a href="../../../../pricing">TinyMCE premium plans</a>.</li>
+          </ol>
+          <h2>A simple table to play with</h2>
+          <table style="border-collapse: collapse; width: 100%;" border="1">
+          <thead>
+          <tr>
+          <th>Product</th>
+          <th>Cost</th>
+          <th>Really?</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+          <td>TinyMCE</td>
+          <td>Free</td>
+          <td>YES!</td>
+          </tr>
+          <tr>
+          <td>Plupload</td>
+          <td>Free</td>
+          <td>YES!</td>
+          </tr>
+          </tbody>
+          </table>
+          <h2>Found a bug?</h2>
+          <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
+          <h2>Finally ...</h2>
+          <p>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank" rel="noopener">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
+          <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
+        `,
+      },
+      {
+        revisionId: '1',
+        createdAt: '2023-11-29T10:11:21.578Z',
+        author: {
+          id: 'tiny.user',
+          name: 'A Tiny User',
+          avatar: '{{imagesdir}}/logos/android-chrome-192x192.png'
+        },
+        content: `
+          <p><img style="display: block; margin-left: auto; margin-right: auto;" title="Tiny Logo" src="https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128"></p>
+          <h2 style="text-align: center;">Welcome to the TinyMCE editor demo!</h2>
+          <h2>Got questions or need help?</h2>
+          <ul>
+          <li>Our <a href="../">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+          <li>Have a specific question? Try the <a href="https://stackoverflow.com/questions/tagged/tinymce" target="_blank" rel="noopener"><code>tinymce</code> tag at Stack Overflow</a>.</li>
+          <li>We also offer enterprise grade support as part of <a href="../../../../pricing">TinyMCE premium plans</a>.</li>
+          </ul>
+          <h2>A simple table to play with</h2>
+          <table style="border-collapse: collapse; width: 100%;" border="1">
+          <thead>
+          <tr>
+          <th>Product</th>
+          <th>Cost</th>
+          <th>Really?</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+          <td>TinyMCE</td>
+          <td>Free</td>
+          <td>YES!</td>
+          </tr>
+          <tr>
+          <td>Plupload</td>
+          <td>Free</td>
+          <td>YES!</td>
+          </tr>
+          </tbody>
+          </table>
+          <h2>Found a bug?</h2>
+          <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
+          <h2>Finally ...</h2>
+          <p>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank" rel="noopener">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
+          <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
+        `,
       },
     ]);
   },

--- a/modules/ROOT/examples/live-demos/full-featured/index.js
+++ b/modules/ROOT/examples/live-demos/full-featured/index.js
@@ -274,147 +274,142 @@ tinymce.ScriptLoader.loadScripts(['https://cdn.jsdelivr.net/npm/faker@5/dist/fak
     });
   };
 
-  // revisionhistory_fetch
+  // Fetch revisions
   const fetchRevisions = () => {
-  return new Promise((resolve, _reject) => {
-    /* Simulate fetching revisions from a server */
-    setTimeout(() => {
-      resolve([
-        {
-          revisionId: '3',
-          createdAt: '2023-11-24T22:26:21.578Z',
-          author: {
-            id: 'husky',
-            name: 'A Tiny Husky',
-            avatar: '{{imagesdir}}/tiny-husky.jpg'
-          },
-          content: `
-            <p><img style="display: block; margin-left: auto; margin-right: auto;" title="Tiny Logo" src="https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128"></p>
-            <h2 style="text-align: center;">Welcome to the TinyMCE editor demo!</h2>
-            <h2>A simple table to play with</h2>
-            <table style="border-collapse: collapse; width: 100%;" border="1">
-            <thead>
-            <tr>
-            <th>Product</th>
-            <th>Cost</th>
-            <th>Really?</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-            <td>TinyMCE</td>
-            <td>Free</td>
-            <td>YES!</td>
-            </tr>
-            <tr>
-            <td>Plupload</td>
-            <td>Free</td>
-            <td>YES!</td>
-            </tr>
-            </tbody>
-            </table>
-            <h2>Found a bug?</h2>
-            <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
-            <h2>Finally ...</h2>
-            <p><s>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank" rel="noopener">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</s></p>
-            <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
-          `,
+    return Promise.resolve([
+      {
+        revisionId: '3',
+        createdAt: '2023-11-24T22:26:21.578Z',
+        author: {
+          id: 'husky',
+          name: 'A Tiny Husky',
+          avatar: '{{imagesdir}}/tiny-husky.jpg'
         },
-        {
-          revisionId: '2',
-          createdAt: '2023-11-25T08:30:21.578Z',
-          author: {
-            id: 'tiny.user',
-            name: 'A Tiny User',
-            avatar: '{{imagesdir}}/logos/android-chrome-192x192.png'
-          },
-          content: `
-            <p><img style="display: block; margin-left: auto; margin-right: auto;" title="Tiny Logo" src="https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128"></p>
-            <h2 style="text-align: center;">Welcome to the TinyMCE editor demo!</h2>
-            <h2>Got questions or need help?</span></h2>
-            <ol>
-            <li>Our <a href="../">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-            <li>Have a specific question? Try the <a href="https://stackoverflow.com/questions/tagged/tinymce" target="_blank" rel="noopener"><code>tinymce</code> tag at Stack Overflow</a>.</li>
-            <li>We also offer enterprise grade support as part of <a href="../../../../pricing">TinyMCE premium plans</a>.</li>
-            </ol>
-            <h2>A simple table to play with</h2>
-            <table style="border-collapse: collapse; width: 100%;" border="1">
-            <thead>
-            <tr>
-            <th>Product</th>
-            <th>Cost</th>
-            <th>Really?</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-            <td>TinyMCE</td>
-            <td>Free</td>
-            <td>YES!</td>
-            </tr>
-            <tr>
-            <td>Plupload</td>
-            <td>Free</td>
-            <td>YES!</td>
-            </tr>
-            </tbody>
-            </table>
-            <h2>Found a bug?</h2>
-            <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
-            <h2>Finally ...</h2>
-            <p>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank" rel="noopener">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
-            <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
-          `,
+        content: `
+          <p><img style="display: block; margin-left: auto; margin-right: auto;" title="Tiny Logo" src="https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128"></p>
+          <h2 style="text-align: center;">Welcome to the TinyMCE editor demo!</h2>
+          <h2>A simple table to play with</h2>
+          <table style="border-collapse: collapse; width: 100%;" border="1">
+          <thead>
+          <tr>
+          <th>Product</th>
+          <th>Cost</th>
+          <th>Really?</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+          <td>TinyMCE</td>
+          <td>Free</td>
+          <td>YES!</td>
+          </tr>
+          <tr>
+          <td>Plupload</td>
+          <td>Free</td>
+          <td>YES!</td>
+          </tr>
+          </tbody>
+          </table>
+          <h2>Found a bug?</h2>
+          <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
+          <h2>Finally ...</h2>
+          <p><s>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank" rel="noopener">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</s></p>
+          <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
+        `,
+      },
+      {
+        revisionId: '2',
+        createdAt: '2023-11-25T08:30:21.578Z',
+        author: {
+          id: 'tiny.user',
+          name: 'A Tiny User',
+          avatar: '{{imagesdir}}/logos/android-chrome-192x192.png'
         },
-        {
-          revisionId: '1',
-          createdAt: '2023-11-29T10:11:21.578Z',
-          author: {
-            id: 'tiny.user',
-            name: 'A Tiny User',
-            avatar: '{{imagesdir}}/logos/android-chrome-192x192.png'
-          },
-          content: `
-            <p><img style="display: block; margin-left: auto; margin-right: auto;" title="Tiny Logo" src="https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128"></p>
-            <h2 style="text-align: center;">Welcome to the TinyMCE editor demo!</h2>
-            <h2>Got questions or need help?</h2>
-            <ul>
-            <li>Our <a href="../">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
-            <li>Have a specific question? Try the <a href="https://stackoverflow.com/questions/tagged/tinymce" target="_blank" rel="noopener"><code>tinymce</code> tag at Stack Overflow</a>.</li>
-            <li>We also offer enterprise grade support as part of <a href="../../../../pricing">TinyMCE premium plans</a>.</li>
-            </ul>
-            <h2>A simple table to play with</h2>
-            <table style="border-collapse: collapse; width: 100%;" border="1">
-            <thead>
-            <tr>
-            <th>Product</th>
-            <th>Cost</th>
-            <th>Really?</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-            <td>TinyMCE</td>
-            <td>Free</td>
-            <td>YES!</td>
-            </tr>
-            <tr>
-            <td>Plupload</td>
-            <td>Free</td>
-            <td>YES!</td>
-            </tr>
-            </tbody>
-            </table>
-            <h2>Found a bug?</h2>
-            <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
-            <h2>Finally ...</h2>
-            <p>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank" rel="noopener">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
-            <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
-          `,
+        content: `
+          <p><img style="display: block; margin-left: auto; margin-right: auto;" title="Tiny Logo" src="https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128"></p>
+          <h2 style="text-align: center;">Welcome to the TinyMCE editor demo!</h2>
+          <h2>Got questions or need help?</span></h2>
+          <ol>
+          <li>Our <a href="../">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+          <li>Have a specific question? Try the <a href="https://stackoverflow.com/questions/tagged/tinymce" target="_blank" rel="noopener"><code>tinymce</code> tag at Stack Overflow</a>.</li>
+          <li>We also offer enterprise grade support as part of <a href="../../../../pricing">TinyMCE premium plans</a>.</li>
+          </ol>
+          <h2>A simple table to play with</h2>
+          <table style="border-collapse: collapse; width: 100%;" border="1">
+          <thead>
+          <tr>
+          <th>Product</th>
+          <th>Cost</th>
+          <th>Really?</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+          <td>TinyMCE</td>
+          <td>Free</td>
+          <td>YES!</td>
+          </tr>
+          <tr>
+          <td>Plupload</td>
+          <td>Free</td>
+          <td>YES!</td>
+          </tr>
+          </tbody>
+          </table>
+          <h2>Found a bug?</h2>
+          <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
+          <h2>Finally ...</h2>
+          <p>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank" rel="noopener">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
+          <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
+        `,
+      },
+      {
+        revisionId: '1',
+        createdAt: '2023-11-29T10:11:21.578Z',
+        author: {
+          id: 'tiny.user',
+          name: 'A Tiny User',
+          avatar: '{{imagesdir}}/logos/android-chrome-192x192.png'
         },
-      ]);
-    }, 500);
-  });
+        content: `
+          <p><img style="display: block; margin-left: auto; margin-right: auto;" title="Tiny Logo" src="https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128"></p>
+          <h2 style="text-align: center;">Welcome to the TinyMCE editor demo!</h2>
+          <h2>Got questions or need help?</h2>
+          <ul>
+          <li>Our <a href="../">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+          <li>Have a specific question? Try the <a href="https://stackoverflow.com/questions/tagged/tinymce" target="_blank" rel="noopener"><code>tinymce</code> tag at Stack Overflow</a>.</li>
+          <li>We also offer enterprise grade support as part of <a href="../../../../pricing">TinyMCE premium plans</a>.</li>
+          </ul>
+          <h2>A simple table to play with</h2>
+          <table style="border-collapse: collapse; width: 100%;" border="1">
+          <thead>
+          <tr>
+          <th>Product</th>
+          <th>Cost</th>
+          <th>Really?</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+          <td>TinyMCE</td>
+          <td>Free</td>
+          <td>YES!</td>
+          </tr>
+          <tr>
+          <td>Plupload</td>
+          <td>Free</td>
+          <td>YES!</td>
+          </tr>
+          </tbody>
+          </table>
+          <h2>Found a bug?</h2>
+          <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
+          <h2>Finally ...</h2>
+          <p>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank" rel="noopener">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
+          <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
+        `,
+      },
+    ]);
   };
 
   tinymce.init({

--- a/modules/ROOT/examples/live-demos/revisionhistory/index.js
+++ b/modules/ROOT/examples/live-demos/revisionhistory/index.js
@@ -185,15 +185,12 @@ const revisions = [
 const revisionhistory_fetch_revision = (_editor, revision) =>
   new Promise((resolve, reject) => {
     setTimeout(() => {
-      for (let i = 0; i < revisions.length; i++) {
-        const temp = revisions[i];
-        if (temp.revisionId === revision.revisionId) {
-          resolve(temp);
-          break;
-        }
+      const newRevision = revisions.find((r) => r.revisionId === revision.revisionId);
+      if (newRevision === undefined) {
+        reject(`Revision ${revision.revisionId} is not found`);
+      } else {
+        resolve(newRevision);
       }
-      // reject has no effect when the promise is resolved
-      reject(`Revision ${revision.revisionId} is not found`);
     }, getRandomDelay());
   });
 

--- a/modules/ROOT/examples/live-demos/revisionhistory/index.js
+++ b/modules/ROOT/examples/live-demos/revisionhistory/index.js
@@ -183,17 +183,17 @@ const revisions = [
 ];
 
 const revisionhistory_fetch_revision = (_editor, revision) =>
-  new Promise((resolve) => {
+  new Promise((resolve, reject) => {
     setTimeout(() => {
-      let newRevision = null;
       for (let i = 0; i < revisions.length; i++) {
         const temp = revisions[i];
         if (temp.revisionId === revision.revisionId) {
-          newRevision = temp;
+          resolve(temp);
           break;
         }
       }
-      resolve(newRevision);
+      // reject has no effect when the promise is resolved
+      reject(`Revision ${revision.revisionId} is not found`);
     }, getRandomDelay());
   });
 


### PR DESCRIPTION
Ticket: DOC-2534

Site: [Staging branch](http://docs-<hotfix|feature>-<version>-doc-<num>.staging.tiny.cloud/docs/tinymce/<version>/)

Changes:
* Updated the example to throw an error when the revision being fetched is not found 
* Updated the example.js of full feature to correctly reflect the revisions being shown

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] ~Included a `release note` entry for any `New product features`.~
- [x] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed