### PR TITLE
DOC-2609: Resizing images by typing into the input didn't update the …

### DIFF
--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -101,6 +101,25 @@ In {productname} {release-version}, this issue has been resolved by ensuring the
 
 For information on the **Enhanced Table** plugin, see: xref:advtable.adoc[Enhanced Tables].
 
+=== Image Optimizer
+
+The {productname} {release-version} release includes an accompanying release of the **Image Optimizer** premium plugin.
+
+**Image Optimizer** includes the following fixes.
+
+==== Resizing images by typing into the input didn't update the `style` attribute correctly.
+
+An issue was identified where the `data-mce-style` attribute of an image was not updated correctly when its width and height were modified via user input.
+
+This was caused by triggering the resize function when the selection was somewhere else due to a debounce between the input and the resize, but the resize operation would be performed on the current selection.
+
+This resulted in other editor components that contain the `data-mce-style` attribute accidentally reading outdated values, and the resize not being applied as the selection would not be on the image.
+
+{productname} {release-version} addresses this by updating the `data-mce-style` attribute accordingly when a resize operation is performed and the resize function takes the image as a parameter. 
+This ensures that all editor components that reference the `data-mce-style` attribute read the most recent value entered, and the resize operation is applied to the correct image even before the debounce time has elapsed.
+
+For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Image Optimizer].
+
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement
 

--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -110,14 +110,13 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== Resizing images by typing into the input didn't update the `style` attribute correctly.
 // TINY-11669
 
-An issue was identified where the `data-mce-style` attribute of an image was not updated correctly when its width and height were modified via user input.
+An issue was identified where the `style` attribute of an image was not updated correctly when its width and height were modified via user input.
 
-This was caused by triggering the resize function when the selection was somewhere else due to a debounce between the input and the resize, but the resize operation would be performed on the current selection.
+This occurred because the resize function was triggered while the selection was elsewhere, due to a debounce delay between the input and the resize operation. As a result, the resize operation was performed on the current selection instead of the intended image.
 
-This resulted in other editor components that contain the `data-mce-style` attribute accidentally reading outdated values, and the resize not being applied as the selection would not be on the image.
+This led to other editor components that rely on the `style` attribute accidentally reading outdated values, and the resize not being applied correctly since the selection was not on the image.
 
-{productname} {release-version} addresses this by updating the `data-mce-style` attribute accordingly when a resize operation is performed and the resize function takes the image as a parameter. 
-This ensures that all editor components that reference the `data-mce-style` attribute read the most recent value entered, and the resize operation is applied to the correct image even before the debounce time has elapsed.
+{productname} {release-version} resolves this issue by updating the `style` attribute appropriately whenever a resize operation is performed. The resize function now takes in the intended image as a parameter, ensuring that all editor components referencing the `style` attribute read the most recent value entered. Additionally, the resize operation is applied to the correct image, even before the debounce time elapses.
 
 For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Image Optimizer].
 

--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -104,7 +104,7 @@ For information on the **Enhanced Table** plugin, see: xref:advtable.adoc[Enhanc
 === Image Optimizer
 
 The {productname} {release-version} release includes an accompanying release of the **Image Optimizer** premium plugin.
-
+// TINY-11669
 **Image Optimizer** includes the following fixes.
 
 ==== Resizing images by typing into the input didn't update the `style` attribute correctly.

--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -110,7 +110,7 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== Resizing images by typing into the input didn't update the `style` attribute correctly.
 // TINY-11669
 
-An issue was identified where the `style` attribute of an image was not updated correctly when its width and height were modified via user input.
+An issue was identified where the internal custom `style` attribute of an image was not updated correctly when its width and height were modified via user input.
 
 This occurred because the resize function was triggered while the selection was elsewhere, due to a debounce delay between the input and the resize operation. As a result, the resize operation was performed on the current selection instead of the intended image.
 

--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -114,7 +114,7 @@ An issue was identified where the internal custom `style` attribute of an image 
 
 This occurred because the resize function was triggered while the selection was elsewhere, due to a debounce delay between the input and the resize operation. As a result, the resize operation was performed on the current selection instead of the intended image.
 
-This led to other editor components that rely on the `style` attribute accidentally reading outdated values, and the resize not being applied correctly since the selection was not on the image.
+This led to other editor components that rely on that custom `style` attribute accidentally reading outdated values, and the resize not being applied correctly since the selection was not on the image.
 
 {productname} {release-version} resolves this issue by updating that custom `style` attribute appropriately whenever a resize operation is performed. The resize function now takes in the intended image as a parameter, ensuring that all editor components referencing that custom `style` attribute read the most recent value entered. Additionally, the resize operation is applied to the correct image, even before the debounce time elapses.
 

--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -116,7 +116,7 @@ This occurred because the resize function was triggered while the selection was 
 
 This led to other editor components that rely on the `style` attribute accidentally reading outdated values, and the resize not being applied correctly since the selection was not on the image.
 
-{productname} {release-version} resolves this issue by updating the `style` attribute appropriately whenever a resize operation is performed. The resize function now takes in the intended image as a parameter, ensuring that all editor components referencing the `style` attribute read the most recent value entered. Additionally, the resize operation is applied to the correct image, even before the debounce time elapses.
+{productname} {release-version} resolves this issue by updating that custom `style` attribute appropriately whenever a resize operation is performed. The resize function now takes in the intended image as a parameter, ensuring that all editor components referencing that custom `style` attribute read the most recent value entered. Additionally, the resize operation is applied to the correct image, even before the debounce time elapses.
 
 For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Image Optimizer].
 

--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -110,13 +110,13 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== Resizing images by typing into the input didn't update the `style` attribute correctly.
 // TINY-11669
 
-An issue was identified where the internal custom `style` attribute of an image was not updated correctly when its width and height were modified via user input.
+An issue was identified where an internal custom `style` attribute of an image was not updated correctly after a user modified its width and height.
 
-This occurred because the resize function was triggered while the selection was elsewhere, due to a debounce delay between the input and the resize operation. As a result, the resize operation was performed on the current selection instead of the intended image.
+This issue occurred because the resize function was triggered while the selection focus was elsewhere, due to a debounce delay between the input and the resize operation. As a result, the resize operation was performed on the current selection instead of the intended image.
 
-This led to other editor components that rely on that custom `style` attribute accidentally reading outdated values, and the resize not being applied correctly since the selection was not on the image.
+This led to other editor components that rely on that custom `style` attribute to accidentally read outdated values, resulting in the resize not being applied correctly since the selection was not on the intended image.
 
-{productname} {release-version} resolves this issue by updating that custom `style` attribute appropriately whenever a resize operation is performed. The resize function now takes in the intended image as a parameter, ensuring that all editor components referencing that custom `style` attribute read the most recent value entered. Additionally, the resize operation is applied to the correct image, even before the debounce time elapses.
+{productname} {release-version} addresses this issue, by updating the custom `style` attribute appropriately whenever a resize operation is performed. The resize function now takes in the intended image as a parameter, ensuring that all editor components referencing that custom `style` attribute read the most recent value entered. Additionally, the resize operation is applied to the correct image, even before the debounce time elapses.
 
 For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Image Optimizer].
 

--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -104,10 +104,11 @@ For information on the **Enhanced Table** plugin, see: xref:advtable.adoc[Enhanc
 === Image Optimizer
 
 The {productname} {release-version} release includes an accompanying release of the **Image Optimizer** premium plugin.
-// TINY-11669
+
 **Image Optimizer** includes the following fixes.
 
 ==== Resizing images by typing into the input didn't update the `style` attribute correctly.
+// TINY-11669
 
 An issue was identified where the `data-mce-style` attribute of an image was not updated correctly when its width and height were modified via user input.
 


### PR DESCRIPTION
… attribute correctly.

Ticket: DOC-2609

Site: [Staging branch](http://docs-feature-761-doc-2609tiny-11669.staging.tiny.cloud/docs/tinymce/latest/7.6.1-release-notes/#resizing-images-by-typing-into-the-input-didnt-update-the-style-attribute-correctly)

Changes:
* Documented the bug fix for TINY-11669.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed