### PR TITLE
DOC-1928: Clean up `partials/configuration` directory

### DIFF
--- a/modules/ROOT/pages/advanced-typography.adoc
+++ b/modules/ROOT/pages/advanced-typography.adoc
@@ -77,7 +77,7 @@ tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
   plugins: '{plugincode}',
   toolbar: '{plugincode}',
-  typography_default_lang: [ "en-US" ], // Required to set specific typography language rules.
+  typography_default_lang: 'en-US', // Required to set specific typography language rules.
 });
 ----
 

--- a/modules/ROOT/pages/customsidebar.adoc
+++ b/modules/ROOT/pages/customsidebar.adoc
@@ -18,42 +18,30 @@ When a new sidebar is registered, a corresponding toolbar button for toggling th
 
 === Specification object
 
-[[tooltip]]
-==== `+tooltip+`
+[cols="1,1,4", options="header"]
+|===
+| Property | Type | Description
 
-The `+tooltip+` specifies a tooltip to be displayed when hovering over the sidebar toggle button.
+| `+tooltip+`
+| `+String+`
+| Specifies a tooltip to be displayed when hovering over the sidebar toggle button.
 
-*Type:* `+String+`
+| `+icon+`
+| `+String+`
+| Specifies an icon for the sidebar toggle button. The icon should be the name of an icon provided by the {productname} skin or a xref:apis/tinymce.editor.ui.registry.adoc#addIcon[custom icon].
 
-[[icon]]
-==== `+icon+`
+| `+onSetup+`
+| `+Function+`
+| Specifies a function to be called when the panel is first created. It passes in an API object and should return a callback that takes an API. The default is `+(api) => (api) => {}+`. This function runs whenever the sidebar is rendered, and the returned callback is executed when the sidebar is destroyed. Therefore, the returned function is essentially an `+onTeardown+` handler, and can be used to unbind events and callbacks.
 
-The `+icon+` specifies an icon for the sidebar toggle button. The icon should be the name of an icon provided by the {productname} skin or a xref:apis/tinymce.editor.ui.registry.adoc#addIcon[custom icon].
+| `+onShow+`
+| `+Function+`
+| Specifies a function to be called when the panel is displayed. It passes in an API object.
 
-*Type:* `+String+`
-
-[[onSetup]]
-==== `+onSetup+`
-
-The `+onSetup+` specifies a function to be called when the panel is first created. It passes in an API object and should return a callback that takes an API. The default is `+(api) => (api) => {}+`.
-
-`+onSetup+` is a complex property. It requires a function that takes the sidebar’s API and should return a callback that takes the sidebar's API and returns nothing. This occurs because `+onSetup+` runs whenever the sidebar is rendered, and the returned callback is executed when the sidebar is destroyed. Therefore the returned function is essentially an `+onTeardown+` handler, and can be used to unbind events and callbacks.
-
-*Type:* `+Function+`
-
-[[onShow]]
-==== `+onShow+`
-
-The `+onShow+` specifies a function to be called when the panel displayed. It passes in an API object.
-
-*Type:* `+Function+`
-
-[[onHide]]
-==== `+onHide+`
-
-The `+onHide+` specifies a function to be called when the panel is hidden. It passes in an API object.
-
-*Type:* `+Function+`
+| `+onHide+`
+| `+Function+`
+| Specifies a function to be called when the panel is hidden. It passes in an API object.
+|===
 
 === API Object
 
@@ -72,7 +60,8 @@ include::partial$configuration/sidebar_show.adoc[leveloffset=+1]
 [source,js]
 ----
 tinymce.init({
-  ...
+  selector: 'textarea', // change this value according to your HTML
+  sidebar_show: 'mysidebar',
   toolbar: 'mysidebar',
   setup: (editor) => {
     editor.ui.registry.addSidebar('mysidebar', {

--- a/modules/ROOT/partials/configuration/advanced-typography.adoc
+++ b/modules/ROOT/partials/configuration/advanced-typography.adoc
@@ -73,7 +73,7 @@ This option sets which languages are available for applying language-specific ty
 
 A user can then select text and select from the available languages. That language’s language-specific typography rules are then applied to the selected text.
 
-*Type:* `+Object+`
+*Type:* `+Array+`
 
 === Example: Using `typography_langs`
 
@@ -161,7 +161,7 @@ tinymce.init({
 |Russian
 |ru
 
-|Servian
+|Serbian
 |sr
 
 |Slovak
@@ -203,7 +203,7 @@ tinymce.init({
   selector: 'textarea',  // change this value according to your html
   plugins: '{plugincode}',
   toolbar: '{plugincode}',
-  typography_default_lang: 'en_US', // This is required to configure the default language used by typography.
+  typography_default_lang: 'en-US', // This is required to configure the default language used by typography.
   typography_rules: [
     'common/punctuation/quote',
     'en-US/dash/main',

--- a/modules/ROOT/partials/configuration/advcode.adoc
+++ b/modules/ROOT/partials/configuration/advcode.adoc
@@ -5,9 +5,11 @@ include::partial$misc/admon-requires-6.3v.adoc[]
 
 As part of the {productname} 6.3 release, the {pluginname} plugin includes a new option, `advcode_inline`, that allows users to open the Enhanced Code Editor within {productname}’s existing editor space instead of being displayed in a separate dialog box.
 
-Type : `boolean`,
+*Type:* `+Boolean+`
 
-Default: false
+*Possible values:* `+true+`, `+false+`
+
+*Default value:* `+false+`
 
 == Example: basic setup
 
@@ -62,9 +64,9 @@ As part of the {productname} 7.3 release, the {pluginname} plugin includes a new
 
 By default, any code rendered inside **Enhanced Coded Editor** will be formatted with correct indentation.
 
-Type : `boolean`,
+*Type:* `+Boolean+`
 
-Default: `+true+`
+*Default value:* `+true+`
 
 *Possible values:* `+true+`, `+false+`
 

--- a/modules/ROOT/partials/configuration/anchor_bottom.adoc
+++ b/modules/ROOT/partials/configuration/anchor_bottom.adoc
@@ -3,7 +3,7 @@
 
 Lets you specify a custom name for the bottom anchor in the url type ahead drop down. To disable the bottom anchor from the drop down set it `+false+`.
 
-*Type:* `+String+`
+*Type:* `+String+` or `+false+`
 
 *Default value:* `+'#bottom'+`
 

--- a/modules/ROOT/partials/configuration/anchor_top.adoc
+++ b/modules/ROOT/partials/configuration/anchor_top.adoc
@@ -3,7 +3,7 @@
 
 Lets you specify a custom name for the top anchor in the url type ahead drop down. To disable the to anchor from the drop down set it `+false+`.
 
-*Type:* `+String+`
+*Type:* `+String+` or `+false+`
 
 *Default value:* `+'#top'+`
 

--- a/modules/ROOT/partials/configuration/auto_focus.adoc
+++ b/modules/ROOT/partials/configuration/auto_focus.adoc
@@ -1,16 +1,26 @@
 [[auto_focus]]
 == `+auto_focus+`
 
-Automatically set the focus to an editor instance. The value of this option should be an editor instance `+id+`. The editor instance id is the id for the original `+textarea+` or `+div+` element that got replaced.
+Automatically set the focus to an editor instance. The value of this option should be an editor instance `+id+`. The editor instance id is the id for the original `+textarea+` or `+div+` element that got replaced. If you set this option to `+true+`, the focus will be set to the last initialized editor instance.
 
-*Type:* `+String+`
+*Type:* `+String+` or `+true+`
 
-=== Example: using `+auto_focus+`
+=== Example: using `+auto_focus+` with custom `+id+`
 
 [source,js]
 ----
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
   auto_focus: 'element1'
+});
+----
+
+=== Example: using `+auto_focus+` with `+true+`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  auto_focus: true
 });
 ----

--- a/modules/ROOT/partials/configuration/autoresize_bottom_margin.adoc
+++ b/modules/ROOT/partials/configuration/autoresize_bottom_margin.adoc
@@ -5,6 +5,8 @@ This option allows you to specify the size of the `+padding+` at the bottom of t
 
 *Type:* `+Number+`
 
+*Default value:* `+50+`
+
 === Example: using `+autoresize_bottom_margin+`
 
 [source,js]

--- a/modules/ROOT/partials/configuration/autoresize_overflow_padding.adoc
+++ b/modules/ROOT/partials/configuration/autoresize_overflow_padding.adoc
@@ -5,6 +5,8 @@ This option allows you to specify the size of the `+padding+` at the sides of th
 
 *Type:* `+Number+`
 
+*Default value:* `+1+`
+
 === Example: `+autoresize_overflow_padding+`
 
 [source,js]

--- a/modules/ROOT/partials/configuration/autosave_prefix.adoc
+++ b/modules/ROOT/partials/configuration/autosave_prefix.adoc
@@ -5,7 +5,7 @@ This option allows you to set the prefix that is used for local storage keys.
 
 *Type:* `+String+`
 
-*Default value:* `+'tinymce-autosave-{path}{query}-{id}-'+`
+*Default value:* `+'tinymce-autosave-{path}{query}{hash}-{id}-'+`
 
 === Example: using `+autosave_prefix+`
 
@@ -14,6 +14,6 @@ This option allows you to set the prefix that is used for local storage keys.
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
   plugins: 'autosave',
-  autosave_prefix: 'tinymce-autosave-{path}{query}-{id}-'
+  autosave_prefix: 'tinymce-autosave-{path}{query}{hash}-{id}-'
 });
 ----

--- a/modules/ROOT/partials/configuration/browser_spellcheck.adoc
+++ b/modules/ROOT/partials/configuration/browser_spellcheck.adoc
@@ -19,4 +19,4 @@ tinymce.init({
 });
 ----
 
-For more information about spell checking in {productname}, see xref:spell-checking.adoc[this page] in the General-configuration-guide/ guide.
+For more information about spell checking in {productname}, refer to xref:spell-checking.adoc[Spell Checking in {productname}].

--- a/modules/ROOT/partials/configuration/comments-tinycomments_access.adoc
+++ b/modules/ROOT/partials/configuration/comments-tinycomments_access.adoc
@@ -3,7 +3,9 @@
 
 *Type:* `+String+`
 
-*Possible values:* `'comment'`
+*Possible values:* `+'full'+`, `'comment'`
+
+*Default value:* `+'full'+`
 
 This option sets the editor to the readonly mode, while still allowing comments to be made. 
 

--- a/modules/ROOT/partials/configuration/content_css.adoc
+++ b/modules/ROOT/partials/configuration/content_css.adoc
@@ -5,6 +5,8 @@ The `+content_css+` option loads the specified CSS files into the editable area.
 
 *Type:* `+String+`, `+Array+`
 
+*Default value:* `+['default']+` for classic mode, `+[]+` for inline mode
+
 NOTE: This option is intended for use with {productname}'s classic mode, as the editable area is sandboxed within an iframe. For inline mode editors, relevant CSS stylesheets should be loaded as part of the webpage {productname} is rendered in, not using the `+content_css+` option.
 
 include::partial$misc/shipped-content-css.adoc[]

--- a/modules/ROOT/partials/configuration/custom_elements.adoc
+++ b/modules/ROOT/partials/configuration/custom_elements.adoc
@@ -5,7 +5,7 @@ This option enables you to specify non-HTML elements for the editor.
 
 This way you can handle non-HTML elements inside an HTML editor. You can prefix the element names with a `+~+` if you want the element to behave as a `+span+` element and not a `+div+` element.
 
-*Type:* `+String+`
+*Type:* `+String+` or `+Object+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/custom_ui_selector.adoc
+++ b/modules/ROOT/partials/configuration/custom_ui_selector.adoc
@@ -7,13 +7,16 @@ Use the *custom_ui_selector* option to specify the elements that you want {produ
 
 === Example: using `+custom_ui_selector+`
 
-[source,html]
+[source,js]
 ----
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
   custom_ui_selector: '.my-custom-button'
 });
-...
+----
+
+[source,html]
+----
 <textarea></textarea>
 <button class="my-custom-button">Button</button>
 ----

--- a/modules/ROOT/partials/configuration/dialog_streamContent.adoc
+++ b/modules/ROOT/partials/configuration/dialog_streamContent.adoc
@@ -1,5 +1,5 @@
 [[streamContent]]
-== `streamContent`
+=== `streamContent`
 
 `+streamContent+` is an optional property, available to add to the `+iframe+` dialog component.
 
@@ -64,7 +64,7 @@ The recommended method for updating content in an `+iframe+` component is:
 
 [source,js]
 ----
-`onAction: (api) => api.setData({ myiframe: 'new content' })`
+onAction: (api) => api.setData({ myiframe: 'new content' })
 ----
 
 . This updates the iframe to contain the string `'new content'`. This text can be any valid html.

--- a/modules/ROOT/partials/configuration/directionality.adoc
+++ b/modules/ROOT/partials/configuration/directionality.adoc
@@ -7,7 +7,7 @@ This option allows you to set the base direction of directionally neutral text (
 
 *Type:* `+String+`
 
-*Default value:* `+'ltr'+`
+*Default value:* `+'ltr'+` for left-to-right languages, `+'rtl'+` for right-to-left languages.
 
 *Possible values:* `+'ltr'+`, `+'rtl'+`
 

--- a/modules/ROOT/partials/configuration/doctype.adoc
+++ b/modules/ROOT/partials/configuration/doctype.adoc
@@ -3,4 +3,21 @@
 
 Set the `+doctype+` for the editing area.
 
-WARNING: Changing the `+doctype+` can have different effects on different browsers and may introduce quirks. Use this feature only if you know what you are doing. For more information on doctypes, go to https://www.w3.org/wiki/Doctypes_and_markup_styles[this link].
+[WARNING]
+====
+Changing the `+doctype+` can have different effects on different browsers and may introduce quirks. Use this feature only if you know what you are doing. For more information on doctypes, refer to https://www.w3.org/wiki/Doctypes_and_markup_styles[W3C - Doctypes and markup styles].
+====
+
+*Type:* `+String+`
+
+*Default value:* `+'<!DOCTYPE html>'+`
+
+=== Example: using `doctype`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  doctype: '<!DOCTYPE html>'
+});
+----

--- a/modules/ROOT/partials/configuration/editimage_fetch_image.adoc
+++ b/modules/ROOT/partials/configuration/editimage_fetch_image.adoc
@@ -3,7 +3,7 @@
 
 This option can be used to define a custom fetch function, which provides another way to access images in complex situations. The function will be passed the HTML element of the image to be fetched and should return a `+Promise+` containing a `+Blob+` representation of the image.
 
-*Type:* `+Function+`
+*Type:* `+Function+` (Returns a https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise[Promise])
 
 === Example: using `+editimage_fetch_image+`
 

--- a/modules/ROOT/partials/configuration/exportword_converter_options.adoc
+++ b/modules/ROOT/partials/configuration/exportword_converter_options.adoc
@@ -11,7 +11,7 @@ As of {productname} 7.5.0, the default value of the `exportword_converter_option
 .**Default value:**
 [source,js]
 ----
-exportword_converter_options: {
+{
   document: {
     size: 'letter'
   }

--- a/modules/ROOT/partials/configuration/fix_list_elements.adoc
+++ b/modules/ROOT/partials/configuration/fix_list_elements.adoc
@@ -12,8 +12,8 @@ This invalid list:
     <ol>
       <li>b</li>
       <li>c</li>
-   </ol>
-    <li>e</li>
+    </ol>
+  <li>e</li>
 </ol>
 ----
 

--- a/modules/ROOT/partials/configuration/importword_converter_options.adoc
+++ b/modules/ROOT/partials/configuration/importword_converter_options.adoc
@@ -1,7 +1,7 @@
 [[importword-converter-options]]
 == `importword_converter_options`
 
-**Type:** `String`
+**Type:** `+Object+`
 
 [NOTE]
 As of {productname} 7.5.0, the default value of the `importword_converter_options` setting has been updated to the following:
@@ -9,7 +9,7 @@ As of {productname} 7.5.0, the default value of the `importword_converter_option
 .**Default value:** 
 [source,js]
 ----
-importword_converter_options: {
+{
   formatting: {
     styles: 'inline',
     resets: 'inline',

--- a/modules/ROOT/partials/configuration/indentation.adoc
+++ b/modules/ROOT/partials/configuration/indentation.adoc
@@ -3,8 +3,6 @@
 
 This option allows specification of the indentation level for indent/outdent buttons in the UI.
 
-The *indentation* option defaults to 30px but can be any value.
-
 *Type:* `+String+`
 
 *Default value:* `+'40px'+`

--- a/modules/ROOT/partials/configuration/inline-css.adoc
+++ b/modules/ROOT/partials/configuration/inline-css.adoc
@@ -2,9 +2,9 @@
 
 Determines whether it is valid for a given CSS selector to have its CSS properties inlined into the HTML content.
 
-Default: All selectors are considered valid to have their CSS inlined.
+*Default value:* All selectors are considered valid to have their CSS inlined.
 
-Type: `String` `RegExp` or `Function`
+*Type:* `+String+`, `+RegExp+` or `+Function+`
 
 [source,ts]
 ----
@@ -17,9 +17,9 @@ inlinecss_selector_filter: (selector: string): boolean => {
 
 Determines whether it is valid for a given CSS stylesheet to have its CSS inspected and inlined into the HTML content.
 
-Default: All CSS stylesheet are considered valid to have their CSS inspected and inlined.
+*Default value:* All CSS stylesheet are considered valid to have their CSS inspected and inlined.
 
-Type: `String` `RegExp` or `Function`
+*Type:* `+String+`, `+RegExp+` or `+Function+`
 
 [source,ts]
 ----

--- a/modules/ROOT/partials/configuration/inline_boundaries_selector.adoc
+++ b/modules/ROOT/partials/configuration/inline_boundaries_selector.adoc
@@ -1,13 +1,13 @@
 [[inline_boundaries_selector]]
 == `+inline_boundaries_selector+`
 
-This option allows you specify what elements the inline boundaries should apply to. This defaults to `+a[href],code,.mce-annotation+` but can be extended to include other inline elements such as `+b+`, `+strong+`, `+i+`, and `+em+`.
+This option allows you specify what elements the inline boundaries should apply to. This defaults to `+'a[href],code,span.mce-annotation'+` but can be extended to include other inline elements such as `+b+`, `+strong+`, `+i+`, and `+em+`.
 
 If you add new elements, you need to add CSS selectors for them in the content CSS. See the xref:editor-content-css.adoc[Boilerplate Content CSS page] for details.
 
 *Type:* `+String+`
 
-*Default value:* `+'a[href],code,.mce-annotation'+`
+*Default value:* `+'a[href],code,span.mce-annotation'+`
 
 === Example: using `+inline_boundaries_selector+`
 

--- a/modules/ROOT/partials/configuration/insert_toolbar.adoc
+++ b/modules/ROOT/partials/configuration/insert_toolbar.adoc
@@ -5,7 +5,7 @@ The *quickbars_insert_toolbar* option configures the Quick Insert toolbar provid
 
 To disable the Quick Insert toolbar, set `+quickbars_insert_toolbar+` to `+false+`.
 
-*Type:* `+String+`
+*Type:* `+String+` or `+false+`
 
 *Default value:* `+'quickimage quicktable'+`
 

--- a/modules/ROOT/partials/configuration/invalid_styles.adoc
+++ b/modules/ROOT/partials/configuration/invalid_styles.adoc
@@ -6,11 +6,9 @@ This option enables you to restrict the styles that are valid for specific eleme
 * *String format* - This is a list of global styles to disallow.
 * *Object format* - This is a more complex format in which you can specify invalid styles for individual elements.
 
-=== Simple global classes
-
 *Type:* `+String+`, `+Object+`
 
-==== Example: using `+invalid_styles+` string
+=== Example: using `+invalid_styles+` string for global classes
 
 [source,js]
 ----
@@ -20,11 +18,7 @@ tinymce.init({
 });
 ----
 
-=== Element specific classes
-
-*Type:* `+String+`, `+Object+`
-
-==== Example: using `+invalid_styles+` object
+=== Example: using `+invalid_styles+` object for element specific classes
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/mentions_selector.adoc
+++ b/modules/ROOT/partials/configuration/mentions_selector.adoc
@@ -3,7 +3,9 @@
 
 This option enables you to provide a custom CSS selector that should match the element created using `+mentions_menu_complete+`. This enables the plugin to find existing mentions. The callback takes two parameters: the editor instance and the userInfo object.
 
-*Type:* `+Function+`
+*Type:* `+String+`
+
+*Default value:* `+.mention+`
 
 === Example: using `+mentions_selector+`
 

--- a/modules/ROOT/partials/configuration/menu.adoc
+++ b/modules/ROOT/partials/configuration/menu.adoc
@@ -10,7 +10,7 @@ To group certain menu items, insert a `+|+` pipe character between the menu item
 *Type:* `+Object+`
 
 [[example-the-tinymce-default-menu-items]]
-=== Example: the TinyMCE Default Menu Items
+=== Example: the {productname} Default Menu Items
 
 include::partial$configuration/defaultmenuitems.adoc[]
 

--- a/modules/ROOT/partials/configuration/menubar.adoc
+++ b/modules/ROOT/partials/configuration/menubar.adoc
@@ -7,7 +7,7 @@ To define the menus on {productname}'s menu bar, provide the menubar option with
 
 *Type:* `+String+` or `+Boolean+`
 
-*Default value:* `+true+`
+*Default value:* `+true+` for desktop and `+false+` for mobile
 
 *Possible values:* `+true+`, `+false+`, or `+string+` of menus
 

--- a/modules/ROOT/partials/configuration/nonbreaking_force_tab.adoc
+++ b/modules/ROOT/partials/configuration/nonbreaking_force_tab.adoc
@@ -1,7 +1,9 @@
 [[nonbreaking_force_tab]]
 == `+nonbreaking_force_tab+`
 
-This option allows you to force {productname} to insert three `+&nbsp;+` entities when the user presses the keyboard `+tab+` key.
+This option allows you to force {productname} to insert a specified number of `+&nbsp;+` entities when the user presses the keyboard `+tab+` key.
+
+When set to `+true+`, it will insert three `+&nbsp;+` entities. When set to a number, it will insert that many `+&nbsp;+` entities.
 
 It's important to note that this does not change the behavior of the menu and toolbar controls, which will continue to insert a single `+&nbsp+` entity when `+nonbreaking_force_tab+` value is `+true+`.
 
@@ -16,11 +18,11 @@ The `+nonbreaking_force_tab+` setting can break the following functionality:
 * The `+lists+` plugin uses the Tab key for item indentation.
 ====
 
-*Type:* `+Boolean+`
+*Type:* `+Boolean+` or `+Number+`
 
 *Default value:* `+false+`
 
-*Possible values:* `+true+`, `+false+`
+*Possible values:* `+true+`, `+false+`, or any positive number
 
 === Example: using `+nonbreaking_force_tab+`
 

--- a/modules/ROOT/partials/configuration/noneditable_regexp.adoc
+++ b/modules/ROOT/partials/configuration/noneditable_regexp.adoc
@@ -5,7 +5,7 @@ This option is used to specify a regular expression or array of regular expressi
 
 NOTE: If elements are matched by the regular expression, the elements will be replaced with spans. Use xref:noneditable_class[`+noneditable_class+`] for elements.
 
-*Type:* `+String+`
+*Type:* `+RegExp+` or `+Array+` of `+RegExp+`
 
 === Example: using `+noneditable_regexp+`
 

--- a/modules/ROOT/partials/configuration/object_resizing.adoc
+++ b/modules/ROOT/partials/configuration/object_resizing.adoc
@@ -3,17 +3,15 @@
 
 This options allows you to turn on/off the resizing handles on images, tables or media objects. This option is enabled by default and allows you to resize table and images. You can also specify a CSS3 selector of what you want to enable resizing on.
 
-=== Disable all resizing of images/tables
-
 *Type:* `+Boolean+`, `+String+`
 
-*Default value:* `+true+`
+*Default value:* `+'table,img,figure.image,div,video,iframe'+` on desktop, `+false+` on mobile
 
 *Possible values:* `+true+`, `+false+`, or a valid CSS selector
 
 include::partial$misc/admon-different-default-for-mobile.adoc[]
 
-==== Example: disable object resizing
+=== Example: disable all object resizing
 
 [source,js]
 ----
@@ -23,15 +21,7 @@ tinymce.init({
 });
 ----
 
-=== Enable resizing on images only
-
-*Type:* `+Boolean+`, `+String+`
-
-*Default value:* `+true+`
-
-*Possible values:* `+true+`, `+false+`, `+img+`
-
-==== Example: enable object resizing for images
+=== Example: enable object resizing for images only
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/pagebreak_separator.adoc
+++ b/modules/ROOT/partials/configuration/pagebreak_separator.adoc
@@ -1,6 +1,8 @@
 [[pagebreak_separator]]
 == `+pagebreak_separator+`
 
+The `+pagebreak_separator+` option allows you to specify the separator string that will be used to identify page breaks in the content.
+
 *Type:* `+String+`
 
 *Default value:* `+'<!-- pagebreak -->'+`

--- a/modules/ROOT/partials/configuration/powerpaste_allow_local_images.adoc
+++ b/modules/ROOT/partials/configuration/powerpaste_allow_local_images.adoc
@@ -10,3 +10,14 @@ When set to `+true+`, Base64 encoded images using a data URI in the copied conte
 *Possible values:* `+true+`, `+false+`
 
 NOTE: If you configure *_PowerPaste_* to allow local images, you can have {productname} automatically upload Base64 encoded images for conversion back to a standard image as described on the xref:upload-images.adoc[image upload documentation].
+
+=== Example: disable local images
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  plugins: 'powerpaste',
+  powerpaste_allow_local_images: false
+});
+----

--- a/modules/ROOT/partials/configuration/powerpaste_googledocs_import.adoc
+++ b/modules/ROOT/partials/configuration/powerpaste_googledocs_import.adoc
@@ -5,8 +5,6 @@ This option controls how content pasted from Google Docs is filtered.
 
 *Type:* `+String+` or `+Function+`
 
-*Possible values:* `+'clean'+`, `+'merge'+`, `+'prompt'+`, or a function that returns a `+Promise+` that resolves to `+'clean'+` or `+'merge'+`
-
 *Default value:* `+'prompt'+`
 
 include::partial$plugins/powerpaste_import_types.adoc[]

--- a/modules/ROOT/partials/configuration/powerpaste_googledocs_import.adoc
+++ b/modules/ROOT/partials/configuration/powerpaste_googledocs_import.adoc
@@ -5,6 +5,8 @@ This option controls how content pasted from Google Docs is filtered.
 
 *Type:* `+String+` or `+Function+`
 
+*Possible values:* `+'clean'+`, `+'merge'+`, `+'prompt'+`, or a function that returns a `+Promise+` that resolves to `+'clean'+` or `+'merge'+`
+
 *Default value:* `+'prompt'+`
 
 include::partial$plugins/powerpaste_import_types.adoc[]

--- a/modules/ROOT/partials/configuration/powerpaste_html_import.adoc
+++ b/modules/ROOT/partials/configuration/powerpaste_html_import.adoc
@@ -7,7 +7,7 @@ This option controls how content pasted from sources other than Microsoft Word a
 
 *Default value:* `+'clean'+`
 
-*Possible values:* `+'clean'+`, `+'merge'+`, `+'prompt'+`, or a function that returns a `+Promise+` that resolves to `+'clean'+` or `+'merge'+`
+include::partial$plugins/powerpaste_import_types.adoc[]
 
 What the supported string-based values do:
 

--- a/modules/ROOT/partials/configuration/powerpaste_html_import.adoc
+++ b/modules/ROOT/partials/configuration/powerpaste_html_import.adoc
@@ -3,15 +3,15 @@
 
 This option controls how content pasted from sources other than Microsoft Word and Google Docs are filtered.
 
-*Type:* `+String+`
+*Type:* `+String+` or `+Function+`
 
 *Default value:* `+'clean'+`
 
-*Possible values:* `+'clean'+`, `+merge+`, `+prompt+`
+*Possible values:* `+'clean'+`, `+'merge'+`, `+'prompt'+`, or a function that returns a `+Promise+` that resolves to `+'clean'+` or `+'merge'+`
 
 What the supported string-based values do:
 
-[cols="1,1"]
+[cols="1,4"]
 |===
 |Value |Behavior
 

--- a/modules/ROOT/partials/configuration/powerpaste_word_import.adoc
+++ b/modules/ROOT/partials/configuration/powerpaste_word_import.adoc
@@ -5,8 +5,6 @@ This option controls how content pasted from Microsoft Word is filtered.
 
 *Type:* `+String+` or `+Function+`
 
-*Possible values:* `+'clean'+`, `+'merge'+`, `+'prompt'+`, or a function that returns a `+Promise+` that resolves to `+'clean'+` or `+'merge'+`
-
 *Default value:* `+'prompt'+`
 
 include::partial$plugins/powerpaste_import_types.adoc[]

--- a/modules/ROOT/partials/configuration/powerpaste_word_import.adoc
+++ b/modules/ROOT/partials/configuration/powerpaste_word_import.adoc
@@ -5,6 +5,8 @@ This option controls how content pasted from Microsoft Word is filtered.
 
 *Type:* `+String+` or `+Function+`
 
+*Possible values:* `+'clean'+`, `+'merge'+`, `+'prompt'+`, or a function that returns a `+Promise+` that resolves to `+'clean'+` or `+'merge'+`
+
 *Default value:* `+'prompt'+`
 
 include::partial$plugins/powerpaste_import_types.adoc[]

--- a/modules/ROOT/partials/configuration/resize.adoc
+++ b/modules/ROOT/partials/configuration/resize.adoc
@@ -10,7 +10,7 @@ When resizing is enabled, the editor can be resized by either:
 
 *Type:* `+Boolean+` or `+String+`
 
-*Default value:* `+true+`
+*Default value:* `+true+` for desktop, `+false+` for mobile
 
 *Possible values:* `+true+`, `+false+`, `+'both'+`
 

--- a/modules/ROOT/partials/configuration/revisionhistory_fetch.adoc
+++ b/modules/ROOT/partials/configuration/revisionhistory_fetch.adoc
@@ -22,7 +22,7 @@ The {pluginname} plugin does not sort results before displaying them, allowing i
 
 [source,js]
 ----
-const revisions = [
+[
   {
     revisionId: '3',
     createdAt: '2023-11-29T10:11:21.578Z',

--- a/modules/ROOT/partials/configuration/selection_toolbar.adoc
+++ b/modules/ROOT/partials/configuration/selection_toolbar.adoc
@@ -5,7 +5,7 @@ The *quickbars_selection_toolbar* option configures the Quick Selection toolbar 
 
 To disable the Quick Selection toolbar, set `+quickbars_selection_toolbar+` to `+false+`.
 
-*Type:* `+String+`
+*Type:* `+String+` or `+false+`
 
 *Default value:* `+'bold italic | quicklink h2 h3 blockquote'+`
 

--- a/modules/ROOT/partials/configuration/table_grid.adoc
+++ b/modules/ROOT/partials/configuration/table_grid.adoc
@@ -9,7 +9,7 @@ NOTE: To configure the Table menu to include both the table picker and the table
 
 *Type:* `+Boolean+`
 
-*Default value:* `+true+`
+*Default value:* `+true+` on desktop, `+false+` on mobile
 
 *Possible values:* `+true+`, `+false+`
 

--- a/modules/ROOT/partials/configuration/tableofcontents_header.adoc
+++ b/modules/ROOT/partials/configuration/tableofcontents_header.adoc
@@ -1,9 +1,11 @@
 [[tableofcontents_header]]
 == `+tableofcontents_header+`
 
-Table of contents has a header and by default it will be marked up with `+H2+` tag. With the `+tableofcontents_header+` option you can change it to some other tag.
+Table of contents has a header and by default it will be marked up with `+H2+` tag. With the `+tableofcontents_header+` option you can change it to any other header tag.
 
 *Type:* `+String+`
+
+*Possible values:* `+'h1'+`, `+'h2'+`, `+'h3'+`, `+'h4'+`, `+'h5'+`, `+'h6'+`
 
 *Default value:* `+'h2'+`
 
@@ -15,6 +17,6 @@ tinymce.init({
   selector: 'textarea', // change this value according to your HTML
   plugins: 'tableofcontents',
   toolbar: 'tableofcontents',
-  tableofcontents_header: 'div' // case doesn't matter
+  tableofcontents_header: 'h3' // case doesn't matter
 });
 ----

--- a/modules/ROOT/partials/configuration/text_color.adoc
+++ b/modules/ROOT/partials/configuration/text_color.adoc
@@ -246,13 +246,13 @@ tinymce.init({
 
 [IMPORTANT]
 .End-user customisation of text color grids
-----
+====
 When end-users add a new custom color via a text color grid, that color is added to the associated text color grid but the new custom color is only held in the host browser’s local storage.
 
 If, for example, an end-user adds a custom color to the foreground text color grid, that new color is presented in the foreground text color grid in the end-user’s {productname} instance. The new custom color is not, however, stored in any of the instance’s color map arrays.
 
 Also, when a user adds a custom color to one palette (for example, the `color_map_background` palette), the {productname} editor instance does not replicate the new custom color in the complementary palette (for example, the `color_map_foreground` palette).
-----
+====
 
 
 [[color_default_background]]

--- a/modules/ROOT/partials/configuration/text_patterns.adoc
+++ b/modules/ROOT/partials/configuration/text_patterns.adoc
@@ -21,7 +21,7 @@ The default value for this option was changed with {productname} 7.0, see more x
 *Default value:*
 [source,js]
 ----
-default: [
+[
   { start: '*', end: '*', format: 'italic' },
   { start: '**', end: '**', format: 'bold' },
   { start: '#', format: 'h1', trigger: 'space' },
@@ -37,6 +37,7 @@ default: [
   { start: '---', cmd: 'InsertHorizontalRule', trigger: 'space' }
 ]
 ----
+
 [TIP]
 When the `text_patterns` option is set in the TinyMCE editor configuration, the new value entirely overwrites the existing default text patterns. This means that the editor will use the patterns specified in the user's configuration and ignore the default patterns. If one wants to add new patterns without losing the default ones, all the default patterns must be included in the custom `text_patterns` array along with any additional patterns.
 

--- a/modules/ROOT/partials/configuration/toolbar_mode.adoc
+++ b/modules/ROOT/partials/configuration/toolbar_mode.adoc
@@ -27,7 +27,7 @@ The toolbar modes are not available when using xref:toolbar-configuration-option
 
 *Type:* `+String+`
 
-*Default value:* `+'floating'+`
+*Default value:* `+'floating'+` for desktop and `+'scrolling'+` for mobile
 
 *Possible values:* `+'floating'+`, `+'sliding'+`, `+'scrolling'+`, or `+'wrap'+`
 

--- a/modules/ROOT/partials/configuration/video_template_callback.adoc
+++ b/modules/ROOT/partials/configuration/video_template_callback.adoc
@@ -3,7 +3,7 @@
 
 This option allows you to specify the function that will return the HTML embed code of the video media that you are attempting to insert into {productname}.
 
-*Type:* `+String+`
+*Type:* `+Function+`
 
 === Example: using `+video_template_callback+`
 

--- a/modules/ROOT/partials/events/accordion-events.adoc
+++ b/modules/ROOT/partials/events/accordion-events.adoc
@@ -3,6 +3,6 @@ The following events are provided by the xref:accordion.adoc[Accordion plugin].
 [cols="1,1,2",options="header"]
 |===
 |Name |Data |Description
-|ToggledAccordion |Passes the state — `+true+` or `~+false+` — and the element. |Fired when an accordion is toggled.
-|ToggledAllAccordions |Passes the state — `+true+`, `~+false+`, or undefined — and all the affected elements. |Fired when all accordions are toggled.
+|ToggledAccordion |Passes the state — `+true+` or `+false+` — and the element. |Fired when an accordion is toggled.
+|ToggledAllAccordions |Passes the state — `+true+`, `+false+`, or undefined — and all the affected elements. |Fired when all accordions are toggled.
 |===


### PR DESCRIPTION
Ticket: DOC-1928

Site: [Staging branch](http://docs-hotfix-7-doc-19283.staging.tiny.cloud/docs/tinymce/latest/)

I recreated the original PR and retained only the essential changes that are fixing something with factual inaccuracy or visual bug. This PR is oly 46 files with small changes in each, so it is easier to review. All changes in this PR have been visually checked for correction using a side-by-side comparison between `tinymce/7` and `hotfix/7/DOC-1928_3`.

Changes:
* Fix basic setup example for Typography plugin
* Refactor custom sidebar spec object into a table
* Fix incomplete `sidebar_show` code example
* Change `typography_langs` type from Object to Array
* Fix language name typo `Servian` to `Serbian`
* Add missing `false` type to `anchor_bottom` and `anchor_top`
* Add missing `true` type to `auto_focus`
* Add missing code example for `auto_focus: true`
* Add missing default value for `autoresize_bottom_margin`
* Add missing default value for `autoresize_overflow_padding`
* Add missing possible and default value `full` for `tinycomments_access`
* Add missing default value for `content_css`
* Add missing Object type for `custom_elements`
* Fix incomplete code example for `custom_ui_selector`
* Fix incomplete default value for `directionality`
* Add missing type, default value, and code example for `doctype`
* Fix incorrect type for `importword_converter_options` from String to Object
* Remove incorrect sentence from `indentation` about the default value
* Add missing `false` type for insert_toolbar`
* Fix incorrect type for `mentions_selector` from Function to String and add default value
* Add missing Number type for `nonbreaking_force_tab`
* Fix incorrect type for `noneditable_regexp` from String to RegExp
* Fix incomplete default value for `object_resizing`
* Add missing description for `pagebreak_separator`
* Add missing code example for `powerpaste_allow_local_images`
* Add missing Function type for `powerpaste_html_import`
* Fix incomplete default value for `resize`
* Add missing `false` type for selection_toolbar`
* Fix incomplete default value for `table_grid`
* Fix incorrect description and code example for `tableofcontents_header`
* Fix broken example block in `text_color.adoc`
* Fix incomplete default value for `toolbar_mode`
* Fix incorrect type for `video_templete_callback` from String to Function

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [-] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [-] Included a `release note` entry for any `New product features`.
- [-] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [ ] Documentation Team Lead has reviewed