### PR TITLE
DOC-3132: The cursor was sometimes incorrectly placed after opening the source code editor

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -109,6 +109,20 @@ This caused confusion in identifying the problem during setup.
 
 For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Image Optimizer].
 
+=== Enhanced Code Editor
+
+The {productname} {release-version} release includes an accompanying release of the **Enhanced Code Editor** premium plugin.
+
+**Enhanced Code Editor** includes the following fix.
+
+==== The cursor was sometimes incorrectly placed after opening source code editor.
+
+In previous versions of the **Enhanced Code Editor** premium plugin, the cursor was sometimes incorrectly positioned when opening the source code editor. This issue occurred when automatic formatting was enabled, particularly if the cursor was placed after indentations, leading to unpredictable cursor behavior.
+
+{productname} {release-version} addresses this by applying optional formatting before determining the cursor's position, ensuring consistent and reliable cursor placement in the source code editor.
+
+For information on the **Enhanced Code Editor** plugin, see: xref:advcode.adoc[Enhanced Code Editor].
+
 [[improvements]]
 == Improvements
 

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -115,7 +115,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 **Enhanced Code Editor** includes the following fix.
 
-==== The cursor was sometimes incorrectly placed after opening source code editor.
+==== The cursor was sometimes incorrectly placed after opening the source code editor.
 
 In previous versions of the **Enhanced Code Editor** premium plugin, the cursor was sometimes incorrectly positioned when opening the source code editor. This issue occurred when automatic formatting was enabled, particularly if the cursor was placed after indentations, leading to unpredictable cursor behavior.
 

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -116,7 +116,7 @@ The {productname} {release-version} release includes an accompanying release of 
 **Enhanced Code Editor** includes the following fix.
 
 ==== The cursor was sometimes incorrectly placed after opening the source code editor.
-
+// #TINY-11686
 In previous versions of the **Enhanced Code Editor** premium plugin, the cursor was sometimes incorrectly positioned when opening the source code editor. This issue occurred when automatic formatting was enabled, particularly if the cursor was placed after indentations, leading to unpredictable cursor behavior.
 
 {productname} {release-version} addresses this by applying optional formatting before determining the cursor's position, ensuring consistent and reliable cursor placement in the source code editor.


### PR DESCRIPTION
Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11686.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#the-cursor-was-sometimes-incorrectly-placed-after-opening-source-code-editor)

Changes:
* Documented the bug fix for TINY-11686

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed