### PR TITLE
DOC-2609: Images with existing srcset were not handled correctly.

### DIFF
--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -101,6 +101,22 @@ In {productname} {release-version}, this issue has been resolved by ensuring the
 
 For information on the **Enhanced Table** plugin, see: xref:advtable.adoc[Enhanced Tables].
 
+=== Image Optimizer
+
+The {productname} {release-version} release includes an accompanying release of the **Image Optimizer** premium plugin.
+
+**Image Optimizer** includes the following fixes.
+
+==== Images with existing `srcset` were not handled correctly.
+
+An issue was identified where images with an existing `srcset` attribute containing an Uploadcare URL were being processed incorrectly.
+
+The problem occurred when attempting to update an `srcset` attribute that did not contain an Uploadcare URL. In such cases, no changes were applied, resulting in the image failing to update if the existing `srcset` had a different structure.
+
+{productname} {release-version} resolves this issue by exclusively targeting `srcset` attributes with Uploadcare URLs. This ensures that all relevant images are updated correctly, with the `srcset` being regenerated from scratch to incorporate any modifications made.
+
+For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Image Optimizer].
+
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement
 


### PR DESCRIPTION
Ticket: DOC-2609

Site: [Staging branch](http://docs-feature-761-doc-2609tiny-11653.staging.tiny.cloud/docs/tinymce/latest/7.6.1-release-notes/#images-with-existing-srcset-were-not-handled-correctly)

Changes:
* Documented the bug fix for TINY-11653.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed