### PR TITLE
DOC-2600: update all document converters to new API doc links

### DIFF
--- a/modules/ROOT/pages/docx-to-html-converter-api.adoc
+++ b/modules/ROOT/pages/docx-to-html-converter-api.adoc
@@ -50,4 +50,4 @@ These configuration options enhance the flexibility and control users have over 
 
 == Docx to HTML Converter API Reference
 
-> Explore the comprehensive API documentation at link:https://exportdocx.converter.tiny.cloud/docs#section/Import-from-Word[Docx to HTML Converter API Reference documentation.^]
+> Explore the comprehensive API documentation at link:https://exportdocx.api.tiny.cloud/docs#section/Import-from-Word[Docx to HTML Converter API Reference documentation.^]

--- a/modules/ROOT/pages/exportpdf.adoc
+++ b/modules/ROOT/pages/exportpdf.adoc
@@ -84,4 +84,4 @@ include::partial$commands/{plugincode}-cmds.adoc[]
 
 == API Reference
 
-> Explore the comprehensive API documentation for the {pluginname} Premium plugin at https://exportpdf.converter.tiny.cloud/docs[Export to PDF.^]
+> Explore the comprehensive API documentation for the {pluginname} Premium plugin at https://exportpdf.api.tiny.cloud/docs[Export to PDF.^]

--- a/modules/ROOT/pages/exportword.adoc
+++ b/modules/ROOT/pages/exportword.adoc
@@ -85,4 +85,4 @@ include::partial$commands/exportword-cmds.adoc[][leveloffset=+1]
 
 == API Reference
 
-> Explore the comprehensive API documentation for the {pluginname} Premium plugin at link:https://exportdocx.converter.tiny.cloud/v2/convert/docs#section/Export-to-Word[Export to Word.^]
+> Explore the comprehensive API documentation for the {pluginname} Premium plugin at link:https://exportdocx.api.tiny.cloud/v2/convert/docs#section/Export-to-Word[Export to Word.^]

--- a/modules/ROOT/pages/html-to-docx-converter-api.adoc
+++ b/modules/ROOT/pages/html-to-docx-converter-api.adoc
@@ -41,4 +41,4 @@ Examples on how you can use the API to convert an HTML document with custom styl
 
 == HTML to Docx Converter API Reference
 
-> Explore the comprehensive API documentation at link:https://exportdocx.converter.tiny.cloud/docs#section/Export-to-Word[HTML to Docx Converter API Reference documentation.^]
+> Explore the comprehensive API documentation at link:https://exportdocx.api.tiny.cloud/docs#section/Export-to-Word[HTML to Docx Converter API Reference documentation.^]

--- a/modules/ROOT/pages/html-to-pdf-converter-api.adoc
+++ b/modules/ROOT/pages/html-to-pdf-converter-api.adoc
@@ -27,9 +27,9 @@ The {servicename} is a powerful tool that seamlessly integrates advanced documen
 
 Tailor your PDF documents to suit your needs:
 
-* **Custom CSS Styling:** Apply link:https://exportpdf.converter.tiny.cloud/docs#section/General/CSS[custom CSS^] styles to your PDFs for brand consistency and enhanced presentation.
-* **Header and Footer Options:** Add link:https://exportpdf.converter.tiny.cloud/docs#section/PDF-options/Header-and-footer[headers, footers^], and other branding elements to your PDF documents for a professional touch.
-* **Page Formatting:** Control page settings such as orientation, link:https://exportpdf.converter.tiny.cloud/docs#section/PDF-options/Margins[margins^], and link:https://exportpdf.converter.tiny.cloud/docs#section/PDF-options/Page-format[page size] to optimize readability.
+* **Custom CSS Styling:** Apply link:https://exportpdf.api.tiny.cloud/docs#section/General/CSS[custom CSS^] styles to your PDFs for brand consistency and enhanced presentation.
+* **Header and Footer Options:** Add link:https://exportpdf.api.tiny.cloud/docs#section/PDF-options/Header-and-footer[headers, footers^], and other branding elements to your PDF documents for a professional touch.
+* **Page Formatting:** Control page settings such as orientation, link:https://exportpdf.api.tiny.cloud/docs#section/PDF-options/Margins[margins^], and link:https://exportpdf.api.tiny.cloud/docs#section/PDF-options/Page-format[page size] to optimize readability.
 
 == Ideal for Various Use Cases
 
@@ -40,4 +40,4 @@ Tailor your PDF documents to suit your needs:
 
 == PDF Converter API Reference
 
-> Explore the comprehensive API documentation at link:https://exportpdf.converter.tiny.cloud/docs[PDF Converter API Reference documentation.^]
+> Explore the comprehensive API documentation at link:https://exportpdf.api.tiny.cloud/docs[PDF Converter API Reference documentation.^]

--- a/modules/ROOT/pages/importword.adoc
+++ b/modules/ROOT/pages/importword.adoc
@@ -83,4 +83,4 @@ include::partial$commands/importword-cmds.adoc[]
 
 == API Reference
 
-> Explore the comprehensive API documentation for the {pluginname} Premium plugin at link:https://importdocx.converter.tiny.cloud/v2/convert/docs#section/Import-from-Word[Import from Word.^]
+> Explore the comprehensive API documentation for the {pluginname} Premium plugin at link:https://importdocx.api.tiny.cloud/v2/convert/docs#section/Import-from-Word[Import from Word.^]

--- a/modules/ROOT/partials/configuration/exportpdf_converter_options.adoc
+++ b/modules/ROOT/partials/configuration/exportpdf_converter_options.adoc
@@ -39,4 +39,4 @@ tinymce.init({
 [NOTE]
 The `exportpdf_service_url` option must be configured for the {pluginname} plugin to work.
 
-> For comprehensive details regarding the `exportpdf_converter_options`, please refer to the https://exportpdf.converter.tiny.cloud/docs[API documentation^] available for the {pluginname} Premium plugin.
+> For comprehensive details regarding the `exportpdf_converter_options`, please refer to the https://exportpdf.api.tiny.cloud/docs[API documentation^] available for the {pluginname} Premium plugin.

--- a/modules/ROOT/partials/configuration/exportword_converter_options.adoc
+++ b/modules/ROOT/partials/configuration/exportword_converter_options.adoc
@@ -65,4 +65,4 @@ tinymce.init({
 [NOTE]
 To use this option, the Export to Word plugin requires the `exportword_service_url` option to be configured.
 
-> For comprehensive details regarding the `exportword_converter_options`, please refer to the link:https://exportdocx.converter.tiny.cloud/v2/convert/docs#section/Export-to-Word[API documentation^] available for the {pluginname} Premium plugin.
+> For comprehensive details regarding the `exportword_converter_options`, please refer to the link:https://exportdocx.api.tiny.cloud/v2/convert/docs#section/Export-to-Word[API documentation^] available for the {pluginname} Premium plugin.

--- a/modules/ROOT/partials/configuration/importword_converter_options.adoc
+++ b/modules/ROOT/partials/configuration/importword_converter_options.adoc
@@ -39,4 +39,4 @@ tinymce.init({
 ----
 
 [NOTE]
-For more information on the available converter options, refer to the link:https://importdocx.converter.tiny.cloud/v2/convert/docs#section/Import-from-Word/Configuration[Import from Word API documentation].
+For more information on the available converter options, refer to the link:https://importdocx.api.tiny.cloud/v2/convert/docs#section/Import-from-Word/Configuration[Import from Word API documentation].

--- a/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-api-usage.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-api-usage.adoc
@@ -7,7 +7,7 @@ The API is available on `+http://localhost:[port]+` (by default the `port` is `8
 
 [NOTE]
 The REST API documentation is available at `+http://localhost:[port]/docs+`.
-Alternatively, refer to the specifications in link:https://exportpdf.converter.tiny.cloud/docs[https://exportpdf.converter.tiny.cloud/docs^].
+Alternatively, refer to the specifications in link:https://exportpdf.api.tiny.cloud/docs[https://exportpdf.api.tiny.cloud/docs^].
 
 If the authorization for the API is enabled, provided an authorization token. More instructions can be found in the xref:individual-export-to-pdf-on-premises.adoc#authorization[authorization] section.
 

--- a/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-autorization.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-autorization.adoc
@@ -91,7 +91,7 @@ axios.post( 'http://localhost:8080/v1/convert', data, config )
 
 `SECRET_KEY` it’s the key which has been passed to the {pluginname} On-Premises instance
 
-Please refer to the link:https://exportpdf.converter.tiny.cloud/docs[{pluginname} REST API documentation] to start using the service.
+Please refer to the link:https://exportpdf.api.tiny.cloud/docs[{pluginname} REST API documentation] to start using the service.
 
 [NOTE]
 If API clients like Postman or Insomnia are used, then set the JWT token as an `Authorization` header in the `Headers` tab. Do not use the built-in token authorization as this will generate invalid header with a `Bearer` prefix added to the token.

--- a/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-fonts.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-fonts.adoc
@@ -5,7 +5,7 @@ During document writing, the possibility of using many different fonts can be ve
 
 Using the appropriate font can change the appearance of the document and emphasize its style.
 
-{pluginname} Converter allows link:https://exportpdf.converter.tiny.cloud/docs#section/Web-Fonts[Web Fonts^] to be used, which provided the integrator with the ability to use standard operating system fonts or use custom fonts without the need to import them using CSS.
+{pluginname} Converter allows link:https://exportpdf.api.tiny.cloud/docs#section/Web-Fonts[Web Fonts^] to be used, which provided the integrator with the ability to use standard operating system fonts or use custom fonts without the need to import them using CSS.
 
 Below is a list of the basic fonts included in the image:
 
@@ -31,7 +31,7 @@ However, additional fonts can be added to {pluginname} Converter in two ways:
 ** See Use Windows fonts in PDF Converter section.
 
 [NOTE]
-The fonts inside the mounted volume will be installed on the docker image operating system. Only the `.ttf` and `.otf` font formats are supported. If other font formats are used, these will need to be converted to the supported format prior or use fonts such as link:https://exportpdf.converter.tiny.cloud/docs#section/Web-Fonts[Web Fonts^].
+The fonts inside the mounted volume will be installed on the docker image operating system. Only the `.ttf` and `.otf` font formats are supported. If other font formats are used, these will need to be converted to the supported format prior or use fonts such as link:https://exportpdf.api.tiny.cloud/docs#section/Web-Fonts[Web Fonts^].
 
 [TIP]
 Ensure that the converted fonts can be installed and used on your local machine first, before installing them on the docker container.

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-api-usage-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-api-usage-on-premises.adoc
@@ -10,6 +10,6 @@ The API is available on `+http://localhost:[port]+` (by default the port is 8080
 
 [NOTE]
 The REST API documentation is available at `+http://localhost:[port]/v2/convert/docs+`.
-Alternatively you can check specification in our public resources for link:https://importdocx.converter.tiny.cloud/v2/convert/docs#section/Import-from-Word[Import from Word^] and the link:https://exportdocx.converter.tiny.cloud/v2/convert/docs#section/Export-to-Word[Export to Word^] plugins.
+Alternatively you can check specification in our public resources for link:https://importdocx.api.tiny.cloud/v2/convert/docs#section/Import-from-Word[Import from Word^] and the link:https://exportdocx.api.tiny.cloud/v2/convert/docs#section/Export-to-Word[Export to Word^] plugins.
 
 If you have the authorization for the API enabled, you should provide an authorization token. More instructions you can find in the authorization section.

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-autorization-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-autorization-on-premises.adoc
@@ -63,7 +63,7 @@ axios.post( 'http://localhost:8080/v2/convert/html-docx', data, config )
 
 `SECRET_KEY`: This is the key what has been passed to the {pluginname} On-Premises instance.
 
-Please refer to the link:https://importdocx.converter.tiny.cloud/v2/convert/docs#section/Import-from-Word[Import from Word^] and the link:https://exportdocx.converter.tiny.cloud/v2/convert/docs#section/Export-to-Word[Export to Word^] REST API documentation to start using the service.
+Please refer to the link:https://importdocx.api.tiny.cloud/v2/convert/docs#section/Import-from-Word[Import from Word^] and the link:https://exportdocx.api.tiny.cloud/v2/convert/docs#section/Export-to-Word[Export to Word^] REST API documentation to start using the service.
 
 [NOTE]
 If API clients like Postman or Insomnia are used, then set the JWT token as an `Authorization` header in the `Headers` tab. Do not use the built-in token authorization as this will generate invalid header with a `Bearer` prefix added to the token.


### PR DESCRIPTION
Ticket: DOC-2600

Pages where the links show up:
Site: [exportpdf on premises](http://docs-hotfix-7-doc-2600.staging.tiny.cloud/docs/tinymce/latest/individual-export-to-pdf-on-premises/)
Site: [importdocx/exportdocx on premises](http://docs-hotfix-7-doc-2600.staging.tiny.cloud/docs/tinymce/latest/individual-import-from-word-and-export-to-word-on-premises/)
Site: [exportpdf plugin page](http://docs-hotfix-7-doc-2600.staging.tiny.cloud/docs/tinymce/latest/exportpdf/)
Site: [exportpdf subpage](http://docs-hotfix-7-doc-2600.staging.tiny.cloud/docs/tinymce/latest/html-to-pdf-converter-api/)
Site: [importdocx plugin page](http://docs-hotfix-7-doc-2600.staging.tiny.cloud/docs/tinymce/latest/importword/)
Site: [importdocx subpage](http://docs-hotfix-7-doc-2600.staging.tiny.cloud/docs/tinymce/latest/docx-to-html-converter-api/)
Site: [exportdocx plugin page](http://docs-hotfix-7-doc-2600.staging.tiny.cloud/docs/tinymce/latest/exportword/)
Site: [exportdocx subpage](http://docs-hotfix-7-doc-2600.staging.tiny.cloud/docs/tinymce/latest/html-to-docx-converter-api/)

Changes:
* Replace all links `https://(.*?).converter.tiny.cloud` with `https://$1.api.tiny.cloud`

NOTE: There are some broken links regarding the JWT Authentication pages, this is being fixed in [another PR](https://github.com/tinymce/tinymce-docs/pull/3560).

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [-] Included a `release note` entry for any `New product features`.
- [-] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [-] Documentation Team Lead has reviewed