### PR TITLE
DOC-3132:  Fixed keyboard navigation for size inputs in context forms.

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -172,7 +172,7 @@ In previous versions of {productname}, hovering over toolbar menu item would dis
 === Fixed keyboard navigation for size inputs in context forms.
 // #TINY-11394
 
-Previously, input and slider elements in the context toolbar did not support keyboard navigation, preventing users from accessing these elements via the keyboard.
+Previously, input and slider elements in the context toolbar did not support keyboard navigation, preventing users from accessing and adjusting these elements via the keyboard.
 
 With the release of {productname} {release-version}, keyboard navigation has been implemented for these elements, ensuring seamless accessibility and improved usability.
 

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -169,6 +169,13 @@ In previous versions of {productname}, hovering over toolbar menu item would dis
 
 {productname} {release-version} resolves this issue by replacing the `title` attribute with the `aria-label` attribute for toolbar groupings, preventing the default browser tooltip from appearing.
 
+=== Fixed keyboard navigation for size inputs in context forms.
+// #TINY-11394
+
+Previously, input and slider elements in the context toolbar did not support keyboard navigation, preventing users from accessing these elements via the keyboard.
+
+With the release of {productname} {release-version}, keyboard navigation has been implemented for these elements, ensuring seamless accessibility and improved usability.
+
 [[known-issues]]
 == Known issues
 


### PR DESCRIPTION
Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11394.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#fixed-keyboard-navigation-for-size-inputs-in-context-forms)

Changes:
* Documented the bug fix for TINY-11394

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed