### PR TITLE
DOC-3132: Toolbar groups had both a  attribute and a custom tooltip, …

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -141,6 +141,13 @@ the help dialog would not open if the plugin was disabled, leading to confusion.
 
 {productname} {release-version} addresses this issue by ensuring that if the help plugin is disabled, the screen reader announces only "Rich Text Area." If the help plugin is enabled, the screen reader announces "Rich Text Area. Press `ALT-0` for help.".
 
+=== Toolbar groups had both a `title` attribute and a custom tooltip, causing overlapping tooltips
+// #TINY-11768
+
+In previous versions of {productname}, hovering over toolbar entries would display both a custom tooltip and the default browser tooltip. This caused confusing behavior, as the custom tooltip was difficult to read due to the browser tooltip overlapping it.
+
+{productname} {release-version} resolves this issue by replacing the `title` attribute with the `aria-label` attribute for toolbar groupings, preventing the default browser tooltip from appearing.
+
 [[known-issues]]
 == Known issues
 

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -144,7 +144,7 @@ the help dialog would not open if the plugin was disabled, leading to confusion.
 === Toolbar groups had both a `title` attribute and a custom tooltip, causing overlapping tooltips
 // #TINY-11768
 
-In previous versions of {productname}, hovering over toolbar entries would display both a custom tooltip and the default browser tooltip. This caused confusing behavior, as the custom tooltip was difficult to read due to the browser tooltip overlapping it.
+In previous versions of {productname}, hovering over toolbar menu item would display both a custom tooltip and the default browser tooltip. This caused confusing behavior, as the custom tooltip was difficult to read due to the browser tooltip overlapping it.
 
 {productname} {release-version} resolves this issue by replacing the `title` attribute with the `aria-label` attribute for toolbar groupings, preventing the default browser tooltip from appearing.
 


### PR DESCRIPTION
…causing overlapping tooltips

Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11768.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#toolbar-groups-had-both-a-title-attribute-and-a-custom-tooltip-causing-overlapping-tooltips)

Changes:
* Documented the bug fix for TINY-11768

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed