### PR TITLE
DOC-2578: Incorrect translation of  `Cut Column` and `Copy Column`  in Hebrew

### DIFF
--- a/modules/ROOT/pages/7.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.0-release-notes.adoc
@@ -387,6 +387,12 @@ This issue affected {productname} versions earlier than 7.1.0.
 
 {productname} {release-version} resolves this issue by updating the `stylesheetLoader` to correctly load the `ui/default/content.css` stylesheet, ensuring that image resize handles are displayed as expected.
 
+=== Incorrect translation of `Cut Column` and `Copy Column` in Hebrew
+// #TINY-11583
+An issue was identified where the Hebrew translations for Cut Column and Copy Column in the table plugin were incorrect. 
+{productname} {release-version} resolves this by providing the correct Hebrew translations for these operations.
+
+
 [[known-issues]]
 == Known issues
 


### PR DESCRIPTION
Ticket: DOC-2578

Site: [Staging branch](http://docs-feature-760-doc-2578tiny-11583.staging.tiny.cloud/docs/tinymce/latest/7.6.0-release-notes/#incorrect-translation-of-cut-column-and-copy-column-in-hebrew)

Changes:
* Documented the bug fix for TINY-11583.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [ ] Documentation Team Lead has reviewed