### PR TITLE
DOC-2513: Insert lists will no longer unexpectedly generate indented lists.

### DIFF
--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -72,6 +72,23 @@ The {productname} {release-version} release includes an accompanying release of 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
 
+=== AI Assistant
+
+The {productname} {release-version} release includes an accompanying release of the **AI Assistant** premium plugin.
+
+**AI Assistant** includes the following improvement.
+
+=== Insert lists will no longer unexpectedly generate indented lists.
+// #TINY-10920
+
+The `+insertContent+` action previously did not handle pasting a list onto another list correctly, causing the **AI Assistant** Premium plugin to generate an unexpected indented list when inserting lists into existing ones.
+
+In {productname} {release-version}, this issue is resolved by adding a paste argument to the `+insertContent+` action, ensuring correct handling of list insertion.
+
+As a result, the **AI Assistant** Premium plugin will no longer create indented lists when inserting a list on top of an existing one.
+
+For information on the **AI Assistant** premium plugin, see: xref:ai.adoc[AI Assistant].
+
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement
 

--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -76,7 +76,7 @@ For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode
 
 The {productname} {release-version} release includes an accompanying release of the **AI Assistant** premium plugin.
 
-**AI Assistant** includes the following improvement.
+**AI Assistant** includes the following fix.
 
 === Insert lists will no longer unexpectedly generate indented lists.
 // #TINY-10920


### PR DESCRIPTION
Ticket: DOC-2513

Site: [Staging branch](http://docs-feature-74-doc-2513tiny-10920.staging.tiny.cloud/docs/tinymce/latest/7.4-release-notes/#insert-lists-will-no-longer-unexpectedly-generate-indented-lists)

Changes:
* added fix documentation for TINY-10920

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed