### PR TITLE
DOC-3132: On chrome, comment card would be jumping when editing a ver…

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -56,6 +56,21 @@ As a result, these extensions were blocked, and users encountered the error mess
 
 For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Image Optimizer].
 
+=== Comments
+
+The {productname} {release-version} release includes an accompanying release of the **Comments** premium plugin.
+
+**Comments** includes the following fixes.
+
+==== On chrome, comment card would be jumping when editing a very large comment.
+// #TINY-11729
+
+Previously, an issue was identified where, when editing comments larger than the height of the comments sidebar, the sidebar would jump up before returning to its intended position. This caused UI glitches that impacted the user experience.
+
+{productname} {release-version} resolves this issue by improving the logic that handles the resizing of the comment textarea, ensuring that the editor no longer jumps when editing large comments.
+
+For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Comments].
+
 [[improvements]]
 == Improvements
 

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -62,7 +62,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 **Comments** includes the following fixes.
 
-==== On chrome, comment card would be jumping when editing a very large comment.
+==== Comment card jumps when editing a large comment in Chrome
 // #TINY-11729
 
 Previously, when editing a comment larger than the height of the comments sidebar, the sidebar would briefly jump before returning to its intended position. This caused visual disruptions that impacted the editing experience.  

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -65,9 +65,9 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== On chrome, comment card would be jumping when editing a very large comment.
 // #TINY-11729
 
-Previously, an issue was identified where, when editing comments larger than the height of the comments sidebar, the sidebar would jump up before returning to its intended position. This caused UI glitches that impacted the user experience.
+Previously, when editing a comment larger than the height of the comments sidebar, the sidebar would briefly jump before returning to its intended position. This caused visual disruptions that impacted the editing experience.  
 
-{productname} {release-version} resolves this issue by improving the logic that handles the resizing of the comment textarea, ensuring that the editor no longer jumps when editing large comments.
+{productname} {release-version} resolves this issue by ensuring the comment sidebar remains stable, preventing unintended jumps when editing large comments. 
 
 For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Comments].
 


### PR DESCRIPTION
…y large comment.

Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11729.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#on-chrome-comment-card-would-be-jumping-when-editing-a-very-large-comment)

Changes:
* Documented the bug fix for TINY-11729.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed