### PR TITLE
DOC-2578: Added tooltips to conversation and comment kebab menus.

### DIFF
--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -168,6 +168,12 @@ In {productname} {release-version}, the focus behaviour has now been improved in
 * Creating a new comment within an existing conversation now brings the focus to the corresponding conversation card.
 * Starting a new conversation now brings the focus to the newly created conversation card.
 
+==== Added tooltips to conversation and comment kebab menus
+
+In previous versions of **Comments**, the kebab menu button in the comments sidebar was missing a tooltip for users relying on assistive technologies.
+
+{productname} {release-version} addresses this issue, by adding an `aria-label` with the description "Comment Actions" to the sidebar comment menu button, ensuring a tooltip is displayed on hover. This update improves accessibility and aligns the user experience across different menu buttons.
+
 For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to {companyname} Comments].
 
 


### PR DESCRIPTION
Ticket: DOC-<num>

Site: [Staging branch](http://docs-feature-760-doc-2578tiny-11422.staging.tiny.cloud/docs/tinymce/latest/7.6.0-release-notes/#added-tooltips-to-conversation-and-comment-kebab-menus)

Changes:
* Documented the improvement for TINY-11422.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed