### PR TITLE
DOC-2498: The command `MarkdownInsert` is now registered immediately and operates in an async manner, instead of waiting for resources before registering the command.

### DIFF
--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -69,6 +69,24 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Markdown
+
+The {productname} {release-version} release includes an accompanying release of the **Markdown** premium plugin.
+
+This **Markdown** premium plugin release includes the following improvement:
+
+==== The command `MarkdownInsert` is now registered immediately and operates in an async manner, instead of waiting for resources before registering the command.
+// #TINY-11280
+
+In {productname} {release-version}, the `MarkdownInsert` command is now registered immediately and operates asynchronously upon execution, rather than waiting for resources to register during initialization. Previously, the command required loading external content, which delayed its availability. By making the command async on execution instead of on loading, it is now accessible at initialization, improving responsiveness without the need for additional loading time.
+
+==== Markdown command `MarkdownInsert` fires new event `MarkdownInserted` when completed.
+// #TINY-11280
+
+In {productname} {release-version}, the `MarkdownInsert` command now triggers a new event, `MarkdownInserted`, upon completion. This event provides a notification when the markdown insertion process has finished, enabling better tracking and handling of post-insertion actions within the editor.
+
+For information on the **Markdown** plugin, see xref:markdown.adoc[Markdown].
+
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement


### PR DESCRIPTION
Ticket: DOC-2498

Site: [Staging branch](http://docs-feature-75-doc-2498tiny-11280.staging.tiny.cloud/docs/tinymce/latest/7.5-release-notes/#markdown)

Changes:
* Improvement and Added fix for TINY-11280

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed