### PR TITLE
DOC-3132: The `insertContent` API was not replacing selected non-editable elements c…

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -64,10 +64,13 @@ For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== The `insertContent` API was not replacing selected non-editable elements correctly.
+// #TINY-11714
 
-// CCFR here.
+Previously in {productname}, an issue was identified where, if an inline non-editable element was the only child of a block, inserting content would not replace the element.
+As a result, integrators were unable to insert content into inline non-editable elements.
+
+{productname} {release-version} resolves this by modifying the functionality of the `insertContent` API to support this scenario. This ensures that integrators can now insert content into inline elements, making the `insertContent` API more robust.
 
 
 [[known-issues]]


### PR DESCRIPTION
…orrectly.

Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11714.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#the-insertcontent-api-was-not-replacing-selected-non-editable-elements-correctly)

Changes:
* Documented the bug fix for TINY-11714.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed