### PR TITLE
DOC-2586: New `disabled` option for disabling all user interactions

### DIFF
--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -114,6 +114,21 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+== New `+disabled+` option for disabling all user interactions
+
+A new `+disabled+` option has been introduced to {productname} in version {release-version}. This option allows integrators to disable all user interactions with the editor, including cursor placement, content modifications, and UI components. When set to `+true+`, the editor behaves similarly to the readonly mode changes introduced in {productname} 7.4.0 but ensures complete non-interactivity.
+
+.Example disabling all user interactions with the editor
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // Specify the target HTML element
+  disabled: true         // Disables all interactions with the editor
+});
+----
+
+For more information on the `+disabled+` option, see xref:editor-important-options.adoc#disabled[Disabled] option.
+
 
 [[additions]]
 == Additions

--- a/modules/ROOT/pages/editor-important-options.adoc
+++ b/modules/ROOT/pages/editor-important-options.adoc
@@ -35,6 +35,10 @@ include::partial$configuration/external_plugins.adoc[leveloffset=+1]
 
 include::partial$configuration/readonly.adoc[leveloffset=+1]
 
+== Setting the editor in a disabled state
+
+include::partial$configuration/disabled.adoc[leveloffset=+1]
+
 == Executing custom functions while the editor starts (initializes)
 
 include::partial$configuration/setup.adoc[leveloffset=+1]

--- a/modules/ROOT/pages/events.adoc
+++ b/modules/ROOT/pages/events.adoc
@@ -160,6 +160,7 @@ The following events are provided by the {productname} editor.
 |ObjectResized |`+{ target: HTMLElement, width: number, height: number, origin: string }+` |Fired when an object (such as an image) has finished being resized.
 |ObjectResizeStart |`+{ target: HTMLElement, width: number, height: number, origin: string }+` |Fired when an object (such as an image) is about to be resized.
 |SwitchMode |`+{ mode: string }+` |Fired when the editor mode is changed. The available modes are "design" and "readonly". Additional modes can be registered using {productname} API xref:apis/tinymce.editormode.adoc#register['tinymce.activeEditor.mode.register()'].
+|DisabledStateChange |+{ state: boolean }+ |Fired when the editor disabled mode state changes.
 |ScrollWindow |(Same data as the native https://developer.mozilla.org/en-US/docs/Web/API/Element/scroll_event[scroll event]) |Fired when the window has scrolled.
 |ResizeWindow |(Same data as the native https://developer.mozilla.org/en-US/docs/Web/API/Window/resize_event[resize event]) |Fired when the window is resized.
 |BeforeExecCommand |`+{ command: string, ui?: boolean, value?: any }+` |Fired before a command is executed.

--- a/modules/ROOT/partials/configuration/disabled.adoc
+++ b/modules/ROOT/partials/configuration/disabled.adoc
@@ -1,0 +1,23 @@
+[[disabled]]
+
+== `+disabled+`
+
+Disables all user interactions with the editor (including cursor placement, content modifications, UI components). This option provides behavior similar to the changes made to {productname} in 7.4.0 readonly mode. When enabled, the editor becomes completely non-interactive.
+
+To programmatically enable/disable the editor, use `+tinymce.activeEditor.options.set('disabled', false/true)+`.
+
+*Type:* `+Boolean+`
+
+*Default value:* `+false+`
+
+*Possible values:* `+true+`, `+false+`
+
+=== Example: using `+disabled+`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  disabled: true
+});
+----


### PR DESCRIPTION
Ticket: DOC-2586

Site: [Staging branch](http://docs-feature-760-doc-2578doc-2586.staging.tiny.cloud/docs/tinymce/latest/7.6.0-release-notes/#new-disabled-option-for-disabling-all-user-interactions)

Site: [disabled option: editor important options](http://docs-feature-760-doc-2578doc-2586.staging.tiny.cloud/docs/tinymce/latest/editor-important-options/#disabled)

Site: [Event](http://docs-feature-760-doc-2578doc-2586.staging.tiny.cloud/docs/tinymce/latest/events/#:~:text=DisabledStateChange,mode%20state%20changes.)

Changes:
* Added new `disabled` option for disabling all user interactions to various sections within docs.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] updated `Event` list.
- [x] Included a `release note` entry for any `New product features`.

Review:
- [x] Documentation Team Lead has reviewed