### PR TITLE
DOC-2570: Add LicenseKey property to Blazor Tech Ref

### DIFF
--- a/modules/ROOT/partials/integrations/blazor-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/blazor-tech-ref.adoc
@@ -8,7 +8,7 @@ Covered in this section:
 
 The `+TinyMCE.Blazor+` `+Editor+` component accepts the following properties:
 
-[source,cs]
+[source,cs,subs="attributes+"]
 ----
 <Editor
   Id="uuid"


### PR DESCRIPTION
Ticket: DOC-2570

Site: [Staging branch](http://docs-hotfix-7-doc-2570.staging.tiny.cloud/docs/tinymce/latest/blazor-ref)

Changes:
* Add LicenseKey property
* Update CloudChannel to 7

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [-] Included a `release note` entry for any `New product features`.
- [-] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed