### PR TITLE
DOC-2498: The toolbar-sticky-offset would still be applied after entering fullscreen mode.

### DIFF
--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -158,6 +158,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== The `toolbar-sticky-offset` would still be applied after entering fullscreen mode.
+// #TINY-11137
+
+In previous versions of {productname}, a issue was identified where the toolbar offset was incorrectly applied in fullscreen mode, causing the toolbar to overlap with the editor area.
+
+{productname} {release-version} addresses this issue, by implementing a check to verify whether the editor is in fullscreen mode before applying the toolbar offset. As a result, the toolbar now appears in the correct position when in fullscreen mode, even with the `toolbar_sticky_offset` option defined.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-2498

Site: [Staging branch](http://docs-feature-75-doc-2498tiny-11137.staging.tiny.cloud/docs/tinymce/latest/7.5-release-notes/#the-toolbar-sticky-offset-would-still-be-applied-after-entering-fullscreen-mode)

Changes:
* Fix documentation for TINY-11137

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [ ] Documentation Team Lead has reviewed