### PR TITLE
DOC-2609: Error messages were not rendered correctly

### DIFF
--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -109,14 +109,13 @@ The {productname} {release-version} release includes an accompanying release of 
 **Import from Word** includes the following fixes.
 
 ==== Error messages were not rendered correctly
+// #TINY-11662
 
-In previous releases, an error occurring during the import of a Word document triggered an "Operation failed" toast notification featuring a bomb icon without a background. 
+In previous releases of the **Import from Word** premium plugin, an error occurring during the import process triggered an "Operation failed" notification that featured an incorrect icon and lacked the expected background. This design was inconsistent with the error notifications displayed by related plugins, such as the xref:exportpdf.adoc[Export to PDF] plugin and the xref:exportword.adoc[Export to Word] plugin, which use a red background and an exclamation mark to signify errors.
 
-This design was inconsistent with the error notifications displayed by related plugins, such as the xref:exportpdf.adoc[Export to PDF] plugin and the xref:exportword.adoc[Export to Word] plugin, which had a red background and an exclamation mark to signify errors.
+In {productname} {release-version}, this UI inconsistency has been resolved. Error notifications for the Word document import process now render correctly, aligning with the visual standards of related plugins.
 
-In {productname} {release-version}, this UI inconsistency has been resolved. Error notifications for the Word document import process now feature a red background and an exclamation mark, ensuring alignment with the error notification style used across other plugins in the editor.
-
-For information on the **Import from Word** plugin, see: xref:importword.adoc[Import from Word].
+For more information on the **Import from Word** plugin, see xref:importword.adoc[Import from Word].
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement

--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -101,6 +101,23 @@ In {productname} {release-version}, this issue has been resolved by ensuring the
 
 For information on the **Enhanced Table** plugin, see: xref:advtable.adoc[Enhanced Tables].
 
+=== Import from Word
+// #TINY-11662
+
+The {productname} {release-version} release includes an accompanying release of the **Import from Word** premium plugin.
+
+**Import from Word** includes the following fixes.
+
+==== Error messages were not rendered correctly
+
+In previous releases, an error occurring during the import of a Word document triggered an "Operation failed" toast notification featuring a bomb icon without a background. 
+
+This design was inconsistent with the error notifications displayed by related plugins, such as the xref:exportpdf.adoc[Export to PDF] plugin and the xref:exportword.adoc[Export to Word] plugin, which had a red background and an exclamation mark to signify errors.
+
+In {productname} {release-version}, this UI inconsistency has been resolved. Error notifications for the Word document import process now feature a red background and an exclamation mark, ensuring alignment with the error notification style used across other plugins in the editor.
+
+For information on the **Import from Word** plugin, see: xref:importword.adoc[Import from Word].
+
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement
 


### PR DESCRIPTION
Ticket: DOC-2609

Site: [Staging branch](http://docs-feature-761-doc-2609tiny-11662.staging.tiny.cloud/docs/tinymce/latest/7.6.1-release-notes/#error-messages-were-not-rendered-correctly)

Changes:
* Documented the bug fix for TINY-11662

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed