### PR TITLE
DOC-2609: Text input was prevented in form elements in the contents of the editor.

### DIFF
--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -187,7 +187,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Text input was prevented in form elements in the contents of the editor.
 // #TINY-11446
 
-Previously, an issue was identified in Google Chrome where text input was prevented within form elements, resulting in the inability to insert text into these elements.
+Previously, an issue was identified in Google Chrome and Microsoft Edge where text input was prevented within form elements, resulting in the inability to insert text into these elements.
 
 {productname} {release-version} addresses this issue, by updating the logic for handling text input on non-editable elements to include support for form elements. As a result, text can now be successfully inserted into form elements in Google Chrome.
 

--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -182,13 +182,14 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 [[bug-fixes]]
 == Bug fixes
 
-{productname} {release-version} also includes the following bug fix<es>:
+{productname} {release-version} also includes the following bug fixes:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Text input was prevented in form elements in the contents of the editor.
+// #TINY-11446
 
-// CCFR here.
+Previously, an issue was identified in Google Chrome where text input was prevented within form elements, resulting in the inability to insert text into these elements.
 
+This has been addressed in {productname} {release-version} by updating the logic for handling text input on non-editable elements to include support for form elements. As a result, text can now be successfully inserted into form elements in Google Chrome.
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -189,7 +189,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 Previously, an issue was identified in Google Chrome and Microsoft Edge where text input was prevented within form elements, resulting in the inability to insert text into these elements.
 
-{productname} {release-version} addresses this issue, by updating the logic for handling text input on non-editable elements to include support for form elements. As a result, text can now be successfully inserted into form elements in Google Chrome.
+{productname} {release-version} addresses this issue, by updating the logic for handling text input on non-editable elements to include support for form elements. As a result, text can now be successfully inserted into form elements in Google Chrome and Microsoft Edge.
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -189,7 +189,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 Previously, an issue was identified in Google Chrome where text input was prevented within form elements, resulting in the inability to insert text into these elements.
 
-This has been addressed in {productname} {release-version} by updating the logic for handling text input on non-editable elements to include support for form elements. As a result, text can now be successfully inserted into form elements in Google Chrome.
+{productname} {release-version} addresses this issue, by updating the logic for handling text input on non-editable elements to include support for form elements. As a result, text can now be successfully inserted into form elements in Google Chrome.
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-2609

Site: [Staging branch](http://docs-feature-761-doc-2609tiny-11446.staging.tiny.cloud/docs/tinymce/latest/7.6.1-release-notes/#text-input-was-prevented-in-form-elements-in-the-contents-of-the-editor)

Changes:
* Documented the bug fix for TINY-11446

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed