### PR TITLE
DOC-3132: Serbian and Ukrainian languages were spelled incorrectly.

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -24,17 +24,20 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
-=== <Premium plugin name 1> <Premium plugin name 1 version>
+=== Advanced Typography
 
-The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+The {productname} {release-version} release includes an accompanying release of the **Advanced Typography** premium plugin.
 
-**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+**Advanced Typography** includes the following fix.
 
-==== <Premium plugin name 1 change 1>
+=== Serbian and Ukrainian languages were spelled incorrectly.
+// #TINY-11713
 
-// CCFR here.
+Previously, an issue was identified where `Ukrainian` and `Serbian` were incorrectly spelt in the typography plugin.
 
-For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+{productname} {release-version} addresses this by fixing the spelling.
+
+For information on the **Advanced Typography** plugin, see: xref:advanced-typography.adoc[Advanced Typography].
 
 
 [[improvements]]
@@ -62,14 +65,12 @@ For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode
 [[bug-fixes]]
 == Bug fixes
 
-{productname} {release-version} also includes the following bug fix<es>:
+{productname} <x.y[.z]> also includes the following bug fix<es>:
 
-=== Serbian and Ukrainian languages were spelled incorrectly.
-// #TINY-11713
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
 
-Previously, an issue was identified where `Ukrainian` and `Serbian` were incorrectly spelt in the typography plugin.
-
-{productname} {release-version} addresses this by fixing the spelling.
+// CCFR here.
 
 
 [[known-issues]]

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -64,10 +64,12 @@ For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Serbian and Ukrainian languages were spelled incorrectly.
+// #TINY-11713
 
-// CCFR here.
+Previously, an issue was identified where `Ukrainian` and `Serbian` were incorrectly spelt in the typography plugin.
+
+{productname} {release-version} addresses this by fixing the spelling.
 
 
 [[known-issues]]


### PR DESCRIPTION
Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11713.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#serbian-and-ukrainian-languages-were-spelled-incorrectly)

Changes:
* Documented the bug fix for TINY-11713.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed