### PR TITLE
DOC-2498: Default values for tinycomments_author and tinycomments_author_name when empty string provided

### DIFF
--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -368,7 +368,7 @@ tinycomments_author_name: '',
 
 Previously, instead of assigning default user/author values as in `7-stable` (7.3), the latest release {release-version} disables all comment features when these fields are empty.
 
-**Status**: Currently under investigation.
+**Status**: This issue has been resolved in xref:7.5-release-notes.adoc#use-default-anon-value-for-tinycomments_author-and-tinycomments_author_name-options-when-the-provided-value-is-an-empty-string[{productname} 7.5.0].
 
 === Comment card not removed after deleting content
 // #TINY-11366

--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -81,6 +81,13 @@ In previous versions of the tinycomments plugin, the `conversationAuthor` proper
 
 {productname} {release-version} addresses this issue. Now, the `conversationAuthor` property is included in 'create' events in the event log.
 
+==== Use default 'Anon' value for `tinycomments_author` and `tinycomments_author_name` options when the provided value is an empty string.
+// #TINY-11323
+
+Previously in xref:7.4-release-notes.adoc#comments-not-functional-with-empty-tinycomments_author-and-tinycomments_author_name[{productname} 7.4.0], an issue was identified in **Embedded mode** where the commenting functionality became non-operational when either the `tinycomments_author` or the `tinycomments_author_name` options were configured as empty strings `""`. As a consequence, users were unable to create comments when these options were empty.
+
+In {productname} {release-version}, the `tinycomments_author` and `tinycomments_author_name` options now default to "Anon" when the provided value is an empty string. As a result, the commenting functionality is now operational even when these options are empty.
+
 For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to {companyname} Comments].
 
 

--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -73,7 +73,7 @@ For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode
 
 The {productname} {release-version} release includes an accompanying release of the **Comments** premium plugin.
 
-**Comments** Premium plugin includes the following fix.
+**Comments** Premium plugin includes the following fixes.
 
 ==== The `conversationAuthor` property was missing from 'create` conversation events in the EventLog API.
 


### PR DESCRIPTION
Ticket: DOC-2498

Site: [Staging branch](http://docs-feature-75-doc-2498tiny-11323.staging.tiny.cloud/docs/tinymce/latest/7.5-release-notes#use-default-anon-value-for-tinycomments_author-and-tinycomments_author_name-options-when-the-provided-value-is-an-empty-string)
Site: [Known issue](http://docs-feature-75-doc-2498tiny-11323.staging.tiny.cloud/docs/tinymce/latest/7.4-release-notes/#comments-not-functional-with-empty-tinycomments_author-and-tinycomments_author_name)

Changes:
* fix for TINY-11323
* update 7.4 release notes - known issues

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.
- [-] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed