### PR TITLE
DOC-3132: Preview Dialog incorrectly opened anchor links in a new tab.

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -64,11 +64,15 @@ For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Preview Dialog incorrectly opened anchor links in a new tab.
+// #TINY-11740
 
-// CCFR here.
+In previous versions of {productname}, an issue was identified in dialogs (e.g., Preview) where anchor links behaved inconsistently when clicked in the editor.
 
+The problem was that clicking an anchor link in a dialog caused the editor to attempt to open the link in a new browser tab. This behavior differed from the expected functionality in the editor, where clicking an anchor link navigates to the corresponding anchor element. 
+This resulted in a poor user experience as users could not engage with anchor links as expected.
+
+{productname} {release-version} resolves this issue by first checking whether a link is an anchor link and ensuring that users are navigated to the corresponding anchor element, which is the expected behavior.
 
 [[known-issues]]
 == Known issues

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -67,7 +67,7 @@ For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode
 === Preview Dialog incorrectly opened anchor links in a new tab.
 // #TINY-11740
 
-In previous versions of {productname}, an issue was identified in dialogs (e.g., Preview) where anchor links behaved inconsistently when clicked in the editor.
+In earlier versions of {productname}, an issue was identified in dialogs like the Preview dialog, where anchor links behaved inconsistently when clicked within the editor.
 
 The problem was that clicking an anchor link in a dialog caused the editor to attempt to open the link in a new browser tab. This behavior differed from the expected functionality in the editor, where clicking an anchor link navigates to the corresponding anchor element. 
 This resulted in a poor user experience as users could not engage with anchor links as expected.


### PR DESCRIPTION
Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11740.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#preview-dialog-incorrectly-opened-anchor-links-in-a-new-tab)

Changes:
* Documented the bug fix for TINY-11740.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed