### PR TITLE
DOC-2578: Changing the table row type when a `contentEditable="false"` cell was selected would not work as expected.

### DIFF
--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -156,9 +156,9 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Numbered table context menu not properly applying changes
 // #TINY-11383
 
-Previously, there was an issue where changes to the row type in numbered tables were not properly applied. This occurred because the action of modifying the row type from a Content Editable False (CEF) cell was being deliberately blocked.
+Previously, there was an issue where changes to the row type in numbered tables were not properly applied. This occurred because the action of modifying the row type from a `+contentEditable="false"+` cell was being deliberately blocked.
 
-In {productname} {release-version}, this issue has been resolved by removing the restriction on changing the row type from a CEF cell. As a result, changes to the row type are now correctly applied.
+In {productname} {release-version}, this issue has been resolved by removing the restriction on changing the row type from a `+contentEditable="false"+` cell. As a result, changes to the row type are now correctly applied.
 
 
 [[security-fixes]]

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -156,9 +156,9 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Numbered table context menu not properly applying changes
 // #TINY-11383
 
-Previously, an issue was identified where changes to the row type in numbered tables were not being applied. This occurred because the action of modifying the type of a CEF (Content Editable False) cell was being blocked.
+Previously, there was an issue where changes to the row type in numbered tables were not properly applied. This occurred because the action of modifying the row type from a Content Editable False (CEF) cell was being deliberately blocked.
 
-In TinyMCE 7.6.0, this issue has been resolved by removing the restriction on changing the type of CEF cells, resulting in changes to the row type now being properly applied.
+In {productname} {release-version}, this issue has been resolved by removing the restriction on changing the row type from a CEF cell. As a result, changes to the row type are now correctly applied.
 
 
 [[security-fixes]]

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -151,12 +151,14 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 [[bug-fixes]]
 == Bug fixes
 
-{productname} {release-version} also includes the following bug fix<es>:
+{productname} {release-version} also includes the following bug fixes:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Numbered table context menu not properly applying changes
+// #TINY-11383
 
-// CCFR here.
+Previously, an issue was identified where changes to the row type in numbered tables were not being applied. This occurred because the action of modifying the type of a CEF (Content Editable False) cell was being blocked.
+
+In TinyMCE 7.6.0, this issue has been resolved by removing the restriction on changing the type of CEF cells, resulting in changes to the row type now being properly applied.
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-2578

Site: [Staging branch](http://docs-feature-760-doc-2578tiny-11383.staging.tiny.cloud/docs/tinymce/latest/7.6.0-release-notes/#numbered-table-context-menu-not-properly-applying-changes)

Changes:
* Documented the bug fix for TINY-11383.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed