### PR TITLE
DOC-3132: Dialog menu dropdowns now close when a dialog is moved.

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -136,7 +136,7 @@ For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Ima
 
 {productname} <x.y[.z]> also includes the following bug fix<es>:
 
-=== Dialog menu dropdowns now close when a dialog is moved.
+=== Dialog menu dropdowns now close when scrolling the editor container.
 // #TINY-11398
 
 Previously, dialog menu dropdowns were not positioned correctly after scrolling the editor container, causing them to remain visible even when the editor was no longer in view. This resulted in dropdowns being displayed without their corresponding dialog context. {productname} {release-version} updates the behavior to ensure that dialog menu dropdowns close on the window scroll event, preventing them from appearing out of context.

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -136,6 +136,11 @@ For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Ima
 
 {productname} <x.y[.z]> also includes the following bug fix<es>:
 
+=== Dialog menu dropdowns now close when a dialog is moved.
+// #TINY-11398
+
+Previously, dialog menu dropdowns were not positioned correctly after scrolling the editor container, causing them to remain visible even when the editor was no longer in view. This resulted in dropdowns being displayed without their corresponding dialog context. {productname} {release-version} updates the behavior to ensure that dialog menu dropdowns close on the window scroll event, preventing them from appearing out of context.
+
 === The `insertContent` API was not replacing selected non-editable elements correctly.
 // #TINY-11714
 


### PR DESCRIPTION
Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11368.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#dialog-menu-dropdowns-now-close-when-a-dialog-is-moved)

Changes:
* add fix documentation for TINY-11368

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed