### PR TITLE
DOC-3132: Expanding selection to word didn't work inside inline editing host elements.

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -230,7 +230,7 @@ In previous versions of {productname}, hovering over toolbar menu item would dis
 
 {productname} {release-version} resolves this issue by replacing the `title` attribute with the `aria-label` attribute for toolbar groupings, preventing the default browser tooltip from appearing.
 
-=== Expanding selection to word didn't work inside inline editing host elements.
+=== Expanding selection to a word didn't work inside inline editing host elements.
 // #TINY-11304
 
 Previously, an issue occurred where the selection would not expand as expected when expand to word was called within an inline edit host element inside a non-editable parent.

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -233,7 +233,7 @@ In previous versions of {productname}, hovering over toolbar menu item would dis
 === Expanding selection to a word didn't work inside inline editing host elements.
 // #TINY-11304
 
-Previously, an issue occurred where the selection would not expand as expected when expand to word was called within an inline edit host element inside a non-editable parent.
+Previously, an issue occurred where the selection did not expand as expected when "expand to word" action was triggered within an inline edit host element inside a non-editable parent.
 
 This has been resolved in {productname} {release-version}, ensuring that the expanded selection now remains within the boundaries of the editable host element.
 

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -233,7 +233,7 @@ In previous versions of {productname}, hovering over toolbar menu item would dis
 === Expanding selection to a word didn't work inside inline editing host elements.
 // #TINY-11304
 
-Previously, an issue occurred where the selection did not expand as expected when "expand to word" action was triggered within an inline edit host element inside a non-editable parent.
+Previously, an issue occurred where the selection did not expand as expected when using the `editor.selection.expand({ type: 'word' })` API when the selection was within an inline edit host element inside a non-editable parent.
 
 This has been resolved in {productname} {release-version}, ensuring that the expanded selection now remains within the boundaries of the editable host element.
 

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -230,6 +230,13 @@ In previous versions of {productname}, hovering over toolbar menu item would dis
 
 {productname} {release-version} resolves this issue by replacing the `title` attribute with the `aria-label` attribute for toolbar groupings, preventing the default browser tooltip from appearing.
 
+=== Expanding selection to word didn't work inside inline editing host elements.
+// #TINY-11304
+
+Previously, an issue occurred where the selection would not expand as expected when expand to word was called within an inline edit host element inside a non-editable parent.
+
+This has been resolved in {productname} {release-version}, ensuring that the expanded selection now remains within the boundaries of the editable host element.
+
 [[known-issues]]
 == Known issues
 


### PR DESCRIPTION
Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11304.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#expanding-selection-to-word-didnt-work-inside-inline-editing-host-elements)

Changes:
* Documented the bug fix for TINY-11304

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed