### PR TITLE
DOC-2544: TinyMCE 6.8.5 Documentation Release.

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -411,6 +411,9 @@
 ** xref:tinymce-and-cors.adoc[Cross-Origin Resource Sharing (CORS)]
 * Release information
 ** xref:release-notes.adoc[Release notes for {productname} 6]
+*** {productname} 6.8.5
+**** xref:6.8.5-release-notes.adoc#overview[Overview]
+**** xref:6.8.5-release-notes.adoc#security-fix[Security fix]
 *** {productname} 6.8.4
 **** xref:6.8.4-release-notes.adoc#overview[Overview]
 **** xref:6.8.4-release-notes.adoc#security-fix[Security fix]

--- a/modules/ROOT/pages/6.8.5-release-notes.adoc
+++ b/modules/ROOT/pages/6.8.5-release-notes.adoc
@@ -1,0 +1,42 @@
+= {productname} {release-version}
+:release-version: 6.8.5
+:description: Release notes for TinyMCE 6.8.5
+:keywords: releasenotes, new, changes, bugfixes
+:page-toclevels: 1
+
+include::partial$misc/admon-releasenotes-for-stable.adoc[]
+
+
+[[overview]]
+== Overview
+
+{productname} {release-version} was released for {enterpriseversion} and {cloudname} on Wednesday, October 10^th^, 2024.
+
+These release notes provide an overview of the changes for {productname} {release-version}, including:
+
+* xref:security-fix[Security fix]
+
+
+[[security-fix]]
+== Security fix
+
+{productname} {release-version} includes one fix for the following security issue:
+
+=== Invalid HTML elements within `SVG` elements were not removed
+// TINY-11332
+
+A https://owasp.org/www-community/attacks/xss/[cross-site scripting] (XSS) vulnerability was discovered in link:https://www.npmjs.com/package/dompurify[DOMPurify] that affects versions of {productname} prior to {release-version} release. The issue was a result of DOMPurify allowing some bypassing which lead to improper sanitization of invalid HTML elements within XML contexts, exploiting parsing inconsistencies between XML and HTML.
+
+=== Affected Versions
+
+DOMPurify versions prior to `+<3.1.7+`
+
+=== Vulnerabilities
+
+* **Invalid HTML Elements in SVG** (link:https://www.cve.org/CVERecord?id=CVE-2024-45801[CVE-2024-45801]): Allowed invalid HTML elements within `SVG` to bypass sanitization.
+* **XML Processing Instruction Bypass**: Exploited differences in XML and HTML parsers regarding Processing Instructions, where XML parsed `+<?xml-stylesheet ><h1>Hello</h1> ?>+` as a single node, allowing `h1` to bypass sanitization.
+* **CDATA Section Bypass**: Leveraged differences in CDATA section handling between XML and HTML namespaces, with CDATA treated as bogus comments in HTML, bypassing end token rules for sanitization.
+
+GHSA: link:https://github.com/cure53/DOMPurify/security/advisories/GHSA-mmhx-hmjr-r674[GitHub Advisory]
+
+CVE: link:https://www.cve.org/CVERecord?id=CVE-2024-45801[CVE-2024-45801]

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -4,6 +4,12 @@
 
 NOTE: This is the {productname} Community version changelog. For information about the latest {cloudname} or {enterpriseversion} Release, see: xref:release-notes.adoc[{productname} Release Notes].
 
+
+== 6.8.5 - 2024-10-10
+
+=== Fixed
+* Invalid HTML elements within SVG elements were not removed.
+
 ## 6.8.4 - 2024-06-19
 
 === Fixed

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -11,6 +11,12 @@ This section lists the releases for {productname} 6 and the changes made in each
 
 a|
 [.lead]
+xref:6.8.5-release-notes.adoc#overview[{productname} 6.8.5]
+
+Release notes for {productname} 6.8.5
+
+a|
+[.lead]
 xref:6.8.4-release-notes.adoc#overview[{productname} 6.8.4]
 
 Release notes for {productname} 6.8.4


### PR DESCRIPTION
Ticket: DOC-2544

Site: [Changelog](http://docs-hotfix-685-doc-2544.staging.tiny.cloud/docs/tinymce/6/changelog/#6-8-5-2024-10-10)
Site: [Release notes 6.8.5](http://docs-hotfix-685-doc-2544.staging.tiny.cloud/docs/tinymce/6/6.8.5-release-notes/#overview)

Changes:
* DOMPurify bump which caused `Invalid HTML elements within SVG elements were not removed`.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.

Review:
- [x] Documentation Team Lead has reviewed