### PR TITLE
DOC-3132: The  property `float` was not properly removed from the image when …

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -169,6 +169,13 @@ In previous versions of {productname}, hovering over toolbar menu item would dis
 
 {productname} {release-version} resolves this issue by replacing the `title` attribute with the `aria-label` attribute for toolbar groupings, preventing the default browser tooltip from appearing.
 
+=== The `float` property was not properly removed from the image when converting an image into a captioned image.
+// #TINY-11670
+
+Previously, an issue occurred where toggling a caption on a floating image did not remove the float property from the image, causing the caption text to be incorrectly positioned.
+
+In {productname} {release-version}, this issue has been resolved by ensuring that the float property is removed when toggling the caption. As a result, the image and caption text now align correctly.
+
 [[known-issues]]
 == Known issues
 


### PR DESCRIPTION
…converting an image into a captioned image.

Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11670.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#the-float-property-was-not-properly-removed-from-the-image-when-converting-an-image-into-a-captioned-image)

Changes:
* Documented the bug fix for TINY-11670

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed