### PR TITLE
DOC-2513: Categories can now be declared as `locked`, making them readonly.

### DIFF
--- a/modules/ROOT/examples/live-demos/advtemplate-readonly-template/example.js
+++ b/modules/ROOT/examples/live-demos/advtemplate-readonly-template/example.js
@@ -12,13 +12,11 @@ const headers = {
     }
   }
   
-  const advtemplate_list = () => {
-    return fetch('/categories', {
-        method: 'GET',
-        headers,
-      })
-      .then(handleResponse('Failed to get template list'))
-  }
+  const advtemplate_list = () => fetch('/categories', {
+      method: 'GET',
+      headers,
+    })
+    .then(handleResponse('Failed to get template list'))
   
   const advtemplate_get_template = (id) => {
     return fetch('/templates/' + id, {

--- a/modules/ROOT/examples/live-demos/advtemplate-readonly-template/example.js
+++ b/modules/ROOT/examples/live-demos/advtemplate-readonly-template/example.js
@@ -1,130 +1,101 @@
 const headers = {
-    'Accept': 'application/json',
-    'Content-Type': 'application/json',
-  }
-  
-  const handleResponse = (message) => (response) => {
-    if (!response.ok) {
-      response.text().then((message) => console.error(message))
-      throw new Error(message);
-    } else {
-      return response.json();
-    }
-  }
-  
-  const advtemplate_list = () => fetch('/categories', {
-      method: 'GET',
-      headers,
-    })
-    .then(handleResponse('Failed to get template list'))
-  
-  const advtemplate_get_template = (id) => fetch('/templates/' + id, {
-      method: 'GET',
-      headers,
-    })
-    .then(handleResponse('Failed to get template'))
-  
-  const advtemplate_create_category = (title) => {
-    return fetch('/categories', {
-        method: 'POST',
-        body: JSON.stringify({
-          title
-        }),
-        headers,
-      })
-      .then(handleResponse('Failed to create category'))
-  }
-  
-  const advtemplate_create_template = (title, content, categoryId) => {
-    return fetch('/templates', {
-        method: 'POST',
-        body: JSON.stringify({
-          title,
-          content,
-          categoryId
-        }),
-        headers,
-      })
-      .then(handleResponse('Failed to create template'))
-  }
-  
-  const advtemplate_rename_category = (id, title) => {
-    return fetch('/categories/' + id, {
-        method: 'PUT',
-        body: JSON.stringify({
-          title
-        }),
-        headers,
-      })
-      .then(handleResponse('Failed to rename category'))
-  }
-  
-  const advtemplate_rename_template = (id, title) => {
-    return fetch('/templates/' + id, {
-        method: 'PUT',
-        body: JSON.stringify({
-          title
-        }),
-        headers,
-      })
-      .then(handleResponse('Failed to rename template'))
-  }
-  
-  const advtemplate_delete_template = (id) => {
-    return fetch('/templates/' + id, {
-        method: 'DELETE',
-        headers,
-      })
-      .then(handleResponse('Failed to delete template'))
-  }
-  
-  const advtemplate_delete_category = (id) => {
-    return fetch('/categories/' + id, {
-        method: 'DELETE',
-        headers,
-      })
-      .then(handleResponse('Failed to delete category'))
-  }
-  const advtemplate_move_template = (id, categoryId) => {
-    return fetch('/templates/' + id, {
-        method: 'PATCH',
-        body: JSON.stringify({
-          categoryId
-        }),
-        headers,
-      })
-      .then(handleResponse('Failed to move template'))
-  }
-  
-  const advtemplate_move_category_items = (id, categoryId) => {
-    return fetch('/categories/' + id, {
-        method: 'PATCH',
-        body: JSON.stringify({
-          categoryId
-        }),
-        headers,
-      })
-      .then(handleResponse('Failed to move all templates to new category'))
-  } 
+  'Accept': 'application/json',
+  'Content-Type': 'application/json',
+};
 
-  tinymce.init({
-    selector: "textarea#readonly-locked-template",
-      plugins: [
-          "advlist", "anchor", "autolink", "charmap", "code", "fullscreen", 
-          "help", "image", "insertdatetime", "link", "lists", "media", 
-          "preview", "searchreplace", "table", "visualblocks", "advtemplate"
-      ],
-    contextmenu: 'advtemplate',
-    toolbar: "addtemplate inserttemplate | undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
-    advtemplate_list,
-    advtemplate_get_template,
-    advtemplate_create_category,
-    advtemplate_create_template,
-    advtemplate_rename_category,
-    advtemplate_rename_template,
-    advtemplate_delete_template,
-    advtemplate_delete_category,
-    advtemplate_move_template,
-    advtemplate_move_category_items
-  });
-  
+const handleResponse = (message) => (response) => {
+  if (!response.ok) {
+    return response.text().then((error) => {
+      console.error(error);
+      throw new Error(message);
+    });
+  }
+  return response.json();
+};
+
+const advtemplate_list = () =>
+  fetch('/categories', {
+    method: 'GET',
+    headers,
+  }).then(handleResponse('Failed to get template list'));
+
+const advtemplate_get_template = (id) =>
+  fetch(`/templates/${id}`, {
+    method: 'GET',
+    headers,
+  }).then(handleResponse('Failed to get template'));
+
+const advtemplate_create_category = (title) =>
+  fetch('/categories', {
+    method: 'POST',
+    body: JSON.stringify({ title }),
+    headers,
+  }).then(handleResponse('Failed to create category'));
+
+const advtemplate_create_template = (title, content, categoryId) =>
+  fetch('/templates', {
+    method: 'POST',
+    body: JSON.stringify({ title, content, categoryId }),
+    headers,
+  }).then(handleResponse('Failed to create template'));
+
+const advtemplate_rename_category = (id, title) =>
+  fetch(`/categories/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify({ title }),
+    headers,
+  }).then(handleResponse('Failed to rename category'));
+
+const advtemplate_rename_template = (id, title) =>
+  fetch(`/templates/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify({ title }),
+    headers,
+  }).then(handleResponse('Failed to rename template'));
+
+const advtemplate_delete_template = (id) =>
+  fetch(`/templates/${id}`, {
+    method: 'DELETE',
+    headers,
+  }).then(handleResponse('Failed to delete template'));
+
+const advtemplate_delete_category = (id) =>
+  fetch(`/categories/${id}`, {
+    method: 'DELETE',
+    headers,
+  }).then(handleResponse('Failed to delete category'));
+
+const advtemplate_move_template = (id, categoryId) =>
+  fetch(`/templates/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ categoryId }),
+    headers,
+  }).then(handleResponse('Failed to move template'));
+
+const advtemplate_move_category_items = (id, categoryId) =>
+  fetch(`/categories/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ categoryId }),
+    headers,
+  }).then(handleResponse('Failed to move all templates to new category'));
+
+tinymce.init({
+  selector: "textarea#readonly-locked-template",
+  plugins: [
+    "advlist", "anchor", "autolink", "charmap", "code", "fullscreen",
+    "help", "image", "insertdatetime", "link", "lists", "media",
+    "preview", "searchreplace", "table", "visualblocks", "advtemplate"
+  ],
+  contextmenu: 'advtemplate',
+  toolbar: "addtemplate inserttemplate | undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
+  advtemplate_list,
+  advtemplate_get_template,
+  advtemplate_create_category,
+  advtemplate_create_template,
+  advtemplate_rename_category,
+  advtemplate_rename_template,
+  advtemplate_delete_template,
+  advtemplate_delete_category,
+  advtemplate_move_template,
+  advtemplate_move_category_items,
+});

--- a/modules/ROOT/examples/live-demos/advtemplate-readonly-template/example.js
+++ b/modules/ROOT/examples/live-demos/advtemplate-readonly-template/example.js
@@ -80,22 +80,23 @@ const advtemplate_move_category_items = (id, categoryId) =>
   }).then(handleResponse('Failed to move all templates to new category'));
 
 tinymce.init({
-  selector: "textarea#readonly-locked-template",
+  selector: 'textarea#readonly-locked-template',
   plugins: [
-    "advlist", "anchor", "autolink", "charmap", "code", "fullscreen",
-    "help", "image", "insertdatetime", "link", "lists", "media",
-    "preview", "searchreplace", "table", "visualblocks", "advtemplate"
+    'advlist', 'anchor', 'autolink', 'charmap', 'code', 'fullscreen',
+    'help', 'image', 'insertdatetime', 'link', 'lists', 'media',
+    'preview', 'searchreplace', 'table', 'visualblocks', 'advtemplate'
   ],
   contextmenu: 'advtemplate',
-  toolbar: "addtemplate inserttemplate | undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
+  toolbar: 'addtemplate inserttemplate | undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image',
+
   advtemplate_list,
   advtemplate_get_template,
   advtemplate_create_category,
   advtemplate_create_template,
   advtemplate_rename_category,
-  advtemplate_rename_template,
-  advtemplate_delete_template,
-  advtemplate_delete_category,
-  advtemplate_move_template,
   advtemplate_move_category_items,
+  advtemplate_delete_category,
+  advtemplate_rename_template,
+  advtemplate_move_template,
+  advtemplate_delete_template,
 });

--- a/modules/ROOT/examples/live-demos/advtemplate-readonly-template/example.js
+++ b/modules/ROOT/examples/live-demos/advtemplate-readonly-template/example.js
@@ -1,0 +1,134 @@
+const headers = {
+    'Accept': 'application/json',
+    'Content-Type': 'application/json',
+  }
+  
+  const handleResponse = (message) => (response) => {
+    if (!response.ok) {
+      response.text().then((message) => console.error(message))
+      throw new Error(message);
+    } else {
+      return response.json();
+    }
+  }
+  
+  const advtemplate_list = () => {
+    return fetch('/categories', {
+        method: 'GET',
+        headers,
+      })
+      .then(handleResponse('Failed to get template list'))
+  }
+  
+  const advtemplate_get_template = (id) => {
+    return fetch('/templates/' + id, {
+        method: 'GET',
+        headers,
+      })
+      .then(handleResponse('Failed to get template'))
+  }
+  
+  const advtemplate_create_category = (title) => {
+    return fetch('/categories', {
+        method: 'POST',
+        body: JSON.stringify({
+          title
+        }),
+        headers,
+      })
+      .then(handleResponse('Failed to create category'))
+  }
+  
+  const advtemplate_create_template = (title, content, categoryId) => {
+    return fetch('/templates', {
+        method: 'POST',
+        body: JSON.stringify({
+          title,
+          content,
+          categoryId
+        }),
+        headers,
+      })
+      .then(handleResponse('Failed to create template'))
+  }
+  
+  const advtemplate_rename_category = (id, title) => {
+    return fetch('/categories/' + id, {
+        method: 'PUT',
+        body: JSON.stringify({
+          title
+        }),
+        headers,
+      })
+      .then(handleResponse('Failed to rename category'))
+  }
+  
+  const advtemplate_rename_template = (id, title) => {
+    return fetch('/templates/' + id, {
+        method: 'PUT',
+        body: JSON.stringify({
+          title
+        }),
+        headers,
+      })
+      .then(handleResponse('Failed to rename template'))
+  }
+  
+  const advtemplate_delete_template = (id) => {
+    return fetch('/templates/' + id, {
+        method: 'DELETE',
+        headers,
+      })
+      .then(handleResponse('Failed to delete template'))
+  }
+  
+  const advtemplate_delete_category = (id) => {
+    return fetch('/categories/' + id, {
+        method: 'DELETE',
+        headers,
+      })
+      .then(handleResponse('Failed to delete category'))
+  }
+  const advtemplate_move_template = (id, categoryId) => {
+    return fetch('/templates/' + id, {
+        method: 'PATCH',
+        body: JSON.stringify({
+          categoryId
+        }),
+        headers,
+      })
+      .then(handleResponse('Failed to move template'))
+  }
+  
+  const advtemplate_move_category_items = (id, categoryId) => {
+    return fetch('/categories/' + id, {
+        method: 'PATCH',
+        body: JSON.stringify({
+          categoryId
+        }),
+        headers,
+      })
+      .then(handleResponse('Failed to move all templates to new category'))
+  } 
+
+  tinymce.init({
+    selector: "textarea#readonly-locked-template",
+      plugins: [
+          "advlist", "anchor", "autolink", "charmap", "code", "fullscreen", 
+          "help", "image", "insertdatetime", "link", "lists", "media", 
+          "preview", "searchreplace", "table", "visualblocks", "advtemplate"
+      ],
+    contextmenu: 'advtemplate',
+    toolbar: "addtemplate inserttemplate | undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
+    advtemplate_list,
+    advtemplate_get_template,
+    advtemplate_create_category,
+    advtemplate_create_template,
+    advtemplate_rename_category,
+    advtemplate_rename_template,
+    advtemplate_delete_template,
+    advtemplate_delete_category,
+    advtemplate_move_template,
+    advtemplate_move_category_items
+  });
+  

--- a/modules/ROOT/examples/live-demos/advtemplate-readonly-template/example.js
+++ b/modules/ROOT/examples/live-demos/advtemplate-readonly-template/example.js
@@ -18,13 +18,11 @@ const headers = {
     })
     .then(handleResponse('Failed to get template list'))
   
-  const advtemplate_get_template = (id) => {
-    return fetch('/templates/' + id, {
-        method: 'GET',
-        headers,
-      })
-      .then(handleResponse('Failed to get template'))
-  }
+  const advtemplate_get_template = (id) => fetch('/templates/' + id, {
+      method: 'GET',
+      headers,
+    })
+    .then(handleResponse('Failed to get template'))
   
   const advtemplate_create_category = (title) => {
     return fetch('/categories', {

--- a/modules/ROOT/examples/live-demos/advtemplate-readonly-template/index.html
+++ b/modules/ROOT/examples/live-demos/advtemplate-readonly-template/index.html
@@ -1,0 +1,52 @@
+<textarea id="readonly-locked-template">
+  <h3 style="font-size: 1.5em; margin: 20px 0;">Working with Templates</h3>
+
+  <h4 style="font-size: 1.25em; margin: 15px 0;">Inserting a template</h4>
+  <p style="margin: 10px 0;">To insert a template:</p>
+  <ol style="margin-left: 20px;">
+    <li>Click the <strong>Insert template</strong> toolbar button or select <strong>Insert template...</strong> from the <strong>Insert</strong> menu.</li>
+    <li>In the <strong>Templates</strong> dialog, you'll see different categories:
+      <ul style="margin-left: 20px;">
+        <li>Regular categories with editable templates</li>
+        <li>Locked categories (marked with a 🔒 icon) containing read-only templates</li>
+      </ul>
+    </li>
+    <li>Select any template to preview its content.</li>
+    <li>Click <strong>Insert</strong> or press <strong>Return</strong> to add the template to your document.</li>
+  </ol>
+  
+  <div style="margin: 15px 0; padding: 10px 15px; border-left: 4px solid #3498db; background-color: #f0f7fb;">
+    <p><strong>Note:</strong> Templates in locked categories cannot be modified, but they can still be inserted into your document.</p>
+  </div>
+  
+  <h4 style="font-size: 1.25em; margin: 15px 0;">Adding a new template</h4>
+  <p style="margin: 10px 0;">To add a new template:</p>
+  <ol style="margin-left: 20px;">
+    <li>Select the content in your document that you want to save as a template.</li>
+    <li>Click the <strong>Save as template</strong> toolbar button or select <strong>Save as template…</strong> from the <strong>Tools</strong> menu.</li>
+    <li>In the <strong>New template</strong> dialog:
+      <ol style="margin-left: 20px;">
+        <li>Enter a name for your template in the <strong>Template name</strong> field.</li>
+        <li>Choose a category from the <strong>Category</strong> dropdown menu.
+          <div style="margin: 15px 0; padding: 10px 15px; border-left: 4px solid #e74c3c; background-color: #fdf7f7;">
+            <p><strong>Important:</strong> Locked categories (marked with a 🔒 icon) are read-only. You cannot save new templates to these categories.</p>
+          </div>
+        </li>
+        <li>Click <strong>Save</strong> or press <strong>Return</strong>.</li>
+      </ol>
+    </li>
+  </ol>
+  
+  <h4 style="font-size: 1.25em; margin: 15px 0;">Managing Templates</h4>
+  <p style="margin: 10px 0;">When working with templates, keep in mind:</p>
+  <ul style="margin-left: 20px;">
+    <li>Templates in regular categories can be edited, renamed, or deleted.</li>
+    <li>Templates in locked categories (🔒) are read-only and cannot be:
+      <ul style="margin-left: 20px;">
+        <li>Modified or renamed</li>
+        <li>Deleted</li>
+        <li>Moved to different categories</li>
+      </ul>
+    </li>
+  </ul>
+</textarea>

--- a/modules/ROOT/examples/live-demos/advtemplate-readonly-template/index.js
+++ b/modules/ROOT/examples/live-demos/advtemplate-readonly-template/index.js
@@ -1,0 +1,347 @@
+const data = [
+  {
+    title: 'Quick replies',
+    items: [
+      {
+        title: 'Message received',
+        content: '<p dir="ltr">Hey {{prefix}}Customer.FirstName\}}!</p>\n<p dir="ltr">Just a quick note to say we&rsquo;ve received your message, and will get back to you within 48 hours.</p>\n<p dir="ltr">For reference, your ticket number is: {{mergetag-open}}Ticket.Number{{suffix}}</p>\n<p dir="ltr">Should you have any questions in the meantime, just reply to this email and it will be attached to this ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Regards,</p>\n<p dir="ltr">{{prefix}}Agent.FirstName{{suffix}}</p>'
+      },
+      {
+        title: 'Thanks for the feedback',
+        content: '<p dir="ltr">Hi {{prefix}}Customer.FirstName{{suffix}},</p>\n<p dir="ltr">We appreciate you taking the time to provide feedback on {{prefix}}Product.Name{{suffix}}.</p>\n<p dir="ltr">It sounds like it wasn&rsquo;t able to fully meet your expectations, for which we apologize. Rest assured our team looks at each piece of feedback and uses it to decide what to focus on next with {{prefix}}Product.Name{{suffix}}.</p>\n<p dir="ltr"><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best, and let us know if there&rsquo;s anything else we can do to help.</p>\n<p dir="ltr">-{{prefix}}Agent.FirstName{{suffix}}</p>'
+      },
+      {
+        title: 'Still working on case',
+        content: '<p dir="ltr">Hi {{prefix}}Customer.FirstName{{suffix}},</p>\n<p dir="ltr">Just a quick note to let you know we&rsquo;re still working on your case. It&rsquo;s taking a bit longer than we hoped, but we&rsquo;re aiming to get you an answer in the next 48 hours.</p>\n<p dir="ltr">Stay tuned,</p>\n<p dir="ltr">{{prefix}}Agent.FirstName{{suffix}}</p>'
+      }
+    ]
+  },
+  {
+    title: 'Closing tickets',
+    items: [
+      {
+        title: 'Closing ticket',
+        content: '<p dir="ltr">Hi {{prefix}}Customer.FirstName{{suffix}},</p>\n<p dir="ltr">We haven&rsquo;t heard back from you in over a week, so we have gone ahead and closed your ticket number {{prefix}}Ticket.Number{{suffix}}.</p>\n<p dir="ltr">If you&rsquo;re still running into issues, not to worry, just reply to this email and we will re-open your ticket.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">All the best,</p>\n<p dir="ltr">{{prefix}}Agent.FirstName{{suffix}}</p>'
+      },
+      {
+        title: 'Post-call survey',
+        content: '<p dir="ltr">Hey {{prefix}}Customer.FirstName{{suffix}}!</p>\n<p dir="ltr">&nbsp;</p>\n<p dir="ltr">How did we do?</p>\n<p dir="ltr">If you have a few moments, we&rsquo;d love you to fill out our post-support survey: {{prefix}}Survey.Link{{suffix}}</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks in advance!<br>{{prefix}}Company.Name{{suffix}} Customer Support</p>'
+      }
+    ]
+  },
+  {
+    title: 'Locked Product support',
+    locked: true,
+    items: [
+      {
+        title: 'How to find model number',
+        content: '<p dir="ltr">Hi {{prefix}}Customer.FirstName{{suffix}},</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">My name is {{prefix}}Agent.FirstName{{suffix}} and I will be glad to assist you today.</p>\n<p dir="ltr">To troubleshoot your issue, we first need your model number, which can be found on the underside of your product beneath the safety warning label.&nbsp;</p>\n<p dir="ltr">It should look something like the following: XX.XXXXX.X</p>\n<p dir="ltr">Once you send it over, I will advise on next steps.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks!</p>\n<p dir="ltr">{{prefix}}Agent.FirstName{{suffix}}</p>'
+      },
+      {
+        title: 'Support escalation',
+        content: '<p dir="ltr">Hi {{prefix}}Customer.FirstName{{suffix}},</p>\n<p dir="ltr">We have escalated your ticket {{prefix}}Ticket.Number{{suffix}} to second-level support.</p>\n<p dir="ltr">You should hear back from the new agent on your case, {{prefix}}NewAgent.FirstName{{suffix}}, shortly.</p>\n<p><strong>&nbsp;</strong></p>\n<p dir="ltr">Thanks,</p>\n<p dir="ltr">{{prefix}}Company.Name{{suffix}} Customer Support</p>'
+      }
+    ]
+  }
+];
+
+
+class StoreError extends Error {
+  constructor(status, message) {
+    super(message);
+    this.name = "StoreError";
+    this.status = status
+  }
+}
+
+const isStoreError = (e) =>
+  e instanceof StoreError
+
+
+const create = (data = []) => {
+  const store = {
+    items: []
+  }
+
+  let id = 0;
+  const genId = () => (++id).toString()
+  const categoryIndex = {}
+  const templateIndex = {}
+
+  const isNonEmptyString = (value) =>
+    typeof value === 'string' && value.length > 0
+
+  const isPositiveInteger = (str) => {
+    const number = Number(str);
+    return Number.isInteger(number) && number > 0
+  }
+
+  const isValidId = (value) =>
+  isNonEmptyString(value) && isPositiveInteger(value)
+
+  const validate = (value, predicate, message) => {
+    if (predicate(value)) {
+      return
+    } else {
+      throw new StoreError(400, message)
+    }
+  }
+
+  const validateId = (id) =>
+    validate(id, isValidId, `Invalid "id" parameter: ${id}`)
+
+  const validateTitle = (title) =>
+    validate(title, isNonEmptyString, `Invalid "title" parameter: ${title}`)
+
+  const getParent = (id) =>
+    typeof id === 'undefined' ? store : getCategory(id);
+
+  const filterOut = (items, id) =>
+    items.filter((item) => item.id !== id)
+
+  const list = () => {
+    const resp = [...store.items]
+    return resp
+  }
+
+  const getCategory = (id) => {
+    validate(id, isValidId, `Invalid "id" parameter: ${id}`)
+    const category = categoryIndex[id]
+    if (typeof category !== 'undefined'){
+      return category
+    } else {
+      throw new StoreError(404, 'Category not found')
+    }
+  }
+
+  const getTemplate = (id) => {
+    validateId(id)
+    const res = templateIndex[id]
+    if (typeof res !== 'undefined'){
+      return res
+    } else {
+      throw new StoreError(404, 'Template not found')
+    }
+  }
+
+  const createCategory = (title, locked) => {
+    validateTitle(title)
+
+    const id = genId()
+    const category = {
+      id,
+      title,
+      locked,
+      items: []
+    }
+    categoryIndex[id] = category;
+    store.items = [...store.items, category]
+    return category
+  }
+
+  const createTemplate = (title, content, categoryId) => {
+    validateTitle(title)
+    validate(content, isNonEmptyString, `Invalid "content" parameter: ${content}`)
+    const id = genId()
+    const template = {
+      id,
+      title,
+      content,
+    }
+    const parent = getParent(categoryId)
+    parent.items = [...parent.items, template]
+    templateIndex[id] = [template, categoryId];
+    return template
+  }
+
+  const renameCategory = (id, title) => {
+    validateTitle(title)
+    const category = getCategory(id)
+    category.title = title;
+  }
+
+  const renameTemplate = (id, title) => {
+    validateTitle(title)
+    const [template] = getTemplate(id)
+    template.title = title;
+  }
+
+  const deleteTemplate = (id) => {
+    const [, categoryId] = getTemplate(id)
+    const parent = getParent(categoryId)
+    parent.items = filterOut(parent.items, id)
+    delete templateIndex[id]
+  }
+
+  const deleteCategory = (id) => {
+    const category = getCategory(id);
+    category.items.forEach((template) => deleteTemplate(template.id))
+    store.items = filterOut(store.items, id)
+    delete categoryIndex[category.id]
+  }
+
+  const moveTemplate = (id, newCategoryId) => {
+    const [template, categoryId] = getTemplate(id)
+    if (categoryId === newCategoryId) {
+      return
+    }
+    const oldParent = getParent(categoryId)
+    const newParent = getParent(newCategoryId)
+    newParent.items = [...newParent.items, template]
+    oldParent.items = filterOut(oldParent.items, id)
+    templateIndex[id] = [template, newCategoryId]
+  }
+
+  const moveCategoryItems = (id, newCategoryId) => {
+    const oldCategory = getCategory(id)
+    if (id === newCategoryId) {
+      return
+    }
+    oldCategory.items.forEach((item) => moveTemplate(item.id, newCategoryId))
+  }
+
+  const load = (items, id) => {
+    for (const item of items) {
+      if (item.items) {
+        const category = createCategory(item.title, item.locked);
+        load(item.items, category.id );
+      } else {
+        createTemplate(item.title, item.content, id);
+      }
+    }
+  };
+
+  load(data);
+
+  return {
+    list,
+    getTemplate,
+    createCategory,
+    createTemplate,
+    renameCategory,
+    renameTemplate,
+    deleteTemplate,
+    deleteCategory,
+    moveTemplate,
+    moveCategoryItems,
+  }
+}
+
+
+const store = create(data);
+const advtemplate_list = async () => store.list()
+
+
+const advtemplate_create_category = async (title) => {
+  try {
+    return store.createCategory(title)
+  } catch (e) {
+    console.error(e)
+    throw new Error('Failed to create category')
+  }
+}
+  
+
+const advtemplate_create_template = async (title, content, categoryId) => {
+  try {
+    return store.createTemplate(title, content, categoryId)
+  } catch (e) {
+    console.error(e)
+    throw new Error('Failed to create template')
+  }
+}
+  
+
+const advtemplate_get_template = async (id) => {
+  try {
+    const [template ] = store.getTemplate(id)
+    return template
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+const advtemplate_rename_category = async (id, title) => {
+  try {
+    store.renameCategory(id, title)
+    return {}
+  } catch (e) {
+    console.error(e)
+    throw new Error('Failed to rename category')
+  }
+}
+  
+const advtemplate_rename_template = async (id, title) => {
+  try {
+    store.renameTemplate(id, title)
+    return {}
+  } catch (e) {
+    console.error(e)
+    throw new Error('Failed to rename template')
+  }
+}
+
+const advtemplate_delete_category = async (id) => {
+  try {
+    store.deleteCategory(id)
+    return {}
+  } catch (e) {
+    console.error(e)
+    throw new Error('Failed to delete category')
+  }
+}
+
+const advtemplate_delete_template = async (id) => {
+  try {
+    store.deleteTemplate(id)
+    return {}
+  } catch (e) {
+    console.error(e)
+    throw new Error('Failed to delete template')
+  }
+}
+
+
+const advtemplate_move_template = async (id, categoryId) => {
+  try {
+    store.moveTemplate(id, categoryId)
+    return {}
+  } catch (e) {
+    console.error(e)
+    throw new Error('Failed to move template')
+  }
+}
+
+const advtemplate_move_category_items = async (id, categoryId) => {
+  try {
+    store.moveCategoryItems(id, categoryId)
+    return {}
+  } catch (e) {
+    console.error(e)
+    throw new Error('Failed to move category items')
+  }
+}
+
+tinymce.init({
+  selector: "textarea#readonly-locked-template",
+    plugins: [
+        "advlist", "anchor", "autolink", "charmap", "code", "fullscreen", 
+        "help", "image", "insertdatetime", "link", "lists", "media", 
+        "preview", "searchreplace", "table", "visualblocks", "advtemplate"
+    ],
+  contextmenu: 'advtemplate',
+  toolbar: "addtemplate inserttemplate | undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
+  advtemplate_list,
+	advtemplate_get_template,
+	
+	advtemplate_create_category,
+	advtemplate_create_template,
+	
+	advtemplate_rename_category,
+	advtemplate_move_category_items,
+	advtemplate_delete_category,
+	
+	advtemplate_rename_template,
+	advtemplate_move_template,
+	advtemplate_delete_template,
+});

--- a/modules/ROOT/examples/live-demos/advtemplate-readonly-template/index.js
+++ b/modules/ROOT/examples/live-demos/advtemplate-readonly-template/index.js
@@ -201,15 +201,14 @@ const create = (data = []) => {
   }
 
   const load = (items, id) => {
-    for (const item of items) {
+    items.forEach((item) => {
       if (item.items) {
         const category = createCategory(item.title, item.locked);
         load(item.items, category.id );
       } else {
         createTemplate(item.title, item.content, id);
       }
-    }
-  };
+    });
 
   load(data);
 

--- a/modules/ROOT/examples/live-demos/advtemplate-readonly-template/index.js
+++ b/modules/ROOT/examples/live-demos/advtemplate-readonly-template/index.js
@@ -59,14 +59,14 @@ const isStoreError = (e) =>
 
 
 const create = (data = []) => {
-  const store = {
+  const storeItems = {
     items: []
   }
 
   let id = 0;
-  const genId = () => (++id).toString()
-  const categoryIndex = {}
-  const templateIndex = {}
+  const genId = () => (++id).toString();
+  const categoryIndex = {};
+  const templateIndex = {};
 
   const isNonEmptyString = (value) =>
     typeof value === 'string' && value.length > 0
@@ -77,57 +77,57 @@ const create = (data = []) => {
   }
 
   const isValidId = (value) =>
-  isNonEmptyString(value) && isPositiveInteger(value)
+    isNonEmptyString(value) && isPositiveInteger(value)
 
   const validate = (value, predicate, message) => {
     if (predicate(value)) {
       return
     } else {
-      throw new StoreError(400, message)
+      throw new StoreError(400, message);
     }
   }
 
   const validateId = (id) =>
-    validate(id, isValidId, `Invalid "id" parameter: ${id}`)
+    validate(id, isValidId, `Invalid "id" parameter: ${id}`);
 
   const validateTitle = (title) =>
-    validate(title, isNonEmptyString, `Invalid "title" parameter: ${title}`)
+    validate(title, isNonEmptyString, `Invalid "title" parameter: ${title}`);
 
   const getParent = (id) =>
-    typeof id === 'undefined' ? store : getCategory(id);
+    typeof id === 'undefined' ? storeItems : getCategory(id);
 
   const filterOut = (items, id) =>
-    items.filter((item) => item.id !== id)
+    items.filter((item) => item.id !== id);
 
   const list = () => {
-    const resp = [...store.items]
+    const resp = [...storeItems.items];
     return resp
   }
 
   const getCategory = (id) => {
     validate(id, isValidId, `Invalid "id" parameter: ${id}`)
-    const category = categoryIndex[id]
-    if (typeof category !== 'undefined'){
+    const category = categoryIndex[id];
+    if (typeof category !== 'undefined') {
       return category
     } else {
-      throw new StoreError(404, 'Category not found')
+      throw new StoreError(404, 'Category not found');
     }
   }
 
   const getTemplate = (id) => {
     validateId(id)
-    const res = templateIndex[id]
-    if (typeof res !== 'undefined'){
+    const res = templateIndex[id];
+    if (typeof res !== 'undefined') {
       return res
     } else {
-      throw new StoreError(404, 'Template not found')
+      throw new StoreError(404, 'Template not found');
     }
   }
 
   const createCategory = (title, locked) => {
-    validateTitle(title)
+    validateTitle(title);
 
-    const id = genId()
+    const id = genId();
     const category = {
       id,
       title,
@@ -135,80 +135,81 @@ const create = (data = []) => {
       items: []
     }
     categoryIndex[id] = category;
-    store.items = [...store.items, category]
+    storeItems.items = [...storeItems.items, category];
     return category
   }
 
   const createTemplate = (title, content, categoryId) => {
-    validateTitle(title)
-    validate(content, isNonEmptyString, `Invalid "content" parameter: ${content}`)
-    const id = genId()
+    validateTitle(title);
+    validate(content, isNonEmptyString, `Invalid "content" parameter: ${content}`);
+    const id = genId();
     const template = {
       id,
       title,
       content,
     }
-    const parent = getParent(categoryId)
-    parent.items = [...parent.items, template]
+    const parent = getParent(categoryId);
+    parent.items = [...parent.items, template];
     templateIndex[id] = [template, categoryId];
     return template
   }
 
   const renameCategory = (id, title) => {
-    validateTitle(title)
-    const category = getCategory(id)
+    validateTitle(title);
+    const category = getCategory(id);
     category.title = title;
   }
 
   const renameTemplate = (id, title) => {
-    validateTitle(title)
-    const [template] = getTemplate(id)
+    validateTitle(title);
+    const [template] = getTemplate(id);
     template.title = title;
   }
 
   const deleteTemplate = (id) => {
-    const [, categoryId] = getTemplate(id)
-    const parent = getParent(categoryId)
-    parent.items = filterOut(parent.items, id)
-    delete templateIndex[id]
+    const [, categoryId] = getTemplate(id);
+    const parent = getParent(categoryId);
+    parent.items = filterOut(parent.items, id);
+    delete templateIndex[id];
   }
 
   const deleteCategory = (id) => {
     const category = getCategory(id);
-    category.items.forEach((template) => deleteTemplate(template.id))
-    store.items = filterOut(store.items, id)
-    delete categoryIndex[category.id]
+    category.items.forEach((template) => deleteTemplate(template.id));
+    store.items = filterOut(storeItems.items, id);
+    delete categoryIndex[category.id];
   }
 
   const moveTemplate = (id, newCategoryId) => {
-    const [template, categoryId] = getTemplate(id)
+    const [template, categoryId] = getTemplate(id);
     if (categoryId === newCategoryId) {
       return
     }
-    const oldParent = getParent(categoryId)
-    const newParent = getParent(newCategoryId)
-    newParent.items = [...newParent.items, template]
-    oldParent.items = filterOut(oldParent.items, id)
-    templateIndex[id] = [template, newCategoryId]
+    const oldParent = getParent(categoryId);
+    const newParent = getParent(newCategoryId);
+    newParent.items = [...newParent.items, template];
+    oldParent.items = filterOut(oldParent.items, id);
+    templateIndex[id] = [template, newCategoryId];
   }
 
   const moveCategoryItems = (id, newCategoryId) => {
-    const oldCategory = getCategory(id)
+    const oldCategory = getCategory(id);
     if (id === newCategoryId) {
       return
     }
-    oldCategory.items.forEach((item) => moveTemplate(item.id, newCategoryId))
+    oldCategory.items.forEach((item) => moveTemplate(item.id, newCategoryId));
   }
 
   const load = (items, id) => {
     items.forEach((item) => {
       if (item.items) {
         const category = createCategory(item.title, item.locked);
-        load(item.items, category.id );
+        load(item.items, category.id);
       } else {
         createTemplate(item.title, item.content, id);
       }
     });
+  };
 
   load(data);
 
@@ -228,118 +229,116 @@ const create = (data = []) => {
 
 
 const store = create(data);
-const advtemplate_list = async () => store.list()
 
+const advtemplate_list = async () => store.list();
 
 const advtemplate_create_category = async (title) => {
   try {
-    return store.createCategory(title)
+    return store.createCategory(title);
   } catch (e) {
-    console.error(e)
-    throw new Error('Failed to create category')
+    console.error(e);
+    throw new Error('Failed to create category');
   }
 }
-  
+
 
 const advtemplate_create_template = async (title, content, categoryId) => {
   try {
-    return store.createTemplate(title, content, categoryId)
+    return store.createTemplate(title, content, categoryId);
   } catch (e) {
-    console.error(e)
-    throw new Error('Failed to create template')
+    console.error(e);
+    throw new Error('Failed to create template');
   }
 }
-  
+
 
 const advtemplate_get_template = async (id) => {
   try {
-    const [template ] = store.getTemplate(id)
+    const [template] = store.getTemplate(id);
     return template
   } catch (e) {
-    console.error(e)
+    console.error(e);
+    throw new Error('Failed to get template');
   }
 }
 
 const advtemplate_rename_category = async (id, title) => {
   try {
-    store.renameCategory(id, title)
+    store.renameCategory(id, title);
     return {}
   } catch (e) {
-    console.error(e)
-    throw new Error('Failed to rename category')
+    console.error(e);
+    throw new Error('Failed to rename category');
   }
 }
-  
+
 const advtemplate_rename_template = async (id, title) => {
   try {
-    store.renameTemplate(id, title)
+    store.renameTemplate(id, title);
     return {}
   } catch (e) {
-    console.error(e)
-    throw new Error('Failed to rename template')
+    console.error(e);
+    throw new Error('Failed to rename template');
   }
 }
 
 const advtemplate_delete_category = async (id) => {
   try {
-    store.deleteCategory(id)
+    store.deleteCategory(id);
     return {}
   } catch (e) {
-    console.error(e)
-    throw new Error('Failed to delete category')
+    console.error(e);
+    throw new Error('Failed to delete category');
   }
 }
 
 const advtemplate_delete_template = async (id) => {
   try {
-    store.deleteTemplate(id)
+    store.deleteTemplate(id);
     return {}
   } catch (e) {
-    console.error(e)
-    throw new Error('Failed to delete template')
+    console.error(e);
+    throw new Error('Failed to delete template');
   }
 }
 
 
 const advtemplate_move_template = async (id, categoryId) => {
   try {
-    store.moveTemplate(id, categoryId)
+    store.moveTemplate(id, categoryId);
     return {}
   } catch (e) {
-    console.error(e)
-    throw new Error('Failed to move template')
+    console.error(e);
+    throw new Error('Failed to move template');
   }
 }
 
 const advtemplate_move_category_items = async (id, categoryId) => {
   try {
-    store.moveCategoryItems(id, categoryId)
+    store.moveCategoryItems(id, categoryId);
     return {}
   } catch (e) {
-    console.error(e)
-    throw new Error('Failed to move category items')
+    console.error(e);
+    throw new Error('Failed to move category items');
   }
 }
 
 tinymce.init({
   selector: "textarea#readonly-locked-template",
-    plugins: [
-        "advlist", "anchor", "autolink", "charmap", "code", "fullscreen", 
-        "help", "image", "insertdatetime", "link", "lists", "media", 
-        "preview", "searchreplace", "table", "visualblocks", "advtemplate"
-    ],
+  plugins: [
+    "advlist", "anchor", "autolink", "charmap", "code", "fullscreen",
+    "help", "image", "insertdatetime", "link", "lists", "media",
+    "preview", "searchreplace", "table", "visualblocks", "advtemplate"
+  ],
   contextmenu: 'advtemplate',
   toolbar: "addtemplate inserttemplate | undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
   advtemplate_list,
   advtemplate_get_template,
-
   advtemplate_create_category,
   advtemplate_create_template,
-
   advtemplate_rename_category,
   advtemplate_move_category_items,
   advtemplate_delete_category,
-
   advtemplate_rename_template,
   advtemplate_move_template,
   advtemplate_delete_template,

--- a/modules/ROOT/examples/live-demos/advtemplate-readonly-template/index.js
+++ b/modules/ROOT/examples/live-demos/advtemplate-readonly-template/index.js
@@ -332,16 +332,16 @@ tinymce.init({
   contextmenu: 'advtemplate',
   toolbar: "addtemplate inserttemplate | undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
   advtemplate_list,
-	advtemplate_get_template,
-	
-	advtemplate_create_category,
-	advtemplate_create_template,
-	
-	advtemplate_rename_category,
-	advtemplate_move_category_items,
-	advtemplate_delete_category,
-	
-	advtemplate_rename_template,
-	advtemplate_move_template,
-	advtemplate_delete_template,
+  advtemplate_get_template,
+
+  advtemplate_create_category,
+  advtemplate_create_template,
+
+  advtemplate_rename_category,
+  advtemplate_move_category_items,
+  advtemplate_delete_category,
+
+  advtemplate_rename_template,
+  advtemplate_move_template,
+  advtemplate_delete_template,
 });

--- a/modules/ROOT/examples/live-demos/advtemplate-readonly-template/index.js
+++ b/modules/ROOT/examples/live-demos/advtemplate-readonly-template/index.js
@@ -45,7 +45,6 @@ const data = [
   }
 ];
 
-
 class StoreError extends Error {
   constructor(status, message) {
     super(message);
@@ -55,13 +54,13 @@ class StoreError extends Error {
 }
 
 const isStoreError = (e) =>
-  e instanceof StoreError
+  e instanceof StoreError;
 
 
 const create = (data = []) => {
   const storeItems = {
     items: []
-  }
+  };
 
   let id = 0;
   const genId = () => (++id).toString();
@@ -69,23 +68,23 @@ const create = (data = []) => {
   const templateIndex = {};
 
   const isNonEmptyString = (value) =>
-    typeof value === 'string' && value.length > 0
+    typeof value === 'string' && value.length > 0;
 
   const isPositiveInteger = (str) => {
     const number = Number(str);
-    return Number.isInteger(number) && number > 0
+    return Number.isInteger(number) && number > 0;
   }
 
   const isValidId = (value) =>
-    isNonEmptyString(value) && isPositiveInteger(value)
+    isNonEmptyString(value) && isPositiveInteger(value);
 
   const validate = (value, predicate, message) => {
     if (predicate(value)) {
-      return
+      return;
     } else {
       throw new StoreError(400, message);
     }
-  }
+  };
 
   const validateId = (id) =>
     validate(id, isValidId, `Invalid "id" parameter: ${id}`);
@@ -101,18 +100,18 @@ const create = (data = []) => {
 
   const list = () => {
     const resp = [...storeItems.items];
-    return resp
-  }
+    return resp;
+  };
 
   const getCategory = (id) => {
     validate(id, isValidId, `Invalid "id" parameter: ${id}`)
     const category = categoryIndex[id];
     if (typeof category !== 'undefined') {
-      return category
+      return category;
     } else {
       throw new StoreError(404, 'Category not found');
     }
-  }
+  };
 
   const getTemplate = (id) => {
     validateId(id)
@@ -122,7 +121,7 @@ const create = (data = []) => {
     } else {
       throw new StoreError(404, 'Template not found');
     }
-  }
+  };
 
   const createCategory = (title, locked) => {
     validateTitle(title);
@@ -133,72 +132,75 @@ const create = (data = []) => {
       title,
       locked,
       items: []
-    }
+    };
     categoryIndex[id] = category;
     storeItems.items = [...storeItems.items, category];
-    return category
-  }
+    return category;
+  };
 
   const createTemplate = (title, content, categoryId) => {
     validateTitle(title);
     validate(content, isNonEmptyString, `Invalid "content" parameter: ${content}`);
+
     const id = genId();
     const template = {
       id,
       title,
       content,
-    }
+    };
     const parent = getParent(categoryId);
     parent.items = [...parent.items, template];
     templateIndex[id] = [template, categoryId];
-    return template
-  }
+
+    return template;
+  };
 
   const renameCategory = (id, title) => {
     validateTitle(title);
     const category = getCategory(id);
     category.title = title;
-  }
+  };
 
   const renameTemplate = (id, title) => {
     validateTitle(title);
     const [template] = getTemplate(id);
     template.title = title;
-  }
+  };
 
   const deleteTemplate = (id) => {
     const [, categoryId] = getTemplate(id);
     const parent = getParent(categoryId);
     parent.items = filterOut(parent.items, id);
     delete templateIndex[id];
-  }
+  };
 
   const deleteCategory = (id) => {
     const category = getCategory(id);
     category.items.forEach((template) => deleteTemplate(template.id));
     store.items = filterOut(storeItems.items, id);
     delete categoryIndex[category.id];
-  }
+  };
 
   const moveTemplate = (id, newCategoryId) => {
     const [template, categoryId] = getTemplate(id);
     if (categoryId === newCategoryId) {
-      return
+      return;
     }
+
     const oldParent = getParent(categoryId);
     const newParent = getParent(newCategoryId);
     newParent.items = [...newParent.items, template];
     oldParent.items = filterOut(oldParent.items, id);
     templateIndex[id] = [template, newCategoryId];
-  }
+  };
 
   const moveCategoryItems = (id, newCategoryId) => {
     const oldCategory = getCategory(id);
     if (id === newCategoryId) {
-      return
+      return;
     }
     oldCategory.items.forEach((item) => moveTemplate(item.id, newCategoryId));
-  }
+  };
 
   const load = (items, id) => {
     items.forEach((item) => {
@@ -223,8 +225,8 @@ const create = (data = []) => {
     deleteTemplate,
     deleteCategory,
     moveTemplate,
-    moveCategoryItems,
-  }
+    moveCategoryItems
+  };
 }
 
 
@@ -239,7 +241,7 @@ const advtemplate_create_category = async (title) => {
     console.error(e);
     throw new Error('Failed to create category');
   }
-}
+};
 
 
 const advtemplate_create_template = async (title, content, categoryId) => {
@@ -249,89 +251,90 @@ const advtemplate_create_template = async (title, content, categoryId) => {
     console.error(e);
     throw new Error('Failed to create template');
   }
-}
+};
 
 
 const advtemplate_get_template = async (id) => {
   try {
     const [template] = store.getTemplate(id);
-    return template
+    return template;
   } catch (e) {
     console.error(e);
     throw new Error('Failed to get template');
   }
-}
+};
 
 const advtemplate_rename_category = async (id, title) => {
   try {
     store.renameCategory(id, title);
-    return {}
+    return {};
   } catch (e) {
     console.error(e);
     throw new Error('Failed to rename category');
   }
-}
+};
 
 const advtemplate_rename_template = async (id, title) => {
   try {
     store.renameTemplate(id, title);
-    return {}
+    return {};
   } catch (e) {
     console.error(e);
     throw new Error('Failed to rename template');
   }
-}
+};
 
 const advtemplate_delete_category = async (id) => {
   try {
     store.deleteCategory(id);
-    return {}
+    return {};
   } catch (e) {
     console.error(e);
     throw new Error('Failed to delete category');
   }
-}
+};
 
 const advtemplate_delete_template = async (id) => {
   try {
     store.deleteTemplate(id);
-    return {}
+    return {};
   } catch (e) {
     console.error(e);
     throw new Error('Failed to delete template');
   }
-}
+};
 
 
 const advtemplate_move_template = async (id, categoryId) => {
   try {
     store.moveTemplate(id, categoryId);
-    return {}
+    return {};
   } catch (e) {
     console.error(e);
     throw new Error('Failed to move template');
   }
-}
+};
 
 const advtemplate_move_category_items = async (id, categoryId) => {
   try {
     store.moveCategoryItems(id, categoryId);
-    return {}
+    return {};
   } catch (e) {
     console.error(e);
     throw new Error('Failed to move category items');
   }
-}
+};
 
 tinymce.init({
-  selector: "textarea#readonly-locked-template",
+  selector: 'textarea#readonly-locked-template',
   plugins: [
-    "advlist", "anchor", "autolink", "charmap", "code", "fullscreen",
-    "help", "image", "insertdatetime", "link", "lists", "media",
-    "preview", "searchreplace", "table", "visualblocks", "advtemplate"
+    'advlist', 'anchor', 'autolink', 'charmap', 'code', 'fullscreen',
+    'help', 'image', 'insertdatetime', 'link', 'lists', 'media',
+    'preview', 'searchreplace', 'table', 'visualblocks', 'advtemplate'
   ],
   contextmenu: 'advtemplate',
-  toolbar: "addtemplate inserttemplate | undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
+  toolbar: 'addtemplate inserttemplate | undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image',
+
   advtemplate_list,
   advtemplate_get_template,
   advtemplate_create_category,

--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -82,13 +82,13 @@ The {productname} {release-version} release includes an accompanying release of 
 
 include::partial$misc/admon-requires-7.4v.adoc[]
 
-The {productname} release introduces readonly image:icons/lock.svg[lock.svg] categories for improved template management. This feature allows administrators to lock down specific categories, ensuring they remain unaltered while providing clear visual cues for non-editable items.
+The {productname} release introduces readonly categories for improved template management. This feature allows administrators to lock down specific template categories, preventing users from modifying the category or its templates.
 
 === Key Features
 
-- **Readonly Templates**: Templates assigned to readonly categories are automatically locked, preventing actions such as renaming, editing content, or moving templates between categories. These templates are marked with a lock image:icons/lock.svg[lock.svg] icon to indicate their status.
-- **Readonly Categories**: Categories can be marked as readonly by adding `locked: true` in the configuration. Once locked, categories cannot be modified, and users are prevented from adding or moving templates within these categories. A lock icon visually distinguishes readonly categories.
-- **Client-Side Restrictions**: Attempts to modify readonly templates or categories are blocked on the client side, and the UI reflects the readonly status to provide a seamless user experience.
+- **Readonly Templates**: Templates within readonly categories are locked, preventing the user from renaming, editing, moving, or deleting them. These templates are marked with a lock image:icons/lock.svg[lock.svg] icon to indicate their status.
+- **Readonly Categories**: Categories can be marked as readonly by setting `locked: true` in the configuration. Once locked, categories cannot be renamed or deleted, and users are prevented from moving templates into or out of the category. A lock icon visually distinguishes readonly categories. Readonly categories are marked with a lock image:icons/lock.svg[lock.svg] icon to indicate their status.
+- **Client-Side Restrictions**: Attempts to modify readonly categories are blocked on the client side, and the UI reflects the readonly status to provide a seamless user experience.
 
 .Example: Locking a category
 [source,js]

--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -110,7 +110,7 @@ The {productname} release introduces readonly categories for improved template m
 }
 ----
 
-For information on the **Templates** plugin, see: xref:advanced-templates.adoc#read-only-templates[Read-only Templates].
+For information on the **Templates** plugin, see: xref:advanced-templates.adoc#read-only-categories[Read-only Categories].
 
 === Import from Word
 

--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -71,6 +71,47 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Templates
+
+The {productname} {release-version} release includes an accompanying release of the **Templates** premium plugin.
+
+**Templates** includes the following improvement.
+
+==== Categories can now be declared as locked, making them readonly.
+// #TINY-11116
+
+include::partial$misc/admon-requires-7.4v.adoc[]
+
+The {productname} release introduces readonly image:icons/lock.svg[lock.svg] categories for improved template management. This feature allows administrators to lock down specific categories, ensuring they remain unaltered while providing clear visual cues for non-editable items.
+
+=== Key Features
+
+- **Readonly Templates**: Templates assigned to readonly categories are automatically locked, preventing actions such as renaming, editing content, or moving templates between categories. These templates are marked with a lock image:icons/lock.svg[lock.svg] icon to indicate their status.
+- **Readonly Categories**: Categories can be marked as readonly by adding `locked: true` in the configuration. Once locked, categories cannot be modified, and users are prevented from adding or moving templates within these categories. A lock icon visually distinguishes readonly categories.
+- **Client-Side Restrictions**: Attempts to modify readonly templates or categories are blocked on the client side, and the UI reflects the readonly status to provide a seamless user experience.
+
+.Example: Locking a category
+[source,js]
+----
+// Template data with locked category
+{
+  title: 'Locked Templates',
+  locked: true, // Locks the category as readonly
+  items: [
+    {
+      title: 'How to find model number',
+      content: '<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p>...</p>'
+    },
+    {
+      title: 'Support escalation',
+      content: '<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p>...</p>'
+    }
+  ]
+}
+----
+
+For information on the **Templates** plugin, see: xref:advanced-templates.adoc#read-only-templates[Read-only Templates].
+
 === Import from Word
 
 The {productname} {release-version} release includes an accompanying release of the **Import from Word** premium plugin.

--- a/modules/ROOT/pages/advanced-templates.adoc
+++ b/modules/ROOT/pages/advanced-templates.adoc
@@ -132,16 +132,6 @@ tinymce.init({
 });
 ----
 
-==== Behavior
-
-When a category is marked as locked:
-
-. Users **cannot**:
-* add new templates to the category.
-* delete templates from the category.
-* rename templates in the category.
-* move templates into or out of the category.
-
 liveDemo::{plugincode}-readonly-template[]
 
 == Basic setup

--- a/modules/ROOT/pages/advanced-templates.adoc
+++ b/modules/ROOT/pages/advanced-templates.adoc
@@ -98,38 +98,20 @@ To create a locked (read-only) category, add the `+locked: true+` property to th
 .Example of a locked category
 [source,js]
 ----
-// Initialize TinyMCE with locked templates
-tinymce.init({
-  selector: 'textarea',
-  plugins: ['advtemplate'],
-  toolbar: 'addtemplate inserttemplate',
-  setup: (editor) => {
-    // Your setup code here
-  },
-  advtemplate_data: [
+{
+  title: 'Locked Templates',
+  locked: true, // Locks the category as readonly
+  items: [
     {
-      title: 'Regular Templates',
-      items: [
-        // ... regular templates
-      ]
+      title: 'How to find model number',
+      content: '<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p>...</p>'
     },
-    // Template data with locked category
     {
-      title: 'Locked Templates',
-      locked: true,
-      items: [
-        {
-          title: 'How to find model number',
-          content: '<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p>...</p>'
-        },
-        {
-          title: 'Support escalation',
-          content: '<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p>...</p>'
-        }
-      ]
+      title: 'Support escalation',
+      content: '<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p>...</p>'
     }
   ]
-});
+}
 ----
 
 liveDemo::{plugincode}-readonly-template[]

--- a/modules/ROOT/pages/advanced-templates.adoc
+++ b/modules/ROOT/pages/advanced-templates.adoc
@@ -79,6 +79,65 @@ To manage the template list
 ** Move all category items to another category.
 ** Delete template/category.
 
+[[read-only-templates]]
+=== Readonly templates
+
+include::partial$misc/admon-requires-7.4v.adoc[]
+
+To manage read-only templates preventing users from modifying, adding, or deleting templates within those categories.
+
+==== Data Structure
+
+To create a locked (read-only) category, add the `+locked: true+` property to the category object in your templates data:
+
+[source,js]
+----
+// Initialize TinyMCE with locked templates
+tinymce.init({
+  selector: 'textarea',
+  plugins: ['advtemplate'],
+  toolbar: 'addtemplate inserttemplate',
+  setup: function(editor) {
+    // Your setup code here
+  },
+  advtemplate_data: [
+    {
+      title: 'Regular Templates',
+      items: [
+        // ... regular templates
+      ]
+    },
+    // Template data with locked category
+    {
+      title: 'Locked Templates',
+      locked: true,
+      items: [
+        {
+          title: 'How to find model number',
+          content: '<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p>...</p>'
+        },
+        {
+          title: 'Support escalation',
+          content: '<p dir="ltr">Hi {{Customer.FirstName}},</p>\n<p>...</p>'
+        }
+      ]
+    }
+  ]
+});
+----
+
+==== Behavior
+
+When a category is marked as locked:
+
+. Users **cannot**:
+* add new templates to the category.
+* delete templates from the category.
+* rename templates in the category.
+* move templates into or out of the category.
+
+liveDemo::{plugincode}-readonly-template[]
+
 == Basic setup
 
 To setup the {pluginname} plugin user-interface in the editor:

--- a/modules/ROOT/pages/advanced-templates.adoc
+++ b/modules/ROOT/pages/advanced-templates.adoc
@@ -99,7 +99,7 @@ tinymce.init({
   selector: 'textarea',
   plugins: ['advtemplate'],
   toolbar: 'addtemplate inserttemplate',
-  setup: function(editor) {
+  setup: (editor) => {
     // Your setup code here
   },
   advtemplate_data: [

--- a/modules/ROOT/pages/advanced-templates.adoc
+++ b/modules/ROOT/pages/advanced-templates.adoc
@@ -91,6 +91,7 @@ This option sets a {pluginname} category to read-only in {productname}, streamli
 
 To create a locked (read-only) category, add the `+locked: true+` property to the category object in your templates data:
 
+.Example of a locked category
 [source,js]
 ----
 // Initialize TinyMCE with locked templates

--- a/modules/ROOT/pages/advanced-templates.adoc
+++ b/modules/ROOT/pages/advanced-templates.adoc
@@ -79,15 +79,19 @@ To manage the template list
 ** Move all category items to another category.
 ** Delete template/category.
 
-[[read-only-templates]]
-=== Readonly templates
+[[read-only-categories]]
+=== Readonly categories
 
 include::partial$misc/admon-requires-7.4v.adoc[]
 
-This option sets a {pluginname} category to read-only in {productname}, streamlining template management. When set to read-only, users cannot perform actions such as moving, renaming, or adding new items to the category or its templates. A lock image
-/lock.svg[lock.svg] icon visually indicates that the templates are non-editable, and client-side restrictions prevent modification attempts from being submitted to the server.
+{pluginname} categories can be set to read-only in {productname}, preventing users from modifying the category or its templates. When a category is set to read-only, users cannot:
 
-==== Data Structure
+* add new templates to the category
+* delete the category or its templates
+* rename the category or its templates
+* move templates into or out of the category
+
+A lock image:icons/lock.svg[lock.svg] icon visually indicates that a category is read-only, preventing users from modifying the category or its templates through the user interface.
 
 To create a locked (read-only) category, add the `+locked: true+` property to the category object in your templates data:
 

--- a/modules/ROOT/pages/advanced-templates.adoc
+++ b/modules/ROOT/pages/advanced-templates.adoc
@@ -84,7 +84,8 @@ To manage the template list
 
 include::partial$misc/admon-requires-7.4v.adoc[]
 
-To manage read-only templates preventing users from modifying, adding, or deleting templates within those categories.
+This option sets a {pluginname} category to read-only in {productname}, streamlining template management. When set to read-only, users cannot perform actions such as moving, renaming, or adding new items to the category or its templates. A lock image
+/lock.svg[lock.svg] icon visually indicates that the templates are non-editable, and client-side restrictions prevent modification attempts from being submitted to the server.
 
 ==== Data Structure
 

--- a/modules/ROOT/pages/editor-command-identifiers.adoc
+++ b/modules/ROOT/pages/editor-command-identifiers.adoc
@@ -250,6 +250,7 @@ Commands are available for the following plugins:
 * xref:spellchecker[Spell Checker]
 * xref:table[Table]
 * xref:tableofcontents[Table of Content]
+* xref:advtemplate[Templates]
 * xref:visualblocks[Visual Blocks]
 * xref:visualcharacters[Visual Characters]
 * xref:wordcount[Word Count]
@@ -523,6 +524,13 @@ include::partial$commands/table-cmds.adoc[leveloffset=+3]
 The following commands require the xref:tableofcontents.adoc[Table of Contents (`+tableofcontents+`)] plugin.
 
 include::partial$commands/tableofcontents-cmds.adoc[leveloffset=+3]
+
+[[advtemplate]]
+==== Templates
+
+The following commands require the xref:advanced-templates.adoc[Templates (`+advtemplate+`)] plugin.
+
+include::partial$commands/advtemplate-cmds.adoc[leveloffset=+3]
 
 [[visualblocks]]
 ==== Visual Blocks


### PR DESCRIPTION
Ticket: DOC-2513

Site: [Release notes](http://docs-feature-74-doc-2513tiny-11117.staging.tiny.cloud/docs/tinymce/latest/7.4-release-notes/#categories-can-now-be-declared-as-locked-making-them-readonly)
Site: [readonly templates option and demo](http://docs-feature-74-doc-2513tiny-11117.staging.tiny.cloud/docs/tinymce/latest/advanced-templates/#read-only-templates)

Changes:
* Added new option to support TINY-11117

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] Included a `release note` entry for any `New product features`.
- [x] Verify demo by updating antora.yml to use `7-dev`.

Review:
- [x] Documentation Team Lead has reviewed