### PR TITLE
DOC-3132: Extended the `forceReadOnly` functionality to support the new  option in a…

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -168,11 +168,10 @@ For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Ima
 
 {productname} {release-version} also includes the following improvement<s>:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Extended the `forceReadOnly` functionality to support the new `disabled` option in addition to readonly mode.
+// #TINY-11490
 
-// CCFR here.
-
+In previous versions of {productname}, the editor would transition to read-only mode if the API key was missing, invalid, or if the domain was invalid. With the release of {productname} {release-version}, this behavior has been updated to instead activate disabled mode in these scenarios.
 
 [[additions]]
 == Additions

--- a/modules/ROOT/pages/cloud-troubleshooting.adoc
+++ b/modules/ROOT/pages/cloud-troubleshooting.adoc
@@ -176,3 +176,5 @@ This message is shown when {productname} is loaded from a domain that has not be
 ==== Solution
 
 Please request that your admin add this domain to the approved domains in the Customer Portal. For more information see xref:cloud-troubleshooting.adoc#domain-not-registered[Domain not registered]
+
+NOTE: From xref:7.6.0-release-notes.adoc[{productname} 7.6.0] onwards, the editor uses disabled mode instead of read-only mode.


### PR DESCRIPTION
…ddition to readonly mode.

Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11490.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#extended-the-forcereadonly-functionality-to-support-the-new-disabled-option-in-addition-to-readonly-mode)

Site: (Scroll all the way to the bottom to find a note)[Cloud Trouble Shooting Docs](http://docs-feature-770-doc-3132tiny-11490.staging.tiny.cloud/docs/tinymce/latest/cloud-troubleshooting/)

Changes:
* Documented the improvement for TINY-11490

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed