### PR TITLE
DOC-2609: The mentions dropdown remained visible even after the menti…

### DIFF
--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -56,7 +56,7 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== The mentions dropdown remained visible even after the mention text was deleted in quick succession.
 // #TINY-11673
 
-An issue was identified where the mentions in comments dropdown was still visibile after the mentioned text was removed in quick succession. 
+In previous versions of the **Comments** plugin, an issue was identified where the mentions in comments dropdown was still visible after the `@` mentioned text was removed in quick succession. 
 
 This behavior occurred when the users list was updated following a successful API fetch request, even when the mentioned text was completely deleted.
 

--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -49,7 +49,7 @@ The following premium plugin updates were released alongside {productname} {rele
 
 === Comments
 
-The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+The {productname} {release-version} release includes an accompanying release of the **Comments** premium plugin.
 
 **Comments** Comments includes the following fixes.
 

--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -58,11 +58,11 @@ The {productname} {release-version} release includes an accompanying release of 
 
 An issue was identified where the mentions in comments dropdown was still visibile after the mentioned text was removed in quick succession. 
 
-This behavior occurred because the users list was updated following a successful API fetch request, even when the mentioned text was completely deleted. 
-As a result, users were unable to interact with or close the dropdown.
+This behavior occurred when the users list was updated following a successful API fetch request, even when the mentioned text was completely deleted.
 
-In {productname} {release-version}, the logic has been updated to ensure the users list is only refreshed if the mentioned text is not entirely removed. 
-This change ensures that the mentions dropdown automatically disappears when the mentioned text is deleted, improving user experience and functionality.
+As a result, users were unable to interact with or close the `@` mentions dropdown.
+
+In {productname} {release-version}, the logic has been updated to ensure the users list is only refreshed if the mentioned text is not entirely removed. This change ensures that the mentions dropdown automatically closes when the `@` mentioned text is deleted.
 
 For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to {companyname} Comments].
 

--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -47,17 +47,24 @@ For information on the **<Open source plugin name>** plugin, see xref:<plugincod
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
-=== <Premium plugin name 1> <Premium plugin name 1 version>
+=== Comments
 
 The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
 
-**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+**Comments** Comments includes the following fixes.
 
-==== <Premium plugin name 1 change 1>
+==== The mentions dropdown remained visible even after the mention text was deleted in quick succession.
+// #TINY-11673
 
-// CCFR here.
+An issue was identified where the mentions in comments dropdown was still visibile after the mentioned text was removed in quick succession. 
 
-For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+This behavior occurred because the users list was updated following a successful API fetch request, even when the mentioned text was completely deleted. 
+As a result, users were unable to interact with or close the dropdown.
+
+In {productname} {release-version}, the logic has been updated to ensure the users list is only refreshed if the mentioned text is not entirely removed. 
+This change ensures that the mentions dropdown automatically disappears when the mentioned text is deleted, improving user experience and functionality.
+
+For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to {companyname} Comments].
 
 
 [[accompanying-premium-plugin-end-of-life-announcement]]

--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -51,7 +51,7 @@ The following premium plugin updates were released alongside {productname} {rele
 
 The {productname} {release-version} release includes an accompanying release of the **Comments** premium plugin.
 
-**Comments** Comments includes the following fixes.
+**Comments** includes the following fixes.
 
 ==== The mentions dropdown remained visible even after the mention text was deleted in quick succession.
 // #TINY-11673


### PR DESCRIPTION
…on text was deleted in quick succession.

Ticket: DOC-2609

Site: [Staging branch](http://docs-feature-761-doc-2609tiny-11673.staging.tiny.cloud/docs/tinymce/latest/7.6.1-release-notes/#the-mentions-dropdown-remained-visible-even-after-the-mention-text-was-deleted-in-quick-succession)

Changes:
* Documented the bug fix for TINY-11673.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed