### PR TITLE
DOC-3132: Dropping files on the placeholder would sometimes insert th…

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -36,7 +36,7 @@ The {productname} {release-version} release includes an accompanying release of 
 Previously, an issue was identified where the drag-and-drop functionality on an image placeholder in a table would insert the image outside of the table cell.
 This resulted in unpredictable behavior when users dragged and dropped an image into the image placeholder.
 
-{productname} {release-version} resolves this issue by making it so that that the image placeholder handles the drop event instead of the editor content element. This ensures predictable and consistent drag-and-drop behavior on image placeholders in Uploadcare.
+{productname} {release-version} resolves this issue by making it so that that the image placeholder handles the drop event instead of the editor content element. This improvement provides predictable and consistent drag-and-drop behavior for image placeholders in **Image Optimizer**.
 
 For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Image Optimizer].
 

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -24,17 +24,21 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
-=== <Premium plugin name 1> <Premium plugin name 1 version>
+=== Image Optimizer
 
-The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+The {productname} {release-version} release includes an accompanying release of the **Image Optimizer** premium plugin.
 
-**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+**Image Optimizer** includes the following fixes and improvements.
 
-==== <Premium plugin name 1 change 1>
+==== Dropping files on the placeholder would sometimes insert the image in an incorrect location.
+// #TINY-11643
 
-// CCFR here.
+Previously, an issue was identified where the drag-and-drop functionality on an image placeholder in a table would insert the image outside of the table cell.
+This resulted in unpredictable behavior when users dragged and dropped an image into the image placeholder.
 
-For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+{productname} {release-version} resolves this issue by ensuring that the image placeholder handles the drop event instead of the editor content element. This results in more predictable and consistent drag-and-drop behavior on image placeholders in Uploadcare.
+
+For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Image Optimizer].
 
 
 [[improvements]]

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -36,7 +36,7 @@ The {productname} {release-version} release includes an accompanying release of 
 Previously, an issue was identified where the drag-and-drop functionality on an image placeholder in a table would insert the image outside of the table cell.
 This resulted in unpredictable behavior when users dragged and dropped an image into the image placeholder.
 
-{productname} {release-version} resolves this issue by ensuring that the image placeholder handles the drop event instead of the editor content element. This results in more predictable and consistent drag-and-drop behavior on image placeholders in Uploadcare.
+{productname} {release-version} resolves this issue by making it so that that the image placeholder handles the drop event instead of the editor content element. This ensures predictable and consistent drag-and-drop behavior on image placeholders in Uploadcare.
 
 For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Image Optimizer].
 


### PR DESCRIPTION
…e image in an incorrect location.

Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11643.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#dropping-files-on-the-placeholder-would-sometimes-insert-the-image-in-an-incorrect-location)

Changes:
* Documented the bug fix for TINY-11643.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed