### PR TITLE
DOC-2578: Spelling error in tooltip for  toggle button

### DIFF
--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -170,6 +170,18 @@ In {productname} {release-version}, the focus behaviour has now been improved in
 
 For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to {companyname} Comments].
 
+=== Advanced Code Editor
+// #TINY-11298
+
+The {productname} {release-version} release includes an accompanying release of the **Advanced Code Editor** premium plugin.
+
+**Advanced Code Editor** Premium plugin includes the following fix.
+
+==== Spelling error in tooltip for `fullscreen` toggle button
+
+The tooltip for the `fullscreen` toggle button was incorrectly labeled as `Fullsceen`. {productname} {release-version} addresses this issue which has now been corrected to `Fullscreen`.
+
+For information on the **Advanced Code Editor** plugin, see: xref:advcode.adoc[Enhanced Code Editor]
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -170,7 +170,7 @@ In {productname} {release-version}, the focus behaviour has now been improved in
 
 For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to {companyname} Comments].
 
-=== Advanced Code Editor
+=== Enhanced Code Editor
 // #TINY-11298
 
 The {productname} {release-version} release includes an accompanying release of the **Advanced Code Editor** premium plugin.

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -173,15 +173,15 @@ For information on the **Comments** plugin, see: xref:introduction-to-tiny-comme
 === Enhanced Code Editor
 // #TINY-11298
 
-The {productname} {release-version} release includes an accompanying release of the **Advanced Code Editor** premium plugin.
+The {productname} {release-version} release includes an accompanying release of the **Enhanced Code Editor** premium plugin.
 
-**Advanced Code Editor** Premium plugin includes the following fix.
+**Enhanced Code Editor** Premium plugin includes the following fix.
 
 ==== Spelling error in tooltip for `fullscreen` toggle button
 
 The tooltip for the `fullscreen` toggle button was incorrectly labeled as `Fullsceen`. {productname} {release-version} addresses this issue which has now been corrected to `Fullscreen`.
 
-For information on the **Advanced Code Editor** plugin, see: xref:advcode.adoc[Enhanced Code Editor]
+For information on the **Enhanced Code Editor** plugin, see: xref:advcode.adoc[Enhanced Code Editor]
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement


### PR DESCRIPTION
Ticket: DOC-2578

Site: [Staging branch](http://docs-feature-760-doc-2578tiny-11298.staging.tiny.cloud/docs/tinymce/latest/7.6.0-release-notes/#advanced-code-editor)

Changes:
* Documented the bug fix for TINY-11298.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed