### PR TITLE
DOC-2578: The `commentAuthor` property is now included in reply events for the event log.

### DIFF
--- a/modules/ROOT/examples/live-demos/comments-callback/example.js
+++ b/modules/ROOT/examples/live-demos/comments-callback/example.js
@@ -48,7 +48,11 @@ const tinycomments_reply = (req, done, fail) => {
     })
     .then((req2) => {
       const commentUid = req2.commentUid;
-      done({ commentUid });
+      done({
+        commentUid: replyUid,
+        author: currentUser.id,
+        authorName: currentUser.fullName
+      });
     })
     .catch((e) => {
       fail(e);

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -78,6 +78,15 @@ The {productname} {release-version} release includes an accompanying release of 
 
 **Comments** includes the following fixes and improvements.
 
+==== The `commentAuthor` property is now included in reply events of the event log.
+// #TINY-11489
+
+In previous versions of the tinycomments plugin, the `commentAuthor` property was missing from 'reply' events within the event log, which led to incomplete tracking of user interactions when retrieving data through the `+getEventLog()+` API.
+
+{productname} {release-version} addresses this issue. Now, the `commentAuthor` property is included in 'reply' events in the event log.
+
+For more information on the `getEventLog`, see xref:comments-commands-events-apis.adoc#getEventLog[getEventLog].
+
 ==== Allow mentions in comments dropdown to flow freely outside of the editor container
 // #TINY-11504
 

--- a/modules/ROOT/partials/configuration/tinycomments_reply.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_reply.adoc
@@ -16,7 +16,9 @@ The `+done+` callback should accept the following object:
 [source,js]
 ----
 {
-  commentUid: string // the value of the new comment uid
+  commentUid: string, // the value of the new comment uid
+  author: string, // the id of the current author
+  authorName: string // the name of the current authorName
 }
 ----
 
@@ -42,7 +44,11 @@ const reply_comment = (ref, done, fail) => {
     })
     .then((ref2) => {
       let commentUid = ref2.commentUid;
-      done({ commentUid: commentUid });
+      done({
+        commentUid: replyUid,
+        author: currentUser.id,
+        authorName: currentUser.fullName
+      });
     })
     .catch((e) => {
       fail(e);

--- a/modules/ROOT/partials/configuration/tinycomments_reply.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_reply.adoc
@@ -18,7 +18,7 @@ The `+done+` callback should accept the following object:
 {
   commentUid: string, // the value of the new comment uid
   author: string, // the id of the current author
-  authorName: string // the name of the current authorName
+  authorName: string // the name of the current author
 }
 ----
 

--- a/modules/ROOT/partials/plugin-apis/comments-apis.adoc
+++ b/modules/ROOT/partials/plugin-apis/comments-apis.adoc
@@ -60,8 +60,8 @@ The `getEventLog` returns a log that contains information and timestamps of all 
   "conversationUid": "annotation-r1nn5xdo5ye",
   "commentUid": "annotation-uh00rb41kma",
   "conversationContext": "Welcome",
-  "conversationContent": "new comment",
-  "conversationCreatedAt": "2024-12-06T06:38:42.444Z",
+  "conversationContent": "new comment (Edit comment)",
+  "conversationCreatedAt": "2024-10-01T03:07:53.771Z",
   "commentContent": "reply to existing comment",
   "commentAuthor": {
       "author": "DEMO USER",

--- a/modules/ROOT/partials/plugin-apis/comments-apis.adoc
+++ b/modules/ROOT/partials/plugin-apis/comments-apis.adoc
@@ -58,7 +58,7 @@ The `getEventLog` returns a log that contains information and timestamps of all 
   "type": "reply",
   "timestamp": "2024-12-06T06:38:42.444Z",
   "conversationUid": "annotation-r1nn5xdo5ye",
-  "commentUid": "mce-reply_70110186641733467132519",
+  "commentUid": "annotation-uh00rb41kma",
   "conversationContext": "Welcome",
   "conversationContent": "new comment",
   "conversationCreatedAt": "2024-12-06T06:38:42.444Z",

--- a/modules/ROOT/partials/plugin-apis/comments-apis.adoc
+++ b/modules/ROOT/partials/plugin-apis/comments-apis.adoc
@@ -56,7 +56,7 @@ The `getEventLog` returns a log that contains information and timestamps of all 
 ----
 {
   "type": "reply",
-  "timestamp": "2024-12-06T06:38:42.444Z",
+  "timestamp": "2024-10-01T03:07:53.771Z",
   "conversationUid": "annotation-r1nn5xdo5ye",
   "commentUid": "annotation-uh00rb41kma",
   "conversationContext": "Welcome",

--- a/modules/ROOT/partials/plugin-apis/comments-apis.adoc
+++ b/modules/ROOT/partials/plugin-apis/comments-apis.adoc
@@ -57,7 +57,7 @@ The `getEventLog` returns a log that contains information and timestamps of all 
 {
   "type": "reply",
   "timestamp": "2024-12-06T06:38:42.444Z",
-  "conversationUid": "mce-conversation_16214546531733467122444",
+  "conversationUid": "annotation-r1nn5xdo5ye",
   "commentUid": "mce-reply_70110186641733467132519",
   "conversationContext": "Welcome",
   "conversationContent": "new comment",

--- a/modules/ROOT/partials/plugin-apis/comments-apis.adoc
+++ b/modules/ROOT/partials/plugin-apis/comments-apis.adoc
@@ -62,7 +62,7 @@ The `getEventLog` returns a log that contains information and timestamps of all 
   "conversationContext": "Welcome",
   "conversationContent": "new comment",
   "conversationCreatedAt": "2024-12-06T06:38:42.444Z",
-  "commentContent": "reply to comment",
+  "commentContent": "reply to existing comment",
   "commentAuthor": {
       "author": "DEMO USER",
       "authorName": "DEMO USER"

--- a/modules/ROOT/partials/plugin-apis/comments-apis.adoc
+++ b/modules/ROOT/partials/plugin-apis/comments-apis.adoc
@@ -56,13 +56,17 @@ The `getEventLog` returns a log that contains information and timestamps of all 
 ----
 {
   "type": "reply",
-  "timestamp": "2024-10-01T03:07:53.771Z",
-  "conversationUid": "annotation-r1nn5xdo5ye",
-  "commentUid": "annotation-uh00rb41kma",
+  "timestamp": "2024-12-06T06:38:42.444Z",
+  "conversationUid": "mce-conversation_16214546531733467122444",
+  "commentUid": "mce-reply_70110186641733467132519",
   "conversationContext": "Welcome",
-  "conversationContent": "new comment (Edit comment)",
-  "conversationCreatedAt": "2024-10-01T03:07:53.771Z",
-  "commentContent": "reply to existing comment",
+  "conversationContent": "new comment",
+  "conversationCreatedAt": "2024-12-06T06:38:42.444Z",
+  "commentContent": "reply to comment",
+  "commentAuthor": {
+      "author": "DEMO USER",
+      "authorName": "DEMO USER"
+  },
   "conversationAuthor": {
       "author": "DEMO USER",
       "authorName": "DEMO USER"


### PR DESCRIPTION
Ticket: DOC-2578

Site: [Staging branch](http://docs-feature-760-doc-2578tiny-11486.staging.tiny.cloud/docs/tinymce/latest/7.6.0-release-notes/#the-commentauthor-property-is-now-included-in-reply-events-of-the-event-log)
Site: [updated example](http://docs-feature-760-doc-2578tiny-11486.staging.tiny.cloud/docs/tinymce/latest/comments-commands-events-apis/#getEventLog:~:text=%7B%0A%20%20%22type%22%3A%20%22reply,%3A%20%22DEMO%20USER%22%0A%20%20%7D%0A%7D%2C)

Changes:
* add fix documentation for TINY-11486

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed