### PR TITLE
DOC-2513: In read-only mode the editor now allows normal cursor movement and block element selection, including video playback & New  property for all ui components.

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -180,6 +180,7 @@
 *** xref:creating-custom-notifications.adoc[Notifications]
 *** xref:customsidebar.adoc[Sidebars]
 *** xref:custom-view.adoc[Views]
+*** xref:context.adoc[Context]
 *** xref:contextform.adoc[Context forms]
 *** xref:contextmenu.adoc[Context menus]
 *** xref:contexttoolbar.adoc[Context toolbar]

--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -116,6 +116,17 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== In read-only mode the editor now allows normal cursor movement and block element selection, including video playback.
+// #TINY-11264
+
+In read-only mode, the editor now allows normal cursor movement and block element selection, including video playback. This behavior is now the **default** when the `readonly` option is set to `+true+` or when switching to read-only mode.
+
+Prior to this improvement, the editor's body element was set to `+contentEditable="false"+`, which blocked cursor placement and all user inputs. In the new behavior, the body element is set to `+contentEditable="true"+`, and input blocking is handled by the editor.
+
+For more information, see xref:editor-important-options.adoc#readonly[Read-only option].
+
+[NOTE]
+In this mode, menu buttons, read-only menu items, and read-only buttons remain enabled. To revert to the old behavior, use `+tinymce.activeEditor.ui.setEnabled(false)+`.
 
 [[additions]]
 == Additions
@@ -127,6 +138,30 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+
+=== New `context` property for all ui components.
+// #TINY-11211
+
+A new `context` property has been introduced for all UI components, allowing buttons and menu items to be dynamically enabled or disabled based on whether their context matches a given predicate. This feature ensures that components reflect the current editing context, improving the user interface's adaptability.
+
+The status of the UI components is updated on `init`, `NodeChange`, and `SwitchMode` events. For the `mode` context, updates occur **only** on `SwitchMode` and `init`.
+
+To register a new context, integrators can now use:
+
+==== Default Contexts:
+
+- `editable`: Checks if the current selection is editable.
+- `mode`: Enables components based on the current mode (e.g., `mode:design`, `mode:!readonly`).
+- `any`: Always enables the UI component.
+- `formatting`: Verifies if a specific format can be applied at the current selection.
+- `insert`: Determines if a specific element can be inserted at the current selection.
+
+[TIP]
+Syntax for context usage is `key:value`, and negation is possible by prefixing the value with `!`. For instance, `mode:!readonly` enables a button unless the editor is in readonly mode.
+
+This enhancement allows for more context-sensitive UI components, improving user interaction by ensuring appropriate options are available based on the editor's state.
+
+For more information about the `context` property, see xref:context.adoc[Context].
 
 [[changes]]
 == Changes

--- a/modules/ROOT/pages/context.adoc
+++ b/modules/ROOT/pages/context.adoc
@@ -1,0 +1,107 @@
+= Context
+:navtitle: Context
+:description: Adding the context property to UI components for {productname} {productmajorversion}
+:keywords: context, context property, context property for UI components, context property for buttons, context property for menu items, context property for UI components in {productname}
+
+The context property for UI components in {productname} enables dynamic activation or deactivation of buttons and menu items based on predefined or custom conditions.
+
+[[registering-a-context]]
+== Registering a Context
+
+Methods for adding custom contexts are available in the UI Registry section of the editor API `+editor.ui.registry+`.
+
+* `editor.ui.registry.addContext(identifier, predicate: (value: string) => boolean)`
+
+These methods accept two arguments:
+
+* `+identifier+` - a unique name for the context
+* `+predicate+` - a function that determines whether the context condition is met. It accepts a single string parameter and returns a boolean:
+  ** Parameter (string): The value provided in the context syntax (e.g., in 'mode:design', 'design' would be passed to the predicate).
+  ** Return value (boolean): Returns true if the condition is met (the component should be enabled); otherwise, returns false.
+
+.Example
+[source,js]
+----
+setup: (editor) => {
+  editor.ui.registry.addContext('mode', (value: string) => {
+    return value === editor.mode.get();
+  });
+}
+----
+
+[[context-syntax]]
+== Context Syntax
+
+Contexts are specified using the syntax: `+<key>:<value>+`.
+
+* `+key+` - the type of context, used to look up registered contexts.
+* `+value+` - the condition passed to the predicate function for evaluation.
+
+[NOTE]
+To negate any context, place `!` before the value, using the format: `+<key>:!<value>+`.
+
+[[built-in-contexts]]
+== Built-in Contexts
+
+{productname} provides several built-in contexts:
+
+[cols="1,2,1"]
+|===
+|Name |Description |Defined by
+
+|`+any+`
+a|
+This context is always enabled, regardless of the editor's state.
+|`xref:apis/tinymce.util.uri.adoc[URI]`
+
+|`+mode:<mode_name>+`
+a|
+This context is used to enable or disable UI components based on the editor's current mode.
+[role="example"]
+* `+mode:design+`: Enabled only in design mode.
+* `+mode:readonly+`: Enabled only in readonly mode.
+|`xref:apis/tinymce.util.uri.adoc[URI]`
+
+|`+insert:<element_name>+`
+a|
+This context determines if a specific child element can be inserted at the current selection. It uses `+editor.schema.isValidChild+` to check if the specified element and its child are valid.
+[role="example"]
+* `+insert:p+`: Enabled if a paragraph can be inserted at the current selection.
+|`xref:apis/tinymce.util.uri.adoc[URI]`
+
+|`+formatting:<format_name>+`
+a|
+This context checks if a specific format can be applied to the current selection, using `+editor.formatter.canApply+`.
+[role="example"]
+* `+formatting:bold+`: Enabled if bold formatting can be applied to the current selection.
+|`xref:apis/tinymce.util.uri.adoc[URI]`
+
+|`+editable+`
+a|
+This context checks if the current selection is editable using `+editor.selection.isEditable()+`.
+|`xref:apis/tinymce.util.uri.adoc[URI]`
+|===
+
+[[using-context-in-ui-components]]
+== Using Context in UI Components
+
+To utilize the context in a UI component, apply the `+context+` property.
+
+.For example:
+[source,js]
+----
+setup: (editor) => {
+  editor.ui.registry.addButton('customToolbarButton', {
+    text: 'button',
+    onAction: () => {
+      console.log('clicked');
+    },
+    context: 'any'
+  });
+}
+----
+
+[[state-updates]]
+== State Updates
+//TODO
+UI components (buttons, menus, etc.) update their state (enabled/disabled) in response to specific editor events. Understanding when these updates occur can help optimize the UI and prevent unexpected behavior.

--- a/modules/ROOT/pages/context.adoc
+++ b/modules/ROOT/pages/context.adoc
@@ -45,14 +45,13 @@ To negate any context, place `!` before the value, using the format: `+<key>:!<v
 
 {productname} provides several built-in contexts:
 
-[cols="1,2,1"]
+[cols="1,2"]
 |===
-|Name |Description |Defined by
+|Name |Description
 
 |`+any+`
 a|
 This context is always enabled, regardless of the editor's state.
-|`xref:apis/tinymce.util.uri.adoc[URI]`
 
 |`+mode:<mode_name>+`
 a|
@@ -60,26 +59,22 @@ This context is used to enable or disable UI components based on the editor's cu
 [role="example"]
 * `+mode:design+`: Enabled only in design mode.
 * `+mode:readonly+`: Enabled only in readonly mode.
-|`xref:apis/tinymce.util.uri.adoc[URI]`
 
 |`+insert:<element_name>+`
 a|
 This context determines if a specific child element can be inserted at the current selection. It uses `+editor.schema.isValidChild+` to check if the specified element and its child are valid.
 [role="example"]
 * `+insert:p+`: Enabled if a paragraph can be inserted at the current selection.
-|`xref:apis/tinymce.util.uri.adoc[URI]`
 
 |`+formatting:<format_name>+`
 a|
 This context checks if a specific format can be applied to the current selection, using `+editor.formatter.canApply+`.
 [role="example"]
 * `+formatting:bold+`: Enabled if bold formatting can be applied to the current selection.
-|`xref:apis/tinymce.util.uri.adoc[URI]`
 
 |`+editable+`
 a|
-This context checks if the current selection is editable using `+editor.selection.isEditable()+`.
-|`xref:apis/tinymce.util.uri.adoc[URI]`
+This context checks if the current selection is editable using `+editor.selection.isEditable+`.
 |===
 
 [[using-context-in-ui-components]]
@@ -103,5 +98,12 @@ setup: (editor) => {
 
 [[state-updates]]
 == State Updates
-//TODO
-UI components (buttons, menus, etc.) update their state (enabled/disabled) in response to specific editor events. Understanding when these updates occur can help optimize the UI and prevent unexpected behavior.
+The following events will trigger a state update for UI components. During these updates, UI components re-evaluate their contexts and update their enabled/disabled state accordingly:
+
+. NodeChange: Fired when the selected node inside the editor content has changed.
+* Affects: All contexts except mode, including formatting, editable, insert, and any custom contexts.
+
+. SwitchMode: Fired when the editor mode is changed.
+
+. init: Fired when the editor is fully initialized.
+

--- a/modules/ROOT/pages/context.adoc
+++ b/modules/ROOT/pages/context.adoc
@@ -16,8 +16,8 @@ These methods accept two arguments:
 
 * `+identifier+` - a unique name for the context
 * `+predicate+` - a function that determines whether the context condition is met. It accepts a single string parameter and returns a boolean:
-  ** Parameter (string): The value provided in the context syntax (e.g., in 'mode:design', 'design' would be passed to the predicate).
-  ** Return value (boolean): Returns true if the condition is met (the component should be enabled); otherwise, returns false.
+** Parameter (string): The value provided in the context syntax (e.g., in 'mode:design', 'design' would be passed to the predicate).
+** Return value (boolean): Returns true if the condition is met (the component should be enabled); otherwise, returns false.
 
 .Example
 [source,js]
@@ -98,12 +98,12 @@ setup: (editor) => {
 
 [[state-updates]]
 == State Updates
-The following events will trigger a state update for UI components. During these updates, UI components re-evaluate their contexts and update their enabled/disabled state accordingly:
+The following events trigger state updates for UI components:
 
-. NodeChange: Fired when the selected node inside the editor content has changed.
-* Affects: All contexts except mode, including formatting, editable, insert, and any custom contexts.
+[NOTE]
+During these updates, UI components re-evaluate their contexts and adjust their enabled or disabled state as needed:
 
-. SwitchMode: Fired when the editor mode is changed.
-
-. init: Fired when the editor is fully initialized.
-
+. `NodeChange`: Triggered when the selected node within the editor content changes.
+* Affects: All contexts except mode, including formatting, editable, insert, and custom contexts.
+. `SwitchMode`: Triggered when the editor's mode is changed.
+. `init`: Triggered when the editor is fully initialized.

--- a/modules/ROOT/pages/custom-basic-menu-items.adoc
+++ b/modules/ROOT/pages/custom-basic-menu-items.adoc
@@ -18,6 +18,7 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |onSetup |`+(api) => (api) => void+` |optional |default: `+() => () => {}+` - Function invoked when the menu item is rendered, each time its menu is opened. For details, see: xref:using-onsetup[Using `+onSetup+`].
 |onAction |`+(api) => void+` |required |Function invoked when the menu item is clicked.
 |shortcut |string |optional |Text to display in the shortcut label. To register a shortcut, see: xref:shortcuts.adoc[Add custom shortcuts to TinyMCE].
+4+|
 include::partial$misc/admon-requires-7.4v.adoc[]
 |context |string |optional |default: `mode:design` - The context property dynamically enables or disables the menu item based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===

--- a/modules/ROOT/pages/custom-basic-menu-items.adoc
+++ b/modules/ROOT/pages/custom-basic-menu-items.adoc
@@ -18,6 +18,8 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |onSetup |`+(api) => (api) => void+` |optional |default: `+() => () => {}+` - Function invoked when the menu item is rendered, each time its menu is opened. For details, see: xref:using-onsetup[Using `+onSetup+`].
 |onAction |`+(api) => void+` |required |Function invoked when the menu item is clicked.
 |shortcut |string |optional |Text to display in the shortcut label. To register a shortcut, see: xref:shortcuts.adoc[Add custom shortcuts to TinyMCE].
+include::partial$misc/admon-requires-7.4v.adoc[]
+|context |string |optional |default: `mode:design` - The context property dynamically enables or disables the menu item based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===
 
 == API

--- a/modules/ROOT/pages/custom-basic-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-basic-toolbar-button.adoc
@@ -20,6 +20,8 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 4+|
 include::partial$misc/admon-requires-7.0v.adoc[]
 |shortcut |string |optional |Shortcut to display in the tooltip. To register a shortcut, see: xref:shortcuts.adoc[Add custom shortcuts to TinyMCE].
+include::partial$misc/admon-requires-7.4v.adoc[]
+|context |string |optional |default: `mode:design` - The context property dynamically enables or disables the button based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===
 
 == API

--- a/modules/ROOT/pages/custom-basic-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-basic-toolbar-button.adoc
@@ -20,6 +20,7 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 4+|
 include::partial$misc/admon-requires-7.0v.adoc[]
 |shortcut |string |optional |Shortcut to display in the tooltip. To register a shortcut, see: xref:shortcuts.adoc[Add custom shortcuts to TinyMCE].
+4+|
 include::partial$misc/admon-requires-7.4v.adoc[]
 |context |string |optional |default: `mode:design` - The context property dynamically enables or disables the button based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===

--- a/modules/ROOT/pages/custom-group-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-group-toolbar-button.adoc
@@ -18,6 +18,8 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |tooltip |string |optional |Text for button tooltip.
 |items |string or `+LabelledToolbar[]+` |required |A string of space separated toolbar button names, or an array of xref:toolbar-configuration-options.adoc#adding-toolbar-group-labels[labelled toolbar buttons].
 |onSetup |`+(api) => (api) => void+` |optional |default: `+() => () => {}+` - Function that's invoked when the button is rendered. For details, see: xref:using-onsetup[Using `+onSetup+`].
+include::partial$misc/admon-requires-7.4v.adoc[]
+|context |string |optional |default: `mode:design` - The context property dynamically enables or disables the button based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===
 
 == API

--- a/modules/ROOT/pages/custom-group-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-group-toolbar-button.adoc
@@ -18,6 +18,7 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |tooltip |string |optional |Text for button tooltip.
 |items |string or `+LabelledToolbar[]+` |required |A string of space separated toolbar button names, or an array of xref:toolbar-configuration-options.adoc#adding-toolbar-group-labels[labelled toolbar buttons].
 |onSetup |`+(api) => (api) => void+` |optional |default: `+() => () => {}+` - Function that's invoked when the button is rendered. For details, see: xref:using-onsetup[Using `+onSetup+`].
+4+|
 include::partial$misc/admon-requires-7.4v.adoc[]
 |context |string |optional |default: `mode:design` - The context property dynamically enables or disables the button based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===

--- a/modules/ROOT/pages/custom-menu-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-menu-toolbar-button.adoc
@@ -19,6 +19,7 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |search|boolean or object|optional |If not false, adds a search field to the menu. For more details, see xref:searchable-menu-buttons[Searchable Menu Buttons]
 |tooltip |string |optional |Text for button tooltip.
 |onSetup |`+(api) => (api) => void+` |optional |default: `+() => () => {}+` - Function that's invoked when the button is rendered. For details, see: xref:using-onsetup[Using `+onSetup+`].
+4+|
 include::partial$misc/admon-requires-7.4v.adoc[]
 |context |string |optional |default: `mode:design` - The context property dynamically enables or disables the button based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===

--- a/modules/ROOT/pages/custom-menu-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-menu-toolbar-button.adoc
@@ -19,6 +19,8 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |search|boolean or object|optional |If not false, adds a search field to the menu. For more details, see xref:searchable-menu-buttons[Searchable Menu Buttons]
 |tooltip |string |optional |Text for button tooltip.
 |onSetup |`+(api) => (api) => void+` |optional |default: `+() => () => {}+` - Function that's invoked when the button is rendered. For details, see: xref:using-onsetup[Using `+onSetup+`].
+include::partial$misc/admon-requires-7.4v.adoc[]
+|context |string |optional |default: `mode:design` - The context property dynamically enables or disables the button based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===
 
 == API

--- a/modules/ROOT/pages/custom-nested-menu-items.adoc
+++ b/modules/ROOT/pages/custom-nested-menu-items.adoc
@@ -15,6 +15,7 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |onSetup |`+(api) => (api) => void+` |optional |default: `+() => () => {}+` - Function invoked when the menu item is rendered, each time its menu is opened. For details, see: xref:using-onsetup[Using `+onSetup+`].
 |getSubmenuItems |`+() => string+` or `+MenuItem[]+` |required |Function invoked when the menu item is clicked to open its submenu. Must return either a space separated string of registered menu names or an array of basic, toggle or nested menu items specifications.
 |shortcut |string |optional |Text to display in the shortcut label. To register a shortcut, see: xref:shortcuts.adoc[Add custom shortcuts to TinyMCE].
+4+|
 include::partial$misc/admon-requires-7.4v.adoc[]
 |context |string |optional |default: `mode:design` - The context property dynamically enables or disables the menu item based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===

--- a/modules/ROOT/pages/custom-nested-menu-items.adoc
+++ b/modules/ROOT/pages/custom-nested-menu-items.adoc
@@ -15,6 +15,8 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |onSetup |`+(api) => (api) => void+` |optional |default: `+() => () => {}+` - Function invoked when the menu item is rendered, each time its menu is opened. For details, see: xref:using-onsetup[Using `+onSetup+`].
 |getSubmenuItems |`+() => string+` or `+MenuItem[]+` |required |Function invoked when the menu item is clicked to open its submenu. Must return either a space separated string of registered menu names or an array of basic, toggle or nested menu items specifications.
 |shortcut |string |optional |Text to display in the shortcut label. To register a shortcut, see: xref:shortcuts.adoc[Add custom shortcuts to TinyMCE].
+include::partial$misc/admon-requires-7.4v.adoc[]
+|context |string |optional |default: `mode:design` - The context property dynamically enables or disables the menu item based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===
 
 == API

--- a/modules/ROOT/pages/custom-split-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-split-toolbar-button.adoc
@@ -19,6 +19,8 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |fetch |`+(success: (menu) => void) => void+` |Drop-down menu |required |A callback function that should be passed a list of xref:choice-menu-items[choice menu items] for the dropdown menu.
 |onItemAction |`+(api, value) => void+` |Choice menu items |required |Function invoked when a dropdown list option is clicked. The `+value+` is passed from the selected choice menu item.
 |onSetup |`+(api) => (api) => void+` |All |optional |default: `+() => () => {}+` - Function invoked when the button is rendered. For details, see: xref:using-onsetup[Using `+onSetup+`].
+include::partial$misc/admon-requires-7.4v.adoc[]
+|context |string |optional |default: `mode:design` - The context property dynamically enables or disables the button based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===
 
 == API

--- a/modules/ROOT/pages/custom-split-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-split-toolbar-button.adoc
@@ -19,8 +19,9 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |fetch |`+(success: (menu) => void) => void+` |Drop-down menu |required |A callback function that should be passed a list of xref:choice-menu-items[choice menu items] for the dropdown menu.
 |onItemAction |`+(api, value) => void+` |Choice menu items |required |Function invoked when a dropdown list option is clicked. The `+value+` is passed from the selected choice menu item.
 |onSetup |`+(api) => (api) => void+` |All |optional |default: `+() => () => {}+` - Function invoked when the button is rendered. For details, see: xref:using-onsetup[Using `+onSetup+`].
+5+|
 include::partial$misc/admon-requires-7.4v.adoc[]
-|context |string |optional |default: `mode:design` - The context property dynamically enables or disables the button based on the editor's current state. For details, see: xref:context.adoc[Context].
+|context |string |All |optional |default: `mode:design` - The context property dynamically enables or disables the button based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===
 
 == API

--- a/modules/ROOT/pages/custom-toggle-menu-items.adoc
+++ b/modules/ROOT/pages/custom-toggle-menu-items.adoc
@@ -18,6 +18,8 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |enabled |boolean |optional |default: `true` - Represents the menu item's state. When `false`, the menu item is unclickable. Toggled by the menu item's API.
 |onSetup |`+(api) => (api) => void+` |optional |default: `+() => () => {}+` - Function invoked when the menu item is rendered, each time its menu is opened. For details, see: xref:using-onsetup[Using `+onSetup+`].
 |onAction |`+(api) => void+` |required |Function invoked when the menu item is clicked.
+include::partial$misc/admon-requires-7.4v.adoc[]
+|context |string |optional |default: `mode:design` - The context property dynamically enables or disables the menu item based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===
 
 == API

--- a/modules/ROOT/pages/custom-toggle-menu-items.adoc
+++ b/modules/ROOT/pages/custom-toggle-menu-items.adoc
@@ -18,6 +18,7 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |enabled |boolean |optional |default: `true` - Represents the menu item's state. When `false`, the menu item is unclickable. Toggled by the menu item's API.
 |onSetup |`+(api) => (api) => void+` |optional |default: `+() => () => {}+` - Function invoked when the menu item is rendered, each time its menu is opened. For details, see: xref:using-onsetup[Using `+onSetup+`].
 |onAction |`+(api) => void+` |required |Function invoked when the menu item is clicked.
+4+|
 include::partial$misc/admon-requires-7.4v.adoc[]
 |context |string |optional |default: `mode:design` - The context property dynamically enables or disables the menu item based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===

--- a/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
@@ -21,6 +21,7 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 4+|
 include::partial$misc/admon-requires-7.0v.adoc[]
 |shortcut |string |optional |Shortcut to display in the tooltip. To register a shortcut, see: xref:shortcuts.adoc[Add custom shortcuts to TinyMCE].
+4+|
 include::partial$misc/admon-requires-7.4v.adoc[]
 |context |string |optional |default: `mode:design` - The context property dynamically enables or disables the button based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===

--- a/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
@@ -21,6 +21,8 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 4+|
 include::partial$misc/admon-requires-7.0v.adoc[]
 |shortcut |string |optional |Shortcut to display in the tooltip. To register a shortcut, see: xref:shortcuts.adoc[Add custom shortcuts to TinyMCE].
+include::partial$misc/admon-requires-7.4v.adoc[]
+|context |string |optional |default: `mode:design` - The context property dynamically enables or disables the button based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===
 
 == API

--- a/modules/ROOT/pages/dialog-components.adoc
+++ b/modules/ROOT/pages/dialog-components.adoc
@@ -226,6 +226,8 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 *When configured, the button will display the icon instead of text.*
 |buttonType |`+'primary'+`, `+'secondary'+`, or `+'toolbar'+` |optional |default: `+'secondary'+` - Whether to style the button as a primary, secondary, or toolbar button.
 |borderless |boolean |optional |default: `+false+` - Whether to style the button without a border and background color.
+include::partial$misc/admon-requires-7.4v.adoc[]
+|context |string |optional |default: `mode:design` - The context property dynamically enables or disables the button based on the editor's current state. Only effective when `+enabled+` is true. For details, see: xref:context.adoc[Context].
 |===
 
 NOTE: Buttons do not support mixing icons and text at the moment.
@@ -237,8 +239,9 @@ NOTE: Buttons do not support mixing icons and text at the moment.
   text: 'Alpha',
   buttonType: 'primary',
   name: 'alpha-button',
-  enabled: false,
-  borderless: false
+  enabled: true,
+  borderless: false,
+  context: 'mode:design'
 }
 ----
 
@@ -255,7 +258,8 @@ A *checkbox* is a composite component with a checkbox and a label, and with `+on
   type: 'checkbox', // component type
   name: 'checkbox-1', // identifier
   label: 'Checkbox Label', // text for the label
-  enabled: false // enabled state
+  enabled: true, // enabled state
+  context: 'mode:design' // checkbox is active when the editor is in design mode, only effective when enabled is true
 }
 ----
 
@@ -269,7 +273,8 @@ A *colorinput* is a specialized composite component with a label, an input field
 {
   type: 'colorinput', // component type
   name: 'colorinput', // identifier
-  label: 'Color Label' // text for the label
+  label: 'Color Label', // text for the label
+  context: 'mode:design' // colorinput is active when the editor is in design mode, only effective when enabled is true
 }
 ----
 
@@ -298,7 +303,8 @@ A *dropzone* is a composite component that catches drag and drops items or lets 
 {
   type: 'dropzone', // component type
   name: 'dropzone', // identifier
-  label: 'Dropzone' // text for the label
+  label: 'Dropzone', // text for the label
+  context: 'mode:design' // dropzone is active when the editor is in design mode, only effective when enabled is true
 }
 ----
 
@@ -399,6 +405,8 @@ An *input* is a composite component that renders a label and a single line text 
 |placeholder |string |optional |String of placeholder text for the input field.
 |enabled |boolean |optional |Allows the field to be disabled. Default is `+true+`.
 |inputMode |string |optional |Allows for the specification of input type for displaying contextual onscreen keyboards on mobile devices.
+include::partial$misc/admon-requires-7.4v.adoc[]
+|context |string |optional |default: `mode:design` - The context property dynamically enables or disables the input based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===
 
 [source,js]
@@ -409,8 +417,9 @@ An *input* is a composite component that renders a label and a single line text 
   inputMode: 'text',
   label: 'Input Label', // text for the label
   placeholder: 'example', // placeholder text for the input
-  enabled: false, // disabled state
-  maximized: false // grow width to take as much space as possible
+  enabled: true, // enabled state
+  maximized: false, // grow width to take as much space as possible
+  context: 'mode:design' // input is active when the editor is in design mode, only effective when enabled is true
 }
 ----
 
@@ -436,14 +445,15 @@ A *listbox* is a composite component with a label and a dropdown list of options
   type: 'listbox', // component type
   name: 'ListBoxA', // identifier
   label: 'ListBox Label',
-  enabled: false, // enabled state
+  enabled: true, // enabled state
   items: [
     { text: 'One', value: 'one' },
     { text: 'Two', value: 'two' },
     { text: 'Submenu', items: [
       { text: 'Three', value: 'three' }
     ]}
-  ]
+  ],
+  context: 'mode:design' // listbox is active when the editor is in design mode, only effective when enabled is true
 }
 ----
 
@@ -461,12 +471,13 @@ A *selectbox* is a composite component with a label and a single dropdown list o
   type: 'selectbox', // component type
   name: 'SelectA', // identifier
   label: 'Select Label',
-  enabled: false, // enabled state
+  enabled: true, // enabled state
   size: 1, // number of visible values (optional)
   items: [
     { value: 'one', text: 'One' },
     { value: 'two', text: 'Two' }
-  ]
+  ],
+  context: 'mode:design' // selectbox is active when the editor is in design mode, only effective when enabled is true
 }
 ----
 
@@ -483,7 +494,8 @@ A *sizeinput* is a specialized composite component with two input fields labelle
   type: 'sizeinput', // component type
   name: 'size', // identifier
   label: 'Dimensions',
-  enabled: false // enabled state
+  enabled: true, // enabled state
+  context: 'mode:design' // sizeinput is active when the editor is in design mode, only effective when enabled is true
 }
 ----
 
@@ -536,8 +548,9 @@ A *textarea* is a multiline text field.
   name: 'text-a', // identifier
   label: 'Text: ',
   placeholder: 'example',
-  enabled: false, // enabled state
-  maximized: false // grow width to take as much space as possible
+  enabled: true, // enabled state
+  maximized: false, // grow width to take as much space as possible
+  context: 'mode:design' // textarea is active when the editor is in design mode, only effective when enabled is true
 }
 ----
 
@@ -724,6 +737,9 @@ If `picker_text` is not specified, the tooltip defaults to the value provided by
 
 
 This option *requires* `+file_picker_callback+` to be configured.
+
+include::partial$misc/admon-requires-7.4v.adoc[]
+|context |string |optional |default: `mode:design` - The context property dynamically enables or disables the urlinput based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===
 
 ==== urlinput examples
@@ -739,8 +755,9 @@ The filepicker will accept any file type; the typeahead will include 5 previousl
   name: 'url', // identifier
   filetype: 'file', // allow any file types
   label: 'Url', // text for component label
-  enabled: false, // enabled state
+  enabled: true, // enabled state
   picker_text: 'Find local files', // set a custom tooltip for the filepicker button
+  context: 'mode:design' // urlinput is active when the editor is in design mode, only effective when enabled is true
 }
 ----
 
@@ -755,6 +772,7 @@ The filepicker will only accept images and the typeahead will include 5 previous
   name: 'src', // identifier
   filetype: 'image', // restrict file types to image types
   label: 'Source', // text for component label
-  enabled: false // enabled state
+  enabled: true, // enabled state
+  context: 'mode:design' // urlinput is active when the editor is in design mode, only effective when enabled is true
 }
 ----

--- a/modules/ROOT/pages/dialog-components.adoc
+++ b/modules/ROOT/pages/dialog-components.adoc
@@ -406,6 +406,7 @@ An *input* is a composite component that renders a label and a single line text 
 |placeholder |string |optional |String of placeholder text for the input field.
 |enabled |boolean |optional |Allows the field to be disabled. Default is `+true+`.
 |inputMode |string |optional |Allows for the specification of input type for displaying contextual onscreen keyboards on mobile devices.
+4+|
 include::partial$misc/admon-requires-7.4v.adoc[]
 |context |string |optional |default: `mode:design` - The context property dynamically enables or disables the input based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===

--- a/modules/ROOT/pages/dialog-components.adoc
+++ b/modules/ROOT/pages/dialog-components.adoc
@@ -226,6 +226,7 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 *When configured, the button will display the icon instead of text.*
 |buttonType |`+'primary'+`, `+'secondary'+`, or `+'toolbar'+` |optional |default: `+'secondary'+` - Whether to style the button as a primary, secondary, or toolbar button.
 |borderless |boolean |optional |default: `+false+` - Whether to style the button without a border and background color.
+4+|
 include::partial$misc/admon-requires-7.4v.adoc[]
 |context |string |optional |default: `mode:design` - The context property dynamically enables or disables the button based on the editor's current state. Only effective when `+enabled+` is true. For details, see: xref:context.adoc[Context].
 |===

--- a/modules/ROOT/pages/dialog-components.adoc
+++ b/modules/ROOT/pages/dialog-components.adoc
@@ -740,6 +740,7 @@ If `picker_text` is not specified, the tooltip defaults to the value provided by
 
 This option *requires* `+file_picker_callback+` to be configured.
 
+4+|
 include::partial$misc/admon-requires-7.4v.adoc[]
 |context |string |optional |default: `mode:design` - The context property dynamically enables or disables the urlinput based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===

--- a/modules/ROOT/pages/dialog-footer-buttons.adoc
+++ b/modules/ROOT/pages/dialog-footer-buttons.adoc
@@ -93,6 +93,7 @@ The following options can be specified for a dialog menu button _item_:
 |type |string |required |The type `+togglemenuitem+` should be used.
 |text |string |optional |Text to display if no icon is found.
 |value |string |optional |A value to associate with the menu item.
+4+|
 include::partial$misc/admon-requires-7.4v.adoc[]
 |context |string |optional |default: `mode:design` - The context property dynamically enables or disables the menu item based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===

--- a/modules/ROOT/pages/dialog-footer-buttons.adoc
+++ b/modules/ROOT/pages/dialog-footer-buttons.adoc
@@ -21,6 +21,7 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |buttonType |`+'primary'+`, or `+'secondary'+` |optional |default: `+'secondary'+` - Whether to style the button as a primary, or secondary button.
 |enabled |boolean |optional |default: `+true+` - When `+false+`, the button will be disabled when the dialog loads.
 |align |`+'end'+` or `+'start'+` |optional |default: `+'end'+` - When set to `+'end'+` the button will display on the right-hand side of the dialog. When set to `+'start'+` the button will display on the left-hand side.
+4+|
 include::partial$misc/admon-requires-7.4v.adoc[]
 |context |string |optional |default: `mode:design` for all types except `cancel`, which defaults to `any` - The context property dynamically enables or disables the menu item based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===

--- a/modules/ROOT/pages/dialog-footer-buttons.adoc
+++ b/modules/ROOT/pages/dialog-footer-buttons.adoc
@@ -21,6 +21,8 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |buttonType |`+'primary'+`, or `+'secondary'+` |optional |default: `+'secondary'+` - Whether to style the button as a primary, or secondary button.
 |enabled |boolean |optional |default: `+true+` - When `+false+`, the button will be disabled when the dialog loads.
 |align |`+'end'+` or `+'start'+` |optional |default: `+'end'+` - When set to `+'end'+` the button will display on the right-hand side of the dialog. When set to `+'start'+` the button will display on the left-hand side.
+include::partial$misc/admon-requires-7.4v.adoc[]
+|context |string |optional |default: `mode:design` for all types except `cancel`, which defaults to `any` - The context property dynamically enables or disables the menu item based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===
 
 NOTE: Buttons do not support mixing icons and text at the moment.
@@ -51,7 +53,8 @@ See the xref:dialog-configuration.adoc#options[dialog configuration options] doc
   // icon: 'checkmark', // will replace the text if configured
   enabled: true, // button is active when the dialog opens
   buttonType: 'primary', // style the button as a primary button
-  align: 'start' // align the button to the left of the dialog footer
+  align: 'start', // align the button to the left of the dialog footer
+  context: 'mode:design' // button is active when the editor is in design mode, only effective if enabled is true
 }
 ----
 
@@ -89,6 +92,8 @@ The following options can be specified for a dialog menu button _item_:
 |type |string |required |The type `+togglemenuitem+` should be used.
 |text |string |optional |Text to display if no icon is found.
 |value |string |optional |A value to associate with the menu item.
+include::partial$misc/admon-requires-7.4v.adoc[]
+|context |string |optional |default: `mode:design` - The context property dynamically enables or disables the menu item based on the editor's current state. For details, see: xref:context.adoc[Context].
 |===
 
 ==== Example: dialog footer menu button
@@ -108,12 +113,14 @@ buttons: [
       {
         name: 'dialogMenuButtonItem1',
         type: 'togglemenuitem',
-        text: 'Item 1.'
+        text: 'Item 1.',
+        context: 'mode:design'
       },
       {
         name: 'dialogMenuButtonItem2',
         type: 'togglemenuitem',
-        text: 'Item 2.'
+        text: 'Item 2.',
+        context: 'mode:design'
       }
     ]
   }

--- a/modules/ROOT/partials/configuration/readonly.adoc
+++ b/modules/ROOT/partials/configuration/readonly.adoc
@@ -1,15 +1,15 @@
 [[readonly]]
-== `+readonly+`
+== `readonly`
 
-Setting the `+readonly+` option to `+true+` will initialize the editor in `+"readonly"+` mode instead of editing (`+"design"+`) mode. Once initialized, the editor can be set to editing (`+"design"+`) mode using the xref:apis/tinymce.editormode.adoc#set[`+tinymce.editor.mode.set+` API].
+Setting the `readonly` option to `true` initializes the editor in **readonly** mode instead of editing (**design**) mode. Once initialized, the editor can be switched to **design** mode using the xref:apis/tinymce.editormode.adoc#set[`tinymce.editor.mode.set` API].
 
-*Type:* `+Boolean+`
+*Type:* `Boolean`
 
-*Default value:* `+false+`
+*Default value:* `false`
 
-*Possible values:* `+true+`, `+false+`
+*Possible values:* `true`, `false`
 
-=== Example: using `+readonly+`
+=== Example: Using `readonly`
 
 [source,js]
 ----
@@ -20,3 +20,61 @@ tinymce.init({
 ----
 
 liveDemo::readonly-demo[]
+
+=== Behavior in `readonly` mode
+
+[cols="1,3,1", options="header"]
+|===
+| **Behavior** | **Details** | **Allowed (True/False)**
+
+| Navigation and Interaction 
+a|
+* Users can place the cursor within the editor
+* Navigation behaves the same as in design mode, including:
+  ** Moving through block elements (table of contents, images, media elements)
+  ** Using arrow keys, Home, End, Page Up, Page Down
+* Media elements can be played
+* Users can select and copy text
+* Users can interact with links
+| True
+| Prevented Actions
+a|
+* All input events (keyboard and IME input)
+* Content modifications:
+  ** Pasting content
+  ** Cutting content
+  ** Deleting content
+  ** Drag and drop operations
+* Formatting changes:
+  ** Keyboard shortcuts for formatting (e.g., Cmd/Ctrl + B)
+  ** Auto-linking when pressing space after URLs
+* Element modifications:
+  ** Toggling checklists (via click or Cmd/Ctrl + Enter)
+  ** Indenting lists
+  ** Adding new table rows via Tab key
+  ** Resizing tables, media elements, or images
+| False
+| Toolbar and UI Behavior
+a|
+* Most toolbar buttons are disabled
+* Fields in dialogs (e.g., link dialog) are disabled
+* When switching from **design** to **readonly** mode:
+  ** All open dialogs and UI components adjust to reflect readonly state
+| False
+
+| Enabled Features
+a| 
+* The following toolbar/menu items remain enabled in **readonly** mode:
+** xref:fullscreen.adoc[Full Screen]
+** xref:help.adoc[Help]
+** xref:preview.adoc[Preview]
+** xref:visualblocks.adoc[Visual Blocks]
+** xref:visualchars.adoc[Visual Characters]
+** xref:wordcount.adoc[Word Count]
+** xref:exportpdf.adoc[Export to PDF]
+** xref:exportword.adoc[Export to Word]
+** xref:content-appearance.adoc#visual[Visual Aid]
+** Copy
+** Select all
+| True
+|===

--- a/modules/ROOT/partials/misc/admon-requires-7.4v.adoc
+++ b/modules/ROOT/partials/misc/admon-requires-7.4v.adoc
@@ -1,0 +1,1 @@
+NOTE: This feature is only available for {productname} 7.4 and later.


### PR DESCRIPTION
Ticket: DOC-2513 & DOC-2540 & DOC-2497

Site: [Context.adoc new page](http://docs-feature-74-doc-2513doc-2540.staging.tiny.cloud/docs/tinymce/latest/context/)
Site: [Release note entry 1](http://docs-feature-74-doc-2513doc-2540.staging.tiny.cloud/docs/tinymce/latest/7.4-release-notes/#in-read-only-mode-the-editor-now-allows-normal-cursor-movement-and-block-element-selection-including-video-playback)
Site: [Release note entry 2](http://docs-feature-74-doc-2513doc-2540.staging.tiny.cloud/docs/tinymce/latest/7.4-release-notes/#new-context-property-for-all-ui-components)

Changes:
* Added `In read-only mode the editor now allows normal cursor movement and block element selection, including video playback.`
* Added `New  property for all ui components.`
* Added new `context.adoc`.

- [x] TODO:// Update `state-updates` @shanmen-tiny 

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.

Review:
- [x] Documentation Team Lead has reviewed