### PR TITLE
DOC-2609: Toggle sidebar shortcut remained active when the editor was…

### DIFF
--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -76,7 +76,7 @@ This issue also caused the `Space` and `Enter` keys to be non-functional, result
 ==== Toggle sidebar shortcut remained active when the editor was disabled.
 // #TINY-11646
 
-Previously, an issue was identified where the comment sidebar would close when using the keyboard shortcut `Cmd + Opt + M` while the editor was in a disabled state.
+Previously, an issue was identified where the comment sidebar would close when using the keyboard shortcut `Cmd + Opt + M` on Mac and `Ctrl + Alt + M` on Windows while the editor was in a disabled state.
 
 This led to inconsistent behavior, as keyboard shortcuts remained functional despite the editor being disabled.
 

--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -80,8 +80,7 @@ Previously, an issue was identified where the comment sidebar would close when u
 
 This led to inconsistent behavior, as keyboard shortcuts remained functional despite the editor being disabled.
 
-With the release of {productname} {release version}, this issue has been resolved. The behavior of keyboard shortcuts has been updated to ensure that the comment sidebar shortcut is completely disabled when the editor is in a disabled state.
-This change aligns the functionality of the shortcuts with the editor's state, ensuring consistent behavior.
+{productname} {release version} addresses this issue. The behavior of keyboard shortcuts has been updated to ensure that the comment sidebar shortcut is disabled when the editor is in a disabled state.
 
 For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to {companyname} Comments].
 

--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -73,6 +73,16 @@ This issue also caused the `Space` and `Enter` keys to be non-functional, result
 
 {productname} {release-version} resolves this issue by ensuring that pressing the `Space` or `Enter` key closes the dropdown, maintaining consistent functionality between the comment text area and the editor.
 
+==== Toggle sidebar shortcut remained active when the editor was disabled.
+// #TINY-11646
+
+Previously, an issue was identified where the comment sidebar would close when using the keyboard shortcut `Cmd + Opt + M` while the editor was in a disabled state.
+
+This led to inconsistent behavior, as keyboard shortcuts remained functional despite the editor being disabled.
+
+With the release of {productname} {release version}, this issue has been resolved. The behavior of keyboard shortcuts has been updated to ensure that the comment sidebar shortcut is completely disabled when the editor is in a disabled state.
+This change aligns the functionality of the shortcuts with the editor's state, ensuring consistent behavior.
+
 For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to {companyname} Comments].
 
 


### PR DESCRIPTION
… disabled.

Ticket: DOC-2609

Site: [Staging branch](http://docs-feature-761-doc-2609tiny-11646.staging.tiny.cloud/docs/tinymce/latest/7.6.1-release-notes/#toggle-sidebar-shortcut-remained-active-when-the-editor-was-disabled)

Changes:
* Documented the bug fix for TINY-11646

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [ ] Documentation Team Lead has reviewed