### PR TITLE
DOC-2609: Opening a notification when the toolbar is at the bottom threw an error.

### DIFF
--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -187,11 +187,11 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Opening a notification when the toolbar is at the bottom threw an error.
 // #TINY-11498
 
-An issue was previously identified in the inline mode editor where, if the toolbar was positioned at the bottom of the screen, a UI error occurred that rendered notifications non-functional after being opened.
+An issue was identified in the inline mode editor where, if the toolbar was positioned at the bottom of the screen, a UI error occurred that rendered notifications non-functional after being opened.
 
 This issue significantly impacted the user experience, preventing users from interacting with the notification interface effectively.
 
-{productname} {release-version} update resolves this issue by enhancing the notification positioning logic to account for the toolbar's location. This ensures notifications function seamlessly, regardless of the toolbar's placement on the screen.
+{productname} {release-version} resolves this issue by enhancing the notification positioning logic to account for the toolbar's location. Notifications now function seamlessly, regardless of the toolbar's placement on the screen.
 
 
 [[security-fixes]]

--- a/modules/ROOT/pages/7.6.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.6.1-release-notes.adoc
@@ -184,10 +184,14 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Opening a notification when the toolbar is at the bottom threw an error.
+// #TINY-11498
 
-// CCFR here.
+An issue was previously identified in the inline mode editor where, if the toolbar was positioned at the bottom of the screen, a UI error occurred that rendered notifications non-functional after being opened.
+
+This issue significantly impacted the user experience, preventing users from interacting with the notification interface effectively.
+
+{productname} {release-version} update resolves this issue by enhancing the notification positioning logic to account for the toolbar's location. This ensures notifications function seamlessly, regardless of the toolbar's placement on the screen.
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-2609

Site: [Staging branch](http://docs-feature-761-doc-2609tiny-11498.staging.tiny.cloud/docs/tinymce/latest/7.6.1-release-notes/#opening-a-notification-when-the-toolbar-is-at-the-bottom-threw-an-error)

Changes:
* Documented the bug fix for TINY-11498

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed