### PR TITLE
DOC-3132: New `revisionhistory_allow_restore` option to control restoration of old revisions.

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -126,7 +126,6 @@ This improvement enhances access control within the **Revision History** plugin,
 
 For more information, see: xref:revisionhistory.adoc[Revision History].
 
-==== New `revisionhistory_allow_restore` option to control if users can restore old versions.
 
 [[improvements]]
 == Improvements

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -124,7 +124,7 @@ Previously, integrators had no way to control whether users could restore old re
 
 This improvement enhances access control within the **Revision History** plugin, providing greater flexibility for managing revision restoration.
 
-For more information, see: xref:revisionhistory.adoc[Revision History].
+For more information on the **Revision History** plugin, see: xref:revisionhistory.adoc[Revision History].
 
 
 [[improvements]]

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -109,6 +109,25 @@ This caused confusion in identifying the problem during setup.
 
 For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Image Optimizer].
 
+=== Revision History
+
+The {productname} {release-version} release includes an accompanying release of the **Revision History** premium plugin.
+
+**Revision History** includes the following addition.
+
+==== New `revisionhistory_allow_restore` option to control restoration of old revisions  
+// #TINY-11746
+
+Previously, integrators had no way to control whether users could restore old revisions in the **Revision History** plugin.
+
+{prductname} {release-version} introduces a new `revisionhistory_allow_restore` option, which provides integrators with a way to manage this behavior. By default, it is set to `+true+`, setting it to `+false+` prevents users from restoring previous versions.
+
+This improvement enhances access control within the **Revision History** plugin, providing greater flexibility for managing revision restoration.
+
+For more information, see: xref:revisionhistory.adoc[Revision History].
+
+==== New `revisionhistory_allow_restore` option to control if users can restore old versions.
+
 [[improvements]]
 == Improvements
 

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -118,7 +118,6 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== New `revisionhistory_allow_restore` option to control restoration of old revisions  
 // #TINY-11746
 
-
 {productname} {release-version} introduces a new `revisionhistory_allow_restore` option, which provides a way to control if a user can restore revisions. By default, it is set to `+true+`, setting it to `+false+` prevents users from restoring previous versions.
 
 This improvement enhances access control within the **Revision History** plugin, providing greater flexibility for managing revision restoration.

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -120,7 +120,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 Previously, integrators had no way to control whether users could restore old revisions in the **Revision History** plugin.
 
-{productname} {release-version} introduces a new `revisionhistory_allow_restore` option, which provides integrators with a way to manage this behavior. By default, it is set to `+true+`, setting it to `+false+` prevents users from restoring previous versions.
+{productname} {release-version} introduces a new `revisionhistory_allow_restore` option, which provides a way to control if a user can restore revisions. By default, it is set to `+true+`, setting it to `+false+` prevents users from restoring previous versions.
 
 This improvement enhances access control within the **Revision History** plugin, providing greater flexibility for managing revision restoration.
 

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -118,7 +118,6 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== New `revisionhistory_allow_restore` option to control restoration of old revisions  
 // #TINY-11746
 
-Previously, integrators had no way to control whether users could restore old revisions in the **Revision History** plugin.
 
 {productname} {release-version} introduces a new `revisionhistory_allow_restore` option, which provides a way to control if a user can restore revisions. By default, it is set to `+true+`, setting it to `+false+` prevents users from restoring previous versions.
 

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -120,7 +120,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 Previously, integrators had no way to control whether users could restore old revisions in the **Revision History** plugin.
 
-{prductname} {release-version} introduces a new `revisionhistory_allow_restore` option, which provides integrators with a way to manage this behavior. By default, it is set to `+true+`, setting it to `+false+` prevents users from restoring previous versions.
+{productname} {release-version} introduces a new `revisionhistory_allow_restore` option, which provides integrators with a way to manage this behavior. By default, it is set to `+true+`, setting it to `+false+` prevents users from restoring previous versions.
 
 This improvement enhances access control within the **Revision History** plugin, providing greater flexibility for managing revision restoration.
 

--- a/modules/ROOT/pages/revisionhistory.adoc
+++ b/modules/ROOT/pages/revisionhistory.adoc
@@ -109,6 +109,8 @@ include::partial$configuration/revisionhistory_fetch.adoc[leveloffset=+1]
 
 include::partial$configuration/revisionhistory_fetch_revision.adoc[leveloffset=+1]
 
+include::partial$configuration/revisionhistory_allow_restore.adoc[leveloffset=+1]
+
 include::partial$configuration/revisionhistory_author.adoc[leveloffset=+1]
 
 include::partial$configuration/revisionhistory_display_author.adoc[leveloffset=+1]

--- a/modules/ROOT/partials/configuration/revisionhistory_allow_restore.adoc
+++ b/modules/ROOT/partials/configuration/revisionhistory_allow_restore.adoc
@@ -1,7 +1,7 @@
 [[revisionhistory_allow_restore]]
 == `revisionhistory_allow_restore`
 
-The `revisionhistory_allow_restore` option enables or disables the ability to restore a revision from the Revision History view.
+The `revisionhistory_allow_restore` option enables or disables the ability to restore a revision.
 
 *Type:* `+Boolean+`
 

--- a/modules/ROOT/partials/configuration/revisionhistory_allow_restore.adoc
+++ b/modules/ROOT/partials/configuration/revisionhistory_allow_restore.adoc
@@ -1,0 +1,20 @@
+[[revisionhistory_allow_restore]]
+== `revisionhistory_allow_restore`
+
+The `revisionhistory_allow_restore` option enables or disables the ability to restore a revision from the Revision History view.
+
+*Type:* `+Boolean+`
+
+*Default vale:* `+true+`
+
+=== Example: Using `revisionhistory_allow_restore`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  plugins: 'revisionhistory',
+  toolbar: 'revisionhistory',
+  revisionhistory_fetch: () => Promise.resolve([]), // Required option for the plugin - replace with actual API request
+  revisionhistory_allow_restore: false
+----

--- a/modules/ROOT/partials/configuration/revisionhistory_allow_restore.adoc
+++ b/modules/ROOT/partials/configuration/revisionhistory_allow_restore.adoc
@@ -17,4 +17,5 @@ tinymce.init({
   toolbar: 'revisionhistory',
   revisionhistory_fetch: () => Promise.resolve([]), // Required option for the plugin - replace with actual API request
   revisionhistory_allow_restore: false
+  });
 ----


### PR DESCRIPTION
Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11746.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#new-revisionhistory_allow_restore-option-to-control-restoration-of-old-revisions)
Site: [revisionhistory_allow_restore](http://docs-feature-770-doc-3132tiny-11746.staging.tiny.cloud/docs/tinymce/latest/revisionhistory/#revisionhistory_allow_restore)

Changes:
* add new option to revisionhistory plugin for TINY-11746

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] Included a `release note` entry for any `New product features`.

Review:
- [x] Documentation Team Lead has reviewed