### PR TITLE
DOC-2498: `Forecolor` and `backcolor` toolbar buttons were not completely greyed out while in readonly mode.

### DIFF
--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -158,6 +158,14 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Forecolor and backcolor toolbar buttons were not completely greyed out while in readonly mode.
+// #TINY-11313
+
+In previous versions of {productname}, an issue was identified where the `backcolor` and `forecolor` toolbar buttons were not completely greyed out while in readonly mode due to an incorrect CSS selector.
+
+This led to a visual inconsistency in the readonly editor state.
+
+{productname} {release-version} addresses this issue. Now, the CSS selector has been corrected, ensuring that both `backcolor` and `forecolor` buttons are now completely greyed out, providing a consistent user experience when the editor is in readonly mode.
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-2498

Site: [Staging branch](http://docs-feature-75-doc-2498tiny-11313.staging.tiny.cloud/docs/tinymce/latest/7.5-release-notes/#forecolor-and-backcolor-toolbar-buttons-were-not-completely-greyed-out-while-in-readonly-mode)

Changes:
* Fix documentation for TINY-11313

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed