### PR TITLE
DOC-2578: New `QuickbarInsertImage` command that is executed by the `quickimage` button.

### DIFF
--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -230,6 +230,32 @@ For more details on configuring context toolbar groups and labels, see: xref:con
 === New `QuickbarInsertImage` command that is executed by the `quickimage` button.
 // #TINY-11399
 
+The **Quickbars** Plugin now allows integrators to overwrite the `+QuickbarInsertImage+` command, enabling customization of the quickimage button's behavior.
+
+.Example of how to override the `+QuickbarInsertImage+` command:
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',
+  plugins: 'quickbars',
+  toolbar: false,
+  setup: (editor) => {
+    editor.addCommand('QuickbarInsertImage', () => { // Add a custom command to the editor named "QuickbarInsertImage"
+      const input = document.createElement('input'); // Create a new <input> element for file selection
+      input.type = 'file'; // Set the input type to "file" for uploading files
+      input.accept = 'image/*'; // Restrict the input to accept only image files
+      input.onchange = (e) => { // Add an event listener to handle the file selection event
+        const file = (e.target as HTMLInputElement).files?.[0]; // Get the selected file from the input element
+        if (file) {
+          console.log(file);
+        }
+      };
+      input.click();
+    });
+  }
+});
+----
+
 === New `onSetup` function for context forms
 // #TINY-11494
 


### PR DESCRIPTION
Ticket: DOC-2578 & DOC-2572

Site: [Staging branch](http://docs-feature-760-doc-2578tiny-11399.staging.tiny.cloud/docs/tinymce/latest/7.6.0-release-notes/#new-quickbarinsertimage-command-that-is-executed-by-the-quickimage-button)

Changes:
*  Add new addition documentation for TINY-11399

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed