### PR TITLE
DOC-2543: Add title to `comments-tinycomments_access.adoc`.

### DIFF
--- a/modules/ROOT/pages/comments-access-options.adoc
+++ b/modules/ROOT/pages/comments-access-options.adoc
@@ -1,3 +1,4 @@
+= Configuring the Comments plugin access option
 :navtitle: Comments Access Options
 :description: TinyMCE Comments plugin access options.
 :keywords: comments, commenting, tinycomments, access options

--- a/modules/ROOT/partials/configuration/comments-tinycomments_access.adoc
+++ b/modules/ROOT/partials/configuration/comments-tinycomments_access.adoc
@@ -23,8 +23,9 @@ When `tinycomments_access` is set to `comment`, the editor will be in xref:edito
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
   plugins: 'tinycomments',
+  tinycomments_mode: 'embedded',
   toolbar: 'addcomment showcomments',
-  tinycomments_access: 'comment' 
+  tinycomments_access: 'comment'
 });
 ----
 


### PR DESCRIPTION
Ticket: DOC-2543

Site: [Staging branch](http://docs-hotfix-74-doc-2543.staging.tiny.cloud/docs/tinymce/latest/comments-access-options/)

Changes:
* Fixed page `Title` is coming up as "untitled"
* Updated code snippet `comments-access-options`.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed