### PR TITLE
DOC-2594: Remove admonition statement in `tinymce/6` about inline editing mode not supported on mobile devices.

### DIFF
--- a/modules/ROOT/pages/use-tinymce-inline.adoc
+++ b/modules/ROOT/pages/use-tinymce-inline.adoc
@@ -6,8 +6,6 @@
 
 {productname} has three main integration modes: a _classic_ full editor mode, an _inline_ editing mode, and a distraction-free mode.
 
-include::partial$misc/admon-not-on-mobile.adoc[]
-
 The inline editing mode is used for merging the editing and reading views of the page for a seamless editing experience and true WYSIWYG behavior.
 
 Inline editing mode does not replace the selected element with an iframe, but instead edits the element's content in-place. Inline editors are designed:


### PR DESCRIPTION
Ticket: DOC-2594

Changes:
* Remove admonition for `not supported on mobile devices`.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed