### PR TITLE
DOC-2498: Autocompleter would not activate after applying an inline format like font size in some cases.

### DIFF
--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -158,6 +158,15 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Autocompleter would not activate after applying an inline format like font size in some cases.
+// #TINY-11273
+
+Previously, when formatting was applied, a span with a zero-width no-break space `+U+FEFF+` was added to the editor. This character was not considered whitespace; as a result, the autocompleter did not trigger as expected. 
+
+{productname} {release-version} addresses this issue by updating the function to include `+U+FEFF+` as a valid character. 
+
+As a result, the autocompleter now triggers as expected after applying formatting.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-2498

Site: [Staging branch](http://docs-feature-75-doc-2498tiny-11273.staging.tiny.cloud/docs/tinymce/latest/7.5-release-notes/#autocompleter-would-not-activate-after-applying-an-inline-format-like-font-size-in-some-cases)

Changes:
* fix documentation for TINY-11273

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed