### PR TITLE
DOC-3132: The `semantics` element in MathML was not properly retained when `annotation` elements was allowed.

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -141,6 +141,14 @@ the help dialog would not open if the plugin was disabled, leading to confusion.
 
 {productname} {release-version} addresses this issue by ensuring that if the help plugin is disabled, the screen reader announces only "Rich Text Area." If the help plugin is enabled, the screen reader announces "Rich Text Area. Press `ALT-0` for help.".
 
+=== The `semantics` element in MathML was not properly retained when `annotation` elements was allowed.
+// #TINY-11755
+
+Previously, in {productname}, an issue was identified where the `semantics` MathML element was removed, even when the `allow_mathml_annotation_encodings` property was configured to allow a specific annotation element. As a result, the generated MathML was invalid because the `annotation` element must be a child of a `semantics` element.
+This also caused rendering issues in some browsers.
+
+In {productname} {release-version}, this issue has been resolved by retaining the `semantics` element whenever the `allow_mathml_annotation_encodings` property is set to a non-empty array. This ensures that valid MathML is generated, improving compatibility with third-party tools and browser rendering.
+
 [[known-issues]]
 == Known issues
 

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -141,13 +141,12 @@ the help dialog would not open if the plugin was disabled, leading to confusion.
 
 {productname} {release-version} addresses this issue by ensuring that if the help plugin is disabled, the screen reader announces only "Rich Text Area." If the help plugin is enabled, the screen reader announces "Rich Text Area. Press `ALT-0` for help.".
 
-=== The `semantics` element in MathML was not properly retained when `annotation` elements was allowed.
+=== The `semantics` element in MathML was not properly preserved when `annotation` elements were allowed.
 // #TINY-11755
 
-Previously, in {productname}, an issue was identified where the `semantics` MathML element was removed, even when the `allow_mathml_annotation_encodings` property was configured to allow a specific annotation element. As a result, the generated MathML was invalid because the `annotation` element must be a child of a `semantics` element.
-This also caused rendering issues in some browsers.
+Previously, in {productname}, an issue was identified in which the `semantics` MathML element was removed, even when a specific annotation element was allowed by the `allow_mathml_annotation_encodings` property. As a result, the generated MathML was invalid because the annotation element must be a child of a `semantics` element. This also caused rendering issues in some browsers.
 
-In {productname} {release-version}, this issue has been resolved by retaining the `semantics` element whenever the `allow_mathml_annotation_encodings` property is set to a non-empty array. This ensures that valid MathML is generated, improving compatibility with third-party tools and browser rendering.
+In {productname} {release-version}, this issue has been resolved by preserving the `semantics` element whenever the `allow_mathml_annotation_encodings` property is set to a non-empty array. This ensures that valid MathML is generated, improving compatibility with third-party tools and browser rendering.
 
 [[known-issues]]
 == Known issues


### PR DESCRIPTION
…ents was allowed.

Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11755.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#the-semantics-element-in-mathml-was-not-properly-retained-when-annotation-elements-was-allowed)

Changes:
* Documented the bug fix for TINY-11755

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed