### PR TITLE
DOC-2578: After creating a conversation, the focus goes to the newly …

### DIFF
--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -92,6 +92,17 @@ In previous versions of {productname}, the `Shift+Enter` key was not properly ha
 
 In {productname} {release-version}, mentions in comments now handle the `Shift+Enter` key by inserting the highlighted user into the comment text area and closing the dropdown, ensuring consistent functionality across the editor and comment areas.
 
+==== Editor Focus after Deleting a Comment
+// #TINY-11293
+
+Previously, an issue was identified where, when a user deleted a comment, the focus exited the comments sidebar and returned to the editor instead of returning to the conversation card.
+
+In {productname} {release-version}, this issue has been resolved by updating the focus behavior in the following situations:
+
+*Deleting a comment now returns the focus to the conversation card that contained the deleted comment.
+*Creating a new comment within an existing conversation now brings the focus to the corresponding conversation card.
+*Starting a new conversation now brings the focus to the newly created conversation card.
+
 For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to {companyname} Comments].
 
 

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -95,13 +95,13 @@ In {productname} {release-version}, mentions in comments now handle the `Shift+E
 ==== Editor Focus after Deleting a Comment
 // #TINY-11293
 
-Previously, an issue was identified where, when a user deleted a comment, the focus exited the comments sidebar and returned to the editor instead of returning to the conversation card.
+Previously, an issue was identified where when a user deleted a comment, the focus exited the comments sidebar and returned to the editor instead of returning to the conversation card. This issue also occurred when a new comment was created inside an existing conversation, and when an entire new conversation was created.
 
 In {productname} {release-version}, this issue has been resolved by updating the focus behavior in the following situations:
 
-*Deleting a comment now returns the focus to the conversation card that contained the deleted comment.
-*Creating a new comment within an existing conversation now brings the focus to the corresponding conversation card.
-*Starting a new conversation now brings the focus to the newly created conversation card.
+* Deleting a comment now returns the focus to the conversation card that contained the deleted comment.
+* Creating a new comment within an existing conversation now brings the focus to the corresponding conversation card.
+* Starting a new conversation now brings the focus to the newly created conversation card.
 
 For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to {companyname} Comments].
 

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -95,9 +95,9 @@ In {productname} {release-version}, mentions in comments now handle the `Shift+E
 ==== Editor Focus after Deleting a Comment
 // #TINY-11293
 
-Previously, an issue was identified where when a user deleted a comment, the focus exited the comments sidebar and returned to the editor instead of returning to the conversation card. This issue also occurred when a new comment was created inside an existing conversation, and when an entire new conversation was created.
+Previously, the focus behaviour in the comments sidebar was observed to be inconsistent. When a user deleted a comment, the focus exited the comments sidebar and returned to the editor instead of returning to the conversation card. This also occurred when a new comment was created inside an existing conversation, and when an entire new conversation was created.
 
-In {productname} {release-version}, this issue has been resolved by updating the focus behavior in the following situations:
+In {productname} {release-version}, the focus behaviour has now been improved in the following situations:
 
 * Deleting a comment now returns the focus to the conversation card that contained the deleted comment.
 * Creating a new comment within an existing conversation now brings the focus to the corresponding conversation card.


### PR DESCRIPTION
…created conversation

Ticket: DOC-2578

Site: [Staging branch](http://docs-feature-760-doc-2578tiny-11293.staging.tiny.cloud/docs/tinymce/latest/7.6.0-release-notes/#editor-focus-after-deleting-a-comment)

Changes:
* Documented the bug fix for TINY-11293.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [ ] Documentation Team Lead has reviewed