### PR TITLE
DOC-3132: Added  `link_attributes_postprocess` option that allows overriding attributes of a link t…

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -168,7 +168,7 @@ For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Ima
 
 {productname} {release-version} also includes the following improvement<s>:
 
-===  Added `link_attributes_postprocess` option that allows overriding attributes of a link that would be inserted through the link dialog.'
+===  Added `link_attributes_postprocess` option that allows overriding attributes of a link inserted through the link dialog.'
 // #TINY-11707
 
 Previously in the xref:link.adoc[Link] plugin, there was no ability to override attributes of a link. With the release of {productname} {release-version}, a new option called `link_attributes_postprocess` has been added that allows this functionality.

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -168,11 +168,10 @@ For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Ima
 
 {productname} {release-version} also includes the following improvement<s>:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+===  Added `link_attributes_postprocess` option that allows overriding attributes of a link that would be inserted through the link dialog.'
+// #TINY-11707
 
-// CCFR here.
-
+Previously in the xref:link.adoc[Link] plugin, there was no ability to override attributes of a link. With the release of {productname} {release-version}, a new option called `link_attributes_postprocess` has been added that allows this functionality.
 
 [[additions]]
 == Additions

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -168,7 +168,7 @@ For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Ima
 
 {productname} {release-version} also includes the following improvement<s>:
 
-===  Added `link_attributes_postprocess` option that allows overriding attributes of a link inserted through the link dialog.'
+===  Added `link_attributes_postprocess` option that allows overriding attributes of a link inserted through the link dialog.
 // #TINY-11707
 
 Previously in the xref:link.adoc[Link] plugin, there was no ability to override attributes of a link. With the release of {productname} {release-version}, a new option called `link_attributes_postprocess` has been added that allows this functionality.

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -171,7 +171,7 @@ For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Ima
 ===  Added `link_attributes_postprocess` option that allows overriding attributes of a link inserted through the link dialog.
 // #TINY-11707
 
-Previously in the xref:link.adoc[Link] plugin, there was no ability to override attributes of a link. With the release of {productname} {release-version}, a new option called `link_attributes_postprocess` has been added that allows this functionality.
+Previously in the xref:link.adoc[Link] plugin, there was no ability to override attributes of a link. With the release of {productname} {release-version}, a new option xref:link.adoc#link_attributes_postprocess[link_attributes_postprocess] has been added that allows this functionality.
 
 [[additions]]
 == Additions

--- a/modules/ROOT/pages/link.adoc
+++ b/modules/ROOT/pages/link.adoc
@@ -46,6 +46,8 @@ include::partial$configuration/link_rel_list.adoc[leveloffset=+1]
 
 include::partial$configuration/link_target_list.adoc[leveloffset=+1]
 
+include::partial$configuration/link_attributes_postprocess.adoc[leveloffset=+1]
+
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]

--- a/modules/ROOT/partials/configuration/link_attributes_postprocess.adoc
+++ b/modules/ROOT/partials/configuration/link_attributes_postprocess.adoc
@@ -1,7 +1,7 @@
 [[link_attributes_postprocess]]
 == `+link_attributes_postprocess+`
 
-This option allows you to override attriutes of the inserted link.
+This option allows overriding attributes of an inserted link.
 
 *Type:* `+Function+`
 

--- a/modules/ROOT/partials/configuration/link_attributes_postprocess.adoc
+++ b/modules/ROOT/partials/configuration/link_attributes_postprocess.adoc
@@ -1,0 +1,26 @@
+[[link_attributes_postprocess]]
+== `+link_attributes_postprocess+`
+
+This option allows you to override attriutes of the inserted link.
+
+*Type:* `+Function+`
+
+*Default value:* `+undefined+`
+
+=== Example: using `+link_attributes_postprocess+`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea', // change this value according to your HTML
+  plugins: 'link',
+  toolbar: 'link',
+  link_attributes_postprocess: (attrs) => {
+    console.log(attrs);
+    if (attrs.rel) {
+      attrs.rel += 'noreferrer';
+    }
+  }
+});
+
+----


### PR DESCRIPTION
…hat would be inserted through the link dialog.

Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11707.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#added-link_attributes_postprocess-option-that-allows-overriding-attributes-of-a-link-that-would-be-inserted-through-the-link-dialog)

New option: [Staging branch](http://docs-feature-770-doc-3132tiny-11707.staging.tiny.cloud/docs/tinymce/latest/link/#link_attributes_postprocess)

Changes:
* Documented the improvement for TINY-11707

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed