### PR TITLE
DOC-3132: Toolbar text field was not properly rendering focus.

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -107,6 +107,12 @@ This caused confusion in identifying the problem during setup.
 
 {productname} {release-version} addresses this by providing a more detailed error message when the `uploadcare_public_key` is not configured.
 
+==== Toolbar text field was properly rendering focus.
+// #TINY-11658
+
+Previously, input elements lacked styling logic to display a border when focused, resulting in no visible indication of focus.
+This issue has been resolved in {productname} {release-version}. Input elements now correctly display a border when focused, ensuring improved visual feedback.
+
 For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Image Optimizer].
 
 [[improvements]]

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -107,7 +107,7 @@ This caused confusion in identifying the problem during setup.
 
 {productname} {release-version} addresses this by providing a more detailed error message when the `uploadcare_public_key` is not configured.
 
-==== Toolbar text field was properly rendering focus.
+==== Toolbar text field was not properly rendering focus.
 // #TINY-11658
 
 Previously, input elements lacked styling logic to display a border when focused, resulting in no visible indication of focus.


### PR DESCRIPTION
Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11658.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#toolbar-text-field-was-properly-rendering-focus)

Changes:
* Documented the bug fix for TINY-11658

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed