### PR TITLE
DOC-3132: Keyboard navigation would get stuck on the 'more' toolbar b…

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -230,6 +230,13 @@ In previous versions of {productname}, hovering over toolbar menu item would dis
 
 {productname} {release-version} resolves this issue by replacing the `title` attribute with the `aria-label` attribute for toolbar groupings, preventing the default browser tooltip from appearing.
 
+=== Keyboard navigation would get stuck on the 'more' toolbar button.
+// #TINY-11762
+
+Previously, an issue was identified where keyboard navigation using the Tab key would become stuck at the "Show More" button in the toolbar. This occurred because hidden toolbar elements were incorrectly detected as valid tab targets, disrupting seamless navigation and negatively impacting the user experience.
+
+In {productname} {release-version}, this issue has been resolved by implementing more precise filtering of viable tab targets. As a result, keyboard navigation now functions smoothly without getting stuck.
+
 [[known-issues]]
 == Known issues
 


### PR DESCRIPTION
…utton.

Ticket: DOC-3132

Site: [Staging branch](http://docs-feature-770-doc-3132tiny-11762.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#keyboard-navigation-would-get-stuck-on-the-more-toolbar-button)

Changes:
* Documented the bug fix for TINY-11762

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed