### PR TITLE
DOC-2498: Removing annotated content, now, removes associated conversation card from the sidebar.

### DIFF
--- a/modules/ROOT/pages/7.4-release-notes.adoc
+++ b/modules/ROOT/pages/7.4-release-notes.adoc
@@ -377,4 +377,4 @@ Currently, after deleting content that has related comments, the corresponding c
 
 This behavior is inconsistent with the expected behavior, where the comment card should be removed automatically after deleting the content.
 
-**Status**: Currently under investigation.
+**Status**: This issue has been resolved in xref:7.5-release-notes.adoc#removing-annotated-content-now-removes-associated-conversation-card-from-the-sidebar[{productname} 7.5.0].

--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -81,6 +81,15 @@ In previous versions of the tinycomments plugin, the `conversationAuthor` proper
 
 {productname} {release-version} addresses this issue. Now, the `conversationAuthor` property is included in 'create' events in the event log.
 
+==== Removing annotated content, now, removes associated conversation card from the sidebar.
+// #TINY-11366
+
+Previously, in xref:7.4-release-notes.adoc#comment-card-not-removed-after-deleting-content[{productname} 7.4.0], an issue was identified where deleting annotated content did not remove the corresponding conversation card from the sidebar, resulting in outdated or irrelevant cards persisting in the user interface.
+
+This behavior led to confusion and increased the risk of interacting with obsolete comments.
+
+In {productname} {release-version}, this issue has been resolved. Now, when annotated content is deleted, the associated conversation card is automatically removed from the sidebar.
+
 For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to {companyname} Comments].
 
 


### PR DESCRIPTION
Ticket: DOC-2498

Site: [Staging branch](http://docs-feature-75-doc-2498tiny-11366.staging.tiny.cloud/docs/tinymce/latest/7.5-release-notes/#removing-annotated-content-now-removes-associated-conversation-card-from-the-sidebar)

Changes:
* Fix documentation for TINY-11366

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed