### PR TITLE
DOC-2578: Scroll to show action buttons when replying/editing a comment.

### DIFF
--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -107,12 +107,14 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 [[improvements]]
 == Improvements
 
-{productname} {release-version} also includes the following improvement<s>:
+{productname} {release-version} also includes the following improvements:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Alway show the comment input field in the viewport when pressing the reply or add comment button
+// #TINY-11402
 
-// CCFR here.
+Previously, if a selected conversation card was positioned near the bottom of the sidebar, the reply input field or edit input field would be below the bottom of the sidebar resulting in the comment input field not being visible to the user.
+
+With the release of {productname} {release-version}, the sidebar now scrolls to display the comment input field. This ensures that the comment input field is always visible to the user.
 
 
 [[additions]]

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -67,7 +67,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 Previously, if a selected conversation card was positioned near the bottom of the sidebar, the reply/edit input field would be below the bottom of the sidebar resulting in the comment input field not being visible to the user.
 
-With the release of {productname} {release-version}, the sidebar now scrolls to display the comment input field if the selected conversation card is near the bottom of the sidebar. This ensures that the comment input field is always visible to the user.
+{productname} {release-version} addresses this issue. Now, the sidebar scrolls to display the comment input field if the selected conversation card is positioned near the bottom of the sidebar. This ensures that the comment input field is always visible to the user.
 
 For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to {companyname} Comments].
 

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -65,7 +65,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 ==== Scroll to show action buttons when replying/editing a comment.
 
-Previously, if a selected conversation card was positioned near the bottom of the sidebar, the reply input field or edit input field would be below the bottom of the sidebar resulting in the comment input field not being visible to the user.
+Previously, if a selected conversation card was positioned near the bottom of the sidebar, the reply/edit input field would be below the bottom of the sidebar resulting in the comment input field not being visible to the user.
 
 With the release of {productname} {release-version}, the sidebar now scrolls to display the comment input field if the selected conversation card is near the bottom of the sidebar. This ensures that the comment input field is always visible to the user.
 

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -63,7 +63,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 **Comments** Premium plugin includes the following fixes and improvements.
 
-==== Always show the comment input field in the viewport when pressing the reply or add comment button
+==== Scroll to show action buttons when replying/editing a comment.
 
 Previously, if a selected conversation card was positioned near the bottom of the sidebar, the reply input field or edit input field would be below the bottom of the sidebar resulting in the comment input field not being visible to the user.
 

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -57,17 +57,19 @@ For information on the **<Open source plugin name>** plugin, see xref:<plugincod
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
-=== <Premium plugin name 1> <Premium plugin name 1 version>
+=== Comments
 
-The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+The {productname} {release-version} release includes an accompanying release of the **Comments** premium plugin.
 
-**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+**Comments** Premium plugin includes the following fixes and improvements.
 
-==== <Premium plugin name 1 change 1>
+==== Always show the comment input field in the viewport when pressing the reply or add comment button
 
-// CCFR here.
+Previously, if a selected conversation card was positioned near the bottom of the sidebar, the reply input field or edit input field would be below the bottom of the sidebar resulting in the comment input field not being visible to the user.
 
-For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+With the release of {productname} {release-version}, the sidebar now scrolls to display the comment input field if the selected conversation card is near the bottom of the sidebar. This ensures that the comment input field is always visible to the user.
+
+For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to {companyname} Comments].
 
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
@@ -107,15 +109,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 [[improvements]]
 == Improvements
 
-{productname} {release-version} also includes the following improvements:
+{productname} {release-version} also includes the following improvement<s>:
 
-=== Alway show the comment input field in the viewport when pressing the reply or add comment button
-// #TINY-11402
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
 
-Previously, if a selected conversation card was positioned near the bottom of the sidebar, the reply input field or edit input field would be below the bottom of the sidebar resulting in the comment input field not being visible to the user.
-
-With the release of {productname} {release-version}, the sidebar now scrolls to display the comment input field. This ensures that the comment input field is always visible to the user.
-
+// CCFR here.
 
 [[additions]]
 == Additions


### PR DESCRIPTION
Ticket: DOC-2578

Site: [Staging branch](http://docs-feature-760-doc-2578tiny-11402.staging.tiny.cloud/docs/tinymce/latest/7.6.0-release-notes/#always-show-the-comment-input-field-in-the-viewport-when-pressing-the-reply-or-add-comment-button)

Changes:
* Documentation for the improvement in TINY-11402.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed