### PR TITLE
DOC-2578: Tooltip would not show for group toolbar button.

### DIFF
--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -153,10 +153,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Tooltips of toolbar groups not showing
+// #TINY-11391
 
-// CCFR here.
+Previously, an issue was identified where there was no tooltip being displayed when hovering over toolbar group buttons. This was caused by swapping the `title` attribute with an `aria-label` attribute in version xref:7.0-release-notes.adoc#overview[7.0.0] without applying the tooltip behavior to the toolbar group buttons. 
+
+In {productname} {release-version}, this issue has now been resolved by applying the tooltip behavior to the toolbar group buttons resulting in the tooltips now showing on hover.
 
 
 [[security-fixes]]

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -156,9 +156,9 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Tooltips of toolbar groups not showing
 // #TINY-11391
 
-Previously, an issue was identified where there was no tooltip being displayed when hovering over toolbar group buttons. This was caused by swapping the `title` attribute with an `aria-label` attribute in version xref:7.0-release-notes.adoc#overview[7.0.0] without applying the tooltip behavior to the toolbar group buttons. 
+Previously, an issue was identified where tooltips were not displayed when hovering over toolbar group buttons. This was due to replacing the `title` attribute with an `aria-label` attribute in xref:7.0-release-notes.adoc#improved-accessibility-for-interactive-elements-with-custom-tooltips[{productname} 7.0.0] without implementing the custom tooltip behavior for the toolbar group buttons.
 
-In {productname} {release-version}, this issue has now been resolved by applying the tooltip behavior to the toolbar group buttons resulting in the tooltips now showing on hover.
+In {productname} {release-version}, this issue has been resolved by applying the custom tooltip behavior to the toolbar group buttons, ensuring that tooltips are now displayed on hover.
 
 
 [[security-fixes]]

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -153,7 +153,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-=== Tooltips of toolbar groups not showing
+=== Tooltip would not show for group toolbar button.
 // #TINY-11391
 
 Previously, an issue was identified where tooltips were not displayed when hovering over toolbar group buttons. This was due to replacing the `title` attribute with an `aria-label` attribute in xref:7.0-release-notes.adoc#improved-accessibility-for-interactive-elements-with-custom-tooltips[{productname} 7.0.0] without implementing the custom tooltip behavior for the toolbar group buttons.


### PR DESCRIPTION
Ticket: DOC-2578

Site: [Staging branch](http://docs-feature-760-doc-2578tiny-11391.staging.tiny.cloud/docs/tinymce/latest/7.6.0-release-notes/#tooltips-of-toolbar-groups-not-showing)

Changes:
* Documented a bug fix for TINY-11391.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [ ] Documentation Team Lead has reviewed