### PR TITLE
DOC-2578: Pressing `Shift + Enter` in the comment textarea now selects the highlighted user.

### DIFF
--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -57,17 +57,20 @@ For information on the **<Open source plugin name>** plugin, see xref:<plugincod
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
-=== <Premium plugin name 1> <Premium plugin name 1 version>
+=== Comments
 
 The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
 
-**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+**Comments** Premium plugin includes the following improvements.
 
-==== <Premium plugin name 1 change 1>
+=== Pressing Shift+Enter in Mentions in Comments dropdown should accept the active menu item
+// #TINY-11455
 
-// CCFR here.
+In previous versions of {productname}, the `Shift+Enter` key was not properly handled when used with mentions in comments. This led to a new line being inserted while the mentions dropdown remained open, resulting in inconsistent behavior compared to mentions within the editor.
 
-For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+In {productname} {release-version}, mentions in comments now handle the `Shift+Enter` key by inserting the highlighted user into the comment text area and closing the dropdown, ensuring consistent functionality across the editor and comment areas.
+
+For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to {companyname} Comments].
 
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
@@ -107,14 +110,10 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 [[improvements]]
 == Improvements
 
-{productname} {release-version} also includes the following improvements:
+{productname} {release-version} also includes the following improvement<s>:
 
-=== Pressing Shift+Enter in Mentions in Comments dropdown should accept the active menu item
-// #TINY-11455
-
-In previous versions of {productname}, the `Shift+Enter` key was not properly handled when used with mentions in comments. This caused a new line to be inserted while the mentions dropdown remained open, leading to inconsistent behavior compared to mentions within the editor.
-
-In {productname} {release-version}, mentions in comments now handle the `Shift+Enter` key correctly by inserting the highlighted user into the comment text area and closing the dropdown. This ensures consistent functionality across the editor and comment areas.
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
 
 
 

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -59,7 +59,7 @@ The following premium plugin updates were released alongside {productname} {rele
 
 === Comments
 
-The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+The {productname} {release-version} release includes an accompanying release of the **Comments** premium plugin.
 
 **Comments** Premium plugin includes the following improvements.
 

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -112,9 +112,9 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Pressing Shift+Enter in Mentions in Comments dropdown should accept the active menu item
 // #TINY-11455
 
-In previous versions of TinyMCE, the `Shift+Enter` key was not properly handled when used with mentions in comments. This led to a new line being inserted while the mentions dropdown remained open, resulting in inconsistent behavior compared to mentions within the editor.
+In previous versions of {productname}, the `Shift+Enter` key was not properly handled when used with mentions in comments. This caused a new line to be inserted while the mentions dropdown remained open, leading to inconsistent behavior compared to mentions within the editor.
 
-In TinyMCE 7.6.0, mentions in comments now handle the `Shift+Enter` key by inserting the highlighted user into the comment text area and closing the dropdown, ensuring consistent functionality across the editor and comment areas.
+In {productname} {release-version}, mentions in comments now handle the `Shift+Enter` key correctly by inserting the highlighted user into the comment text area and closing the dropdown. This ensures consistent functionality across the editor and comment areas.
 
 
 

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -107,12 +107,15 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 [[improvements]]
 == Improvements
 
-{productname} {release-version} also includes the following improvement<s>:
+{productname} {release-version} also includes the following improvements:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Pressing Shift+Enter in Mentions in Comments dropdown should accept the active menu item
+// #TINY-11455
 
-// CCFR here.
+In previous versions of TinyMCE, the `Shift+Enter` key was not properly handled when used with mentions in comments. This led to a new line being inserted while the mentions dropdown remained open, resulting in inconsistent behavior compared to mentions within the editor.
+
+In TinyMCE 7.6.0, mentions in comments now handle the `Shift+Enter` key by inserting the highlighted user into the comment text area and closing the dropdown, ensuring consistent functionality across the editor and comment areas.
+
 
 
 [[additions]]


### PR DESCRIPTION
Ticket: DOC-2578

Site: [Staging branch](http://docs-feature-760-doc-2578tiny-11455.staging.tiny.cloud/docs/tinymce/latest/7.6.0-release-notes/#pressing-shiftenter-in-mentions-in-comments-dropdown-should-accept-the-active-menu-item)

Changes:
* Documented the improvement for TINY-11455.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed