### PR TITLE
DOC-2603: Add Preformatted to block_formats

### DIFF
--- a/modules/ROOT/partials/configuration/block_formats.adoc
+++ b/modules/ROOT/partials/configuration/block_formats.adoc
@@ -5,7 +5,7 @@ This option defines the formats to be displayed in the `+blocks+` dropdown toolb
 
 *Type:* `+String+`
 
-*Default value:* `+'Paragraph=p; Heading 1=h1; Heading 2=h2; Heading 3=h3; Heading 4=h4; Heading 5=h5; Heading 6=h6;+`
+*Default value:* `+'Paragraph=p; Heading 1=h1; Heading 2=h2; Heading 3=h3; Heading 4=h4; Heading 5=h5; Heading 6=h6; Preformatted=pre'+`
 
 === Example: using `+block_formats+`
 


### PR DESCRIPTION
Ticket: DOC-2603

Site: [Staging branch](http://docs-hotfix-7-doc-2603.staging.tiny.cloud/docs/tinymce/latest/user-formatting-options/#block_formats)

Changes:
* Add Preformatted to block_formats

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [-] Included a `release note` entry for any `New product features`.
- [-] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed