### PR TITLE
DOC-2578: Introduced a new live region for screen readers to improve accessibility notifications.

### DIFF
--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -57,17 +57,19 @@ For information on the **<Open source plugin name>** plugin, see xref:<plugincod
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
-=== <Premium plugin name 1> <Premium plugin name 1 version>
+=== Comments
 
 The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
 
-**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+**Comments** Premium plugin includes the following fixes and improvements.
 
-==== <Premium plugin name 1 change 1>
+==== Fixes to the comments dark mode
 
-// CCFR here.
+Previously, an issue was identified where both the default and dark skins for comments had a visible border on comment cards that were not selected. This was inconsistent with the design specification, which stated that only the default skin should have a border for unselected comment cards. This discrepancy caused the two skins to appear inconsistent.
 
-For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+In {productname} {release-version}, this issue has been resolved by ensuring that the border for unselected comment cards matches the comment background color, effectively removing the visible border for unselected comment cards.
+
+For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to {companyname} Comments].
 
 
 [[accompanying-premium-plugin-end-of-life-announcement]]

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -57,19 +57,20 @@ For information on the **<Open source plugin name>** plugin, see xref:<plugincod
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
-=== Comments
+=== Accessibility Checker
 
-The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+The {productname} {release-version} release includes an accompanying release of the **Accessibility Checker** premium plugin.
 
-**Comments** Premium plugin includes the following fixes and improvements.
+**Accessibility Checker** Premium plugin includes the following fixes and improvements.
 
-==== Fixes to the comments dark mode
+==== Screen reader is not announcing everything in the accessibility checker dialog
+// TINY-11523
 
-Previously, an issue was identified where both the default and dark skins for comments had a visible border on comment cards that were not selected. This was inconsistent with the design specification, which stated that only the default skin should have a border for unselected comment cards. This discrepancy caused the two skins to appear inconsistent.
+Previously, an issue was identified where screen reader announcements for the accessibility dialog were inconsistent across different browsers. This inconsistency resulted in a poor user experience with screen readers and accessibility dialogs.
 
-In {productname} {release-version}, this issue has been resolved by ensuring that the border for unselected comment cards matches the comment background color, effectively removing the visible border for unselected comment cards.
+In {productname} {release-version}, this issue has been resolved by adding a dedicated screen reader section within the dialog structure, ensuring consistent and accurate announcements across browsers.
 
-For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to {companyname} Comments].
+For information on the **Accessibility Checker** plugin, see: xref:a11ychecker.adoc[Accessibility Checker].
 
 
 [[accompanying-premium-plugin-end-of-life-announcement]]

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -64,13 +64,41 @@ The {productname} {release-version} release includes an accompanying release of 
 **Accessibility Checker** Premium plugin includes the following fixes and improvements.
 
 ==== Screen reader is not announcing everything in the accessibility checker dialog
-// TINY-11523
 
 Previously, an issue was identified where screen reader announcements for the accessibility dialog were inconsistent across different browsers. This inconsistency resulted in a poor user experience with screen readers and accessibility dialogs.
 
 In {productname} {release-version}, this issue has been resolved by adding a dedicated screen reader section within the dialog structure, ensuring consistent and accurate announcements across browsers.
 
+==== Improve editor content highlighting when using accessibility checker
+// #TINY-11463
+
+Previously, an issue involving the accessibility checker was identified where the content area highlights did not properly meet accessibility standards. This issue caused users with vision impairments to encounter difficulty in identifying the currently focused element.
+
+In {productname} {release-version}, this issue has been resolved by unifying the color palette to meet accessibility color contrast standards, ensuring that all users can easily locate the currently focused element.
+
 For information on the **Accessibility Checker** plugin, see: xref:a11ychecker.adoc[Accessibility Checker].
+
+=== Comments
+
+The {productname} {release-version} release includes an accompanying release of the **Comments** premium plugin.
+
+**Comments** Premium plugin includes the following fixes and improvements.
+
+==== Scroll to show action buttons when replying/editing a comment.
+// #TINY-11402
+
+Previously, if a selected conversation card was positioned near the bottom of the sidebar, the reply/edit input field would be below the bottom of the sidebar resulting in the comment input field not being visible to the user.
+
+{productname} {release-version} addresses this issue. Now, the sidebar scrolls to display the comment input field if the selected conversation card is positioned near the bottom of the sidebar. This ensures that the comment input field is always visible to the user.
+
+==== Pressing Shift+Enter in Mentions in Comments dropdown should accept the active menu item
+// #TINY-11455
+
+In previous versions of {productname}, the `Shift+Enter` key was not properly handled when used with mentions in comments. This led to a new line being inserted while the mentions dropdown remained open, resulting in inconsistent behavior compared to mentions within the editor.
+
+In {productname} {release-version}, mentions in comments now handle the `Shift+Enter` key by inserting the highlighted user into the comment text area and closing the dropdown, ensuring consistent functionality across the editor and comment areas.
+
+For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to {companyname} Comments].
 
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
@@ -115,8 +143,20 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1
 
-// CCFR here.
+== New `+disabled+` option for disabling all user interactions
 
+A new `+disabled+` option has been introduced to {productname} in version {release-version}. This option allows integrators to disable all user interactions with the editor, including cursor placement, content modifications, and UI components. When set to `+true+`, the editor behaves similarly to the readonly mode changes introduced in {productname} 7.4.0 but ensures complete non-interactivity.
+
+.Example disabling all user interactions with the editor
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // Specify the target HTML element
+  disabled: true         // Disables all interactions with the editor
+});
+----
+
+For more information on the `+disabled+` option, see xref:editor-important-options.adoc#disabled[Disabled] option.
 
 [[additions]]
 == Additions
@@ -154,12 +194,21 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 [[bug-fixes]]
 == Bug fixes
 
-{productname} {release-version} also includes the following bug fix<es>:
+{productname} {release-version} also includes the following bug fixes:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Tooltip would not show for group toolbar button.
+// #TINY-11391
 
-// CCFR here.
+Previously, an issue was identified where tooltips were not displayed when hovering over toolbar group buttons. This was due to replacing the `title` attribute with an `aria-label` attribute in xref:7.0-release-notes.adoc#improved-accessibility-for-interactive-elements-with-custom-tooltips[{productname} 7.0.0] without implementing the custom tooltip behavior for the toolbar group buttons.
+
+In {productname} {release-version}, this issue has been resolved by applying the custom tooltip behavior to the toolbar group buttons, ensuring that tooltips are now displayed on hover.
+
+=== Numbered table context menu not properly applying changes
+// #TINY-11383
+
+Previously, there was an issue where changes to the row type in numbered tables were not properly applied. This occurred because the action of modifying the row type from a `+contentEditable="false"+` cell was being deliberately blocked.
+
+In {productname} {release-version}, this issue has been resolved by removing the restriction on changing the row type from a `+contentEditable="false"+` cell. As a result, changes to the row type are now correctly applied.
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-2578

Site: [Staging branch](http://docs-feature-760-doc-2578tiny-11523.staging.tiny.cloud/docs/tinymce/latest/7.6.0-release-notes/#screen-reader-is-not-announcing-everything-in-the-accessibility-checker-dialog)

Changes:
* Documented the bug fix for TINY-11523.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [ ] Documentation Team Lead has reviewed