### PR TITLE
DOC-2609: Table resize bars was not properly aligned for inline edito…

### DIFF
--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -75,6 +75,21 @@ This issue also caused the `Space` and `Enter` keys to be non-functional, result
 
 For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to {companyname} Comments].
 
+=== Enhanced Tables
+
+The {productname} {release-version} release includes an accompanying release of the **Enhanced Tables** premium plugin.
+
+**Enhanced Tables** includes the following fixes.
+
+==== Table resize bars was not properly aligned for inline editors inside scrollable containers.
+
+In earlier versions of {productname}, an issue was identified in the inline mode editor where table resize bars were improperly positioned when placed within a scrollable container. When the container was scrolled, the resize bars became misaligned with the corresponding table rows and columns.
+
+This misalignment caused a disconnect between the table rows and their associated resize handles, leading to usability challenges as the handles appeared in the incorrect location.
+
+In {productname} {release-version}, this issue has been resolved by ensuring the table resize bars are properly attached to the respective table rows and columns when the container is scrolled, enhancing usability and functionality.
+
+For information on the **Enhanced Table** plugin, see: xref:advtable.adoc[Enhanced Tables].
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement

--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -82,6 +82,7 @@ The {productname} {release-version} release includes an accompanying release of 
 **Enhanced Tables** includes the following fixes.
 
 ==== Table resize bars was not properly aligned for inline editors inside scrollable containers.
+// #TINY-11215
 
 In earlier versions of {productname}, an issue was identified in the inline mode editor where table resize bars were improperly positioned when placed within a scrollable container. When the container was scrolled, the resize bars became misaligned with the corresponding table rows and columns.
 


### PR DESCRIPTION
…rs inside scrollable containers.

Ticket: DOC-2609

Site: [Staging branch](http://docs-feature-761-doc-2609.staging.tiny.cloud/docs/tinymce/latest/7.6.1-release-notes/#table-resize-bars-was-not-properly-aligned-for-inline-editors-inside-scrollable-containers)

Changes:
* Documented the bug fix for TINY-11215

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [ ] Documentation Team Lead has reviewed