### PR TITLE
DOC-2564: Release Note Entry for Mentions in Comments

### DIFF
--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -98,7 +98,6 @@ The {productname} {release-version} release includes an accompanying release of 
 
 The **Comments** plugin now supports the use of mentions in comments, with the **Mentions** plugin enabled.
 
-
 In {productname} {release-version}, the **Comments** plugin has been enhanced to support xref:mentions.adoc[Mentions] in comments. Users can now mention other users in comments by typing the `+@+` symbol followed by the user's name.
 
 Additionally, the **Comments** plugin now includes a new `mentionedUids` property for events within the EventLog API when the Mentions plugin is enabled. This property provides an array of UIDs mentioned in the comment, allowing integrators to retrieve which users have been mentioned in comments.

--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -104,8 +104,6 @@ Additionally, the **Comments** plugin now includes a new `mentionedUids` propert
 
 The **Comments** plugin now offers the `xref:comments-with-mentions.adoc#tinycomments_mentions_enabled[tinycomments_mentions_enabled]` option to enable or disable mentioning other users in comments when both plugins are included in the configuration.
 
-liveDemo::comments-embedded-with-mentions[]
-
 For information on the **Comments with Mentions** feature, see xref:comments-with-mentions.adoc[Configuring the Comments plugin with the Mentions plugin].
 
 ==== The `conversationAuthor` property was missing from 'create` conversation events in the EventLog API.

--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -98,7 +98,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 The **Comments** plugin now supports mentions in comments.
 
-Previously, the Comments plugin allowed users to add comments to content in the editor. However, users could not mention other users in comments, limiting the ability to notify specific users or direct comments to them.
+Previously, the **Comments** plugin allowed users to add comments to content in the editor. However, users could not mention other users in comments sidebar, limiting the ability to notify specific users or direct comments to them.
 
 In {productname} {release-version}, the **Comments** plugin has been enhanced to support mentions in comments. Users can now mention other users in comments by typing the `+@+` symbol followed by the user's name. This feature enables users to notify specific individuals, direct comments to them, or engage in conversations with other users directly within the editor.
 

--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -91,7 +91,24 @@ For information on the **Markdown** plugin, see xref:markdown.adoc[Markdown].
 
 The {productname} {release-version} release includes an accompanying release of the **Comments** premium plugin.
 
-**Comments** Premium plugin includes the following fixes.
+**Comments** Premium plugin includes the following additions and fixes.
+
+==== Comments with Mentions
+// EPIC-111
+
+The **Comments** plugin now supports mentions in comments.
+
+Previously, the Comments plugin allowed users to add comments to content in the editor. However, users could not mention other users in comments, limiting the ability to notify specific users or direct comments to them.
+
+In {productname} {release-version}, the **Comments** plugin has been enhanced to support mentions in comments. Users can now mention other users in comments by typing the `+@+` symbol followed by the user's name. This feature enables users to notify specific individuals, direct comments to them, or engage in conversations with other users directly within the editor.
+
+Additionally, the **Comments** plugin now includes a new `mentionedUids` property in the EventLog API when the xref:mentions.adoc[Mentions] plugin is enabled. This property provides an array of UIDs mentioned in the comment, allowing integrators to retrieve which users have been mentioned in comments.
+
+The **Comments** plugin now offers the `+tinycomments_mentions_enabled+` option to enable or disable the incorporation of the xref:mentions.adoc[Mentions] plugin into the **Comments** plugin, provided both plugins are included in the configuration.
+
+liveDemo::comments-embedded-with-mentions[]
+
+For information on the **Comments with Mentions** feature, see xref:comments-with-mentions.adoc[Configuring the Comments plugin with the Mentions plugin].
 
 ==== The `conversationAuthor` property was missing from 'create` conversation events in the EventLog API.
 // #TINY-11352

--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -96,7 +96,7 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== Comments with Mentions
 // EPIC-111
 
-The **Comments** plugin now supports mentions in comments.
+The **Comments** plugin now supports the use of mentions in comments, with the **Mentions** plugin enabled.
 
 Previously, the **Comments** plugin allowed users to add comments to content in the editor. However, users could not mention other users in the comments sidebar, limiting the ability to notify specific users or direct comments to them.
 

--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -101,7 +101,7 @@ The **Comments** plugin now supports the use of mentions in comments, with the *
 
 In {productname} {release-version}, the **Comments** plugin has been enhanced to support xref:mentions.adoc[Mentions] in comments. Users can now mention other users in comments by typing the `+@+` symbol followed by the user's name.
 
-Additionally, the **Comments** plugin now includes a new `mentionedUids` property in the EventLog API when the Mentions plugin is enabled. This property provides an array of UIDs mentioned in the comment, allowing integrators to retrieve which users have been mentioned in comments.
+Additionally, the **Comments** plugin now includes a new `mentionedUids` property for events within the EventLog API when the Mentions plugin is enabled. This property provides an array of UIDs mentioned in the comment, allowing integrators to retrieve which users have been mentioned in comments.
 
 The **Comments** plugin now offers the `xref:comments-with-mentions.adoc#tinycomments_mentions_enabled[tinycomments_mentions_enabled]` option to enable or disable mentioning other users in comments when both plugins are included in the configuration.
 

--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -98,13 +98,13 @@ The {productname} {release-version} release includes an accompanying release of 
 
 The **Comments** plugin now supports mentions in comments.
 
-Previously, the **Comments** plugin allowed users to add comments to content in the editor. However, users could not mention other users in comments sidebar, limiting the ability to notify specific users or direct comments to them.
+Previously, the **Comments** plugin allowed users to add comments to content in the editor. However, users could not mention other users in the comments sidebar, limiting the ability to notify specific users or direct comments to them.
 
-In {productname} {release-version}, the **Comments** plugin has been enhanced to support mentions in comments. Users can now mention other users in comments by typing the `+@+` symbol followed by the user's name. This feature enables users to notify specific individuals, direct comments to them, or engage in conversations with other users directly within the editor.
+In {productname} {release-version}, the **Comments** plugin has been enhanced to support xref:mentions.adoc[Mentions] in comments. Users can now mention other users in comments by typing the `+@+` symbol followed by the user's name. This feature enables users to notify specific individuals, direct comments to them, or engage in conversations with other users directly within the editor.
 
-Additionally, the **Comments** plugin now includes a new `mentionedUids` property in the EventLog API when the xref:mentions.adoc[Mentions] plugin is enabled. This property provides an array of UIDs mentioned in the comment, allowing integrators to retrieve which users have been mentioned in comments.
+Additionally, the **Comments** plugin now includes a new `mentionedUids` property in the EventLog API when the Mentions plugin is enabled. This property provides an array of UIDs mentioned in the comment, allowing integrators to retrieve which users have been mentioned in comments.
 
-The **Comments** plugin now offers the `+tinycomments_mentions_enabled+` option to enable or disable the incorporation of the xref:mentions.adoc[Mentions] plugin into the **Comments** plugin, provided both plugins are included in the configuration.
+The **Comments** plugin now offers the `xref:comments-with-mentions.adoc#tinycomments_mentions_enabled[tinycomments_mentions_enabled]` option to enable or disable the incorporation of the Mentions plugin into the **Comments** plugin, provided both plugins are included in the configuration.
 
 liveDemo::comments-embedded-with-mentions[]
 

--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -99,7 +99,7 @@ The {productname} {release-version} release includes an accompanying release of 
 The **Comments** plugin now supports the use of mentions in comments, with the **Mentions** plugin enabled.
 
 
-In {productname} {release-version}, the **Comments** plugin has been enhanced to support xref:mentions.adoc[Mentions] in comments. Users can now mention other users in comments by typing the `+@+` symbol followed by the user's name. This feature enables users to notify specific individuals, direct comments to them, or engage in conversations with other users directly within the editor.
+In {productname} {release-version}, the **Comments** plugin has been enhanced to support xref:mentions.adoc[Mentions] in comments. Users can now mention other users in comments by typing the `+@+` symbol followed by the user's name.
 
 Additionally, the **Comments** plugin now includes a new `mentionedUids` property in the EventLog API when the Mentions plugin is enabled. This property provides an array of UIDs mentioned in the comment, allowing integrators to retrieve which users have been mentioned in comments.
 

--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -104,7 +104,7 @@ In {productname} {release-version}, the **Comments** plugin has been enhanced to
 
 Additionally, the **Comments** plugin now includes a new `mentionedUids` property in the EventLog API when the Mentions plugin is enabled. This property provides an array of UIDs mentioned in the comment, allowing integrators to retrieve which users have been mentioned in comments.
 
-The **Comments** plugin now offers the `xref:comments-with-mentions.adoc#tinycomments_mentions_enabled[tinycomments_mentions_enabled]` option to enable or disable the incorporation of the Mentions plugin into the **Comments** plugin, provided both plugins are included in the configuration.
+The **Comments** plugin now offers the `xref:comments-with-mentions.adoc#tinycomments_mentions_enabled[tinycomments_mentions_enabled]` option to enable or disable mentioning other users in comments when both plugins are included in the configuration.
 
 liveDemo::comments-embedded-with-mentions[]
 

--- a/modules/ROOT/pages/7.5-release-notes.adoc
+++ b/modules/ROOT/pages/7.5-release-notes.adoc
@@ -98,7 +98,6 @@ The {productname} {release-version} release includes an accompanying release of 
 
 The **Comments** plugin now supports the use of mentions in comments, with the **Mentions** plugin enabled.
 
-Previously, the **Comments** plugin allowed users to add comments to content in the editor. However, users could not mention other users in the comments sidebar, limiting the ability to notify specific users or direct comments to them.
 
 In {productname} {release-version}, the **Comments** plugin has been enhanced to support xref:mentions.adoc[Mentions] in comments. Users can now mention other users in comments by typing the `+@+` symbol followed by the user's name. This feature enables users to notify specific individuals, direct comments to them, or engage in conversations with other users directly within the editor.
 


### PR DESCRIPTION
Ticket: DOC-2564

Site: [Staging branch](http://docs-feature-75-doc-2564.staging.tiny.cloud/docs/tinymce/latest/7.5-release-notes/#comments-with-mentions)

Changes:
* DOC-2564: Release Note Entry for Mentions in Comments

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.
- [-] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed