### PR TITLE
DOC-2524: Update: Embedded Mode (Comments).

### DIFF
--- a/modules/ROOT/examples/live-demos/comments-embedded/index.js
+++ b/modules/ROOT/examples/live-demos/comments-embedded/index.js
@@ -4,7 +4,7 @@ const userAllowedToResolve = 'Admin1';
 tinymce.init({
   selector: 'textarea#comments-embedded',
   plugins: 'code tinycomments',
-  toolbar: 'bold italic underline | addcomment showcomments',
+  toolbar: 'addcomment showcomments | bold italic underline',
   menubar: 'file edit view insert format tools tc',
   menu: {
     tc: {
@@ -22,10 +22,4 @@ tinymce.init({
     });
   },
   content_style: 'body { font-family:Helvetica,Arial,sans-serif; font-size:16px }',
-  /* The following setup callback opens the comments sidebar when the editor loads */
-  setup: (editor) => {
-    editor.on('SkinLoaded', () => {
-      editor.execCommand('ToggleSidebar', false, 'showcomments', { skip_focus: true });
-    });
-  }
 });

--- a/modules/ROOT/pages/comments-embedded-mode.adoc
+++ b/modules/ROOT/pages/comments-embedded-mode.adoc
@@ -1,26 +1,27 @@
-= Configuring the Comments plugin in embedded mode
+= Configuring the {pluginname} plugin in embedded mode
 :navtitle: Embedded mode
 :description: Information on configuring the Comments plugin in embedded mode
 :keywords: comments, commenting, tinycomments, embedded, embedded mode
 :pluginname: Comments
 :plugincode: comments
 
-== Add the Comments plugin in embedded mode
+== Add the {pluginname} plugin in embedded mode
 
-To add the Comments plugin in embedded mode to the {productname}, configure the following options:
+To add the {pluginname} plugin in embedded mode to the {productname}, configure the following options:
 
 [source,js]
 ----
 tinymce.init({
   selector: 'textarea',  // change this value according to your html
   plugins: 'tinycomments',
+  toolbar: 'addcomment showcomments',
   tinycomments_author: 'author',
   tinycomments_author_name: 'Name of the commenter',
   tinycomments_mode: 'embedded'
 });
 ----
 
-This is the minimum recommended setup for the Comments plugin in embedded mode. If the `+tinycomments_author+` and `+tinycomments_author_name+` options are not configured, all users will be assigned the name "_ANON_".
+This is the minimum recommended setup for the {pluginname} plugin in embedded mode. If the `+tinycomments_author+` and `+tinycomments_author_name+` options are not configured, all users will be assigned the name "_ANON_".
 
 == Interactive example
 

--- a/modules/ROOT/partials/configuration/tinycomments_author.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_author.adoc
@@ -14,6 +14,7 @@ This option sets the author id to be used when creating or replying to comments.
 tinymce.init({
   selector: 'textarea',  // change this value according to your html
   plugins: 'tinycomments',
+  toolbar: 'addcomment showcomments',
   tinycomments_mode: 'embedded',
   tinycomments_author: 'embedded_journalist',
 });

--- a/modules/ROOT/partials/configuration/tinycomments_author_avatar.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_author_avatar.adoc
@@ -3,12 +3,13 @@
 
 include::partial$misc/admon-requires-6.1v.adoc[]
 
-_Optional_ - This option sets the URL for the author's avatar to be used when creating or replying to comments. If this option is omitted, a generated avatar will be used instead. The avatar, if provided:
+_Optional_: This option sets the URL for the author's avatar to be used when creating or replying to comments. If this option is omitted, a generated avatar will be used instead. The avatar, if provided:
 
 * will be scaled to a 36px diameter circle; and
-* can be any filetype able to be wrapped in an `<img>` element.
+* can be any filetype able to be wrapped in an `+<img>+` element.
 
-IMPORTANT: The avatar will be stored alongside the embedded comment data when a new comment is created and cannot be changed later by changing this options value. To change the avatar image, the image on the server that the URL points to should be updated instead.
+[IMPORTANT]
+The avatar will be stored alongside the embedded comment data when a new comment is created and cannot be changed later by changing this options value. To change the avatar image, the image on the server that the URL points to should be updated instead.
 
 *Type:* `+String+`
 
@@ -19,6 +20,7 @@ IMPORTANT: The avatar will be stored alongside the embedded comment data when a 
 tinymce.init({
   selector: 'textarea',  // change this value according to your html
   plugins: 'tinycomments',
+  toolbar: 'addcomment showcomments',
   tinycomments_mode: 'embedded',
   tinycomments_author: 'embedded_journalist',
   tinycomments_author_name: 'Embedded Journalist',

--- a/modules/ROOT/partials/configuration/tinycomments_author_name.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_author_name.adoc
@@ -1,7 +1,7 @@
 [[tinycomments_author_name]]
 == `+tinycomments_author_name+`
 
-_Optional_ - This option sets the author's display name to be used when creating or replying to comments. If this option is omitted, then the author id is used instead.
+_Optional_: This option sets the author's display name to be used when creating or replying to comments. If this option is omitted, the author `+id+` is used instead.
 
 *Type:* `+String+`
 
@@ -12,6 +12,7 @@ _Optional_ - This option sets the author's display name to be used when creating
 tinymce.init({
   selector: 'textarea',  // change this value according to your html
   plugins: 'tinycomments',
+  toolbar: 'addcomment showcomments',
   tinycomments_mode: 'embedded',
   tinycomments_author: 'embedded_journalist',
   tinycomments_author_name: 'Embedded Journalist',

--- a/modules/ROOT/partials/configuration/tinycomments_can_delete.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_can_delete.adoc
@@ -1,7 +1,7 @@
 [[tinycomments_can_delete]]
 == `+tinycomments_can_delete+`
 
-_Optional_ - This option sets the author permissions for _deleting comment conversations_. If the `+tinycomments_can_delete+` option is not included, the current author (`+tinycomments_author+`) cannot delete comment conversations created by other authors.
+_Optional_: This option sets the author permissions for _deleting comment conversations_. If the `+tinycomments_can_delete+` option is not included, the current author (`+tinycomments_author+`) cannot delete comment conversations created by other authors.
 
 *Type:* `+Function+`
 
@@ -9,15 +9,15 @@ _Optional_ - This option sets the author permissions for _deleting comment conve
 [source,js]
 ----
 (req, done, fail) => {
-  const allowed = req.comments.length > 0 &&
-                req.comments[0].author === <Current_tinycomments_author>;
+  const allowed = req.comments.length > 0 && req.comments[0].author === <Current_tinycomments_author>;
   done({
     canDelete: allowed
   });
 }
 ----
 
-The following example extends the default behavior to allow the author `<Admin user>` to delete other author's comment conversations by adding `|| currentAuthor === '<Admin user>'`.
+[NOTE]
+The following example extends the default behavior to allow the author `+<Admin user>+` to delete other author's comment conversations by adding `|| currentAuthor === '<Admin user>'`.
 
 === Example: using `tinycomments_can_delete`
 
@@ -28,11 +28,11 @@ const currentAuthor = 'embedded_journalist';
 tinymce.init({
   selector: 'textarea',  // change this value according to your html
   plugins: 'tinycomments',
+  toolbar: 'addcomment showcomments',
   tinycomments_mode: 'embedded',
   tinycomments_author: currentAuthor,
   tinycomments_can_delete: (req, done, fail) => {
-    const allowed = req.comments.length > 0 &&
-                  req.comments[0].author === currentAuthor;
+    const allowed = req.comments.length > 0 && req.comments[0].author === currentAuthor;
     done({
       canDelete: allowed || currentAuthor === '<Admin user>'
     });

--- a/modules/ROOT/partials/configuration/tinycomments_can_delete_comment.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_can_delete_comment.adoc
@@ -1,7 +1,7 @@
 [[tinycomments_can_delete_comment]]
 == `+tinycomments_can_delete_comment+`
 
-_Optional_ - This option sets the author permissions for _deleting comments_. If the `+tinycomments_can_delete_comment+` option is not included, the current author (`+tinycomments_author+`) cannot delete comments added by other authors.
+_Optional_: This option sets the author permissions for _deleting comments_. If the `+tinycomments_can_delete_comment+` option is not included, the current author (`+tinycomments_author+`) **cannot** delete comments added by other authors.
 
 *Type:* `+Function+`
 
@@ -16,7 +16,8 @@ _Optional_ - This option sets the author permissions for _deleting comments_. If
 }
 ----
 
-The following example extends the default behavior to allow the author `<Admin user>` to delete other author's comments by adding `|| currentAuthor === '<Admin user>'`.
+[NOTE]
+The following example extends the default behavior to allow the author `+<Admin user>+` to delete other author's comments by adding `+|| currentAuthor === '<Admin user>'+`.
 
 === Example: using `tinycomments_can_delete_comment`
 
@@ -27,6 +28,7 @@ const currentAuthor = 'embedded_journalist';
 tinymce.init({
   selector: 'textarea',  // change this value according to your html
   plugins: 'tinycomments',
+  toolbar: 'addcomment showcomments',
   tinycomments_mode: 'embedded',
   tinycomments_author: currentAuthor,
   tinycomments_can_delete_comment: (req, done, fail) => {

--- a/modules/ROOT/partials/configuration/tinycomments_can_edit_comment.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_can_edit_comment.adoc
@@ -1,7 +1,7 @@
 [[tinycomments_can_edit_comment]]
 == `+tinycomments_can_edit_comment+`
 
-_Optional_ - This option sets the author permissions for _editing comments_. If the `+tinycomments_can_edit_comment+` option is not included, the current author (`+tinycomments_author+`) cannot edit comments added by other authors.
+_Optional_: This option sets the author permissions for _editing comments_. If the `+tinycomments_can_edit_comment+` option is not included, the current author (`+tinycomments_author+`) cannot edit comments added by other authors.
 
 *Type:* `+Function+`
 
@@ -16,7 +16,7 @@ _Optional_ - This option sets the author permissions for _editing comments_. If 
 }
 ----
 
-The following example extends the default behavior to allow the author `<Admin user>` to edit other author's comments by adding `|| currentAuthor === '<Admin user>'`.
+The following example extends the default behavior to allow the author `+<Admin user>+` to edit other author's comments by adding `|| currentAuthor === '<Admin user>'`.
 
 === Example: using `tinycomments_can_edit_comment`
 
@@ -27,6 +27,7 @@ const currentAuthor = 'embedded_journalist';
 tinymce.init({
   selector: 'textarea',  // change this value according to your html
   plugins: 'tinycomments',
+  toolbar: 'addcomment showcomments',
   tinycomments_mode: 'embedded',
   tinycomments_author: currentAuthor,
   tinycomments_can_edit_comment: (req, done, fail) => {

--- a/modules/ROOT/partials/configuration/tinycomments_can_resolve.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_can_resolve.adoc
@@ -1,7 +1,7 @@
 [[tinycomments_can_resolve]]
 == `+tinycomments_can_resolve+`
 
-_Optional_ - This option adds a _Resolve Conversation_ item to the dropdown menu of the first comment in a conversation. This callback sets the author permissions for _resolving comment conversations_.
+_Optional_: This option adds a _Resolve Conversation_ item to the dropdown menu of the first comment in a conversation. This callback sets the author permissions for _resolving comment conversations_.
 
 *Type:* `+Function+`
 
@@ -14,11 +14,11 @@ const currentAuthor = 'embedded_journalist';
 tinymce.init({
   selector: 'textarea',  // change this value according to your html
   plugins: 'tinycomments',
+  toolbar: 'addcomment showcomments',
   tinycomments_mode: 'embedded',
   tinycomments_author: currentAuthor,
   tinycomments_can_resolve: (req, done, fail) => {
-    const allowed = req.comments.length > 0 &&
-                  req.comments[0].author === currentAuthor;
+    const allowed = req.comments.length > 0 && req.comments[0].author === currentAuthor;
     done({
       canResolve: allowed || currentAuthor === '<Admin user>'
     });


### PR DESCRIPTION
Ticket: DOC-2524

Site: [Staging branch](http://docs-feature-74-doc-2524doc-2529.staging.tiny.cloud/docs/tinymce/latest/comments-embedded-mode/)

Changes:

Updated Live demo `examples/live-demos/comments-embedded/index.js` to:
* remove hacky `showsidebar` on load, and add comments and show comments to toolbar.

Updated:
* pages/comments-embedded-mode.adoc
* partials/configuration/tinycomments_author.adoc
* partials/configuration/tinycomments_author_avatar.adoc
* partials/configuration/tinycomments_author_name.adoc
* partials/configuration/tinycomments_can_delete.adoc
* partials/configuration/tinycomments_can_delete_comment.adoc
* partials/configuration/tinycomments_can_edit_comment.adoc
* partials/configuration/tinycomments_can_resolve.adoc

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed