### PR TITLE
DOC-2562: Add live-demo for document converters and full feature demo pages.

### DIFF
--- a/modules/ROOT/examples/live-demos/exportpdf/index.html
+++ b/modules/ROOT/examples/live-demos/exportpdf/index.html
@@ -1,0 +1,71 @@
+<textarea id="exportpdf">
+  <h1>Streamline - The Next-Gen Learning Management System (LMS)</h1>
+  <p>This document provides a comprehensive overview of the Streamline Learning Management System (LMS) project.</p>
+  <p><img src="https://images.unsplash.com/photo-1522199755839-a2bacb67c546?q=80&w=2072&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="" width="573" height="429"></p>
+  <p>By <a class="N2odk RZQOk eziW_ KHq0c Byk7y KHq0c" href="https://unsplash.com/@anete_lusina">Anete Lūsiņa</a> on <a href="https://unsplash.com">Unsplash</a></p>
+  <h2>Project Goals</h2>
+  <p>Streamline aims to revolutionize online learning by offering a robust and user-friendly platform for educators and learners alike. Our primary goals are:</p>
+  <ul>
+  <li><em><strong>To empower educators</strong></em> with intuitive tools for content creation, course management, and student assessment.&nbsp;</li>
+  <li><em><strong>To enhance the learning experience for students</strong></em> through engaging content delivery, interactive features, and personalized learning paths.</li>
+  <li><em><strong>To increase accessibility and scalability</strong></em> to cater to diverse learning needs and accommodate a growing user base.</li>
+  </ul>
+  <h2>System Features</h2>
+  <p>Streamline will be packed with features to streamline (pun intended) the learning process:</p>
+  <ul>
+  <li><strong>Content Management System (CMS)</strong>: A user-friendly interface for educators to create and upload various learning materials, including videos, documents, presentations, and interactive quizzes.</li>
+  <li><strong>Course Management Tools</strong>: Streamline allows educators to structure courses with clear learning objectives, organize content modules, and manage student enrollment.&nbsp;</li>
+  <li><strong>Interactive Learning Activities</strong>: The platform will incorporate gamification elements, discussion forums, collaborative assignments, and other interactive features to keep students engaged.&nbsp;</li>
+  <li><strong>Assessment &amp; Analytics</strong>: Streamline provides educators with tools to create quizzes, track student progress, generate reports, and identify areas for improvement.&nbsp;</li>
+  <li><strong>Personalized Learning Paths</strong>: The system will utilize machine learning algorithms to personalize learning recommendations and suggest relevant content based on individual student needs and progress.</li>
+  </ul>
+  <p><strong>Table 1: Streamline - Target User Groups</strong></p>
+  <table style="border-collapse: collapse; width: 100%;" border="1"><colgroup><col style="width: 50%;"><col style="width: 50%;"></colgroup>
+  <tbody>
+  <tr>
+  <td><strong>User Group</strong></td>
+  <td>Benefits</td>
+  </tr>
+  <tr>
+  <td><strong>Educators</strong></td>
+  <td>Easy content creation, efficient course management, valuable student insights.</td>
+  </tr>
+  <tr>
+  <td><strong>Learners</strong></td>
+  <td>Engaging learning experience, personalized learning paths, interactive collaboration.</td>
+  </tr>
+  <tr>
+  <td><strong>Administrators</strong></td>
+  <td>Scalable platform management, user access control, comprehensive reporting tools.</td>
+  </tr>
+  </tbody>
+  </table>
+  <h2><br>Technology Stack</h2>
+  <p>Streamline will leverage a robust technology stack to ensure performance, scalability, and security:</p>
+  <ul>
+  <li><strong>Front-End</strong>: ReactJS for a responsive and user-friendly interface.&nbsp;</li>
+  <li><strong>Back-End</strong>: Node.js for efficient server-side operations.&nbsp;</li>
+  <li><strong>Database</strong>: MongoDB for flexible and scalable data storage.&nbsp;</li>
+  <li><strong>Cloud Platform</strong>: Amazon Web Services (AWS) for reliable hosting and infrastructure.&nbsp;</li>
+  </ul>
+  <h2>Code Example&nbsp;</h2>
+  <p>Here's a simplified code snippet demonstrating how educators can create a multiple-choice question within the CMS:</p>
+  <h3>JavaScript</h3>
+  <p><code>const questionData = {</code><br><code>&nbsp; title: "What is the capital of France?",</code><br><code>&nbsp; options: [</code><br><code>&nbsp; &nbsp; "London",</code><br><code>&nbsp; &nbsp; "Paris", &nbsp;**Subscript for correct answer indicator**</code><br><code>&nbsp; &nbsp; "Berlin",</code><br><code>&nbsp; &nbsp; "Madrid"</code><br><code>&nbsp; ],</code><br><code>&nbsp; correctAnswer: 1</code><br><code>};</code></p>
+  <p><code>// Submit question data to the LMS backend for storage</code></p>
+  <blockquote>
+  <p><strong>Note</strong>: This is a basic example for illustration purposes. The actual code will involve API calls and more complex functionalities. (Normal body text with parenthetical information)</p>
+  </blockquote>
+  <h2>Project Timeline&nbsp;</h2>
+  <ul>
+  <li><strong>Phase 1 (2 Months)</strong>: System design, development of core functionalities, and front-end prototype creation.</li>
+  <li><strong>Phase 2 (3 Months)</strong>: Integration of advanced features like personalized learning and assessment tools.</li>
+  <li><strong>Phase 3 (1 Month)</strong>: Rigorous testing, bug fixing, and user interface refinement.</li>
+  <li><strong>Phase 4 (Ongoing)</strong>: Deployment, user feedback collection, and continuous improvement through iterative development cycles.&nbsp;</li>
+  </ul>
+  <blockquote>
+  <p><em>This is a preliminary timeline and may be subject to change.</em></p>
+  </blockquote>
+  <h2>Conclusion</h2>
+  <p>Streamline LMS has the potential to become a game-changer in the online learning landscape. By empowering educators and fostering a more engaging learning experience for students, Streamline aims to contribute to a future of accessible and effective education for all.</p>
+</textarea>

--- a/modules/ROOT/examples/live-demos/exportpdf/index.html
+++ b/modules/ROOT/examples/live-demos/exportpdf/index.html
@@ -1,71 +1,78 @@
 <textarea id="exportpdf">
   <h1>Streamline - The Next-Gen Learning Management System (LMS)</h1>
   <p>This document provides a comprehensive overview of the Streamline Learning Management System (LMS) project.</p>
-  <p><img src="https://images.unsplash.com/photo-1522199755839-a2bacb67c546?q=80&w=2072&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="" width="573" height="429"></p>
-  <p>By <a class="N2odk RZQOk eziW_ KHq0c Byk7y KHq0c" href="https://unsplash.com/@anete_lusina">Anete Lūsiņa</a> on <a href="https://unsplash.com">Unsplash</a></p>
+
+  <figure class="image">
+    <img src="https://images.unsplash.com/photo-1522199755839-a2bacb67c546?q=80&amp;w=2072&amp;auto=format&amp;fit=crop&amp;ixlib=rb-4.0.3&amp;ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" 
+          alt="A laptop on a polished wood table with a bronze cup, creating a warm workspace ambiance" width="573" height="429">
+    <figcaption>An elegant workspace featuring a laptop on a polished wood table, accompanied by a bronze cup, creating a warm and productive atmosphere.</figcaption>
+  </figure>
+  
+  <p>Photo by <a href="https://unsplash.com/@anete_lusina">Anete Lūsiņa</a> on <a href="https://unsplash.com">Unsplash</a></p>
+
   <h2>Project Goals</h2>
-  <p>Streamline aims to revolutionize online learning by offering a robust and user-friendly platform for educators and learners alike. Our primary goals are:</p>
+  <p>Streamline aims to revolutionize online learning by offering a robust and user-friendly platform for educators and learners. The primary goals include:</p>
   <ul>
-  <li><em><strong>To empower educators</strong></em> with intuitive tools for content creation, course management, and student assessment.&nbsp;</li>
-  <li><em><strong>To enhance the learning experience for students</strong></em> through engaging content delivery, interactive features, and personalized learning paths.</li>
-  <li><em><strong>To increase accessibility and scalability</strong></em> to cater to diverse learning needs and accommodate a growing user base.</li>
+    <li><strong>Empowering educators</strong> with intuitive tools for content creation, course management, and student assessment.</li>
+    <li><strong>Enhancing the learning experience for students</strong> through engaging content delivery, interactive features, and personalized learning paths.</li>
+    <li><strong>Increasing accessibility and scalability</strong> to cater to diverse learning needs and support a growing user base.</li>
   </ul>
+  
   <h2>System Features</h2>
-  <p>Streamline will be packed with features to streamline (pun intended) the learning process:</p>
+  <p>Streamline is designed to enrich the learning process through a comprehensive set of features:</p>
   <ul>
-  <li><strong>Content Management System (CMS)</strong>: A user-friendly interface for educators to create and upload various learning materials, including videos, documents, presentations, and interactive quizzes.</li>
-  <li><strong>Course Management Tools</strong>: Streamline allows educators to structure courses with clear learning objectives, organize content modules, and manage student enrollment.&nbsp;</li>
-  <li><strong>Interactive Learning Activities</strong>: The platform will incorporate gamification elements, discussion forums, collaborative assignments, and other interactive features to keep students engaged.&nbsp;</li>
-  <li><strong>Assessment &amp; Analytics</strong>: Streamline provides educators with tools to create quizzes, track student progress, generate reports, and identify areas for improvement.&nbsp;</li>
-  <li><strong>Personalized Learning Paths</strong>: The system will utilize machine learning algorithms to personalize learning recommendations and suggest relevant content based on individual student needs and progress.</li>
+    <li><strong>Content Management System (CMS)</strong>: An intuitive interface enabling educators to create and upload various learning materials, including videos, documents, presentations, and quizzes.</li>
+    <li><strong>Course Management Tools</strong>: Structure courses with clear objectives, organize content modules, and manage student enrollments effectively.</li>
+    <li><strong>Interactive Learning Activities</strong>: Includes gamification, discussion forums, collaborative assignments, and more to maintain student engagement.</li>
+    <li><strong>Assessment & Analytics</strong>: Tools for creating quizzes, tracking student progress, generating reports, and identifying improvement areas.</li>
+    <li><strong>Personalized Learning Paths</strong>: Machine learning algorithms provide tailored content recommendations based on student progress and needs.</li>
   </ul>
-  <p><strong>Table 1: Streamline - Target User Groups</strong></p>
-  <table style="border-collapse: collapse; width: 100%;" border="1"><colgroup><col style="width: 50%;"><col style="width: 50%;"></colgroup>
-  <tbody>
-  <tr>
-  <td><strong>User Group</strong></td>
-  <td>Benefits</td>
-  </tr>
-  <tr>
-  <td><strong>Educators</strong></td>
-  <td>Easy content creation, efficient course management, valuable student insights.</td>
-  </tr>
-  <tr>
-  <td><strong>Learners</strong></td>
-  <td>Engaging learning experience, personalized learning paths, interactive collaboration.</td>
-  </tr>
-  <tr>
-  <td><strong>Administrators</strong></td>
-  <td>Scalable platform management, user access control, comprehensive reporting tools.</td>
-  </tr>
-  </tbody>
+  
+  <h3>Table 1: Streamline - Target User Groups</h3>
+  <table style="border-collapse: collapse; width: 100%;" border="1">
+    <thead>
+      <tr>
+        <th style="text-align: left;">User Group</th>
+        <th style="text-align: left;">Benefits</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Educators</strong></td>
+        <td>Easy content creation, efficient course management, and valuable student insights.</td>
+      </tr>
+      <tr>
+        <td><strong>Learners</strong></td>
+        <td>Engaging learning experience, personalized learning paths, and interactive collaboration.</td>
+      </tr>
+      <tr>
+        <td><strong>Administrators</strong></td>
+        <td>Scalable platform management, user access control, and comprehensive reporting tools.</td>
+      </tr>
+    </tbody>
   </table>
-  <h2><br>Technology Stack</h2>
+  
+  <h2>Technology Stack</h2>
   <p>Streamline will leverage a robust technology stack to ensure performance, scalability, and security:</p>
   <ul>
-  <li><strong>Front-End</strong>: ReactJS for a responsive and user-friendly interface.&nbsp;</li>
-  <li><strong>Back-End</strong>: Node.js for efficient server-side operations.&nbsp;</li>
-  <li><strong>Database</strong>: MongoDB for flexible and scalable data storage.&nbsp;</li>
-  <li><strong>Cloud Platform</strong>: Amazon Web Services (AWS) for reliable hosting and infrastructure.&nbsp;</li>
+    <li><strong>Front-End</strong>: ReactJS for a responsive and user-friendly interface.</li>
+    <li><strong>Back-End</strong>: Node.js for efficient server-side operations.</li>
+    <li><strong>Database</strong>: MongoDB for flexible and scalable data storage.</li>
+    <li><strong>Cloud Platform</strong>: Amazon Web Services (AWS) for reliable hosting and infrastructure.</li>
   </ul>
-  <h2>Code Example&nbsp;</h2>
-  <p>Here's a simplified code snippet demonstrating how educators can create a multiple-choice question within the CMS:</p>
-  <h3>JavaScript</h3>
-  <p><code>const questionData = {</code><br><code>&nbsp; title: "What is the capital of France?",</code><br><code>&nbsp; options: [</code><br><code>&nbsp; &nbsp; "London",</code><br><code>&nbsp; &nbsp; "Paris", &nbsp;**Subscript for correct answer indicator**</code><br><code>&nbsp; &nbsp; "Berlin",</code><br><code>&nbsp; &nbsp; "Madrid"</code><br><code>&nbsp; ],</code><br><code>&nbsp; correctAnswer: 1</code><br><code>};</code></p>
-  <p><code>// Submit question data to the LMS backend for storage</code></p>
-  <blockquote>
-  <p><strong>Note</strong>: This is a basic example for illustration purposes. The actual code will involve API calls and more complex functionalities. (Normal body text with parenthetical information)</p>
-  </blockquote>
-  <h2>Project Timeline&nbsp;</h2>
+  
+  <h2>Project Timeline</h2>
   <ul>
-  <li><strong>Phase 1 (2 Months)</strong>: System design, development of core functionalities, and front-end prototype creation.</li>
-  <li><strong>Phase 2 (3 Months)</strong>: Integration of advanced features like personalized learning and assessment tools.</li>
-  <li><strong>Phase 3 (1 Month)</strong>: Rigorous testing, bug fixing, and user interface refinement.</li>
-  <li><strong>Phase 4 (Ongoing)</strong>: Deployment, user feedback collection, and continuous improvement through iterative development cycles.&nbsp;</li>
+    <li><strong>Phase 1 (2 Months)</strong>: System design, core functionalities development, and front-end prototype creation.</li>
+    <li><strong>Phase 2 (3 Months)</strong>: Integration of advanced features like personalized learning and assessment tools.</li>
+    <li><strong>Phase 3 (1 Month)</strong>: Rigorous testing, bug fixing, and UI refinement.</li>
+    <li><strong>Phase 4 (Ongoing)</strong>: Deployment, user feedback collection, and continuous iterative development.</li>
   </ul>
+  
   <blockquote>
-  <p><em>This is a preliminary timeline and may be subject to change.</em></p>
+    <p><em>This timeline is preliminary and may be subject to change.</em></p>
   </blockquote>
+  
   <h2>Conclusion</h2>
-  <p>Streamline LMS has the potential to become a game-changer in the online learning landscape. By empowering educators and fostering a more engaging learning experience for students, Streamline aims to contribute to a future of accessible and effective education for all.</p>
+  <p>Streamline LMS is poised to become a game-changer in online education. By empowering educators and enhancing student experiences, it aims to make effective and accessible learning available to all.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/exportpdf/index.js
+++ b/modules/ROOT/examples/live-demos/exportpdf/index.js
@@ -2,9 +2,17 @@ tinymce.init({
   selector: 'textarea#exportpdf',
   height: '800px',
   plugins: [
-    "exportpdf", "advlist", "anchor", "autolink", "charmap", "code", "fullscreen",
+    "exportpdf", "advlist", "anchor", "autolink", "charmap", "code", "codesample", "fullscreen",
     "help", "image", "insertdatetime", "link", "lists", "media",
     "preview", "searchreplace", "table", "visualblocks",
-],
-toolbar: "undo redo | exportpdf | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
+  ],
+  toolbar: "undo redo | exportpdf | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
+  image_caption: true,
+  exportpdf_converter_options: {
+    format: 'A4',
+    margin_top: '1in',
+    margin_right: '1in',
+    margin_bottom: '1in',
+    margin_left: '1in'
+  }
 });

--- a/modules/ROOT/examples/live-demos/exportpdf/index.js
+++ b/modules/ROOT/examples/live-demos/exportpdf/index.js
@@ -1,0 +1,10 @@
+tinymce.init({
+  selector: 'textarea#exportpdf',
+  height: '800px',
+  plugins: [
+    "exportpdf", "advlist", "anchor", "autolink", "charmap", "code", "fullscreen",
+    "help", "image", "insertdatetime", "link", "lists", "media",
+    "preview", "searchreplace", "table", "visualblocks",
+],
+toolbar: "undo redo | exportpdf | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
+});

--- a/modules/ROOT/examples/live-demos/exportword/index.html
+++ b/modules/ROOT/examples/live-demos/exportword/index.html
@@ -1,0 +1,71 @@
+<textarea id="exportword">
+  <h1>Streamline - The Next-Gen Learning Management System (LMS)</h1>
+  <p>This document provides a comprehensive overview of the Streamline Learning Management System (LMS) project.</p>
+  <p><img src="https://images.unsplash.com/photo-1522199755839-a2bacb67c546?q=80&w=2072&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="" width="573" height="429"></p>
+  <p>By <a class="N2odk RZQOk eziW_ KHq0c Byk7y KHq0c" href="https://unsplash.com/@anete_lusina">Anete Lūsiņa</a> on <a href="https://unsplash.com">Unsplash</a></p>
+  <h2>Project Goals</h2>
+  <p>Streamline aims to revolutionize online learning by offering a robust and user-friendly platform for educators and learners alike. Our primary goals are:</p>
+  <ul>
+  <li><em><strong>To empower educators</strong></em> with intuitive tools for content creation, course management, and student assessment.&nbsp;</li>
+  <li><em><strong>To enhance the learning experience for students</strong></em> through engaging content delivery, interactive features, and personalized learning paths.</li>
+  <li><em><strong>To increase accessibility and scalability</strong></em> to cater to diverse learning needs and accommodate a growing user base.</li>
+  </ul>
+  <h2>System Features</h2>
+  <p>Streamline will be packed with features to streamline (pun intended) the learning process:</p>
+  <ul>
+  <li><strong>Content Management System (CMS)</strong>: A user-friendly interface for educators to create and upload various learning materials, including videos, documents, presentations, and interactive quizzes.</li>
+  <li><strong>Course Management Tools</strong>: Streamline allows educators to structure courses with clear learning objectives, organize content modules, and manage student enrollment.&nbsp;</li>
+  <li><strong>Interactive Learning Activities</strong>: The platform will incorporate gamification elements, discussion forums, collaborative assignments, and other interactive features to keep students engaged.&nbsp;</li>
+  <li><strong>Assessment &amp; Analytics</strong>: Streamline provides educators with tools to create quizzes, track student progress, generate reports, and identify areas for improvement.&nbsp;</li>
+  <li><strong>Personalized Learning Paths</strong>: The system will utilize machine learning algorithms to personalize learning recommendations and suggest relevant content based on individual student needs and progress.</li>
+  </ul>
+  <p><strong>Table 1: Streamline - Target User Groups</strong></p>
+  <table style="border-collapse: collapse; width: 100%;" border="1"><colgroup><col style="width: 50%;"><col style="width: 50%;"></colgroup>
+  <tbody>
+  <tr>
+  <td><strong>User Group</strong></td>
+  <td>Benefits</td>
+  </tr>
+  <tr>
+  <td><strong>Educators</strong></td>
+  <td>Easy content creation, efficient course management, valuable student insights.</td>
+  </tr>
+  <tr>
+  <td><strong>Learners</strong></td>
+  <td>Engaging learning experience, personalized learning paths, interactive collaboration.</td>
+  </tr>
+  <tr>
+  <td><strong>Administrators</strong></td>
+  <td>Scalable platform management, user access control, comprehensive reporting tools.</td>
+  </tr>
+  </tbody>
+  </table>
+  <h2><br>Technology Stack</h2>
+  <p>Streamline will leverage a robust technology stack to ensure performance, scalability, and security:</p>
+  <ul>
+  <li><strong>Front-End</strong>: ReactJS for a responsive and user-friendly interface.&nbsp;</li>
+  <li><strong>Back-End</strong>: Node.js for efficient server-side operations.&nbsp;</li>
+  <li><strong>Database</strong>: MongoDB for flexible and scalable data storage.&nbsp;</li>
+  <li><strong>Cloud Platform</strong>: Amazon Web Services (AWS) for reliable hosting and infrastructure.&nbsp;</li>
+  </ul>
+  <h2>Code Example&nbsp;</h2>
+  <p>Here's a simplified code snippet demonstrating how educators can create a multiple-choice question within the CMS:</p>
+  <h3>JavaScript</h3>
+  <p><code>const questionData = {</code><br><code>&nbsp; title: "What is the capital of France?",</code><br><code>&nbsp; options: [</code><br><code>&nbsp; &nbsp; "London",</code><br><code>&nbsp; &nbsp; "Paris", &nbsp;**Subscript for correct answer indicator**</code><br><code>&nbsp; &nbsp; "Berlin",</code><br><code>&nbsp; &nbsp; "Madrid"</code><br><code>&nbsp; ],</code><br><code>&nbsp; correctAnswer: 1</code><br><code>};</code></p>
+  <p><code>// Submit question data to the LMS backend for storage</code></p>
+  <blockquote>
+  <p><strong>Note</strong>: This is a basic example for illustration purposes. The actual code will involve API calls and more complex functionalities. (Normal body text with parenthetical information)</p>
+  </blockquote>
+  <h2>Project Timeline&nbsp;</h2>
+  <ul>
+  <li><strong>Phase 1 (2 Months)</strong>: System design, development of core functionalities, and front-end prototype creation.</li>
+  <li><strong>Phase 2 (3 Months)</strong>: Integration of advanced features like personalized learning and assessment tools.</li>
+  <li><strong>Phase 3 (1 Month)</strong>: Rigorous testing, bug fixing, and user interface refinement.</li>
+  <li><strong>Phase 4 (Ongoing)</strong>: Deployment, user feedback collection, and continuous improvement through iterative development cycles.&nbsp;</li>
+  </ul>
+  <blockquote>
+  <p><em>This is a preliminary timeline and may be subject to change.</em></p>
+  </blockquote>
+  <h2>Conclusion</h2>
+  <p>Streamline LMS has the potential to become a game-changer in the online learning landscape. By empowering educators and fostering a more engaging learning experience for students, Streamline aims to contribute to a future of accessible and effective education for all.</p>
+</textarea>

--- a/modules/ROOT/examples/live-demos/exportword/index.html
+++ b/modules/ROOT/examples/live-demos/exportword/index.html
@@ -1,71 +1,78 @@
 <textarea id="exportword">
   <h1>Streamline - The Next-Gen Learning Management System (LMS)</h1>
   <p>This document provides a comprehensive overview of the Streamline Learning Management System (LMS) project.</p>
-  <p><img src="https://images.unsplash.com/photo-1522199755839-a2bacb67c546?q=80&w=2072&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="" width="573" height="429"></p>
-  <p>By <a class="N2odk RZQOk eziW_ KHq0c Byk7y KHq0c" href="https://unsplash.com/@anete_lusina">Anete Lūsiņa</a> on <a href="https://unsplash.com">Unsplash</a></p>
+
+  <figure class="image">
+    <img src="https://images.unsplash.com/photo-1522199755839-a2bacb67c546?q=80&amp;w=2072&amp;auto=format&amp;fit=crop&amp;ixlib=rb-4.0.3&amp;ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" 
+          alt="A laptop on a polished wood table with a bronze cup, creating a warm workspace ambiance" width="573" height="429">
+    <figcaption>An elegant workspace featuring a laptop on a polished wood table, accompanied by a bronze cup, creating a warm and productive atmosphere.</figcaption>
+  </figure>
+  
+  <p>Photo by <a href="https://unsplash.com/@anete_lusina">Anete Lūsiņa</a> on <a href="https://unsplash.com">Unsplash</a></p>
+
   <h2>Project Goals</h2>
-  <p>Streamline aims to revolutionize online learning by offering a robust and user-friendly platform for educators and learners alike. Our primary goals are:</p>
+  <p>Streamline aims to revolutionize online learning by offering a robust and user-friendly platform for educators and learners. The primary goals include:</p>
   <ul>
-  <li><em><strong>To empower educators</strong></em> with intuitive tools for content creation, course management, and student assessment.&nbsp;</li>
-  <li><em><strong>To enhance the learning experience for students</strong></em> through engaging content delivery, interactive features, and personalized learning paths.</li>
-  <li><em><strong>To increase accessibility and scalability</strong></em> to cater to diverse learning needs and accommodate a growing user base.</li>
+    <li><strong>Empowering educators</strong> with intuitive tools for content creation, course management, and student assessment.</li>
+    <li><strong>Enhancing the learning experience for students</strong> through engaging content delivery, interactive features, and personalized learning paths.</li>
+    <li><strong>Increasing accessibility and scalability</strong> to cater to diverse learning needs and support a growing user base.</li>
   </ul>
+  
   <h2>System Features</h2>
-  <p>Streamline will be packed with features to streamline (pun intended) the learning process:</p>
+  <p>Streamline is designed to enrich the learning process through a comprehensive set of features:</p>
   <ul>
-  <li><strong>Content Management System (CMS)</strong>: A user-friendly interface for educators to create and upload various learning materials, including videos, documents, presentations, and interactive quizzes.</li>
-  <li><strong>Course Management Tools</strong>: Streamline allows educators to structure courses with clear learning objectives, organize content modules, and manage student enrollment.&nbsp;</li>
-  <li><strong>Interactive Learning Activities</strong>: The platform will incorporate gamification elements, discussion forums, collaborative assignments, and other interactive features to keep students engaged.&nbsp;</li>
-  <li><strong>Assessment &amp; Analytics</strong>: Streamline provides educators with tools to create quizzes, track student progress, generate reports, and identify areas for improvement.&nbsp;</li>
-  <li><strong>Personalized Learning Paths</strong>: The system will utilize machine learning algorithms to personalize learning recommendations and suggest relevant content based on individual student needs and progress.</li>
+    <li><strong>Content Management System (CMS)</strong>: An intuitive interface enabling educators to create and upload various learning materials, including videos, documents, presentations, and quizzes.</li>
+    <li><strong>Course Management Tools</strong>: Structure courses with clear objectives, organize content modules, and manage student enrollments effectively.</li>
+    <li><strong>Interactive Learning Activities</strong>: Includes gamification, discussion forums, collaborative assignments, and more to maintain student engagement.</li>
+    <li><strong>Assessment & Analytics</strong>: Tools for creating quizzes, tracking student progress, generating reports, and identifying improvement areas.</li>
+    <li><strong>Personalized Learning Paths</strong>: Machine learning algorithms provide tailored content recommendations based on student progress and needs.</li>
   </ul>
-  <p><strong>Table 1: Streamline - Target User Groups</strong></p>
-  <table style="border-collapse: collapse; width: 100%;" border="1"><colgroup><col style="width: 50%;"><col style="width: 50%;"></colgroup>
-  <tbody>
-  <tr>
-  <td><strong>User Group</strong></td>
-  <td>Benefits</td>
-  </tr>
-  <tr>
-  <td><strong>Educators</strong></td>
-  <td>Easy content creation, efficient course management, valuable student insights.</td>
-  </tr>
-  <tr>
-  <td><strong>Learners</strong></td>
-  <td>Engaging learning experience, personalized learning paths, interactive collaboration.</td>
-  </tr>
-  <tr>
-  <td><strong>Administrators</strong></td>
-  <td>Scalable platform management, user access control, comprehensive reporting tools.</td>
-  </tr>
-  </tbody>
+  
+  <h3>Table 1: Streamline - Target User Groups</h3>
+  <table style="border-collapse: collapse; width: 100%;" border="1">
+    <thead>
+      <tr>
+        <th style="text-align: left;">User Group</th>
+        <th style="text-align: left;">Benefits</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Educators</strong></td>
+        <td>Easy content creation, efficient course management, and valuable student insights.</td>
+      </tr>
+      <tr>
+        <td><strong>Learners</strong></td>
+        <td>Engaging learning experience, personalized learning paths, and interactive collaboration.</td>
+      </tr>
+      <tr>
+        <td><strong>Administrators</strong></td>
+        <td>Scalable platform management, user access control, and comprehensive reporting tools.</td>
+      </tr>
+    </tbody>
   </table>
-  <h2><br>Technology Stack</h2>
+  
+  <h2>Technology Stack</h2>
   <p>Streamline will leverage a robust technology stack to ensure performance, scalability, and security:</p>
   <ul>
-  <li><strong>Front-End</strong>: ReactJS for a responsive and user-friendly interface.&nbsp;</li>
-  <li><strong>Back-End</strong>: Node.js for efficient server-side operations.&nbsp;</li>
-  <li><strong>Database</strong>: MongoDB for flexible and scalable data storage.&nbsp;</li>
-  <li><strong>Cloud Platform</strong>: Amazon Web Services (AWS) for reliable hosting and infrastructure.&nbsp;</li>
+    <li><strong>Front-End</strong>: ReactJS for a responsive and user-friendly interface.</li>
+    <li><strong>Back-End</strong>: Node.js for efficient server-side operations.</li>
+    <li><strong>Database</strong>: MongoDB for flexible and scalable data storage.</li>
+    <li><strong>Cloud Platform</strong>: Amazon Web Services (AWS) for reliable hosting and infrastructure.</li>
   </ul>
-  <h2>Code Example&nbsp;</h2>
-  <p>Here's a simplified code snippet demonstrating how educators can create a multiple-choice question within the CMS:</p>
-  <h3>JavaScript</h3>
-  <p><code>const questionData = {</code><br><code>&nbsp; title: "What is the capital of France?",</code><br><code>&nbsp; options: [</code><br><code>&nbsp; &nbsp; "London",</code><br><code>&nbsp; &nbsp; "Paris", &nbsp;**Subscript for correct answer indicator**</code><br><code>&nbsp; &nbsp; "Berlin",</code><br><code>&nbsp; &nbsp; "Madrid"</code><br><code>&nbsp; ],</code><br><code>&nbsp; correctAnswer: 1</code><br><code>};</code></p>
-  <p><code>// Submit question data to the LMS backend for storage</code></p>
-  <blockquote>
-  <p><strong>Note</strong>: This is a basic example for illustration purposes. The actual code will involve API calls and more complex functionalities. (Normal body text with parenthetical information)</p>
-  </blockquote>
-  <h2>Project Timeline&nbsp;</h2>
+  
+  <h2>Project Timeline</h2>
   <ul>
-  <li><strong>Phase 1 (2 Months)</strong>: System design, development of core functionalities, and front-end prototype creation.</li>
-  <li><strong>Phase 2 (3 Months)</strong>: Integration of advanced features like personalized learning and assessment tools.</li>
-  <li><strong>Phase 3 (1 Month)</strong>: Rigorous testing, bug fixing, and user interface refinement.</li>
-  <li><strong>Phase 4 (Ongoing)</strong>: Deployment, user feedback collection, and continuous improvement through iterative development cycles.&nbsp;</li>
+    <li><strong>Phase 1 (2 Months)</strong>: System design, core functionalities development, and front-end prototype creation.</li>
+    <li><strong>Phase 2 (3 Months)</strong>: Integration of advanced features like personalized learning and assessment tools.</li>
+    <li><strong>Phase 3 (1 Month)</strong>: Rigorous testing, bug fixing, and UI refinement.</li>
+    <li><strong>Phase 4 (Ongoing)</strong>: Deployment, user feedback collection, and continuous iterative development.</li>
   </ul>
+  
   <blockquote>
-  <p><em>This is a preliminary timeline and may be subject to change.</em></p>
+    <p><em>This timeline is preliminary and may be subject to change.</em></p>
   </blockquote>
+  
   <h2>Conclusion</h2>
-  <p>Streamline LMS has the potential to become a game-changer in the online learning landscape. By empowering educators and fostering a more engaging learning experience for students, Streamline aims to contribute to a future of accessible and effective education for all.</p>
+  <p>Streamline LMS is poised to become a game-changer in online education. By empowering educators and enhancing student experiences, it aims to make effective and accessible learning available to all.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/exportword/index.js
+++ b/modules/ROOT/examples/live-demos/exportword/index.js
@@ -5,6 +5,17 @@ tinymce.init({
     "exportword", "advlist", "anchor", "autolink", "charmap", "code", "fullscreen",
     "help", "image", "insertdatetime", "link", "lists", "media",
     "preview", "searchreplace", "table", "visualblocks",
-],
-toolbar: "undo redo | exportword | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
+  ],
+  toolbar: "undo redo | exportword | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
+  exportword_converter_options: {
+    document: {
+      size: 'A4',
+      margins: {
+        top: "1in",
+        bottom: "1in",
+        left: "1in",
+        right: "1in"
+      }
+    }
+  }
 });

--- a/modules/ROOT/examples/live-demos/exportword/index.js
+++ b/modules/ROOT/examples/live-demos/exportword/index.js
@@ -1,0 +1,10 @@
+tinymce.init({
+  selector: 'textarea#exportword',
+  height: '800px',
+  plugins: [
+    "exportword", "advlist", "anchor", "autolink", "charmap", "code", "fullscreen",
+    "help", "image", "insertdatetime", "link", "lists", "media",
+    "preview", "searchreplace", "table", "visualblocks",
+],
+toolbar: "undo redo | exportword | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
+});

--- a/modules/ROOT/examples/live-demos/full-featured/example.js
+++ b/modules/ROOT/examples/live-demos/full-featured/example.js
@@ -11,7 +11,7 @@ const isSmallScreen = window.matchMedia('(max-width: 1023.5px)').matches;
 
 tinymce.init({
   selector: 'textarea#full-featured',
-  plugins: 'ai preview powerpaste casechange importcss tinydrive searchreplace autolink autosave save directionality advcode visualblocks visualchars fullscreen image link math media mediaembed codesample table charmap pagebreak nonbreaking anchor tableofcontents insertdatetime advlist lists checklist wordcount tinymcespellchecker a11ychecker editimage help formatpainter permanentpen pageembed charmap tinycomments mentions quickbars linkchecker emoticons advtable footnotes mergetags autocorrect typography advtemplate markdown revisionhistory',
+  plugins: 'importword exportword exportpdf ai preview powerpaste casechange importcss tinydrive searchreplace autolink autosave save directionality advcode visualblocks visualchars fullscreen image link math media mediaembed codesample table charmap pagebreak nonbreaking anchor tableofcontents insertdatetime advlist lists checklist wordcount tinymcespellchecker a11ychecker editimage help formatpainter permanentpen pageembed charmap tinycomments mentions quickbars linkchecker emoticons advtable footnotes mergetags autocorrect typography advtemplate markdown revisionhistory',
   tinydrive_token_provider: 'URL_TO_YOUR_TOKEN_PROVIDER',
   tinydrive_dropbox_app_key: 'YOUR_DROPBOX_APP_KEY',
   tinydrive_google_drive_key: 'YOUR_GOOGLE_DRIVE_KEY',
@@ -26,7 +26,7 @@ tinymce.init({
     }
   },
   menubar: 'file edit view insert format tools table tc help',
-  toolbar: "undo redo | revisionhistory | aidialog aishortcuts | blocks fontsizeinput | bold italic | align numlist bullist | link image | table math media pageembed | lineheight  outdent indent | strikethrough forecolor backcolor formatpainter removeformat | charmap emoticons checklist | code fullscreen preview | save print | pagebreak anchor codesample footnotes mergetags | addtemplate inserttemplate | addcomment showcomments | ltr rtl casechange | spellcheckdialog a11ycheck", // Note: if a toolbar item requires a plugin, the item will not present in the toolbar if the plugin is not also loaded.
+  toolbar: "undo redo | importword exportword exportpdf | revisionhistory | aidialog aishortcuts | blocks fontsizeinput | bold italic | align numlist bullist | link image | table math media pageembed | lineheight  outdent indent | strikethrough forecolor backcolor formatpainter removeformat | charmap emoticons checklist | code fullscreen preview | save print | pagebreak anchor codesample footnotes mergetags | addtemplate inserttemplate | addcomment showcomments | ltr rtl casechange | spellcheckdialog a11ycheck", // Note: if a toolbar item requires a plugin, the item will not present in the toolbar if the plugin is not also loaded.
   autosave_ask_before_unload: true,
   autosave_interval: '30s',
   autosave_prefix: '{path}{query}-{id}-',
@@ -411,6 +411,25 @@ tinymce.init({
         })
         .catch(onerror);
     });
+  },
+  exportpdf_converter_options: {
+    'format': 'Letter',
+    'margin_top': '1in',
+    'margin_right': '1in',
+    'margin_bottom': '1in',
+    'margin_left': '1in'
+  },
+  exportword_converter_options: {
+    'document': { 
+      'size': 'Letter'
+    }
+  },
+  importword_converter_options: {
+    'formatting': {
+      'styles': 'inline',
+      'resets': 'inline',
+      'defaults': 'inline',
+    }
   },
   /*
   The following settings require more configuration than shown here.

--- a/modules/ROOT/examples/live-demos/full-featured/index.js
+++ b/modules/ROOT/examples/live-demos/full-featured/index.js
@@ -414,7 +414,7 @@ tinymce.ScriptLoader.loadScripts(['https://cdn.jsdelivr.net/npm/faker@5/dist/fak
 
   tinymce.init({
     selector: 'textarea#full-featured',
-    plugins: 'ai preview powerpaste casechange importcss tinydrive searchreplace autolink autosave save directionality advcode visualblocks visualchars fullscreen image link math media mediaembed codesample table charmap pagebreak nonbreaking anchor tableofcontents insertdatetime advlist lists checklist wordcount tinymcespellchecker a11ychecker editimage help formatpainter permanentpen pageembed charmap tinycomments mentions quickbars linkchecker emoticons advtable footnotes mergetags autocorrect typography advtemplate markdown revisionhistory',
+    plugins: 'ai preview powerpaste casechange importcss tinydrive searchreplace autolink autosave save directionality advcode visualblocks visualchars fullscreen image link math media mediaembed codesample table charmap pagebreak nonbreaking anchor tableofcontents insertdatetime advlist lists checklist wordcount tinymcespellchecker a11ychecker editimage help formatpainter permanentpen pageembed charmap tinycomments mentions quickbars linkchecker emoticons advtable footnotes mergetags autocorrect typography advtemplate markdown revisionhistory importword exportword exportpdf',
     editimage_cors_hosts: ['picsum.photos'],
     tinydrive_token_provider: (success, failure) => {
       success({ token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJqb2huZG9lIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.Ks_BdfH4CWilyzLNk8S2gDARFhuxIauLa8PwhdEQhEo' });
@@ -433,7 +433,7 @@ tinymce.ScriptLoader.loadScripts(['https://cdn.jsdelivr.net/npm/faker@5/dist/fak
       }
     },
     menubar: 'file edit view insert format tools table tc help',
-      toolbar: "undo redo | revisionhistory | aidialog aishortcuts | blocks fontsizeinput | bold italic | align numlist bullist | link image | table math media pageembed | lineheight  outdent indent | strikethrough forecolor backcolor formatpainter removeformat | charmap emoticons checklist | code fullscreen preview | save print | pagebreak anchor codesample footnotes mergetags | addtemplate inserttemplate | addcomment showcomments | ltr rtl casechange | spellcheckdialog a11ycheck", // Note: if a toolbar item requires a plugin, the item will not present in the toolbar if the plugin is not also loaded.
+      toolbar: "undo redo | importword exportword exportpdf | revisionhistory | aidialog aishortcuts | blocks fontsizeinput | bold italic | align numlist bullist | link image | table math media pageembed | lineheight  outdent indent | strikethrough forecolor backcolor formatpainter removeformat | charmap emoticons checklist | code fullscreen preview | save print | pagebreak anchor codesample footnotes mergetags | addtemplate inserttemplate | addcomment showcomments | ltr rtl casechange | spellcheckdialog a11ycheck", // Note: if a toolbar item requires a plugin, the item will not present in the toolbar if the plugin is not also loaded.
     autosave_ask_before_unload: true,
     autosave_interval: '30s',
     autosave_prefix: '{path}{query}-{id}-',
@@ -565,6 +565,25 @@ tinymce.ScriptLoader.loadScripts(['https://cdn.jsdelivr.net/npm/faker@5/dist/fak
       }
     ],
     ai_request,
+    exportpdf_converter_options: {
+      'format': 'Letter',
+      'margin_top': '1in',
+      'margin_right': '1in',
+      'margin_bottom': '1in',
+      'margin_left': '1in'
+    },
+    exportword_converter_options: {
+      'document': { 
+        'size': 'Letter'
+      }
+    },
+    importword_converter_options: {
+      'formatting': {
+        'styles': 'inline',
+        'resets': 'inline',
+        'defaults': 'inline',
+      }
+    },
     revisionhistory_fetch: fetchRevisions,
     revisionhistory_author: {
       id: 'john.doe',

--- a/modules/ROOT/examples/live-demos/importword/index.html
+++ b/modules/ROOT/examples/live-demos/importword/index.html
@@ -1,0 +1,9 @@
+<textarea id="importword">
+  <h2 style="font-size: 1.5em; color: #0066cc; margin-top: 0; text-align: center;">Import from MS Word</h2>
+  <ol style="padding-left: 20px; margin: 10px 0;">
+      <li style="margin-bottom: 10px;">Click the <strong>Import from Word</strong> button in the toolbar or select <strong>File &gt; Import from Word</strong> in the menu.</li>
+      <li style="margin-bottom: 10px;">Select the DOCX file to upload.</li>
+      <li style="margin-bottom: 10px;">Edit the imported content however you wish.</li>
+  </ol>
+  <p style="font-size: 0.9em; color: #555; text-align: center; margin-top: 15px;">Learn more about <strong>Import from Word</strong> and our other document converters (<a href="https://tiny.cloud/tinymce/features/export-word/" style="color: #0066cc; text-decoration: none; border-bottom: 1px dotted #0066cc;">Export to Word</a> and <a href="https://tiny.cloud/tinymce/features/export-pdf" style="color: #0066cc; text-decoration: none; border-bottom: 1px dotted #0066cc;">Export to PDF</a>) at <a href="https://tiny.cloud" style="color: #0066cc; text-decoration: none; border-bottom: 1px dotted #0066cc;">https://tiny.cloud</a>.</p>
+</textarea>

--- a/modules/ROOT/examples/live-demos/importword/index.html
+++ b/modules/ROOT/examples/live-demos/importword/index.html
@@ -1,9 +1,9 @@
 <textarea id="importword">
-  <h2 style="font-size: 1.5em; color: #0066cc; margin-top: 0; text-align: center;">Import from MS Word</h2>
+  <h1 style="font-size: 1.5em; color: black; margin-top: 0; text-align: left;">Import from MS Word</h2>
   <ol style="padding-left: 20px; margin: 10px 0;">
       <li style="margin-bottom: 10px;">Click the <strong>Import from Word</strong> button in the toolbar or select <strong>File &gt; Import from Word</strong> in the menu.</li>
       <li style="margin-bottom: 10px;">Select the DOCX file to upload.</li>
       <li style="margin-bottom: 10px;">Edit the imported content however you wish.</li>
   </ol>
-  <p style="font-size: 0.9em; color: #555; text-align: center; margin-top: 15px;">Learn more about <strong>Import from Word</strong> and our other document converters (<a href="https://tiny.cloud/tinymce/features/export-word/" style="color: #0066cc; text-decoration: none; border-bottom: 1px dotted #0066cc;">Export to Word</a> and <a href="https://tiny.cloud/tinymce/features/export-pdf" style="color: #0066cc; text-decoration: none; border-bottom: 1px dotted #0066cc;">Export to PDF</a>) at <a href="https://tiny.cloud" style="color: #0066cc; text-decoration: none; border-bottom: 1px dotted #0066cc;">https://tiny.cloud</a>.</p>
+  <p style="font-size: 0.9em; color: #555; text-align: left; margin-top: 15px;">Learn more about <strong>Import from Word</strong> and our other document converters (<a href="https://tiny.cloud/tinymce/features/export-word/" style="color: #0066cc; text-decoration: none; border-bottom: 1px dotted #0066cc;">Export to Word</a> and <a href="https://tiny.cloud/tinymce/features/export-pdf" style="color: #0066cc; text-decoration: none; border-bottom: 1px dotted #0066cc;">Export to PDF</a>) at <a href="https://tiny.cloud" style="color: #0066cc; text-decoration: none; border-bottom: 1px dotted #0066cc;">https://tiny.cloud</a>.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/importword/index.js
+++ b/modules/ROOT/examples/live-demos/importword/index.js
@@ -1,0 +1,10 @@
+tinymce.init({
+  selector: 'textarea#importword',
+  height: '800px',
+  plugins: [
+    "importword", "advlist", "anchor", "autolink", "charmap", "code", "fullscreen",
+    "help", "image", "insertdatetime", "link", "lists", "media",
+    "preview", "searchreplace", "table", "visualblocks",
+],
+toolbar: "undo redo | importword | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
+});

--- a/modules/ROOT/pages/exportpdf.adoc
+++ b/modules/ROOT/pages/exportpdf.adoc
@@ -16,11 +16,7 @@ The {pluginname} feature collects the HTML generated with the `tinymce.editor.ge
 
 == Interactive example
 
-[NOTE]
-.{pluginname} demo
-====
-Demos containing the {pluginname} plugin are currently only available on our main website. Check out https://www.tiny.cloud/tinymce/features/export-pdf[the {pluginname} demo], or the https://www.tiny.cloud/[demo on our home page], to try it out today.
-====
+liveDemo::exportpdf[]
 
 == Basic setup
 

--- a/modules/ROOT/pages/exportword.adoc
+++ b/modules/ROOT/pages/exportword.adoc
@@ -15,11 +15,7 @@ The export to Microsoft Word feature collects the HTML generated with the `tinym
 
 == Interactive example
 
-[NOTE]
-.{pluginname} demo
-====
-Demos containing the {pluginname} plugin are currently only available on our main website. Check out https://www.tiny.cloud/tinymce/features/export-word[the {pluginname} demo], or the https://www.tiny.cloud/[demo on our home page], to try it out today.
-====
+liveDemo::exportword[]
 
 [NOTE]
 .{pluginname} known issues

--- a/modules/ROOT/pages/full-featured-premium-demo.adoc
+++ b/modules/ROOT/pages/full-featured-premium-demo.adoc
@@ -17,21 +17,11 @@ The following plugins are excluded from this example:
 |===
 |Excluded plugins |Notes
 
-
 |xref:autoresize.adoc[Autoresize]
 |Resizes the editor to fit the content.
 
 |xref:code.adoc[Code]
 |xref:advcode.adoc[*Enhanced Code Editor*] included instead.
-
-|xref:exportpdf.adoc[Export to PDF]
-|Logistical concerns regarding exposing internal service URLs preclude adding this.
-
-|xref:exportword.adoc[Export to Word]
-|Logistical concerns regarding exposing internal service URLs preclude adding this.
-
-|xref:importword.adoc[Import from Word]
-|Logistical concerns regarding exposing internal service URLs preclude adding this.
 
 |xref:moxiemanager.adoc[MoxieManager]
 |xref:tinydrive-introduction.adoc[*{cloudfilemanager}*] included instead.

--- a/modules/ROOT/pages/importword.adoc
+++ b/modules/ROOT/pages/importword.adoc
@@ -17,11 +17,7 @@ The {pluginname} plugin lets you import `.docx` (Word document) or `.dotx` (Word
 
 == Interactive example
 
-[NOTE]
-.{pluginname} demo
-====
-Demos containing the {pluginname} plugin are currently only available on our main website. Check out https://www.tiny.cloud/tinymce/features/import-from-word[the {pluginname} demo], or the https://www.tiny.cloud/[demo on our home page], to try it out today.
-====
+liveDemo::importword[]
 
 == Basic setup
 


### PR DESCRIPTION
Ticket: DOC-2562

Site: [Full Feature Demo](http://docs-hotfix-7-doc-2562.staging.tiny.cloud/docs/tinymce/latest/full-featured-premium-demo/)
Site: [ExportWord](http://docs-hotfix-7-doc-2562.staging.tiny.cloud/docs/tinymce/latest/exportword/)
Site: [ExportPDF](http://docs-hotfix-7-doc-2562.staging.tiny.cloud/docs/tinymce/latest/exportpdf/)
Site: [ImportWord](http://docs-hotfix-7-doc-2562.staging.tiny.cloud/docs/tinymce/latest/importword/)

Changes:
* add new demos to plugin pages.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed