### PR TITLE
DOC-3132: Update form validation error message color to be the same a…

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -104,9 +104,9 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== Update form validation error message color to be the same as the error text color.
 // #TINY-11657
 
-In previous versions of the **Accessibility Checker** premium plugin, the form validation error message had insufficient color contrast in dark mode, failing to meet WCAG AA standards and reducing visibility.
+In previous versions of the **Accessibility Checker** premium plugin, the form validation error message had insufficient color contrast in dark mode, failing to meet link:https://www.w3.org/WAI/WCAG2AA-Conformance[WCAG AA] standards and reducing visibility.
 
-With the release of {productname} {release-version}, this issue has been resolved by updating the error message color to be the same as the error text color, ensuring improved visibility and compliance with WCAG AA contrast standards.
+With the release of {productname} {release-version}, this issue has been resolved by updating the error message color to be the same as the error text color, ensuring improved visibility and compliance with link:https://www.w3.org/WAI/WCAG2AA-Conformance[WCAG AA] contrast standards.
 
 For information on the **Accessibility Checker** plugin, see: xref:a11ychecker.adoc[Accessibility Checker].
 

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -95,6 +95,21 @@ This caused confusion in identifying the problem during setup.
 
 For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Image Optimizer].
 
+=== Accessibility Checker
+
+The {productname} {release-version} release includes an accompanying release of the **Accessibility Checker** premium plugin.
+
+**Accessibility Checker** includes the following fix.
+
+==== Update form validation error message color to be the same as the error text color.
+// #TINY-11657
+
+In previous versions of the **Accessibility Checker** premium plugin, the form validation error message had insufficient color contrast in dark mode, failing to meet WCAG AA standards and reducing visibility.
+
+With the release of {productname} {release-version}, this issue has been resolved by updating the error message color to be the same as the error text color, ensuring improved visibility and compliance with WCAG AA contrast standards.
+
+For information on the **Accessibility Checker** plugin, see: xref:a11ychecker.adoc[Accessibility Checker].
+
 [[improvements]]
 == Improvements
 


### PR DESCRIPTION
…s the error text color.

Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11657.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#update-form-validation-error-message-color-to-be-the-same-as-the-error-text-color)

Changes:
* Documented the bug fix for TINY-11657

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed