### PR TITLE
DOC-3132: Iframe aria text used to suggest to open help dialog even w…

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -74,6 +74,14 @@ This resulted in a poor user experience as users could not engage with anchor li
 
 {productname} {release-version} resolves this issue by first checking whether a link is an anchor link and ensuring that users are navigated to the corresponding anchor element, which is the expected behavior.
 
+=== Iframe aria text used to suggest to open help dialog even when the help plugin was not
+// #TINY-11672
+
+Previously, an issue was identified where the aria-label attribute in the body element was set to “Rich Text Area. Press `ALT-0` for help”. This affected accessibility because the screen reader would announce this message, but when users pressed `ALT-0`, 
+the help dialog would not open if the plugin was disabled, leading to confusion.
+
+{productname} {release-version} addresses this issue by ensuring that if the help plugin is disabled, the screen reader announces only "Rich Text Area." If the help plugin is enabled, the screen reader announces "Rich Text Area. Press `ALT-0` for help.".
+
 [[known-issues]]
 == Known issues
 

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -74,7 +74,7 @@ This resulted in a poor user experience as users could not engage with anchor li
 
 {productname} {release-version} resolves this issue by first checking whether a link is an anchor link and ensuring that users are navigated to the corresponding anchor element, which is the expected behavior.
 
-=== Iframe aria text used to suggest to open help dialog even when the help plugin was not
+=== Iframe aria text used to suggest to open help dialog even when the help plugin was not enabled.
 // #TINY-11672
 
 Previously, an issue was identified where the aria-label attribute in the body element was set to “Rich Text Area. Press `ALT-0` for help”. This affected accessibility because the screen reader would announce this message, but when users pressed `ALT-0`, 


### PR DESCRIPTION
…hen the help plugin was not enabled.

Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11672.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#iframe-aria-text-used-to-suggest-to-open-help-dialog-even-when-the-help-plugin-was-not)

Changes:
* Documented the bug fix for TINY-11672.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed