### PR TITLE
SEC-281: Add awareness of HSTS to secutiry.adoc for strict transport security.

### DIFF
--- a/modules/ROOT/pages/security.adoc
+++ b/modules/ROOT/pages/security.adoc
@@ -1,19 +1,19 @@
 = Security guide
 :navtitle: Security guide
-:description_short: Security information for TinyMCE.
-:description: Information on reporting security issues, what TinyMCE does to protect users, and what you can do to protect your users.
-:keywords: security, xss, scripting, vulnerability, hack, hacker, csp, mitigation, protection, protect
+:description_short: Security information for {productname}.
+:description: Information on reporting security issues, what {productname} does to protect users, and what you can do to protect your users.
+:keywords: security, xss, scripting, vulnerability, hack, hacker, csp, mitigation, protection, protect, hsts, https
 
 NOTE: The following is _general_ security advice that may be relevant to a website or application using {productname}.
 
 == Overview
 
-* xref:reporting-tinymce-security-issues[Reporting TinyMCE security issues]
-* xref:what-we-do-to-maintain-security-for-tinymce[What we do to maintain security for TinyMCE]
+* xref:reporting-tinymce-security-issues[Reporting {productname} security issues]
+* xref:what-we-do-to-maintain-security-for-tinymce[What we do to maintain security for {productname}]
 ** xref:scripts-and-xss-vulnerabilities[Scripts and XSS vulnerabilities]
 ** xref:keeping-dependencies-up-to-date[Keeping dependencies up-to-date]
 * xref:enforcing-https-with-hsts[Enforcing HTTPS with HSTS]
-* xref:configuring-content-security-policy-csp-for-tinymce[Configuring Content Security Policy (CSP) for TinyMCE]
+* xref:configuring-content-security-policy-csp-for-tinymce[Configuring Content Security Policy (CSP) for {productname}]
 * xref:general-security-risks-for-user-input-elements[General security risks for user input elements]
 ** xref:cross-site-scripting-xss[Cross-Site Scripting (XSS)]
 ** xref:injection[Injection]
@@ -26,7 +26,7 @@ NOTE: The following is _general_ security advice that may be relevant to a websi
 
 // Note: The reportingtinymcesecurityissues anchor is needed for older external links
 [[reporting-tinymce-security-issues]]
-== [[reportingtinymcesecurityissues]] Reporting TinyMCE security issues
+== [[reportingtinymcesecurityissues]] Reporting {productname} security issues
 
 {companyname} values the work of security researchers in improving the security of technology products worldwide. We welcome researchers who wish to responsibly disclose vulnerabilities in our products or systems.
 
@@ -36,10 +36,10 @@ To report a potential security vulnerability, contact our Security team at mailt
 
 In line with the United States National Infrastructure Advisory Council (NIAC) https://dhs.gov/xlibrary/assets/vdwgreport.pdf[Vulnerability Disclosure Framework] (PDF link), Tiny requests community members reporting potential security vulnerabilities maintain the confidentiality of their report and discovery until Tiny has investigated the issue and taken action to fix it.
 
-Tiny will communicate with you regarding the status of your report and will, with your permission, publicly attribute the security issue’s discovery to you after the issue has been fixed and disclosed.
+Tiny will communicate with you regarding the status of your report and will, with your permission, publicly attribute the security issue's discovery to you after the issue has been fixed and disclosed.
 
 [[what-we-do-to-maintain-security-for-tinymce]]
-== What we do to maintain security for TinyMCE
+== What we do to maintain security for {productname}
 
 To protect {productname} users, {companyname}:
 
@@ -60,7 +60,7 @@ From the 1st of January 2020, Security Advisories for patched XSS vulnerabilitie
 [[keeping-dependencies-up-to-date]]
 === Keeping dependencies up-to-date
 
-To protect our users, {companyname} ensures that the TinyMCE dependencies are updated before the next version (major or minor) is released.
+To protect our users, {companyname} ensures that the {productname} dependencies are updated before the next version (major or minor) is released.
 
 [[enforcing-https-with-hsts]]
 == Enforcing HTTPS with HSTS

--- a/modules/ROOT/pages/security.adoc
+++ b/modules/ROOT/pages/security.adoc
@@ -55,6 +55,21 @@ SVGs (Scalable Vector Graphics) are not supported in {productname} to protect ou
 
 From the 1st of January 2020, Security Advisories for patched XSS vulnerabilities will be published on the https://github.com/tinymce/tinymce/security/advisories?state=published[{productname} GitHub repository Security page].
 
+[[enforcing-https-with-hsts]]
+=== Enforcing HTTPS with HSTS
+
+The {companyname} security team strongly recommends that customers embedding {productname} configure their web servers to include the HTTP Strict Transport Security (HSTS) header for websites served over HTTPS. This can be achieved by updating the server configurations to enable HSTS.
+
+HSTS ensures that encrypted communications are exclusively used, mitigates downgrade attacks, and enhances the protection of user data. While integrating HSTS is optional for {productname}, adopting this best practice significantly reduces the risk of vulnerabilities in projects utilizing {productname}.
+
+[IMPORTANT]
+Without HSTS, users accessing a website may be vulnerable to man-in-the-middle (MITM) attacks. Attackers can exploit this vulnerability by intercepting unencrypted HTTP traffic, redirecting users to malicious sites, or executing downgrade attacks to force connections over HTTP instead of HTTPS. This lack of encryption jeopardizes sensitive user data, including credentials, session cookies, and personal information. By enabling HSTS, these risks are effectively mitigated, as the browser enforces secure HTTPS connections for all future interactions with the site.
+
+For comprehensive guidance on implementing HSTS, refer to the following resources:
+
+* link:https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html[OWASP HSTS Cheat Sheet]
+* link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security[MDN Documentation on HSTS]
+
 [[keeping-dependencies-up-to-date]]
 === Keeping dependencies up-to-date
 

--- a/modules/ROOT/pages/security.adoc
+++ b/modules/ROOT/pages/security.adoc
@@ -12,6 +12,7 @@ NOTE: The following is _general_ security advice that may be relevant to a websi
 * xref:what-we-do-to-maintain-security-for-tinymce[What we do to maintain security for TinyMCE]
 ** xref:scripts-and-xss-vulnerabilities[Scripts and XSS vulnerabilities]
 ** xref:keeping-dependencies-up-to-date[Keeping dependencies up-to-date]
+* xref:enforcing-https-with-hsts[Enforcing HTTPS with HSTS]
 * xref:configuring-content-security-policy-csp-for-tinymce[Configuring Content Security Policy (CSP) for TinyMCE]
 * xref:general-security-risks-for-user-input-elements[General security risks for user input elements]
 ** xref:cross-site-scripting-xss[Cross-Site Scripting (XSS)]
@@ -44,6 +45,7 @@ To protect {productname} users, {companyname}:
 
 * Patches Cross-Site Scripting (XSS) vulnerabilities,
 * Keeps {productname} dependencies up to date, and
+* Provides recommendations about enforcing HTTPS with HSTS, and
 * Provides information about how to configure a Content Security Policy that works with {productname}.
 
 [[scripts-and-xss-vulnerabilities]]
@@ -55,8 +57,13 @@ SVGs (Scalable Vector Graphics) are not supported in {productname} to protect ou
 
 From the 1st of January 2020, Security Advisories for patched XSS vulnerabilities will be published on the https://github.com/tinymce/tinymce/security/advisories?state=published[{productname} GitHub repository Security page].
 
+[[keeping-dependencies-up-to-date]]
+=== Keeping dependencies up-to-date
+
+To protect our users, {companyname} ensures that the TinyMCE dependencies are updated before the next version (major or minor) is released.
+
 [[enforcing-https-with-hsts]]
-=== Enforcing HTTPS with HSTS
+== Enforcing HTTPS with HSTS
 
 The {companyname} security team strongly recommends that customers embedding {productname} configure their web servers to include the HTTP Strict Transport Security (HSTS) header for websites served over HTTPS. This can be achieved by updating the server configurations to enable HSTS.
 
@@ -69,11 +76,6 @@ For comprehensive guidance on implementing HSTS, refer to the following resource
 
 * link:https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html[OWASP HSTS Cheat Sheet]
 * link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security[MDN Documentation on HSTS]
-
-[[keeping-dependencies-up-to-date]]
-=== Keeping dependencies up-to-date
-
-To protect our users, {companyname} ensures that the TinyMCE dependencies are updated before the next version (major or minor) is released.
 
 include::partial$misc/general-csp.adoc[]
 


### PR DESCRIPTION
Ticket: SEC-281

Site: [Staging branch](http://docs-hotfix-7-sec-281.staging.tiny.cloud/docs/tinymce/latest/security/#enforcing-https-with-hsts)

Changes:
* Include recommendation for HSTS to `security.adoc`.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed