### PR TITLE
DOC-2578: New `back` function in `ContextFormApi` to go back to the previous toolbar.

### DIFF
--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -227,6 +227,44 @@ For more details on configuring context toolbar groups and labels, see: xref:con
 === New `back` function in `ContextFormApi` to go back to the previous toolbar.
 // #TINY-11344
 
+{productname} {release-version} introduces the `+back+` function in the `ContextFormApi`, enabling users to navigate back to the previous toolbar. This enhancement fulfills the need for a back button in context forms, providing a seamless way to return to the previous toolbar configuration when required.
+
+.Example: Using the `back` function in a context form
+[source,js]
+----
+tinymce.init({
+  selector: "textarea",
+	setup: (ed) => {
+	  ed.ui.registry.addContextToolbar('toolbar-with-back-example', {
+        items: 'form-with-back-example undo redo',
+        position: 'node',
+        scope: 'node',
+        predicate: (node) => node.nodeName.toLowerCase() === 'p'
+      });
+
+    ed.ui.registry.addContextForm('form-with-back-example', {
+      type: 'contextsizeinputform',
+      launch: {
+        type: 'contextformtogglebutton',
+        icon: 'resize',
+        tooltip: 'ABC'
+      },
+      initValue: () => ({ width: '100', height: '200' }),
+      onInput: (formApi) => console.log(`input.${JSON.stringify(formApi.getValue())}`),
+      commands: [
+        {
+          type: 'contextformbutton',
+          icon: 'chevron-left',
+          tooltip: 'Back',
+          align: 'start',
+          onAction: (formApi) => formApi.back()
+        }
+      ]
+    });
+	}
+});
+----
+
 === New `QuickbarInsertImage` command that is executed by the `quickimage` button.
 // #TINY-11399
 

--- a/modules/ROOT/pages/contextform.adoc
+++ b/modules/ROOT/pages/contextform.adoc
@@ -105,12 +105,13 @@ Where the `+toggleButtonApi+` is the same as a regular toolbar toggle button.
 
 === formApi
 
-Both `+contextformbutton+` and `+contextformtogglebutton+` are passed `+formApi+` in their `+onAction+` callback. The `+formApi+` has two functions:
+Both `+contextformbutton+` and `+contextformtogglebutton+` are passed `+formApi+` in their `+onAction+` callback. The `+formApi+` has three functions:
 
 [cols="1,3",options="header"]
 |===
 |Functions |Description
 |`+hide+` |This will hide the form. By default, no button hides the form. It is the responsibility of the developer to hide the form in the `+onAction+` handler of buttons that require that the context form close after the action.
+|`+back+` |This will restore the previous toolbar. This is useful when you want to go back to the previous toolbar when you press back in the toolbar.
 |`+getValue+` |This will retrieve the value current typed in the input field.
 |===
 


### PR DESCRIPTION
Ticket: DOC-2578 & DOC-2596

Site: [Staging branch](http://docs-feature-760-doc-2578tiny-11344.staging.tiny.cloud/docs/tinymce/latest/7.6.0-release-notes/#new-back-function-in-contextformapi-to-go-back-to-the-previous-toolbar)

Changes:
* Add documentation for TINY-11344

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed