### PR TITLE
DOC-2498: Improved color picker aria support.

### DIFF
--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -198,7 +198,7 @@ There <is one | are <number> known issue<s> in {productname} {release-version}.
 === Screenreader on safari has poor consistency of announcing aria-label
 // #TINY-11291 & #TINY-11430
 
-In Safari, when using a screen reader, the focus is incorrectly placed on the content of the input field instead of the input field itself. This behavior results in the screen reader not announcing the content of the `aria-label` associated with the input field.
+In Safari, when using a screen reader on the color picker, the focus is mistakenly placed on the content within the input field rather than the field itself. This causes the screen reader to bypass announcing the aria-label associated with the field.
 
 As a consequence, users relying on screen readers may not hear the intended description of the input field, leading to potential confusion or accessibility challenges.
 

--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -158,6 +158,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Improved color picker aria support.
+// #TINY-11291
+
+In previous versions of {productname}, an issue was identified where screen readers would inconsistently announce the original R/G/B component string in the color picker, leading to a lack of context for visually impaired users. The root cause was an incorrect placement of the `aria-label` attribute, which was initially applied to the label element instead of the input field.
+
+{productname} {release-version} addresses this issue. Now, the `aria-label` attribute has been moved to the input field to ensure it is correctly associated. Additionally, the descriptive text was updated from "Red/Green/Blue component" to "Red/Green/Blue channel" to provide clearer information for assistive technologies. These changes ensure that screen readers consistently and accurately announce the relevant RGB channels, significantly improving accessibility.
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -200,6 +200,6 @@ There <is one | are <number> known issue<s> in {productname} {release-version}.
 
 In Safari, when using a screen reader on the color picker, the focus is mistakenly placed on the content within the input field rather than the field itself. This causes the screen reader to bypass announcing the aria-label associated with the field.
 
-As a consequence, users relying on screen readers may not hear the intended description of the input field, leading to potential confusion or accessibility challenges.
+As a consequence, users who rely on screen readers may not hear the intended description provided by the aria-label, potentially causing confusion or reducing accessibility.
 
 **Status**: Currently under investigation.

--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -193,7 +193,13 @@ This section describes issues that users of {productname} {release-version} may 
 
 There <is one | are <number> known issue<s> in {productname} {release-version}.
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+== Known Issues
 
-// CCFR here.
+=== Screenreader on safari has poor consistency of announcing aria-label
+// #TINY-11291 & #TINY-11430
+
+In Safari, when using a screen reader, the focus is incorrectly placed on the content of the input field instead of the input field itself. This behavior results in the screen reader not announcing the content of the `aria-label` associated with the input field.
+
+As a consequence, users relying on screen readers may not hear the intended description of the input field, leading to potential confusion or accessibility challenges.
+
+**Status**: Currently under investigation.


### PR DESCRIPTION
Ticket: DOC-2498

Site: [Staging branch](http://docs-feature-75-doc-2498tiny-11291.staging.tiny.cloud/docs/tinymce/latest/7.5-release-notes/#improved-color-picker-aria-support)

Changes:
*  fix documentation for TINY-11291

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed