### PR TITLE
DOC-2498: Update TinyMCE for Java Swing `Contact sales` link.

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -38,6 +38,7 @@ asciidoc:
     communityname: TinyMCE Community
     accountpage: Tiny Account
     supportname: Tiny Support
+    contactsales: Contact Sales
     betaprogram: Tiny Insights Program
     #### some plugin names
     prem_skins_icons: Enhanced Skins & Icon Packs

--- a/modules/ROOT/partials/integrations/swing-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/swing-quick-start.adoc
@@ -4,7 +4,7 @@ Users can easily configure the {productname} editor in Swing through the *{produ
 
 To start using {productname} for Swing as your new rich text editor, the first step is to obtain a copy of the *Integration*.
 
-Contact link:{supporturl}[{supportname}] to discuss how to get started with our latest release.
+link:{contactpage}[{contactsales}] to discuss how to get started with our latest release.
 
 == Get started with our TinyMCE in Swing integration
 


### PR DESCRIPTION
Ticket: DOC-2498 & DOC-2563

Site: [Staging branch](http://docs-feature-75-doc-2498doc-2563.staging.tiny.cloud/docs/tinymce/latest/swing/#getting-the-tinymce-for-swing-integration)

Changes:
* Update text from `Contact Tiny Support` to `Contact sales`
* Add new global variable to `antora.yml` to include this new link.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed