### PR TITLE
DOC-2545: TinyMCE 7.4.1 Documentation Release.

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -410,6 +410,9 @@
 ** xref:tinymce-and-cors.adoc[Cross-Origin Resource Sharing (CORS)]
 * Release information
 ** xref:release-notes.adoc[Release notes for {productname} {productmajorversion}]
+*** {productname} 7.4.1
+**** xref:7.4.1-release-notes.adoc#overview[Overview]
+**** xref:7.4.1-release-notes.adoc#security-fix[Security fix]
 *** {productname} 7.4
 **** xref:7.4-release-notes.adoc#overview[Overview]
 **** xref:7.4-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]

--- a/modules/ROOT/pages/7.4.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.4.1-release-notes.adoc
@@ -1,0 +1,42 @@
+= {productname} {release-version}
+:release-version: 7.4.1
+:description: Release notes for TinyMCE 7.4.1
+:keywords: releasenotes, new, changes, bugfixes
+:page-toclevels: 1
+
+include::partial$misc/admon-releasenotes-for-stable.adoc[]
+
+
+[[overview]]
+== Overview
+
+{productname} {release-version} was released for {enterpriseversion} and {cloudname} on Wednesday, October 10^th^, 2024.
+
+These release notes provide an overview of the changes for {productname} {release-version}, including:
+
+* xref:security-fix[Security fix]
+
+
+[[security-fix]]
+== Security fix
+
+{productname} 7.4.1 includes one fix for the following security issue:
+
+=== Invalid HTML elements within `SVG` elements were not removed
+// TINY-11332
+
+A https://owasp.org/www-community/attacks/xss/[cross-site scripting] (XSS) vulnerability was discovered in link:https://www.npmjs.com/package/dompurify[DOMPurify] that affects versions of {productname} prior to {release-version} release. The issue was a result of DOMPurify allowing some bypassing which lead to improper sanitization of invalid HTML elements within XML contexts, exploiting parsing inconsistencies between XML and HTML.
+
+=== Affected Versions
+
+DOMPurify versions prior to `+<3.1.7+`
+
+=== Vulnerabilities
+
+* **Invalid HTML Elements in SVG** (link:https://www.cve.org/CVERecord?id=CVE-2024-45801[CVE-2024-45801]): Allowed invalid HTML elements within `SVG` to bypass sanitization.
+* **XML Processing Instruction Bypass**: Exploited differences in XML and HTML parsers regarding Processing Instructions, where XML parsed `+<?xml-stylesheet ><h1>Hello</h1> ?>+` as a single node, allowing `h1` to bypass sanitization.
+* **CDATA Section Bypass**: Leveraged differences in CDATA section handling between XML and HTML namespaces, with CDATA treated as bogus comments in HTML, bypassing end token rules for sanitization.
+
+GHSA: link:https://github.com/cure53/DOMPurify/security/advisories/GHSA-mmhx-hmjr-r674[GitHub Advisory]
+
+CVE: link:https://www.cve.org/CVERecord?id=CVE-2024-45801[CVE-2024-45801]

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -4,6 +4,13 @@
 
 NOTE: This is the {productname} Community version changelog. For information about the latest {cloudname} or {enterpriseversion} Release, see: xref:release-notes.adoc[{productname} Release Notes].
 
+== 7.4.1 - 2024-10-10
+
+=== Fixed
+
+* Invalid HTML elements within SVG elements were not removed.
+// #TINY-11332
+
 == 7.4.0 - 2024-10-09
 
 === Added

--- a/modules/ROOT/pages/filter-content.adoc
+++ b/modules/ROOT/pages/filter-content.adoc
@@ -16,7 +16,7 @@ Check out the xref:user-formatting-options.adoc#style_formats[custom formats exa
 
 === Style merging
 
-Similar elements and styles are merged by default to reduce the output HTML size. For example, instead of assigning one `+span+` element for font size and another `+span+` element for font face, {productname} merges the two styles into a sing `+span+` element.
+Similar elements and styles are merged by default to reduce the output HTML size. For example, instead of assigning one `+span+` element for font size and another `+span+` element for font face, {productname} merges the two styles into a single `+span+` element.
 
 === Built-in formats
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -10,6 +10,12 @@ This section lists the releases for {productname} 7 and the changes made in each
 |===
 a|
 [.lead]
+xref:7.4.1-release-notes.adoc#overview[{productname} 7.4.1]
+
+Release notes for {productname} 7.4.1
+
+a|
+[.lead]
 xref:7.4-release-notes.adoc#overview[{productname} 7.4]
 
 Release notes for {productname} 7.4

--- a/modules/ROOT/partials/misc/supported-versions.adoc
+++ b/modules/ROOT/partials/misc/supported-versions.adoc
@@ -6,6 +6,8 @@ Supported versions of {productname}:
 [cols="^,^,^",options="header"]
 |===
 |Version |Release Date |End of Premium Support
+|7.4 |2024-10-09 |2026-04-09
+|7.3 |2024-08-07 |2026-02-07
 |7.2 |2024-06-19 |2025-12-19
 |7.1 |2024-05-08 |2025-11-08
 |7.0 |2024-03-20 |2025-09-20


### PR DESCRIPTION
Ticket: DOC-2545

Site: [Changelog](http://docs-hotfix-741-doc-2545.staging.tiny.cloud/docs/tinymce/latest/changelog/#7-4-1-2024-10-10)
Site: [Release notes 7.4.1](http://docs-hotfix-741-doc-2545.staging.tiny.cloud/docs/tinymce/latest/7.4.1-release-notes/#overview)

Changes:
* DOMPurify bump which caused `Invalid HTML elements within SVG elements were not removed`.
* Updates to supported-versions and typo fixes.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.

Review:
- [x] Documentation Team Lead has reviewed