### PR TITLE
DOC-2578: Adjust `tinycomments` UI font size to match the editor UI font size.

### DIFF
--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -87,9 +87,9 @@ In {productname} {release-version}, mentions in comments now handle the `Shift+E
 === Adjust `tinycomments` UI font size to match the editor UI font size
 // #TINY-11592
 
-Previously, the **Comments** plugin used a `small` font size, which was inconsistent with the `medium` font size used in the editor UI.
+Previously, the **Comments** plugin used a `14px` font size for the comment body, which was inconsistent with the `16px` font size used in the rest of the Comments Sidebar and the editor UI.
 
-This issue has been resolved in {productname} {release-version}, ensuring font size consistency between the **Comments** plugin and the editor UI.
+This issue has been resolved in {productname} {release-version} by setting the comment body font size to `16px`, ensuring font size consistency between the **Comments** plugin and the editor UI.
 
 For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to {companyname} Comments].
 

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -84,6 +84,13 @@ In previous versions of {productname}, the `Shift+Enter` key was not properly ha
 
 In {productname} {release-version}, mentions in comments now handle the `Shift+Enter` key by inserting the highlighted user into the comment text area and closing the dropdown, ensuring consistent functionality across the editor and comment areas.
 
+=== Adjust `tinycomments` UI font size to match the editor UI font size
+// #TINY-11592
+
+Previously, the **Comments** plugin used a `small` font size, which was inconsistent with the `medium` font size used in the editor UI.
+
+This issue has been resolved in {productname} {release-version}, ensuring font size consistency between the **Comments** plugin and the editor UI.
+
 For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to {companyname} Comments].
 
 


### PR DESCRIPTION
Ticket: DOC-2578

Site: [Staging branch](http://docs-feature-760-doc-2578tiny-11592.staging.tiny.cloud/docs/tinymce/latest/7.6.0-release-notes/#adjust-tinycomments-ui-font-size-to-match-the-editor-ui-font-size)

Changes:
* Add improvement documentation for TINY-11592

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed