### PR TITLE
DOC-2578: New `onSetup` function for context forms.

### DIFF
--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -238,6 +238,24 @@ For more information on the `+disabled+` option, see xref:editor-important-optio
 
 // CCFR here.
 
+=== New `onSetup` function to the context forms.
+// #TINY-11494
+
+Issue: There wasn’t a way to have a function to be executed when the context form was opened or closed.
+
+Impact: Development of the uploadcare plugin required us to know when the context form is opened and closed.
+
+Solution: A new `onSetup` API was added to the context forms that gets executed when the form is rendered and it’s return function gets executed when the context form is closed.
+
+Improvements/Benefits: There is a new API that handles the life cycle of context forms.
+
+=== New `onSetup` function for context forms
+// #TINY-11494
+
+A new `+onSetup+` API has been introduced for context forms, enabling integrators to execute a function when the form is rendered and handle cleanup when it is closed. This enhancement addresses the previous limitation of not being able to detect or trigger actions during the lifecycle of context forms. The `+onSetup+` API streamlines lifecycle management by supporting initialization at form rendering and providing a return function for cleanup, enhancing integration with plugins and applications.
+
+For more details, refer to xref:contextform.adoc#form[Context Form].
+
 
 [[changes]]
 == Changes

--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -238,17 +238,6 @@ For more information on the `+disabled+` option, see xref:editor-important-optio
 
 // CCFR here.
 
-=== New `onSetup` function to the context forms.
-// #TINY-11494
-
-Issue: There wasn’t a way to have a function to be executed when the context form was opened or closed.
-
-Impact: Development of the uploadcare plugin required us to know when the context form is opened and closed.
-
-Solution: A new `onSetup` API was added to the context forms that gets executed when the form is rendered and it’s return function gets executed when the context form is closed.
-
-Improvements/Benefits: There is a new API that handles the life cycle of context forms.
-
 === New `onSetup` function for context forms
 // #TINY-11494
 

--- a/modules/ROOT/pages/contextform.adoc
+++ b/modules/ROOT/pages/contextform.adoc
@@ -46,6 +46,11 @@ This relates to the form itself. The form specifications are:
 |`+position+` |This controls where the context toolbar will appear with regards to the current cursor.
 |`+scope+` |This controls whether the predicate (condition) is a `+node+`-based predicate, or an `+editor+`-based predicate. See context toolbar priority for more details.
 |`+commands+` |This is a list of the items to show in the context form. They can be either `+contextformbutton+` or `+contextformtogglebutton+`.
+|`+onSetup+`
+a|
+`+(ContextFormApi) => (ContextFormApi) => void+` 
+
+Optional default: `+() => () => {}+` - Function that's  executed when the form is rendered. Once rendered It returns a function that is executed when the context form is closed.
 |===
 
 include::partial$context/positioning.adoc[leveloffset=+1]


### PR DESCRIPTION
Ticket: DOC-2578

Site: [Release notes](http://docs-feature-760-doc-2578tiny-11494.staging.tiny.cloud/docs/tinymce/latest/7.6.0-release-notes/#new-onsetup-function-for-context-forms)
Site: [Add onSetup to Context Form](http://docs-feature-760-doc-2578tiny-11494.staging.tiny.cloud/docs/tinymce/latest/contextform/#form)

Changes:
* Addition documentation for TINY-11494

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] Included a `release note` entry for any `New product features`.

Review:
- [x] Documentation Team Lead has reviewed