### PR TITLE
DOC-2548: Add live-demo links to `Introduction to Tiny Comments` page.

### DIFF
--- a/modules/ROOT/pages/comments-callback-mode.adoc
+++ b/modules/ROOT/pages/comments-callback-mode.adoc
@@ -24,6 +24,7 @@ During the initial editor load, the {pluginname} uses `+tinycomments_fetch+` cal
 
 When a user adds a comment or a reply, the {pluginname} plugin uses the `+tinycomments_lookup+` callback to retrieve the selected conversation. 
 
+[[comments-callback-live-demo]]
 == Interactive example
 
 The following example uses a simulated server (provided by link:https://netflix.github.io/pollyjs/[Polly.js]), which has been hidden from the example JavaScript to keep the example code concise. The interactions between {productname} and Polly.js are visible in the browser console.

--- a/modules/ROOT/pages/comments-embedded-mode.adoc
+++ b/modules/ROOT/pages/comments-embedded-mode.adoc
@@ -23,6 +23,7 @@ tinymce.init({
 
 This is the minimum recommended setup for the {pluginname} plugin in embedded mode. If the `+tinycomments_author+` and `+tinycomments_author_name+` options are not configured, all users will be assigned the name "_ANON_".
 
+[[comments-embedded-live-demo]]
 == Interactive example
 
 liveDemo::comments-embedded[]

--- a/modules/ROOT/pages/introduction-to-tiny-comments.adoc
+++ b/modules/ROOT/pages/introduction-to-tiny-comments.adoc
@@ -19,6 +19,13 @@ include::partial$misc/admon-premium-plugin.adoc[]
 
 The {pluginname} plugin allows users to initiate and engage in conversations by adding comments directly within the {productname} editor. It also supports viewing all comments in a document for efficient collaboration.
 
+=== Interactive examples
+
+For interactive live demos for the {pluginname} plugin, showcasing both callback and embedded modes, see:
+
+* xref:comments-callback-mode.adoc#comments-callback-live-demo[Callback mode] Demo
+* xref:comments-embedded-mode.adoc#comments-embedded-live-demo[Embedded mode] Demo
+
 === Collaborate seamlessly within your content
 
 With the {pluginname} plugin, users can:


### PR DESCRIPTION
Ticket: DOC-2548

Site: [Staging branch](http://docs-hotfix-7-doc-2548.staging.tiny.cloud/docs/tinymce/latest/introduction-to-tiny-comments/#interactive-examples)

Changes:
* add live-demo link for both `callback-mode` and `embedded-mode` to  `introduction-to-tiny-comments` page.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.

Review:
- [x] Documentation Team Lead has reviewed