### PR TITLE
DOC-3132: It was possible to `tab` to a toolbar group that had all childre…

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -93,6 +93,13 @@ This caused confusion in identifying the problem during setup.
 
 {productname} {release-version} addresses this by providing a more detailed error message when the `uploadcare_public_key` is not configured.
 
+==== It was possible to `tab` to a toolbar group that had all children disabled.
+// #TINY-11665
+
+Previously, in **Image Optimizer**, a fallback mechanism caused focus to shift to the nearest ancestor element. As a result, if focus was applied to a disabled input, its container would receive the focus.
+
+{productname} {release-version} resolves this issue by ensuring that containers with only disabled elements are no longer focusable, preventing unintended focus behavior.
+
 For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Image Optimizer].
 
 [[improvements]]

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -96,7 +96,7 @@ This caused confusion in identifying the problem during setup.
 ==== It was possible to `tab` to a toolbar group that had all children disabled.
 // #TINY-11665
 
-Previously, in **Image Optimizer**, a fallback mechanism caused focus to shift to the nearest ancestor element. As a result, if focus was applied to a disabled input, its container would receive the focus.
+Previously in the **Image Optimizer** premium plugin, a fallback mechanism caused focus to shift to the nearest ancestor element. As a result, if focus was applied to a disabled input, its container would receive the focus.
 
 {productname} {release-version} resolves this issue by ensuring that containers with only disabled elements are no longer focusable, preventing unintended focus behavior.
 


### PR DESCRIPTION
…n disabled.

Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11665.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#it-was-possible-to-tab-to-a-toolbar-group-that-had-all-children-disabled)

Changes:
* Documented the bug fix for TINY-11665

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed