### PR TITLE
DOC-2498: Closing a nested modal dialog would lose focus from the editor.

### DIFF
--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -158,6 +158,14 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Closing a nested modal dialog would lose focus from the editor.
+// #TINY-11153
+
+When closing dialogs in an inline editor, focus was unintentionally lost before the dialog was fully closed. This issue was linked to link:https://www.tiny.cloud/docs/tinymce/6/6.5.1-release-notes/#closing-a-dialog-would-scroll-down-the-document-in-safari-on-macos[Closing a dialog would scroll down the document in Safari on macOS^] which was fixed in {productname} 6.5.1, where dismissing the Search/Replace dialog by clicking outside of it in Safari on macOS caused the document to scroll unexpectedly.
+
+As a consequence of this linked issue, the loss of focus led to the editor entirely losing its focus, resulting in the inline editor hiding its UI. This behavior created confusion, as the preceding dialog (e.g., table properties) appeared to close unexpectedly.
+
+The implemented fix ensures that focus is only shifted away from the dialog if it is currently focused. As a result, the editor retains its UI when closing nested dialogs.
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -161,11 +161,11 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Closing a nested modal dialog would lose focus from the editor.
 // #TINY-11153
 
-When closing dialogs in an inline editor, focus was unintentionally lost before the dialog was fully closed. This issue was linked to link:https://www.tiny.cloud/docs/tinymce/6/6.5.1-release-notes/#closing-a-dialog-would-scroll-down-the-document-in-safari-on-macos[Closing a dialog would scroll down the document in Safari on macOS^] which was fixed in {productname} 6.5.1, where dismissing the Search/Replace dialog by clicking outside of it in Safari on macOS caused the document to scroll unexpectedly.
+Previously in {productname}, closing a nested dialog (such as the color picker dialog within the Table Properties dialog) would cause the editor to lose focus on the parent dialog and shift focus to the editor content in the background.
 
-As a consequence of this linked issue, the loss of focus led to the editor entirely losing its focus, resulting in the inline editor hiding its UI. This behavior created confusion, as the preceding dialog (e.g., table properties) appeared to close unexpectedly.
+This issue impacted keyboard users, preventing them from navigating or closing the parent dialog since the focus was no longer on the dialog. Additionally, in inline mode editors, the dialog UI would disappear entirely when focus shifted to the editor area, giving the impression that the dialog had closed unexpectedly.
 
-The implemented fix ensures that focus is only shifted away from the dialog if it is currently focused. As a result, the editor retains its UI when closing nested dialogs.
+This issue has been resolved by ensuring focus returns to the parent dialog when a nested dialog is closed. As a result, keyboard users can now navigate and close dialogs as expected, and the dialog UI remains visible in inline mode editors.
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-2498

Site: [Staging branch](http://docs-feature-75-doc-2498tiny-11153.staging.tiny.cloud/docs/tinymce/latest/7.5-release-notes/#closing-a-nested-modal-dialog-would-lose-focus-from-the-editor)

Changes:
* fix documentation for TINY-11153

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed