### PR TITLE
DOC-3132: Pressing Keyboard shorctut  when cursor is on annotated content now opens and focuses the reply textarea.

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -51,7 +51,7 @@ The {productname} {release-version} release includes an accompanying release of 
 Previously, an issue was identified where pressing the keyboard shortcut `cmd-alt-m` on Mac and `ctrl-alt-m` on Windows while the cursor was on annotated content and the comments sidebar was open resulted in the focus shifting to the corresponding comment, which was not the desired behavior.
 
 {productname} {release-version} fixes this by ensuring that the focus now moves to the reply text area instead of the corresponding comment. 
-This matches the behavior when the Add new comment button is clicked, resulting in more consistent functionality.
+This matches the behavior when the "Add New Comment" button is clicked, resulting in more consistent functionality.
 
 For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Comments].
 

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -39,6 +39,23 @@ Previously, an issue was identified where `Ukrainian` and `Serbian` were incorre
 
 For information on the **Advanced Typography** plugin, see: xref:advanced-typography.adoc[Advanced Typography].
 
+=== Comments
+
+The {productname} {release-version} release includes an accompanying release of the **Comments** premium plugin.
+
+**Comments** includes the following fixes.
+
+==== Pressing Keyboard shorctut `cmd+alt+m` when cursor is on annotated content now opens and focuses the reply textarea.
+// #TINY-11321
+
+Previously, an issue was identified where pressing the keyboard shortcut `cmd-alt-m` on Mac and `ctrl-alt-m` on Windows while the cursor was on annotated content and the comments sidebar was open resulted in the focus shifting to the corresponding comment, 
+which was not the desired behavior.
+
+{productname} {release-version} fixes this by ensuring that the focus now moves to the reply text area instead of the corresponding comment. 
+This matches the behavior when the Add new comment button is clicked, resulting in more consistent functionality.
+
+For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Comments].
+
 
 [[improvements]]
 == Improvements

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -48,8 +48,7 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== Pressing Keyboard shorctut `cmd+alt+m` when cursor is on annotated content now opens and focuses the reply textarea.
 // #TINY-11321
 
-Previously, an issue was identified where pressing the keyboard shortcut `cmd-alt-m` on Mac and `ctrl-alt-m` on Windows while the cursor was on annotated content and the comments sidebar was open resulted in the focus shifting to the corresponding comment, 
-which was not the desired behavior.
+Previously, an issue was identified where pressing the keyboard shortcut `cmd-alt-m` on Mac and `ctrl-alt-m` on Windows while the cursor was on annotated content and the comments sidebar was open resulted in the focus shifting to the corresponding comment, which was not the desired behavior.
 
 {productname} {release-version} fixes this by ensuring that the focus now moves to the reply text area instead of the corresponding comment. 
 This matches the behavior when the Add new comment button is clicked, resulting in more consistent functionality.


### PR DESCRIPTION
Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11321.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#pressing-keyboard-shorctut-cmdaltm-when-cursor-is-on-annotated-content-now-opens-and-focuses-the-reply-textarea)

Changes:
* Documented the bug fix for TINY-11321.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed