### PR TITLE
DOC-2609: The mentions menu without items was not closed when pressin…

### DIFF
--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -47,17 +47,21 @@ For information on the **<Open source plugin name>** plugin, see xref:<plugincod
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
-=== <Premium plugin name 1> <Premium plugin name 1 version>
+=== Comments
 
-The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+The {productname} {release-version} release includes an accompanying release of the **Comments** premium plugin.
 
-**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+**Comments** Comments includes the following fixes.
 
-==== <Premium plugin name 1 change 1>
+==== The mentions menu without items was not closed when pressing Space or Enter key.
 
-// CCFR here.
+Previously, an issue was identified where pressing the `Space` or `Enter` key when the mentions dropdown displayed the message "no users found" did not close the dropdown unlike in the editor.
 
-For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+This issue also caused the `Space` and `Enter` keys to be non-functional, resulting in a poor user experience.
+
+{productname} {release-version} resolves this issue by ensuring that pressing the `Space` or `Enter` key closes the dropdown, maintaining consistent functionality between the comment text area and the editor.
+
+For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to {companyname} Comments].
 
 
 [[accompanying-premium-plugin-end-of-life-announcement]]

--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -51,7 +51,7 @@ The following premium plugin updates were released alongside {productname} {rele
 
 The {productname} {release-version} release includes an accompanying release of the **Comments** premium plugin.
 
-**Comments** Comments includes the following fixes.
+**Comments** includes the following fixes.
 
 ==== The mentions menu without items was not closed when pressing Space or Enter key.
 // #TINY-11454

--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -54,7 +54,7 @@ The {productname} {release-version} release includes an accompanying release of 
 **Comments** Comments includes the following fixes.
 
 ==== The mentions menu without items was not closed when pressing Space or Enter key.
-
+// #TINY-11454
 Previously, an issue was identified where pressing the `Space` or `Enter` key when the mentions dropdown displayed the message "no users found" did not close the dropdown unlike in the editor.
 
 This issue also caused the `Space` and `Enter` keys to be non-functional, resulting in a poor user experience.


### PR DESCRIPTION
…g Space or Enter key.

Ticket: DOC-2609

Site: [Staging branch](http://docs-feature-761-doc-2609tiny-11454.staging.tiny.cloud/docs/tinymce/latest/7.6.1-release-notes/#the-mentions-menu-without-items-was-not-closed-when-pressing-space-or-enter-key)

Changes:
* Documented the bug fix for TINY-11454

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [ ] Documentation Team Lead has reviewed