### PR TITLE
DOC-2524: Update: Callback Mode (Comments)

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -8,9 +8,9 @@ asciidoc:
     idseparator: '-@'
     # generic variables
     companyurl: https://www.tiny.cloud
-    cdnurl: https://cdn.tiny.cloud/1/no-api-key/tinymce/7-dev/tinymce.min.js
+    cdnurl: https://cdn.tiny.cloud/1/no-api-key/tinymce/7/tinymce.min.js
     tdcdnurl: https://cdn.tiny.cloud/1/_your_api_key_/tinydrive/7/tinydrive.min.js
-    tinymce_live_demo_url: https://cdn.tiny.cloud/1/qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc/tinymce/7-dev/tinymce.min.js
+    tinymce_live_demo_url: https://cdn.tiny.cloud/1/qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc/tinymce/7/tinymce.min.js
     tinydrive_live_demo_url: https://cdn.tiny.cloud/1/qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc/tinydrive/7/tinydrive.min.js
     webcomponent_url: https://cdn.jsdelivr.net/npm/@tinymce/tinymce-webcomponent@2/dist/tinymce-webcomponent.min.js
     jquery_url: https://cdn.jsdelivr.net/npm/@tinymce/tinymce-jquery@2/dist/tinymce-jquery.min.js

--- a/antora.yml
+++ b/antora.yml
@@ -8,9 +8,9 @@ asciidoc:
     idseparator: '-@'
     # generic variables
     companyurl: https://www.tiny.cloud
-    cdnurl: https://cdn.tiny.cloud/1/no-api-key/tinymce/7/tinymce.min.js
+    cdnurl: https://cdn.tiny.cloud/1/no-api-key/tinymce/7-dev/tinymce.min.js
     tdcdnurl: https://cdn.tiny.cloud/1/_your_api_key_/tinydrive/7/tinydrive.min.js
-    tinymce_live_demo_url: https://cdn.tiny.cloud/1/qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc/tinymce/7/tinymce.min.js
+    tinymce_live_demo_url: https://cdn.tiny.cloud/1/qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc/tinymce/7-dev/tinymce.min.js
     tinydrive_live_demo_url: https://cdn.tiny.cloud/1/qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc/tinydrive/7/tinydrive.min.js
     webcomponent_url: https://cdn.jsdelivr.net/npm/@tinymce/tinymce-webcomponent@2/dist/tinymce-webcomponent.min.js
     jquery_url: https://cdn.jsdelivr.net/npm/@tinymce/tinymce-jquery@2/dist/tinymce-jquery.min.js

--- a/modules/ROOT/examples/live-demos/comments-callback/example.js
+++ b/modules/ROOT/examples/live-demos/comments-callback/example.js
@@ -170,22 +170,35 @@ const tinycomments_lookup = ({ conversationUid }, done, fail) => {
 };
 
 const tinycomments_fetch = (conversationUids, done, fail) => {
-  fetch(`https://api.example/conversations`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ uids: conversationUids }),
-  })
+  const requests = conversationUids.map((uid) => fetch(`https://api.example/conversations/${uid}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      }})
+      .then((response) => response.json())
+      .then((data) => ({
+        [uid]: {
+          uid: uid,
+          comments: data
+        }
+      }))
+    );
+
+  Promise.all(requests)
     .then((data) => {
-      console.log(`Lookup success ${conversationUids}`, data);
-      done(data);
+      console.log('data', data);
+      const conversations = data.reduce((conv, d) => ({
+          ...conv,
+          ...d
+        })
+      , {});
+      console.log(`Fetch success ${conversationUids}`, conversations);
+      done({ conversations });
     })
     .catch((err) => {
-      console.error(`Lookup failure ${conversationUids}`, err);
-      fail(err);
+      console.error(`Fetch failure ${conversationUids}`, err);
+      fail('Fetching conversations failed');
     });
-    console.log('fetching', conversationUids);
 };
 
 tinymce.init({

--- a/modules/ROOT/examples/live-demos/comments-callback/example.js
+++ b/modules/ROOT/examples/live-demos/comments-callback/example.js
@@ -170,7 +170,7 @@ const tinycomments_lookup = ({ conversationUid }, done, fail) => {
 };
 
 const tinycomments_fetch = (conversationUids, done, fail) => {
-  fetch(`https://api.example/conversations/${conversationUids}`, {
+  fetch(`https://api.example/conversations`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/modules/ROOT/examples/live-demos/comments-callback/example.js
+++ b/modules/ROOT/examples/live-demos/comments-callback/example.js
@@ -177,12 +177,6 @@ const tinycomments_fetch = (conversationUids, done, fail) => {
     },
     body: JSON.stringify({ uids: conversationUids }),
   })
-    // .then(response => {
-    //   if (!response.ok) {
-    //     throw new Error('Network response was not ok');
-    //   }
-    //   return response.json();
-    // })
     .then((data) => {
       console.log(`Lookup success ${conversationUids}`, data);
       done(data);

--- a/modules/ROOT/examples/live-demos/comments-callback/example.js
+++ b/modules/ROOT/examples/live-demos/comments-callback/example.js
@@ -225,4 +225,5 @@ tinymce.init({
   tinycomments_delete_comment,
   tinycomments_lookup,
   tinycomments_fetch,
+  sidebar_show: 'showcomments',
 });

--- a/modules/ROOT/examples/live-demos/comments-callback/example.js
+++ b/modules/ROOT/examples/live-demos/comments-callback/example.js
@@ -169,15 +169,40 @@ const tinycomments_lookup = ({ conversationUid }, done, fail) => {
     });
 };
 
+const tinycomments_fetch = (conversationUids, done, fail) => {
+  fetch(`https://api.example/conversations/${conversationUids}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ uids: conversationUids }),
+  })
+    // .then(response => {
+    //   if (!response.ok) {
+    //     throw new Error('Network response was not ok');
+    //   }
+    //   return response.json();
+    // })
+    .then((data) => {
+      console.log(`Lookup success ${conversationUids}`, data);
+      done(data);
+    })
+    .catch((err) => {
+      console.error(`Lookup failure ${conversationUids}`, err);
+      fail(err);
+    });
+    console.log('fetching', conversationUids);
+};
+
 tinymce.init({
   selector: 'textarea#comments-callback',
   height: 800,
   plugins: 'code tinycomments help lists',
   toolbar:
-    'undo redo | blocks | ' +
+    'addcomment showcomments | undo redo | blocks | ' +
     'bold italic backcolor | alignleft aligncenter ' +
     'alignright alignjustify | bullist numlist outdent indent | ' +
-    'removeformat | addcomment showcomments | help',
+    'removeformat | help',
   menubar: 'file edit view insert format tc',
   menu: {
     tc: {
@@ -192,10 +217,5 @@ tinymce.init({
   tinycomments_delete_all,
   tinycomments_delete_comment,
   tinycomments_lookup,
-  /* The following setup callback opens the comments sidebar when the editor loads */
-  setup: (editor) => {
-    editor.on('SkinLoaded', () => {
-      editor.execCommand('ToggleSidebar', false, 'showcomments');
-    });
-  },
+  tinycomments_fetch,
 });

--- a/modules/ROOT/examples/live-demos/comments-callback/index.html
+++ b/modules/ROOT/examples/live-demos/comments-callback/index.html
@@ -7,7 +7,7 @@
     <li>Type your comment into the text field at the bottom of the Comment sidebar.</li>
     <li>Click <strong>Comment</strong>.</li>
   </ol>
-  <p>Your comment is then attached to the text, exactly like this!</p>
+  <p>Your comment is <span class="mce-annotation tox-comment" data-mce-annotation-uid="mce-conversation_420304606321716900864126" data-mce-annotation="tinycomments">then</span> attached to the text, <span class="mce-annotation tox-comment" data-mce-annotation-uid="mce-conversation_19679600221621399703915" data-mce-annotation="tinycomments">exactly like this!</span></p>
   <p>If you want to take Tiny Comments for a test drive in your own environment, Tiny Comments is one of the premium plugins you can try for free for 14 days by signing up for a Tiny account. Make sure to check out our documentation as well.</p>
   <h2>A simple table to play with</h2>
   <table style="border-collapse: collapse; width: 100%;" border="1">

--- a/modules/ROOT/examples/live-demos/comments-callback/index.js
+++ b/modules/ROOT/examples/live-demos/comments-callback/index.js
@@ -621,16 +621,42 @@ tinymce.ScriptLoader.loadScripts(
         fail(err);
       });
   };
+  
+  const tinycomments_fetch = (conversationUids, done, fail) => {
+
+    fetch(`https://api.example/conversations/${conversationUids}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ uids: conversationUids }),
+    })
+      // .then(response => {
+      //   if (!response.ok) {
+      //     throw new Error('Network response was not ok');
+      //   }
+      //   return response.json();
+      // })
+      .then((data) => {
+        console.log(`Lookup success ${conversationUids}`, data);
+        done(data);
+      })
+      .catch((err) => {
+        console.error(`Lookup failure ${conversationUids}`, err);
+        fail(err);
+      });
+      console.log('fetching', conversationUids);
+  };
 
   tinymce.init({
     selector: 'textarea#comments-callback',
     height: 800,
     plugins: 'code tinycomments help lists',
     toolbar:
-      'undo redo | blocks | ' +
+      'addcomment showcomments | undo redo | blocks | ' +
       'bold italic backcolor | alignleft aligncenter ' +
       'alignright alignjustify | bullist numlist outdent indent | ' +
-      'removeformat | addcomment showcomments | help',
+      'removeformat | help',
     menubar: 'file edit view insert format tc',
     menu: {
       tc: {
@@ -645,13 +671,6 @@ tinymce.ScriptLoader.loadScripts(
     tinycomments_delete_all,
     tinycomments_delete_comment,
     tinycomments_lookup,
-    /* The following setup callback opens the comments sidebar when the editor loads */
-    setup: (editor) => {
-      editor.on('SkinLoaded', () => {
-        editor.execCommand('ToggleSidebar', false, 'showcomments', {
-          skip_focus: true,
-        });
-      });
-    },
+    tinycomments_fetch,
   });
 });

--- a/modules/ROOT/examples/live-demos/comments-callback/index.js
+++ b/modules/ROOT/examples/live-demos/comments-callback/index.js
@@ -46,8 +46,53 @@ tinymce.ScriptLoader.loadScripts(
   };
 
   /* Our server "database" */
-  const getDB = () =>
-    JSON.parse(localStorage.getItem('fakedb') ?? '{}');
+  const initialDB = {
+    "mce-conversation_19679600221621399703915": {
+      uid: "mce-conversation_19679600221621399703915",
+      comments: [
+        {
+          uid: "mce-conversation_19679600221621399703915",
+          author: "Another Tiny User",
+          authorName: "Another Tiny User",
+          content: "Please revise this sentence, exclamation points are unprofessional!",
+          createdAt: "2021-05-19T04:48:23.914Z",
+          modifiedAt: "2021-05-19T04:48:23.914Z",
+        },
+        {
+          uid: "mce-conversation_19679600221621399703917",
+          author: "Another Tiny User",
+          authorName: "Another Tiny User",
+          content: "Replied",
+          createdAt: "2021-05-19T04:48:23.914Z",
+          modifiedAt: "2021-05-19T04:48:23.914Z",
+        },
+        {
+          uid: "mce-conversation_19679600221621399703918",
+          author: "Another Tiny User",
+          authorName: "Another Tiny User",
+          content: "Replied again",
+          createdAt: "2021-05-19T04:48:23.914Z",
+          modifiedAt: "2021-05-19T04:48:23.914Z",
+        },
+      ],
+    },
+    "mce-conversation_420304606321716900864126": {
+      uid: "mce-conversation_420304606321716900864126",
+      comments: [
+        {
+          uid: "mce-conversation_420304606321716900864126",
+          author: "john_smith",
+          authorName: "John Smith",
+          authorAvatar: "https://i.pravatar.cc/150?img=11",
+          content: "I think this is a great idea!",
+          createdAt: "2024-05-28T12:54:24.126Z",
+          modifiedAt: "2024-05-28T12:54:24.126Z",
+        },
+      ],
+    },
+  };
+
+  const getDB = () => JSON.parse(localStorage.getItem('fakedb') ?? JSON.stringify(initialDB));
   const setDB = (data) => {
     localStorage.setItem('fakedb', JSON.stringify(data));
   };

--- a/modules/ROOT/examples/live-demos/comments-callback/index.js
+++ b/modules/ROOT/examples/live-demos/comments-callback/index.js
@@ -717,5 +717,6 @@ tinymce.ScriptLoader.loadScripts(
     tinycomments_delete_comment,
     tinycomments_lookup,
     tinycomments_fetch,
+    sidebar_show: 'showcomments',
   });
 });

--- a/modules/ROOT/examples/live-demos/comments-callback/index.js
+++ b/modules/ROOT/examples/live-demos/comments-callback/index.js
@@ -624,7 +624,7 @@ tinymce.ScriptLoader.loadScripts(
   
   const tinycomments_fetch = (conversationUids, done, fail) => {
 
-    fetch(`https://api.example/conversations/${conversationUids}`, {
+    fetch(`https://api.example/conversations`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/modules/ROOT/examples/live-demos/comments-callback/index.js
+++ b/modules/ROOT/examples/live-demos/comments-callback/index.js
@@ -631,12 +631,6 @@ tinymce.ScriptLoader.loadScripts(
       },
       body: JSON.stringify({ uids: conversationUids }),
     })
-      // .then(response => {
-      //   if (!response.ok) {
-      //     throw new Error('Network response was not ok');
-      //   }
-      //   return response.json();
-      // })
       .then((data) => {
         console.log(`Lookup success ${conversationUids}`, data);
         done(data);

--- a/modules/ROOT/examples/live-demos/comments-callback/index.js
+++ b/modules/ROOT/examples/live-demos/comments-callback/index.js
@@ -47,49 +47,43 @@ tinymce.ScriptLoader.loadScripts(
 
   /* Our server "database" */
   const initialDB = {
-    "mce-conversation_19679600221621399703915": {
-      uid: "mce-conversation_19679600221621399703915",
-      comments: [
-        {
-          uid: "mce-conversation_19679600221621399703915",
-          author: "Another Tiny User",
-          authorName: "Another Tiny User",
-          content: "Please revise this sentence, exclamation points are unprofessional!",
-          createdAt: "2021-05-19T04:48:23.914Z",
-          modifiedAt: "2021-05-19T04:48:23.914Z",
-        },
-        {
-          uid: "mce-conversation_19679600221621399703917",
-          author: "Another Tiny User",
-          authorName: "Another Tiny User",
-          content: "Replied",
-          createdAt: "2021-05-19T04:48:23.914Z",
-          modifiedAt: "2021-05-19T04:48:23.914Z",
-        },
-        {
-          uid: "mce-conversation_19679600221621399703918",
-          author: "Another Tiny User",
-          authorName: "Another Tiny User",
-          content: "Replied again",
-          createdAt: "2021-05-19T04:48:23.914Z",
-          modifiedAt: "2021-05-19T04:48:23.914Z",
-        },
-      ],
-    },
-    "mce-conversation_420304606321716900864126": {
-      uid: "mce-conversation_420304606321716900864126",
-      comments: [
-        {
-          uid: "mce-conversation_420304606321716900864126",
-          author: "john_smith",
-          authorName: "John Smith",
-          authorAvatar: "https://i.pravatar.cc/150?img=11",
-          content: "I think this is a great idea!",
-          createdAt: "2024-05-28T12:54:24.126Z",
-          modifiedAt: "2024-05-28T12:54:24.126Z",
-        },
-      ],
-    },
+    "mce-conversation_19679600221621399703915": [
+      {
+        uid: "mce-conversation_19679600221621399703915",
+        author: "Another Tiny User",
+        authorName: "Another Tiny User",
+        content: "Please revise this sentence, exclamation points are unprofessional!",
+        createdAt: "2021-05-19T04:48:23.914Z",
+        modifiedAt: "2021-05-19T04:48:23.914Z",
+      },
+      {
+        uid: "mce-conversation_19679600221621399703917",
+        author: "Another Tiny User",
+        authorName: "Another Tiny User",
+        content: "Replied",
+        createdAt: "2021-05-19T04:48:23.914Z",
+        modifiedAt: "2021-05-19T04:48:23.914Z",
+      },
+      {
+        uid: "mce-conversation_19679600221621399703918",
+        author: "Another Tiny User",
+        authorName: "Another Tiny User",
+        content: "Replied again",
+        createdAt: "2021-05-19T04:48:23.914Z",
+        modifiedAt: "2021-05-19T04:48:23.914Z",
+      },
+    ],
+    "mce-conversation_420304606321716900864126": [
+      {
+        uid: "mce-conversation_420304606321716900864126",
+        author: "john_smith",
+        authorName: "John Smith",
+        authorAvatar: "https://i.pravatar.cc/150?img=11",
+        content: "I think this is a great idea!",
+        createdAt: "2024-05-28T12:54:24.126Z",
+        modifiedAt: "2024-05-28T12:54:24.126Z",
+      },
+    ],
   };
 
   const getDB = () => JSON.parse(localStorage.getItem('fakedb') ?? JSON.stringify(initialDB));

--- a/modules/ROOT/examples/live-demos/comments-callback/index.js
+++ b/modules/ROOT/examples/live-demos/comments-callback/index.js
@@ -623,23 +623,35 @@ tinymce.ScriptLoader.loadScripts(
   };
   
   const tinycomments_fetch = (conversationUids, done, fail) => {
+    const requests = conversationUids.map((uid) => fetch(`https://api.example/conversations/${uid}`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        }})
+        .then((response) => response.json())
+        .then((data) => ({
+          [uid]: {
+            uid: uid,
+            comments: data
+          }
+        }))
+      );
 
-    fetch(`https://api.example/conversations`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ uids: conversationUids }),
-    })
+    Promise.all(requests)
       .then((data) => {
-        console.log(`Lookup success ${conversationUids}`, data);
-        done(data);
+        console.log('data', data);
+        const conversations = data.reduce((conv, d) => ({
+            ...conv,
+            ...d
+          })
+        , {});
+        console.log(`Fetch success ${conversationUids}`, conversations);
+        done({ conversations });
       })
       .catch((err) => {
-        console.error(`Lookup failure ${conversationUids}`, err);
-        fail(err);
+        console.error(`Fetch failure ${conversationUids}`, err);
+        fail('Fetching conversations failed');
       });
-      console.log('fetching', conversationUids);
   };
 
   tinymce.init({

--- a/modules/ROOT/pages/comments-callback-mode.adoc
+++ b/modules/ROOT/pages/comments-callback-mode.adoc
@@ -20,7 +20,9 @@ Most functions (create, reply, and edit) require an `+id+` identifying the *curr
 [NOTE]
 **Current author**: The {pluginname} plugin does not know the name of the current user. Determining the current user and storing the comment related to that user is required to be configured by the integrator.
 
-After a user comments (triggering `+tinycomments_create+` for the first comment or `+tinycomments_reply+` for subsequent comments), the {pluginname} plugin requests the updated conversation/s using both `+tinycomments_lookup+` and `+tinycomments_fetch+`, which contains the additional comment with the proper author.
+During the initial load, the {pluginname} uses `+tinycomments_fetch+` callback to retrieve the existing conversation including any additional comments with their respective authors . If not configured, the {pluginname} will fallback to `+tinycomments_lookup+`. 
+
+When a user adds a comment, the {pluginname} plugin uses the `+tinycomments_lookup+` callback to retrieve the selected conversation. 
 
 == Interactive example
 

--- a/modules/ROOT/pages/comments-callback-mode.adoc
+++ b/modules/ROOT/pages/comments-callback-mode.adoc
@@ -1,4 +1,4 @@
-= Configuring the Comments plugin in callback mode
+= Configuring the {pluginname} plugin in callback mode
 :navtitle: Callback mode
 :description: Information on configuring the Comments plugin in callback mode
 :keywords: comments, commenting, tinycomments, callback
@@ -6,32 +6,33 @@
 :plugincode: comments
 :commentsMode: callback
 
-*Callback mode* is the default mode for the Comments plugin. In the callback mode, callback functions are required to save user comments on a server. The Comments functions (create, reply, edit, delete comment, delete all conversations, resolve, and lookup) are configured differently depending upon the server-side storage configuration.
+*Callback mode* is the default mode for the {pluginname} plugin. In the callback mode, callback functions are required to save user comments on a server. The {pluginname} functions (create, reply, edit, delete comment, delete all conversations, resolve, lookup, and fetch all conversations) are configured differently depending upon the server-side storage configuration.
 
-== Interactive example
-
-The following example uses a simulated server (provided by https://netflix.github.io/pollyjs/[Polly.js]) which has been hidden from the example javascript to keep the example code concise. The interactions between TinyMCE and Polly.js are visible in the browser console.
-
-liveDemo::comments-callback[]
-
-=== How the comments plugin works in callback mode
+== How the {pluginname} plugin works in callback mode
 
 All options accept functions incorporating `+done+` and `+fail+` callbacks as parameters. The function return type is not important, but all functions must call exactly one of these two callbacks: `+fail+` or `+done+`.
 
 * The `+fail+` callback takes either a string or a JavaScript Error type.
 * The `+done+` callback takes an argument specific to each function.
 
-Most (create, reply, and edit) functions require an `+id+` identifying the *current author*.
+Most functions (create, reply, and edit) require an `+id+` identifying the *current author*.
 
-Current author:: The Comments plugin does not know the name of the current user. Determining the current user and storing the comment related to that user, has to be configured by the developer.
+[NOTE]
+**Current author**: The {pluginname} plugin does not know the name of the current user. Determining the current user and storing the comment related to that user is required to be configured by the integrator.
 
-After a user comments (triggering `+tinycomments_create+` for the first comment, or `+tinycomments_reply+` for subsequent comments), the Comments plugin requests the updated conversation using `+tinycomments_lookup+`, which should now contain the additional comment with the proper author.
+After a user comments (triggering `+tinycomments_create+` for the first comment or `+tinycomments_reply+` for subsequent comments), the {pluginname} plugin requests the updated conversation/s using both `+tinycomments_lookup+` and `+tinycomments_fetch+`, which contains the additional comment with the proper author.
+
+== Interactive example
+
+The following example uses a simulated server (provided by link:https://netflix.github.io/pollyjs/[Polly.js]), which has been hidden from the example JavaScript to keep the example code concise. The interactions between {productname} and Polly.js are visible in the browser console.
+
+liveDemo::comments-callback[]
 
 == Options
 
 === Required options
 
-When using callback mode, the Comments plugin requires callback functions for the following options:
+When using callback mode, the {pluginname} plugin requires callback functions for the following options:
 
 * xref:tinycomments_create[`+tinycomments_create+`]
 * xref:tinycomments_reply[`+tinycomments_reply+`]
@@ -40,16 +41,13 @@ When using callback mode, the Comments plugin requires callback functions for th
 * xref:tinycomments_delete[`+tinycomments_delete+`]
 * xref:tinycomments_delete_all[`+tinycomments_delete_all+`]
 * xref:tinycomments_lookup[`+tinycomments_lookup+`]
-
-The xref:tinycomments_resolve[`+tinycomments_resolve+`] option is _optional_.
+* xref:tinycomments_fetch[`+tinycomments_fetch+`]
 
 include::partial$configuration/tinycomments_create.adoc[leveloffset=+1]
 
 include::partial$configuration/tinycomments_reply.adoc[leveloffset=+1]
 
 include::partial$configuration/tinycomments_edit_comment.adoc[leveloffset=+1]
-
-include::partial$configuration/tinycomments_resolve.adoc[leveloffset=+1]
 
 include::partial$configuration/tinycomments_delete_comment.adoc[leveloffset=+1]
 
@@ -58,6 +56,14 @@ include::partial$configuration/tinycomments_delete.adoc[leveloffset=+1]
 include::partial$configuration/tinycomments_delete_all.adoc[leveloffset=+1]
 
 include::partial$configuration/tinycomments_lookup.adoc[leveloffset=+1]
+
+include::partial$configuration/tinycomments_fetch.adoc[leveloffset=+1]
+
+=== Optional options
+
+* xref:tinycomments_resolve[`+tinycomments_resolve+`]
+
+include::partial$configuration/tinycomments_resolve.adoc[leveloffset=+1]
 
 include::partial$plugins/comments-open-sidebar.adoc[]
 

--- a/modules/ROOT/pages/comments-callback-mode.adoc
+++ b/modules/ROOT/pages/comments-callback-mode.adoc
@@ -61,8 +61,11 @@ include::partial$configuration/tinycomments_fetch.adoc[leveloffset=+1]
 === Optional options
 
 * xref:tinycomments_resolve[`+tinycomments_resolve+`]
+* xref:tinycomments_fetch[`+tinycomments_fetch+`]
 
 include::partial$configuration/tinycomments_resolve.adoc[leveloffset=+1]
+
+include::partial$configuration/tinycomments_fetch.adoc[leveloffset=+1]
 
 include::partial$plugins/comments-open-sidebar.adoc[]
 

--- a/modules/ROOT/pages/comments-callback-mode.adoc
+++ b/modules/ROOT/pages/comments-callback-mode.adoc
@@ -56,7 +56,7 @@ include::partial$configuration/tinycomments_delete_all.adoc[leveloffset=+1]
 
 include::partial$configuration/tinycomments_lookup.adoc[leveloffset=+1]
 
-=== Optional options
+== Optional options
 
 * xref:tinycomments_resolve[`+tinycomments_resolve+`]
 * xref:tinycomments_fetch[`+tinycomments_fetch+`]

--- a/modules/ROOT/pages/comments-callback-mode.adoc
+++ b/modules/ROOT/pages/comments-callback-mode.adoc
@@ -41,7 +41,6 @@ When using callback mode, the {pluginname} plugin requires callback functions fo
 * xref:tinycomments_delete[`+tinycomments_delete+`]
 * xref:tinycomments_delete_all[`+tinycomments_delete_all+`]
 * xref:tinycomments_lookup[`+tinycomments_lookup+`]
-* xref:tinycomments_fetch[`+tinycomments_fetch+`]
 
 include::partial$configuration/tinycomments_create.adoc[leveloffset=+1]
 

--- a/modules/ROOT/pages/comments-callback-mode.adoc
+++ b/modules/ROOT/pages/comments-callback-mode.adoc
@@ -56,8 +56,6 @@ include::partial$configuration/tinycomments_delete_all.adoc[leveloffset=+1]
 
 include::partial$configuration/tinycomments_lookup.adoc[leveloffset=+1]
 
-include::partial$configuration/tinycomments_fetch.adoc[leveloffset=+1]
-
 === Optional options
 
 * xref:tinycomments_resolve[`+tinycomments_resolve+`]

--- a/modules/ROOT/pages/comments-callback-mode.adoc
+++ b/modules/ROOT/pages/comments-callback-mode.adoc
@@ -20,7 +20,7 @@ Most functions (create, reply, and edit) require an `+id+` identifying the *curr
 [NOTE]
 **Current author**: The {pluginname} plugin does not know the name of the current user. Determining the current user and storing the comment related to that user is required to be configured by the integrator.
 
-During the initial load, the {pluginname} uses `+tinycomments_fetch+` callback to retrieve the existing conversation including any additional comments with their respective authors . If not configured, the {pluginname} will fallback to `+tinycomments_lookup+`. 
+During the initial editor load, the {pluginname} uses `+tinycomments_fetch+` callback to retrieve the existing conversations in the document. If not configured, the {pluginname} will fallback to `+tinycomments_lookup+`. 
 
 When a user adds a comment or a reply, the {pluginname} plugin uses the `+tinycomments_lookup+` callback to retrieve the selected conversation. 
 

--- a/modules/ROOT/pages/comments-callback-mode.adoc
+++ b/modules/ROOT/pages/comments-callback-mode.adoc
@@ -22,7 +22,7 @@ Most functions (create, reply, and edit) require an `+id+` identifying the *curr
 
 During the initial load, the {pluginname} uses `+tinycomments_fetch+` callback to retrieve the existing conversation including any additional comments with their respective authors . If not configured, the {pluginname} will fallback to `+tinycomments_lookup+`. 
 
-When a user adds a comment, the {pluginname} plugin uses the `+tinycomments_lookup+` callback to retrieve the selected conversation. 
+When a user adds a comment or a reply, the {pluginname} plugin uses the `+tinycomments_lookup+` callback to retrieve the selected conversation. 
 
 == Interactive example
 

--- a/modules/ROOT/pages/comments-callback-mode.adoc
+++ b/modules/ROOT/pages/comments-callback-mode.adoc
@@ -6,7 +6,7 @@
 :plugincode: comments
 :commentsMode: callback
 
-*Callback mode* is the default mode for the {pluginname} plugin. In the callback mode, callback functions are required to save user comments on a server. The {pluginname} functions (create, reply, edit, delete comment, delete all conversations, resolve, lookup, and fetch all conversations) are configured differently depending upon the server-side storage configuration.
+*Callback mode* is the default mode for the {pluginname} plugin. In the callback mode, callback functions are required to save user comments on a server. The {pluginname} functions (create, reply, edit, delete comment, delete all conversations, resolve, lookup, and fetch conversations) are configured differently depending upon the server-side storage configuration.
 
 == How the {pluginname} plugin works in callback mode
 

--- a/modules/ROOT/partials/configuration/tinycomments_create.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_create.adoc
@@ -63,6 +63,6 @@ tinymce.init({
   tinycomments_delete_all: delete_all_comment_threads,
   tinycomments_delete_comment: delete_comment,
   tinycomments_lookup: lookup_comment,
-  tinycomments_fetch: fetch_comments
+  tinycomments_fetch: fetch_comments // Optional callback
 });
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_create.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_create.adoc
@@ -1,15 +1,14 @@
 [[tinycomments_create]]
 == `+tinycomments_create+`
 
-The Comments plugin uses the `+tinycomments_create+` function to create a comment.
+The {pluginname} plugin uses the `+tinycomments_create+` function to create a comment.
 
 The `+tinycomments_create+` function saves the comment as a new conversation and returns a unique conversation ID via the `+done+` callback. If an unrecoverable error occurs, it should indicate this with the fail callback.
 
 The `+tinycomments_create+` function is given a request (req) object as the first parameter, which has these fields:
 
-`+content+`:: The content of the comment to create.
-
-`+createdAt+`:: The date the comment was created.
+* `+content+`: The content of the comment to create.
+* `+createdAt+`: The date the comment was created.
 
 The `+done+` callback should accept the following object:
 
@@ -24,8 +23,7 @@ The `+done+` callback should accept the following object:
 }
 ----
 
-For example:
-
+.For example:
 [source,js]
 ----
 const create_comment = (ref, done, fail) => {
@@ -64,6 +62,7 @@ tinymce.init({
   tinycomments_delete: delete_comment_thread,
   tinycomments_delete_all: delete_all_comment_threads,
   tinycomments_delete_comment: delete_comment,
-  tinycomments_lookup: lookup_comment
+  tinycomments_lookup: lookup_comment,
+  tinycomments_fetch: fetch_comments
 });
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_delete.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_delete.adoc
@@ -5,7 +5,7 @@ The `+tinycomments_delete+` function should asynchronously return a flag indicat
 
 The `+tinycomments_delete+` function is passed a (`+req+`) object as the first parameter, which contains the following key-value pair:
 
-`+conversationUid+`:: The uid of the conversation the reply is targeting.
+* `+conversationUid+`: The uid of the conversation the reply is targeting.
 
 The `+done+` callback should accept the following object:
 
@@ -17,7 +17,8 @@ The `+done+` callback should accept the following object:
 }
 ----
 
-NOTE: Failure to delete due to permissions or business rules is indicated by "false", while unexpected errors should be indicated using the "fail" callback.
+[NOTE]
+Failure to delete due to permissions or business rules is indicated by "false", while unexpected errors should be indicated using the "fail" callback.
 
 For example:
 
@@ -48,6 +49,7 @@ tinymce.init({
   tinycomments_delete: delete_comment_thread, // Add the callback to TinyMCE
   tinycomments_delete_all: delete_all_comment_threads,
   tinycomments_delete_comment: delete_comment,
-  tinycomments_lookup: lookup_comment
+  tinycomments_lookup: lookup_comment,
+  tinycomments_fetch: fetch_comments
 });
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_delete.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_delete.adoc
@@ -50,6 +50,6 @@ tinymce.init({
   tinycomments_delete_all: delete_all_comment_threads,
   tinycomments_delete_comment: delete_comment,
   tinycomments_lookup: lookup_comment,
-  tinycomments_fetch: fetch_comments
+  tinycomments_fetch: fetch_comments // Optional callback
 });
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_delete_all.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_delete_all.adoc
@@ -46,6 +46,6 @@ tinymce.init({
   tinycomments_delete_all: delete_all_comment_threads, // Add the callback to TinyMCE
   tinycomments_delete_comment: delete_comment,
   tinycomments_lookup: lookup_comment,
-  tinycomments_fetch: fetch_comments
+  tinycomments_fetch: fetch_comments // Optional callback
 });
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_delete_all.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_delete_all.adoc
@@ -15,10 +15,10 @@ The `+done+` callback should accept the following object:
 }
 ----
 
-NOTE: Failure to delete due to permissions or business rules should be indicated by `+canDelete: false+`, while unexpected errors should be indicated using the `+fail+` callback.
+[NOTE]
+Failure to delete due to permissions or business rules should be indicated by `+canDelete: false+`, while unexpected errors should be indicated using the `+fail+` callback.
 
-For example:
-
+.For example:
 [source,js]
 ----
 const delete_all_comment_threads = (_req, done, fail) => {
@@ -45,6 +45,7 @@ tinymce.init({
   tinycomments_delete: delete_comment_thread,
   tinycomments_delete_all: delete_all_comment_threads, // Add the callback to TinyMCE
   tinycomments_delete_comment: delete_comment,
-  tinycomments_lookup: lookup_comment
+  tinycomments_lookup: lookup_comment,
+  tinycomments_fetch: fetch_comments
 });
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_delete_comment.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_delete_comment.adoc
@@ -54,6 +54,6 @@ tinymce.init({
   tinycomments_delete_all: delete_all_comment_threads,
   tinycomments_delete_comment: delete_comment,
   tinycomments_lookup: lookup_comment,
-  tinycomments_fetch: fetch_comments
+  tinycomments_fetch: fetch_comments // Optional callback
 });
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_delete_comment.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_delete_comment.adoc
@@ -5,9 +5,8 @@ The `+tinycomments_delete_comment+` function should asynchronously return a flag
 
 The `+tinycomments_delete_comment+` function is given a request (req) object as the first parameter, which has these fields:
 
-`+conversationUid+`:: The uid of the conversation the reply is targeting.
-
-`+commentUid+`:: The uid of the comment to delete (cannot be the same as `+conversationUid+`).
+* `+conversationUid+`: The uid of the conversation the reply is targeting.
+* `+commentUid+`: The uid of the comment to delete (cannot be the same as `+conversationUid+`).
 
 The `+done+` callback should accept the following object:
 
@@ -19,10 +18,10 @@ The `+done+` callback should accept the following object:
 }
 ----
 
-NOTE: Failure to delete due to permissions or business rules is indicated by "false", while unexpected errors should be indicated using the "fail" callback.
+[NOTE]
+Failure to delete due to permissions or business rules is indicated by "false", while unexpected errors should be indicated using the "fail" callback.
 
-For example:
-
+.For example:
 [source,js]
 ----
 const delete_comment = (ref, done, fail) => {
@@ -54,6 +53,6 @@ tinymce.init({
   tinycomments_delete: delete_comment_thread, // Add the callback to TinyMCE
   tinycomments_delete_all: delete_all_comment_threads,
   tinycomments_delete_comment: delete_comment,
-  tinycomments_lookup: lookup_comment
+  tinycomments_lookup: fetch_comments,
 });
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_delete_comment.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_delete_comment.adoc
@@ -53,6 +53,7 @@ tinymce.init({
   tinycomments_delete: delete_comment_thread, // Add the callback to TinyMCE
   tinycomments_delete_all: delete_all_comment_threads,
   tinycomments_delete_comment: delete_comment,
-  tinycomments_lookup: fetch_comments,
+  tinycomments_lookup: lookup_comment,
+  tinycomments_fetch: fetch_comments
 });
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_edit_comment.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_edit_comment.adoc
@@ -1,19 +1,16 @@
 [[tinycomments_edit_comment]]
 == `+tinycomments_edit_comment+`
 
-The Comments plugin uses the `+tinycomments_edit_comment+` function to edit a comment.
+The {pluginname} plugin uses the `+tinycomments_edit_comment+` function to edit a comment.
 
 The `+tinycomments_edit_comment+` function allows updating or changing existing comments and returns via the `+done+` callback once successful. Unrecoverable errors are communicated to {productname} by calling the `+fail+` callback instead.
 
 The `+tinycomments_edit_comment+` function is given a request (req) object as the first parameter, which has these fields:
 
-`+conversationUid+`:: The uid of the conversation the reply is targeting.
-
-`+commentUid+`:: The uid of the comment to edit (it can be the same as `+conversationUid+` if editing the first comment in a conversation).
-
-`+content+`:: The content of the comment to create.
-
-`+modifiedAt+`:: The date the comment was modified.
+* `+conversationUid+`: The uid of the conversation the reply is targeting.
+* `+commentUid+`: The uid of the comment to edit (it can be the same as `+conversationUid+` if editing the first comment in a conversation).
+* `+content+`: The content of the comment to create.
+* `+modifiedAt+`: The date the comment was modified.
 
 The `+done+` callback should accept the following object:
 
@@ -25,8 +22,7 @@ The `+done+` callback should accept the following object:
 }
 ----
 
-For example:
-
+.For example:
 [source,js]
 ----
 const edit_comment = (ref, done, fail) => {
@@ -68,6 +64,7 @@ tinymce.init({
   tinycomments_delete: delete_comment_thread,
   tinycomments_delete_all: delete_all_comment_threads,
   tinycomments_delete_comment: delete_comment,
-  tinycomments_lookup: lookup_comment
+  tinycomments_lookup: lookup_comment,
+  tinycomments_fetch: fetch_comments
 });
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_edit_comment.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_edit_comment.adoc
@@ -65,6 +65,6 @@ tinymce.init({
   tinycomments_delete_all: delete_all_comment_threads,
   tinycomments_delete_comment: delete_comment,
   tinycomments_lookup: lookup_comment,
-  tinycomments_fetch: fetch_comments
+  tinycomments_fetch: fetch_comments // Optional callback
 });
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_fetch.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_fetch.adoc
@@ -1,0 +1,78 @@
+[[tinycomments_fetch]]
+== `+tinycomments_fetch+`
+
+The {pluginname} plugin uses the `+tinycomments_fetch+` callback function retrieves multiple conversations based on their unique identifiers.
+
+The conventional conversation object structure that should be returned via the `+done+` callback is as follows:
+
+The `+tinycomments_fetch+` function is passed a (`+req+`) object as the first parameter, which contains the following key-value pair:
+
+* `+conversationUids+`: An array of strings representing the unique identifiers of the conversations to fetch.
+
+The `+done+` callback should accept the following object:
+
+[source,js]
+----
+{
+  conversations: {
+    [conversationUid: string]: {
+      uid: string,
+      comments: [
+        {
+          uid: string,
+          author: string,
+          authorName?: string,
+          authorAvatar?: string,
+          content: string,
+          createdAt: string, // ISO 8601 date string
+          modifiedAt: string // ISO 8601 date string
+        },
+        // ... more comments
+      ]
+    },
+    // ... more conversations
+  }
+}
+----
+
+.For example:
+[source,js]
+----
+const fetch_comments = (conversationUids, done, fail) => {
+  fetch(`https://api.example/conversations/${conversationUids}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ uids: conversationUids }),
+  })
+    .then(response => {
+      if (!response.ok) {
+        throw new Error('Network response was not ok');
+      }
+      return response.json();
+    })
+    .then((data) => {
+      console.log(`Lookup success ${conversationUids}`, data);
+      done(data);
+    })
+    .catch((err) => {
+      console.error(`Lookup failure ${conversationUids}`, err);
+      fail(err);
+    });
+};
+
+tinymce.init({
+  selector: '#editor',
+  plugins: 'tinycomments',
+  tinycomments_mode: 'callback',
+  tinycomments_create: create_comment,
+  tinycomments_reply: reply_comment,
+  tinycomments_edit_comment: edit_comment,
+  tinycomments_delete: delete_comment_thread,
+  tinycomments_delete_all: delete_all_comment_threads,
+  tinycomments_delete_comment: delete_comment,
+  tinycomments_lookup: lookup_comment,
+  tinycomments_fetch: fetch_comments // Add the callback to TinyMCE
+});
+----

--- a/modules/ROOT/partials/configuration/tinycomments_fetch.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_fetch.adoc
@@ -39,7 +39,7 @@ The `+done+` callback should accept the following object:
 [source,js]
 ----
 const fetch_comments = (conversationUids, done, fail) => {
-  fetch(`https://api.example/conversations/${conversationUids}`, {
+  fetch(`https://api.example/conversations`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/modules/ROOT/partials/configuration/tinycomments_fetch.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_fetch.adoc
@@ -38,29 +38,36 @@ The `+done+` callback should accept the following object:
 .For example:
 [source,js]
 ----
-const fetch_comments = (conversationUids, done, fail) => {
-  fetch(`https://api.example/conversations`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ uids: conversationUids }),
-  })
-    .then(response => {
-      if (!response.ok) {
-        throw new Error('Network response was not ok');
-      }
-      return response.json();
-    })
+const tinycomments_fetch = (conversationUids, done, fail) => {
+  const requests = conversationUids.map((uid) => fetch(`https://api.example/conversations/${uid}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      }})
+      .then((response) => response.json())
+      .then((data) => ({
+        [uid]: {
+          uid: uid,
+          comments: data
+        }
+      }))
+    );
+
+  Promise.all(requests)
     .then((data) => {
-      console.log(`Lookup success ${conversationUids}`, data);
-      done(data);
+      console.log('data', data);
+      const conversations = data.reduce((conv, d) => ({
+          ...conv,
+          ...d
+        })
+      , {});
+      console.log(`Fetch success ${conversationUids}`, conversations);
+      done({ conversations });
     })
     .catch((err) => {
-      console.error(`Lookup failure ${conversationUids}`, err);
-      fail(err);
+      console.error(`Fetch failure ${conversationUids}`, err);
+      fail('Fetching conversations failed');
     });
-};
 
 tinymce.init({
   selector: '#editor',

--- a/modules/ROOT/partials/configuration/tinycomments_lookup.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_lookup.adoc
@@ -110,6 +110,6 @@ tinymce.init({
   tinycomments_delete_all: delete_all_comment_threads,
   tinycomments_delete_comment: delete_comment,
   tinycomments_lookup: lookup_comment, // Add the callback to TinyMCE
-  tinycomments_fetch: fetch_comments
+  tinycomments_fetch: fetch_comments // Optional callback
 });
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_lookup.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_lookup.adoc
@@ -1,7 +1,7 @@
 [[tinycomments_lookup]]
 == `+tinycomments_lookup+`
 
-The {pluginname} plugin uses the `+tinycomments_lookup+` function to retrieve an (1) existing conversation using a conversation's unique ID.
+The {pluginname} plugin uses the `+tinycomments_lookup+` function to retrieve one existing conversation using a conversation's unique ID.
 
 The *Display names* configuration must be considered for the `+tinycomments_lookup+` function:
 

--- a/modules/ROOT/partials/configuration/tinycomments_lookup.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_lookup.adoc
@@ -1,7 +1,7 @@
 [[tinycomments_lookup]]
 == `+tinycomments_lookup+`
 
-The Comments plugin uses the `+tinycomments_lookup+` function to retrieve an existing conversation using a conversation's unique ID.
+The {pluginname} plugin uses the `+tinycomments_lookup+` function to retrieve an (1) existing conversation using a conversation's unique ID.
 
 The *Display names* configuration must be considered for the `+tinycomments_lookup+` function:
 
@@ -54,8 +54,7 @@ The author avatar feature is only available in {productname} 6.1 or higher and i
 * can be any filetype able to be wrapped in an `<img>` element.
 ====
 
-For example:
-
+.For example:
 [source,js]
 ----
 const lookup_comment = ({ conversationUid }, done, fail) => {
@@ -110,6 +109,7 @@ tinymce.init({
   tinycomments_delete: delete_comment_thread,
   tinycomments_delete_all: delete_all_comment_threads,
   tinycomments_delete_comment: delete_comment,
-  tinycomments_lookup: lookup_comment // Add the callback to TinyMCE
+  tinycomments_lookup: lookup_comment, // Add the callback to TinyMCE
+  tinycomments_fetch: fetch_comments
 });
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_reply.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_reply.adoc
@@ -9,7 +9,7 @@ The `+tinycomments_reply+` function is given a request (req) object as the first
 
 * `+conversationUid+`: The uid of the conversation the reply is targeting.
 * `+content+`: The content of the comment to create.
-* `+createdAt+`: The date the comment was created.
+* `+createdAt+`: The date the comment was created (ISO 8601 date string) format.
 
 The `+done+` callback should accept the following object:
 

--- a/modules/ROOT/partials/configuration/tinycomments_reply.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_reply.adoc
@@ -1,17 +1,15 @@
 [[tinycomments_reply]]
 == `+tinycomments_reply+`
 
-The Comments plugin uses the `+tinycomments_reply+` function to reply to a comment.
+The {pluginname} plugin uses the `+tinycomments_reply+` function to reply to a comment.
 
 The `+tinycomments_reply+` function saves the comment as a reply to an existing conversation and returns via the `+done+` callback once successful. Unrecoverable errors are communicated to {productname} by calling the `+fail+` callback instead.
 
 The `+tinycomments_reply+` function is given a request (req) object as the first parameter, which has these fields:
 
-`+conversationUid+`:: The uid of the conversation the reply is targeting.
-
-`+content+`:: The content of the comment to create.
-
-`+createdAt+`:: The date the comment was created.
+* `+conversationUid+`: The uid of the conversation the reply is targeting.
+* `+content+`: The content of the comment to create.
+* `+createdAt+`: The date the comment was created.
 
 The `+done+` callback should accept the following object:
 
@@ -22,8 +20,7 @@ The `+done+` callback should accept the following object:
 }
 ----
 
-For example:
-
+.For example:
 [source,js]
 ----
 const reply_comment = (ref, done, fail) => {
@@ -62,6 +59,7 @@ tinymce.init({
   tinycomments_delete: delete_comment_thread,
   tinycomments_delete_all: delete_all_comment_threads,
   tinycomments_delete_comment: delete_comment,
-  tinycomments_lookup: lookup_comment
+  tinycomments_lookup: lookup_comment,
+  tinycomments_fetch: fetch_comments
 });
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_reply.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_reply.adoc
@@ -60,6 +60,6 @@ tinymce.init({
   tinycomments_delete_all: delete_all_comment_threads,
   tinycomments_delete_comment: delete_comment,
   tinycomments_lookup: lookup_comment,
-  tinycomments_fetch: fetch_comments
+  tinycomments_fetch: fetch_comments // Optional callback
 });
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_resolve.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_resolve.adoc
@@ -7,7 +7,7 @@ The `+tinycomments_resolve+` function should asynchronously return a flag indica
 
 The `+tinycomments_resolve+` function is passed a (`+req+`) object as the first parameter, which contains the following key-value pair:
 
-`+conversationUid+`:: The uid of the conversation the reply is targeting.
+* `+conversationUid+`: The uid of the conversation the reply is targeting.
 
 The `+done+` callback should accept the following object:
 
@@ -19,10 +19,10 @@ The `+done+` callback should accept the following object:
 }
 ----
 
-NOTE: Failure to resolve due to permissions or business rules should be indicated by `+canResolve: false+`, while unexpected errors should be indicated using the `+fail+` callback.
+[NOTE]
+Failure to resolve due to permissions or business rules should be indicated by `+canResolve: false+`, while unexpected errors should be indicated using the `+fail+` callback.
 
-For example:
-
+.For example:
 [source,js]
 ----
 const resolve_comment_thread = (ref, done, fail) => {
@@ -51,6 +51,7 @@ tinymce.init({
   tinycomments_delete: delete_comment_thread,
   tinycomments_delete_all: delete_all_comment_threads,
   tinycomments_delete_comment: delete_comment,
-  tinycomments_lookup: lookup_comment
+  tinycomments_lookup: lookup_comment,
+  tinycomments_fetch: fetch_comments
 });
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_resolve.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_resolve.adoc
@@ -7,7 +7,7 @@ The `+tinycomments_resolve+` function should asynchronously return a flag indica
 
 The `+tinycomments_resolve+` function is passed a (`+req+`) object as the first parameter, which contains the following key-value pair:
 
-* `+conversationUid+`: The uid of the conversation the reply is targeting.
+* `+conversationUid+`: The uid of the targeting conversation
 
 The `+done+` callback should accept the following object:
 

--- a/modules/ROOT/partials/plugins/comments-highlighting-css.adoc
+++ b/modules/ROOT/partials/plugins/comments-highlighting-css.adoc
@@ -2,7 +2,7 @@
 
 The highlight styles are now a part of the overall content skin and are changed through customizing the skin.
 
-{productname} open source project https://github.com/tinymce/oxide/blob/master/src/less/theme/content/comments/comments.less[oxide] (default skin), defines the variables used for changing the annotation colours.
+{productname} open source project https://github.com/tinymce/oxide/blob/master/src/less/theme/content/comments/comments.less[oxide] (default skin), defines the variables used for changing the annotation colors.
 
 Refer to the xref:creating-a-skin.adoc[documentation] for building a skin using this repo.
 

--- a/modules/ROOT/partials/plugins/comments-open-sidebar.adoc
+++ b/modules/ROOT/partials/plugins/comments-open-sidebar.adoc
@@ -1,9 +1,8 @@
-== Show the comments sidebar when TinyMCE loads
+== Show the {pluginname} sidebar when TinyMCE loads
 
-The xref:customsidebar.adoc#sidebar_show[`sidebar_show`] option can be used to show the comments sidebar when the editor is loaded.
+The xref:customsidebar.adoc#sidebar_show[`sidebar_show`] option can be used to show the {pluginname} sidebar when the editor is loaded.
 
-For example:
-
+.For example:
 ifeval::["{commentsMode}" == "callback"]
 [source,js]
 ----
@@ -18,6 +17,7 @@ tinymce.init({
   tinycomments_delete_all,
   tinycomments_delete_comment,
   tinycomments_lookup,
+  tinycomments_fetch,
   sidebar_show: 'showcomments'
 });
 ----


### PR DESCRIPTION
Ticket: DOC-2524

Site: [Staging branch](http://docs-feature-74-doc-2524doc-2528.staging.tiny.cloud/docs/tinymce/latest/comments-callback-mode/)

Changes:
* Update live demo to include `tinycomment_fetch`
* live-demos/comments-callback/example.js
* live-demos/comments-callback/index.js

Updates to:
* pages/comments-callback-mode.adoc
* partials/configuration/tinycomments_create.adoc
* partials/configuration/tinycomments_delete.adoc
* partials/configuration/tinycomments_delete_all.adoc
* partials/configuration/tinycomments_delete_comment.adoc
* partials/configuration/tinycomments_edit_comment.adoc
* partials/configuration/tinycomments_fetch.adoc
* partials/configuration/tinycomments_lookup.adoc
* partials/configuration/tinycomments_reply.adoc
* partials/configuration/tinycomments_resolve.adoc
* partials/configuration/comments-highlighting-css.adoc
* partials/configuration/comments-open-sidebar.adoc

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed