### PR TITLE
DOC-3132: A document watermark can now be specified for the exported file

### DIFF
--- a/modules/ROOT/examples/live-demos/exportword/index.js
+++ b/modules/ROOT/examples/live-demos/exportword/index.js
@@ -16,6 +16,10 @@ tinymce.init({
         left: "1in",
         right: "1in"
       }
-    }
+    },
+    watermark: {
+      source: 'http://moxiecode.cachefly.net/tinymce/v9/images/logo.png',
+      washout: true
+    },
   }
 });

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -34,7 +34,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 Previously, the **Export to Word** premium plugin did not support watermarks, preventing integrators from adding them to exported Word documents.
 
-{productname} {release-version} resolves this by introducing watermark functionality in the plugin, allowing users to add watermarks to their documents.
+With the release of {productname} {release-version} watermark functionality has been introduced, enabling watermarks to be included in exported documents.
 
 For information on the **Export to Word** plugin, see: xref:exportword.adoc[Export to Word].
 

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -32,7 +32,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 ==== A document watermark can now be specified for the exported file
 
-In previous versions of the Export to Word premium plugin, there was no watermark functionality, preventing users from adding watermarks to their exported Word documents.
+Previously, the **Export to Word** premium plugin did not support watermarks, preventing integrators from adding them to exported Word documents.
 
 {productname} {release-version} resolves this by introducing watermark functionality in the plugin, allowing users to add watermarks to their documents.
 

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -24,17 +24,19 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
-=== <Premium plugin name 1> <Premium plugin name 1 version>
+=== Export to Word
 
-The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+The {productname} {release-version} release includes an accompanying release of the **Export to Word** premium plugin.
 
-**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+**Export to Word**  includes the following fix.
 
-==== <Premium plugin name 1 change 1>
+==== A document watermark can now be specified for the exported file
 
-// CCFR here.
+In previous versions of the Export to Word premium plugin, there was no watermark functionality, preventing users from adding watermarks to their exported Word documents.
 
-For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+{productname} {release-version} resolves this by introducing watermark functionality in the plugin, allowing users to add watermarks to their documents.
+
+For information on the **Export to Word** plugin, see: xref:exportword.adoc[Export to Word].
 
 
 [[improvements]]

--- a/modules/ROOT/pages/exportword.adoc
+++ b/modules/ROOT/pages/exportword.adoc
@@ -77,6 +77,8 @@ include::partial$configuration/exportword_converter_options.adoc[leveloffset=+1]
 
 include::partial$configuration/exportword_converter_style.adoc[leveloffset=+1]
 
+include::partial$configuration/exportword_watermark.adoc[leveloffset=+1]
+
 == Commands
 
 The {pluginname} plugin provides the following {productname} commands.

--- a/modules/ROOT/partials/configuration/exportword_watermark.adoc
+++ b/modules/ROOT/partials/configuration/exportword_watermark.adoc
@@ -1,7 +1,7 @@
 [[watermark]]
 == `watermark`
 
-The `watermark` option allows integrators to add watermarks to their exported word documents.
+The `watermark` option provides integrators with a way to include semi-transparent image watermarks on each page of the exported document, which can be useful for branding, copyright protection, or decorative purposes.
 
 *Type:* `+Object+`
 

--- a/modules/ROOT/partials/configuration/exportword_watermark.adoc
+++ b/modules/ROOT/partials/configuration/exportword_watermark.adoc
@@ -1,0 +1,23 @@
+[[watermark]]
+== `watermark`
+
+The `watermark` option allows integrators to add watermarks to their exported word documents.
+
+*Type:* `+Object+`
+
+=== Example : using `watermark`
+
+[source,js]
+----
+tinymce.init({
+    selector: "textarea",
+    plugins: ['exportword'],
+    toolbar: 'exportword',
+	exportword_converter_options: {
+	  watermark: {
+		source: 'http://moxiecode.cachefly.net/tinymce/v9/images/logo.png',
+		washout: true,
+	  }
+	}
+});
+----

--- a/modules/ROOT/partials/configuration/exportword_watermark.adoc
+++ b/modules/ROOT/partials/configuration/exportword_watermark.adoc
@@ -10,14 +10,14 @@ The `watermark` option allows integrators to add watermarks to their exported wo
 [source,js]
 ----
 tinymce.init({
-    selector: "textarea",
-    plugins: ['exportword'],
-    toolbar: 'exportword',
-	exportword_converter_options: {
-	  watermark: {
-		source: 'http://moxiecode.cachefly.net/tinymce/v9/images/logo.png',
-		washout: true,
-	  }
-	}
+  selector: "textarea",
+  plugins: ['exportword'],
+  toolbar: 'exportword',
+  exportword_converter_options: {
+    watermark: {
+      source: 'http://moxiecode.cachefly.net/tinymce/v9/images/logo.png',
+      washout: true,
+    }
+  }
 });
 ----


### PR DESCRIPTION
Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11675.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#A-document-watermark-can-now-be-specified-for-the-exported-file)

New watermark option: [watermark](http://docs-feature-770-doc-3132tiny-11675.staging.tiny.cloud/docs/tinymce/latest/exportword/#watermark)

Changes:
* Documented the bug fix for TINY-11675.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed