### PR TITLE
DOC-3132: Some image file extensions would sometimes be incorrectly considered unsupported.

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -39,6 +39,22 @@ Previously, an issue was identified where `Ukrainian` and `Serbian` were incorre
 
 For information on the **Advanced Typography** plugin, see: xref:advanced-typography.adoc[Advanced Typography].
 
+=== Image Optimizer
+
+The {productname} {release-version} release includes an accompanying release of the **Image Optimizer** premium plugin.
+
+**Image Optimizer** includes the following fixes and improvements.
+
+==== Some image file extensions would sometimes be incorrectly considered unsupported.
+// #TINY-11668
+
+Previously, an issue was identified where `.jfi` and `.jif` file extensions were incorrectly considered unsupported due to the validation logic.
+
+As a result, these extensions were blocked, and users encountered the error message: "Failed to upload: The image is not a supported file format."
+
+{productname} {release-version} resolves this issue by fixing the validation logic to correctly detect the MIME type of uploaded images, ensuring that users can now successfully upload `.jfi` and `.jif` files.
+
+For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Image Optimizer].
 
 [[improvements]]
 == Improvements


### PR DESCRIPTION
Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11668.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#some-image-file-extensions-would-sometimes-be-incorrectly-considered-unsupported)

Changes:
* Documented the improvement for TINY-11668

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed