### PR TITLE
DOC-2498: The `conversationAuthor` property was missing from create conversation events in the EventLog API.

### DIFF
--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -69,6 +69,20 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Comments
+
+The {productname} {release-version} release includes an accompanying release of the **Comments** premium plugin.
+
+**Comments** Premium plugin includes the following fix.
+
+==== The `conversationAuthor` property was missing from 'create` conversation events in the EventLog API.
+
+In previous versions of the tinycomments plugin, the `conversationAuthor` property was missing from 'create' events within the event log, which lead to incomplete tracking of user interactions when retrieving data through the `+getEventLog()+` API.
+
+{productname} {release-version} addresses this issue. Now, the `conversationAuthor` property is included in 'create' events in the event log.
+
+For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to {companyname} Comments].
+
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement

--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -77,7 +77,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 ==== The `conversationAuthor` property was missing from 'create` conversation events in the EventLog API.
 
-In previous versions of the tinycomments plugin, the `conversationAuthor` property was missing from 'create' events within the event log, which lead to incomplete tracking of user interactions when retrieving data through the `+getEventLog()+` API.
+In previous versions of the tinycomments plugin, the `conversationAuthor` property was missing from 'create' events within the event log, which led to incomplete tracking of user interactions when retrieving data through the `+getEventLog()+` API.
 
 {productname} {release-version} addresses this issue. Now, the `conversationAuthor` property is included in 'create' events in the event log.
 


### PR DESCRIPTION
Ticket: DOC-2498

Site: [Staging branch](http://docs-feature-75-doc-2498tiny-11352.staging.tiny.cloud/docs/tinymce/latest/7.5-release-notes/#the-conversationauthor-property-was-missing-from-create-conversation-events-in-the-eventlog-api)

Changes:
* fix documentation for TINY-11352

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed