### PR TITLE
DOC-1928: Fix options leveling

### DIFF
--- a/modules/ROOT/examples/live-demos/advcode/index.html
+++ b/modules/ROOT/examples/live-demos/advcode/index.html
@@ -1,4 +1,4 @@
-<table>
+<table style="width: 100%;">
   <thead>
     <tr>
       <th style="width: 50%;"><h2>The Code Plugin</h2></th>

--- a/modules/ROOT/pages/accordion.adoc
+++ b/modules/ROOT/pages/accordion.adoc
@@ -36,9 +36,9 @@ tinymce.init({
 
 The following configuration options affect the behavior of the {pluginname} plugin.
 
-include::partial$configuration/details_initial_state.adoc[][leveloffset=+1]
+include::partial$configuration/details_initial_state.adoc[leveloffset=+1]
 
-include::partial$configuration/details_serialized_state.adoc[][leveloffset=+1]
+include::partial$configuration/details_serialized_state.adoc[leveloffset=+1]
 
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 

--- a/modules/ROOT/pages/advanced-typography.adoc
+++ b/modules/ROOT/pages/advanced-typography.adoc
@@ -85,7 +85,7 @@ tinymce.init({
 
 The following configuration options affect the behavior of the {pluginname} plugin.
 
-include::partial$configuration/advanced-typography.adoc[]
+include::partial$configuration/advanced-typography.adoc[leveloffset=+1]
 
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 

--- a/modules/ROOT/pages/advcode.adoc
+++ b/modules/ROOT/pages/advcode.adoc
@@ -10,9 +10,11 @@
 include::partial$misc/admon-premium-plugin.adoc[]
 
 [TIP]
-As of {productname} 7.0, the Advanced Code Editor plugin has been renamed to {pluginname}. When adding {pluginname} in your editor, continue to use {plugincode}.
+====
+As of {productname} 7.0, the Advanced Code Editor plugin has been renamed to {pluginname}. When adding {pluginname} in your editor, continue to use `{plugincode}`.
+====
 
-The xref:advcode.adoc[Enhanced Code Editor] plugin (`+advcode+`) brings a more advanced code editor to {productname}. This code editor makes it easier to modify the HTML, and is a useful add-on for power users. It comes with features often found in IDEs, all enabled by default:
+The {pluginname} plugin (`{plugincode}`) brings a more advanced code editor to {productname}. This code editor makes it easier to modify the HTML, and is a useful add-on for power users. It comes with features often found in IDEs, all enabled by default:
 
 * Syntax color highlighting.
 * Bracket matching.
@@ -23,7 +25,10 @@ The xref:advcode.adoc[Enhanced Code Editor] plugin (`+advcode+`) brings a more a
 * Increase and decrease display font size buttons.
 * Full-screen mode button.
 
-NOTE: For the {pluginname} to offer a full-screen mode requires the xref:fullscreen.adoc[Full screen] plugin and requires {pluginname} to be running in xref:advcode.adoc#advcode_inline[inline mode].
+[NOTE]
+====
+For the {pluginname} to offer a full-screen mode requires the xref:fullscreen.adoc[Full screen] plugin and requires {pluginname} to be running in `xref:advcode.adoc#advcode_inline[advcode_inline]` mode.
+====
 
 == The difference between the Code and Enhanced Code Editor plugins
 
@@ -58,7 +63,11 @@ tinymce.init({
 
 include::partial$misc/code-dialog-and-selection-state.adoc[]
 
-include::partial$configuration/advcode.adoc[]
+== Options
+
+The following configuration options affect the behavior of the {pluginname} plugin.
+
+include::partial$configuration/advcode.adoc[leveloffset=+1]
 
 include::partial$misc/advcode-shortcuts.adoc[]
 

--- a/modules/ROOT/pages/editimage.adoc
+++ b/modules/ROOT/pages/editimage.adoc
@@ -73,7 +73,7 @@ include::partial$configuration/editimage_toolbar.adoc[leveloffset=+1]
 
 include::partial$configuration/editimage_upload_timeout.adoc[leveloffset=+1]
 
-include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[leveloffset=+1]
+include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 == Commands
 

--- a/modules/ROOT/pages/exportword.adoc
+++ b/modules/ROOT/pages/exportword.adoc
@@ -81,7 +81,7 @@ include::partial$configuration/exportword_converter_style.adoc[leveloffset=+1]
 
 The {pluginname} plugin provides the following {productname} commands.
 
-include::partial$commands/exportword-cmds.adoc[][leveloffset=+1]
+include::partial$commands/exportword-cmds.adoc[]
 
 == API Reference
 

--- a/modules/ROOT/pages/markdown.adoc
+++ b/modules/ROOT/pages/markdown.adoc
@@ -61,7 +61,7 @@ liveDemo::{plugincode}[]
 
 The following configuration options affect the behavior of the {pluginname} plugin.
 
-include::partial$configuration/markdown.adoc[][leveloffset=+1]
+include::partial$configuration/markdown.adoc[leveloffset=+1]
 
 == Commands
 


### PR DESCRIPTION
Ticket: DOC-1928

Site: [Staging branch](http://docs-hotfix-7-doc-19282.staging.tiny.cloud/docs/tinymce/latest/)
Site: [Visual DOM Diff](https://sneak-preview.tiny.cloud/tinymce-docs-vdd-2/index.html)

Changes:
- [x] Fix `advcode` Options level offset
- [ ] Split `advcode` Options into multiple files
- [x] Fix `advcode` live demo table width
- [x] Fix `typography` Options level offset
- [ ] Move `typography` languages list to above the options
- [ ] Split `typography` Options into multiple files
- [x] Fix `editimage` Toolbar Buttons level offset
- [x] Fix `markdown` Options level offset
- [x] Fix `accordion` Options level offset
- [x] Fix `exportword1 Commands level offset

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [-] Included a `release note` entry for any `New product features`.
- [-] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [ ] Documentation Team Lead has reviewed