### PR TITLE
DOC-2547: update documentation for Doc Converters service url's.

### DIFF
--- a/modules/ROOT/partials/configuration/exportpdf.adoc
+++ b/modules/ROOT/partials/configuration/exportpdf.adoc
@@ -7,7 +7,7 @@ The {pluginname} feature is currently only available exclusively for `on-premise
 
 
 [TIP]
-Configure the `exportpdf_service_url` setting in your {productname} instance to match your custom host. For example, if your host is `mycustomhost.com`, set the URL to `https://mycustomhost.com/`. {productname} will **automatically append** `v1/convert` to the URL to ensure the correct endpoint is reached.
+Configure the `exportpdf_service_url` setting in your {productname} instance to match your custom host. For example, if your host is `mycustomhost.com`, set the URL to `https://mycustomhost.com/`.
 
 *Type:* `+String+`
 

--- a/modules/ROOT/partials/configuration/exportpdf.adoc
+++ b/modules/ROOT/partials/configuration/exportpdf.adoc
@@ -5,8 +5,9 @@ The {pluginname} uses the HTML to PDF converter service to generate the `documen
 
 The {pluginname} feature is currently only available exclusively for `on-premise` setups, requiring a self-hosted HTML to PDF converter service and the `exportpdf_service_url` option to be properly configured. If you require access to this feature, please link:https://www.tiny.cloud/contact/[contact us]. Refer to our xref:individual-export-to-pdf-on-premises.adoc[on-premises documentation] for detailed instructions on deploying the {pluginname} service server-side component using Docker.
 
+
 [TIP]
-Update the `exportpdf_service_url` configuration in your {productname} setup to point to your host. For instance, if your host is `mycustomhost.com`, the URL will be `https://mycustomhost.com/v1/convert`.
+Configure the `exportpdf_service_url` setting in your {productname} instance to match your custom host. For example, if your host is `mycustomhost.com`, set the URL to `https://mycustomhost.com/`. {productname} will **automatically append** `v1/convert` to the URL to ensure the correct endpoint is reached.
 
 *Type:* `+String+`
 

--- a/modules/ROOT/partials/configuration/exportword.adoc
+++ b/modules/ROOT/partials/configuration/exportword.adoc
@@ -9,7 +9,8 @@ The {pluginname} feature is currently only available exclusively for `on-premise
 NOTE: The {pluginname} feature is currently only available `on-premise` and requires the `exportword_service_url` option to be configured. link:https://www.tiny.cloud/contact/[Contact us] if you require this feature.
 
 [TIP]
-Update the `exportword_service_url` configuration in your {productname} setup to point to your host. For instance, if your host is `mycustomhost.com`, the URL will be `https://mycustomhost.com/v2/convert/html-docx`.
+Configure the `exportword_service_url` setting in your {productname} instance to match your custom host. For example, if your host is `mycustomhost.com`, set the URL to `https://mycustomhost.com/`. {productname} will **automatically append** `v2/convert/html-docx` to the URL to ensure the correct endpoint is reached.
+
 
 *Type:* `+String+`
 

--- a/modules/ROOT/partials/configuration/exportword.adoc
+++ b/modules/ROOT/partials/configuration/exportword.adoc
@@ -9,7 +9,7 @@ The {pluginname} feature is currently only available exclusively for `on-premise
 NOTE: The {pluginname} feature is currently only available `on-premise` and requires the `exportword_service_url` option to be configured. link:https://www.tiny.cloud/contact/[Contact us] if you require this feature.
 
 [TIP]
-Configure the `exportword_service_url` setting in your {productname} instance to match your custom host. For example, if your host is `mycustomhost.com`, set the URL to `https://mycustomhost.com/`. {productname} will **automatically append** `v2/convert/html-docx` to the URL to ensure the correct endpoint is reached.
+Configure the `exportword_service_url` setting in your {productname} instance to match your custom host. For example, if your host is `mycustomhost.com`, set the URL to `https://mycustomhost.com/`.
 
 
 *Type:* `+String+`

--- a/modules/ROOT/partials/configuration/importword-service-url.adoc
+++ b/modules/ROOT/partials/configuration/importword-service-url.adoc
@@ -7,7 +7,7 @@ The {pluginname} feature is currently only available exclusively for `on-premise
 
 
 [TIP]
-Configure the `importword_service_url` setting in your {productname} instance to match your custom host. For example, if your host is `mycustomhost.com`, set the URL to `https://mycustomhost.com/`. {productname} will **automatically append** `v2/convert/docx-html` to the URL to ensure the correct endpoint is reached.
+Configure the `importword_service_url` setting in your {productname} instance to match your custom host. For example, if your host is `mycustomhost.com`, set the URL to `https://mycustomhost.com/`.
 
 *Type:* `+String+`
 

--- a/modules/ROOT/partials/configuration/importword-service-url.adoc
+++ b/modules/ROOT/partials/configuration/importword-service-url.adoc
@@ -5,8 +5,9 @@ This option is used for setting the URL endpoint for the DOCX to HTML conversion
 
 The {pluginname} feature is currently only available exclusively for `on-premise` setups, requiring a self-hosted version of the DOCX to HTML conversion service and the `importword_service_url` option to be properly configured. If you require access to this feature, please link:https://www.tiny.cloud/contact/[contact us]. Refer to our xref:individual-import-from-word-and-export-to-word-on-premises.adoc[on-premises documentation] for detailed instructions on deploying the {pluginname} service server-side component using Docker.
 
+
 [TIP]
-Update the `importword_service_url` configuration in your {productname} setup to point to your host. For instance, if your host is `mycustomhost.com`, the URL will be `https://mycustomhost.com/v2/convert/docx-html`.
+Configure the `importword_service_url` setting in your {productname} instance to match your custom host. For example, if your host is `mycustomhost.com`, set the URL to `https://mycustomhost.com/`. {productname} will **automatically append** `v2/convert/docx-html` to the URL to ensure the correct endpoint is reached.
 
 *Type:* `+String+`
 


### PR DESCRIPTION
Ticket: DOC-2547

Site: [Staging branch: exportword](http://docs-hotfix-7-doc-2547.staging.tiny.cloud/docs/tinymce/latest/exportword/#exportword-service-url)
Site: [Staging branch: importword](http://docs-hotfix-7-doc-2547.staging.tiny.cloud/docs/tinymce/latest/importword/#importword-service-url)
Site: [Staging branch: exportpdf](http://docs-hotfix-7-doc-2547.staging.tiny.cloud/docs/tinymce/latest/exportpdf/#exportpdf-service-urll)

Changes:
* Update `TIP` for `<pluginname>_service_url` setting as it now appends `v2/convert/...` for example automatically when configured with a custom host in {productname} config.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed