### PR TITLE
DOC-2498: Corrected focus highlight visibility in statusbar path.

### DIFF
--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -158,6 +158,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Corrected focus highlight visibility in `Statusbar` path
+
+A visual bug introduced in {productname} version xref:7.2.1-release-notes.adoc#long-translations-of-the-bottom-help-text-would-cause-minor-graphical-issues[7.1.2] caused the focus highlight to appear behind the tag name in the statusbar path, making it difficult for users to visually track their focus.
+
+In {productname} {release-version}, this has been corrected. The focus highlight is now correctly displayed above the tag name when navigating through the statusbar path, ensuring a clear and visible focus indication. 
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-2498

Site: [Staging branch](http://docs-feature-75-doc-2498tiny-11381.staging.tiny.cloud/docs/tinymce/latest/7.5-release-notes/#corrected-focus-highlight-visibility-in-statusbar-path)

Changes:
* fix documentation for TINY-11381

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed