### PR TITLE
DOC-2578: Fixed CSS Bundling for Skin UI Content CSS.

### DIFF
--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -189,7 +189,7 @@ In {productname} {release-version}, this issue has been resolved by removing the
 
 In self-hosted React setups, image resize handles were not displayed when using bundled {productname} editors. This issue impacted the usability of features such as image resizing.
 
-The root cause was a misconfiguration of resource keys for the CSS bundling JS files and CSS loading logic in {prodcutname} core. As a result, bundled editors failed to load the necessary styles, causing the resize handles to remain hidden.
+The root cause was a misconfiguration of resource keys for the CSS bundling JS files and CSS loading logic in {productname} core. As a result, bundled editors failed to load the necessary styles, causing the resize handles to remain hidden.
 
 This issue affected {productname} versions earlier than 7.1.0.
 

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -183,7 +183,7 @@ Previously, there was an issue where changes to the row type in numbered tables 
 
 In {productname} {release-version}, this issue has been resolved by removing the restriction on changing the row type from a `+contentEditable="false"+` cell. As a result, changes to the row type are now correctly applied.
 
-== Fixed CSS Bundling for Skin UI Content CSS
+=== Fixed CSS Bundling for Skin UI Content CSS
 
 // #TINY-11558
 

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -193,7 +193,7 @@ The root cause was a misconfiguration of resource keys for the CSS bundling JS f
 
 This issue affected {productname} versions earlier than 7.1.0.
 
-{prodcutname} {release-version} resolves this issue by updating the `stylesheetLoader` to correctly load the `ui/default/content.css` stylesheet, ensuring that image resize handles are displayed as expected.
+{productname} {release-version} resolves this issue by updating the `stylesheetLoader` to correctly load the `ui/default/content.css` stylesheet, ensuring that image resize handles are displayed as expected.
 
 
 [[security-fixes]]

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -183,6 +183,18 @@ Previously, there was an issue where changes to the row type in numbered tables 
 
 In {productname} {release-version}, this issue has been resolved by removing the restriction on changing the row type from a `+contentEditable="false"+` cell. As a result, changes to the row type are now correctly applied.
 
+== Fixed CSS Bundling for Skin UI Content CSS
+
+// #TINY-11558
+
+In self-hosted React setups, image resize handles were not displayed when using bundled {productname} editors. This issue impacted the usability of features such as image resizing.
+
+The root cause was identified as a misconfiguration in the `stylesheetLoader`, which incorrectly checked for the `content/default/content.css` stylesheet instead of the required `ui/default/content.css`. As a result, bundled editors failed to load the necessary styles, causing the resize handles to remain hidden.
+
+This issue affected {productname} versions earlier than 7.1.0.
+
+{prodcutname} {release-version} resolves this issue by updating the `stylesheetLoader` to correctly load the `ui/default/content.css` stylesheet, ensuring that image resize handles are displayed as expected.
+
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -189,7 +189,7 @@ In {productname} {release-version}, this issue has been resolved by removing the
 
 In self-hosted React setups, image resize handles were not displayed when using bundled {productname} editors. This issue impacted the usability of features such as image resizing.
 
-The root cause was identified as a misconfiguration in the `stylesheetLoader`, which incorrectly checked for the `content/default/content.css` stylesheet instead of the required `ui/default/content.css`. As a result, bundled editors failed to load the necessary styles, causing the resize handles to remain hidden.
+The root cause was a misconfiguration of resource keys for the CSS bundling JS files and CSS loading logic in {prodcutname} core. As a result, bundled editors failed to load the necessary styles, causing the resize handles to remain hidden.
 
 This issue affected {productname} versions earlier than 7.1.0.
 


### PR DESCRIPTION
Ticket: DOC-2578

Site: [Staging branch](http://docs-feature-760-doc-2578tiny-11558.staging.tiny.cloud/docs/tinymce/latest/7.6.0-release-notes/#fixed-css-bundling-for-skin-ui-content-css)

Changes:
* Fix documentation for TINY-11558

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed