### PR TITLE
DOC-2498: Improve Document Converter default value for `<pluginname>converter-options`

### DIFF
--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -69,6 +69,75 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Export to PDF
+
+The {productname} {release-version} release includes an accompanying release of the **Export to PDF** premium plugin.
+
+**Export to PDF** Premium plugin includes the following improvement.
+
+=== Added a default value for the `exportpdf_converter_options` option.
+// #TINY-11396
+
+As of {productname} {release-version}, the **Export to PDF** Plugin now defaults to U.S. letter page size and applies standard 1-inch margins, ensuring consistency in document formatting out of the box for integrators. The following settings have been applied:
+
+[source,js]
+----
+exportpdf_converter_options: {
+  format: 'Letter',
+  margin_top: '1in',
+  margin_right: '1in',
+  margin_bottom: '1in',
+  margin_left: '1in'
+}
+----
+
+For information on the **Export to PDF** plugin, see: xref:exportpdf.adoc[Export to PDF].
+
+=== Export to Word
+
+The {productname} {release-version} release includes an accompanying release of the **Export to Word** premium plugin.
+
+**Export to Word** Premium plugin includes the following improvement.
+
+=== Added a default value for the `exportword_converter_options` option.
+// #TINY-11396
+
+As of {productname} {release-version}, the **Export to Word** Plugin has been updated to default to the U.S. letter page size, improving compatibility with standard document formats, providing a better out-of-the-box experience for integrators. The following setting has been applied:
+
+[source,js]
+----
+exportword_converter_options: {
+  document: {
+    size: 'letter'
+  }
+}
+----
+
+For information on the **Export to Word** plugin, see: xref:exportword.adoc[Export to Word].
+
+=== Import from Word
+
+The {productname} {release-version} release includes an accompanying release of the **Import from Word** premium plugin.
+
+**Import from Word** Premium plugin includes the following improvement.
+
+=== Added a default value for the `importword_converter_options` option.
+// #TINY-11396
+
+As of {productname} {release-version}, the **Import from Word** Plugin now defaults to retaining as much original Word document styling as possible, using the following settings:
+
+[source,js]
+----
+importword_converter_options: {
+  formatting: {
+    styles: 'inline',
+    resets: 'inline',
+    defaults: 'inline',
+  }
+}
+----
+
+For information on the **Import from Word** plugin, see: xref:importword.adoc[Import from Word].
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement

--- a/modules/ROOT/partials/configuration/exportpdf.adoc
+++ b/modules/ROOT/partials/configuration/exportpdf.adoc
@@ -31,7 +31,7 @@ This option allows the editor to download a PDF document containing its content,
 **Type:** `+Object+`
 
 [NOTE]
-As of {productname} 7.5.0, the default value of the `exportpdf_converter_options` setting has been updated to the following:
+As of {productname} 7.5.0, the `exportpdf_converter_options` setting now comes with a default value set to the following:
 
 .**Default value:**
 [source,js]

--- a/modules/ROOT/partials/configuration/exportpdf.adoc
+++ b/modules/ROOT/partials/configuration/exportpdf.adoc
@@ -28,9 +28,22 @@ tinymce.init({
 
 This option allows the editor to download a PDF document containing its content, along with the specified options defined in the `exportpdf_converter_options`.
 
-*Type:* `+Object+`
+**Type:** `+Object+`
 
-*Default value:* `{}`
+[NOTE]
+As of {productname} 7.5.0, the default value of the `exportpdf_converter_options` setting has been updated to the following:
+
+.**Default value:**
+[source,js]
+----
+exportpdf_converter_options: {
+  format: 'Letter',
+  margin_top: '1in',
+  margin_right: '1in',
+  margin_bottom: '1in',
+  margin_left: '1in'
+}
+----
 
 === Example: using `exportpdf_converter_options`
 

--- a/modules/ROOT/partials/configuration/exportword.adoc
+++ b/modules/ROOT/partials/configuration/exportword.adoc
@@ -31,9 +31,20 @@ tinymce.init({
 
 The `exportword_converter_options` option, is used to specify and configure various options related to the process of converting and exporting content from the editor to `.docx` Word file.
 
-*Type:* `+Object+`
+**Type:** `+Object+`
 
-*Default value:* `{}`
+[NOTE]
+As of {productname} 7.5.0, the default value of the `exportword_converter_options` setting has been updated to the following:
+
+.**Default value:**
+[source,js]
+----
+exportword_converter_options: {
+  document: {
+    size: 'letter'
+  }
+}
+----
 
 === Example: using `exportword_converter_options`
 

--- a/modules/ROOT/partials/configuration/importword-converter-options.adoc
+++ b/modules/ROOT/partials/configuration/importword-converter-options.adoc
@@ -3,6 +3,21 @@
 
 **Type:** `String`
 
+[NOTE]
+As of {productname} 7.5.0, the default value of the `importword_converter_options` setting has been updated to the following:
+
+.**Default value:** 
+[source,js]
+----
+importword_converter_options: {
+  formatting: {
+    styles: 'inline',
+    resets: 'inline',
+    defaults: 'inline',
+  }
+}
+----
+
 The `importword_converter_options` setting allows you to customize the behavior of the {pluginname} plugin when converting Word documents to HTML.
 
 .Example: using `importword_converter_options`


### PR DESCRIPTION
Ticket: DOC-2498

Site: [Release notes Export to PDF](http://docs-feature-75-doc-2498tiny-11396.staging.tiny.cloud/docs/tinymce/latest/7.5-release-notes/#export-to-pdf)
Site: [Release notes Export to Word](http://docs-feature-75-doc-2498tiny-11396.staging.tiny.cloud/docs/tinymce/latest/7.5-release-notes/#export-to-word)
Site: [Release notes Import from Word](http://docs-feature-75-doc-2498tiny-11396.staging.tiny.cloud/docs/tinymce/latest/7.5-release-notes/#import-from-word)
Site: [Default value change: Export to PDF](http://docs-feature-75-doc-2498tiny-11396.staging.tiny.cloud/docs/tinymce/latest/exportpdf/#exportpdf-converter-options)
Site: [Default value change: Export from Word](http://docs-feature-75-doc-2498tiny-11396.staging.tiny.cloud/docs/tinymce/latest/exportword/#exportword-converter-options)
Site: [Default value change: Import from Word](http://docs-feature-75-doc-2498tiny-11396.staging.tiny.cloud/docs/tinymce/latest/importword/#importword-converter-options)


Changes:
* Improve Document Converter default value for `<pluginname>converter-options` TINY-11396

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed