### PR TITLE
DOC-2578: Image selection was removed when calling `nodeChanged` while having focus inside the editor UI.

### DIFF
--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -278,6 +278,11 @@ For more information on the `+disabled+` option, see xref:editor-important-optio
 === Image selection was removed when calling nodeChanged while having focus inside the editor UI.
 // #TINY-11437
 
+Previously, executing a `nodeChange` event while an image was selected caused the image to lose its resize handles. This issue disrupted the user experience, requiring users to re-select the image to resize it.
+
+{productname} {release-version} addresses this issue. Now, resize handles are only removed when focus moves out of the editor or its UI components.
+
+As a result, the resize handles remain visible during `nodeChange` events, improving usability.
 
 === Tooltip would not show for group toolbar button.
 // #TINY-11391


### PR DESCRIPTION
Ticket: DOC-2578

Site: [Staging branch](http://docs-feature-760-doc-2578tiny-11437.staging.tiny.cloud/docs/tinymce/latest/7.6.0-release-notes/#image-selection-was-removed-when-calling-nodechanged-while-having-focus-inside-the-editor-ui)

Changes:
* add fix documentation for TINY-11437

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed