### PR TITLE
DOC-3132: Part of the placeholder border was not visible during loading.

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -93,6 +93,13 @@ This caused confusion in identifying the problem during setup.
 
 {productname} {release-version} addresses this by providing a more detailed error message when the `uploadcare_public_key` is not configured.
 
+==== Part of the placeholder border was not visible during loading.
+// #TINY-11690
+
+Previously, the image upload placeholder had a border rendering issue, which affected the visual consistency of the UI during the upload process.
+
+{productname} {release-version} addresses this by refining the CSS to ensure the border is properly rendered, resulting in a more polished and design-compliant user interface.
+
 For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Image Optimizer].
 
 [[improvements]]


### PR DESCRIPTION
Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11690.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#part-of-the-placeholder-border-was-not-visible-during-loading)

Changes:
* Documented the bug fix for TINY-11690

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed