### PR TITLE
DOC-3132: Not specifying a notification type (or specifying incorrect one) now defaults to 'info'

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -168,7 +168,7 @@ For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Ima
 
 {productname} {release-version} also includes the following improvement<s>:
 
-=== Not specifying a notification type (or specifying incorrect one) now defaults to 'info'.
+=== Not specifying a notification type (or specifying an incorrect one) now defaults to 'info'.
 // #TINY-11661
 
 In earlier versions of {productname}, an undefined or incorrect `type` property in the notification manager resulted in irregular notifications with no background and a placeholder icon, making them difficult to read.

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -168,11 +168,12 @@ For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Ima
 
 {productname} {release-version} also includes the following improvement<s>:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Not specifying a notification type (or specifying incorrect one) now defaults to 'info'.
+// #TINY-11661
 
-// CCFR here.
+In earlier versions of {productname}, an undefined or incorrect `type` property in the notification manager resulted in irregular notifications with no background and a placeholder icon, making them difficult to read.
 
+With the release of {productname} {release-version}, this behavior has been improved. The `type` property now defaults to `info` when an invalid or missing value is detected, resulting in a proper looking notification that is easy to understand.
 
 [[additions]]
 == Additions


### PR DESCRIPTION
Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11661.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#not-specifying-a-notification-type-or-specifying-incorrect-one-now-defaults-to-info)

Changes:
* Documented the improvement for TINY-11661

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed