### PR TITLE
DOC-3132: Editor now dispatches `Change` event after a comment is edited or a…

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -77,7 +77,7 @@ In previous versions of **Comments**, the side panel header blended into the bod
 ==== Editor now dispatches `Change` event after a comment is edited or a reply is created.
 // #TINY-11802
 
-Previously, when a comment was edited or replied to, the editor did not enter a dirty state. As a result, in embedded mode with the xref:save.adoc[Save plugin], the save button remained disabled after replying to or editing a comment, which was not the expected behavior.
+Previously, when a comment was edited or replied to, the editor did not enter a dirty state. As a result, in embedded mode with the xref:save.adoc[Save] plugin, the save button remained disabled after replying to or editing a comment, which was not the expected behavior.
 
 In {productname} {release-version}, this issue has been addressed. The editor now transitions to a dirty state when a comment is edited or replied to, ensuring that changes can be saved using the save button as intended.
 

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -74,6 +74,13 @@ In previous versions of **Comments**, the side panel header blended into the bod
 
 {productname} {release-version} improves this by enhancing the side panel header’s visibility, creating a clearer distinction from the body, and refining the overall UI aesthetics.
 
+==== Editor now dispatches `Change` event after a comment is edited or a reply is created.
+// #TINY-11802
+
+Previously, when a comment was edited or replied to, the editor did not enter a dirty state. As a result, in embedded mode with the xref:save.adoc[Save plugin], the save button remained disabled after replying to or editing a comment, which was not the expected behavior.
+
+In {productname} {release-version}, this issue has been addressed. The editor now transitions to a dirty state when a comment is edited or replied to, ensuring that changes can be saved using the save button as intended.
+
 For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Comments].
 
 === Image Optimizer


### PR DESCRIPTION
… reply is created.

Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11802.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#editor-now-dispatches-change-event-after-a-comment-is-edited-or-a-reply-is-created)

Changes:
* Documented the bug fix for TINY-11802

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed