### PR TITLE
TINY-11391 Bug fix documentation

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -26,7 +26,7 @@ asciidoc:
     # product variables
     productname: TinyMCE
     productmajorversion: 7
-    productminorversion: '7.5'
+    productminorversion: '7.6'
     ##### product name in codeblock
     prodnamecode: tinymce
     #### more names

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -151,12 +151,15 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 [[bug-fixes]]
 == Bug fixes
 
-{productname} {release-version} also includes the following bug fix<es>:
+{productname} {release-version} also includes the following bug fixes:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Tooltips of toolbar groups not showing
+// #TINY-11391
 
-// CCFR here.
+Previously, an issue was identified where there was no tooltip being displayed when hovering over toolbar group buttons. This was caused by swapping the `title` attribute with an `aria-label` attribute in version xref:7.0-release-notes.adoc#overview[7.0.0] without applying the tooltip behavior to the toolbar group buttons. 
+
+In {productname} {release-version}, this issue has now been resolved by applying the tooltip behavior to the toolbar group buttons resulting in the tooltips now showing on hover.
+
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-2578

Site: [Staging branch](http://docs-feature-76-doc-2578tiny-11391.staging.tiny.cloud/docs/tinymce/latest/7.6.0-release-notes/#bug-fixes)

Changes:
* Documented the bug fix for TINY-11391 Tooltips of toolbar groups not showing.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.
- [] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [ ] Documentation Team Lead has reviewed