### PR TITLE
DOC-3132: Closing the comment kebab menu with keyboard would result i…

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -64,10 +64,10 @@ The {productname} {release-version} release includes an accompanying release of 
 
 ==== Closing the comment kebab menu with keyboard would result in the editor dispatching a `blur` event.
 // #TINY-11172
-In previous versions of {productname}, an issue was identified where the editor would trigger a `blur` event if the comment kebab menu was closed using the `escape` key.
-This occurred even when the editor still had focus, leading to confusing behavior.
 
-{productname} {release-version} resolves this by manually controlling where the focus goes after closing the kebab menu, rather than relying on the browser. This ensures that the editor does not trigger any `blur` events.
+In previous versions of **Comments**, an issue was identified where the editor would trigger a `blur` event if the comment kebab menu was closed using the `escape` key. This occurred even when the editor still had focus, leading to confusing behavior.
+
+{productname} {release-version} resolves this issue by ensuring that focus is properly managed when closing the kebab menu, rather than relying on the browser. This ensures that the editor does not trigger any `blur` events.
 
 For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Comments].
 

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -56,6 +56,21 @@ As a result, these extensions were blocked, and users encountered the error mess
 
 For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Image Optimizer].
 
+=== Comments
+
+The {productname} {release-version} release includes an accompanying release of the **Comments** premium plugin.
+
+**Comments** includes the following fixes.
+
+==== Closing the comment kebab menu with keyboard would result in the editor dispatching a `blur` event.
+
+In previous versions of {productname}, an issue was identified where the editor would trigger a `blur` event if the comment kebab menu was closed using the `escape` key.
+This occurred even when the editor still had focus, leading to confusing behavior.
+
+{productname} {release-version} resolves this by manually controlling where the focus goes after closing the kebab menu, rather than relying on the browser. This ensures that the editor does not trigger any `blur` events.
+
+For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Comments].
+
 [[improvements]]
 == Improvements
 

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -63,7 +63,7 @@ The {productname} {release-version} release includes an accompanying release of 
 **Comments** includes the following fixes.
 
 ==== Closing the comment kebab menu with keyboard would result in the editor dispatching a `blur` event.
-
+// #TINY-11172
 In previous versions of {productname}, an issue was identified where the editor would trigger a `blur` event if the comment kebab menu was closed using the `escape` key.
 This occurred even when the editor still had focus, leading to confusing behavior.
 


### PR DESCRIPTION
…n the editor dispatching a  event.

Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11172.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#closing-the-comment-kebab-menu-with-keyboard-would-result-in-the-editor-dispatching-a-blur-event)

Changes:
* Documented the bug fix for TINY-11172.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed