### PR TITLE
DOC-3130: Fixed spelling and link in table of contents plugin docs.

### DIFF
--- a/modules/ROOT/partials/configuration/tableofcontents_orderedlist.adoc
+++ b/modules/ROOT/partials/configuration/tableofcontents_orderedlist.adoc
@@ -7,7 +7,7 @@ The `+tableofcontents_orderedlist+` option allows Tables of Contents to be rende
 
 When the `+tableofcontents_orderedlist+` option is set to `+true+`, Tables of Contents are rendered as numeric ordered lists.
 
-To customise the type of ordered list, add the `+xref:tableofcontents_orderedlist_type[tableofcontents_orderedlist_type]+` option to the configuration.
+To customize the type of ordered list, add the xref:tableofcontents_orderedlist_type[tableofcontents_orderedlist_type] option to the configuration.
 
 *Type:* `+Boolean+`
 

--- a/modules/ROOT/partials/configuration/tableofcontents_orderedlist.adoc
+++ b/modules/ROOT/partials/configuration/tableofcontents_orderedlist.adoc
@@ -7,7 +7,7 @@ The `+tableofcontents_orderedlist+` option allows Tables of Contents to be rende
 
 When the `+tableofcontents_orderedlist+` option is set to `+true+`, Tables of Contents are rendered as numeric ordered lists.
 
-To customize the type of ordered list, add the xref:tableofcontents_orderedlist_type[tableofcontents_orderedlist_type] option to the configuration.
+To customize the type of ordered list, add the xref:tableofcontents_orderedlist_type[`+tableofcontents_orderedlist_type+`] option to the configuration.
 
 *Type:* `+Boolean+`
 

--- a/modules/ROOT/partials/configuration/tableofcontents_orderedlist.adoc
+++ b/modules/ROOT/partials/configuration/tableofcontents_orderedlist.adoc
@@ -7,7 +7,7 @@ The `+tableofcontents_orderedlist+` option allows Tables of Contents to be rende
 
 When the `+tableofcontents_orderedlist+` option is set to `+true+`, Tables of Contents are rendered as numeric ordered lists.
 
-To customize the type of ordered list, add the xref:tableofcontents_orderedlist_type[`+tableofcontents_orderedlist_type+`] option to the configuration.
+To customize the type of ordered list, add the xref:tableofcontents_orderedlist_type[tableofcontents_orderedlist_type] option to the configuration.
 
 *Type:* `+Boolean+`
 


### PR DESCRIPTION
Ticket: DOC-3130

Site: [Staging branch](http://docs-hotfix-7-doc-3130.staging.tiny.cloud/docs/tinymce/latest/tableofcontents/#tableofcontents_orderedlist)

Changes:
* Fixed spelling and link in table of contents docs for ordered list configuration.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed