### PR TITLE
DOC-3136: Update documentation for Spelling service using Docker (individually licensed)

### DIFF
--- a/modules/ROOT/pages/individual-spelling-container.adoc
+++ b/modules/ROOT/pages/individual-spelling-container.adoc
@@ -1,6 +1,6 @@
-= Deploy the {productname} Spelling server-side component using Docker (individually licensed)
+= Deploy the {productname} Spelling server-side component using Docker
 :navtitle: Spelling service
-:description: How-to deploy the {productname} Spelling server-side component using Docker (individually licensed).
+:description: How-to deploy the {productname} Spelling server-side component using Docker.
 :shbundledockerfiles: false
 :pluginname: Spell Checker
 

--- a/modules/ROOT/pages/individual-spelling-container.adoc
+++ b/modules/ROOT/pages/individual-spelling-container.adoc
@@ -1,6 +1,11 @@
-= Deploy the TinyMCE Spelling server-side component using Docker (individually licensed)
+= Deploy the {productname} Spelling server-side component using Docker (individually licensed)
 :navtitle: Spelling service
-:description: How-to deploy the TinyMCE Spelling server-side component using Docker (individually licensed).
+:description: How-to deploy the {productname} Spelling server-side component using Docker (individually licensed).
 :shbundledockerfiles: false
+:pluginname: Spell Checker
 
-include::partial$docker/dockerized-spelling-service.adoc[]
+include::partial$docker/spelling-service/spelling-service-overview.adoc[]
+
+include::partial$docker/spelling-service/spelling-service-requirements.adoc[]
+
+include::partial$docker/spelling-service/spelling-service-installation.adoc[]

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
@@ -11,17 +11,17 @@ link:https://www.tiny.cloud/contact/[Contact us] for a trial xref:license-key.ad
 +
 [source, sh, subs="attributes+"]
 ----
-docker login -u [username] -p [password] registry.containers.tiny.cloud
+docker login -u [username] -p [access-token] registry.containers.tiny.cloud
 ----
 
 . Pull the Docker Image from the Docker registry:
 +
 [source, sh, subs="attributes+"]
 ----
-docker pull registry.containers.tiny.cloud/spelling-tiny:[version]
+docker pull registry.containers.tiny.cloud/spelling-tiny:<VERSION>
 ----
 +
-Replace `version` with `latest` or the specific version number.
+Replace `<VERSION>` with `latest` or the specific version number.
 
 === Specify Configurations 
 
@@ -29,7 +29,7 @@ After completing the previous steps, run the Docker container from the pulled im
 
 [source, sh, subs="attributes+"]
 ----
-docker run -p 18080:18080 registry.containers.tiny.cloud/spelling-tiny:[version]
+docker run -p 18080:18080 registry.containers.tiny.cloud/spelling-tiny:<VERSION>
 ----
 
 This triggers `-p 18080:18080`, exposing the service on `localhost:18080`. The service runs on port `18080` inside the Docker container, and this maps it to the same port on your localhost.
@@ -103,10 +103,10 @@ ephox {
 
 Once the application configuration file is ready, proceed with the Docker Compose setup to configure and run the service.
 
-. Create the `docker-compose.yml` file:
+. Create the `docker-compose.yaml` file:
 
 +
-[source, yml]
+[source, yaml]
 ----
 services:
   spelling-tiny:
@@ -130,7 +130,7 @@ services:
         read_only: true
 ----
 
-. Run the service (within the same directory where docker-compose.yaml was placed):
+. Run the service (within the same directory where `docker-compose.yaml` was placed):
 
 +
 [source, sh]
@@ -229,7 +229,7 @@ To do this, configure the link:https://www.tiny.cloud/docs/tinymce/latest/introd
 ----
 tinymce.init({
   …,
-  spellchecker_rpc_url: "<http://localhost:18080>"
+  spellchecker_rpc_url: "http://localhost:18080"
 });
 ----
 

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
@@ -1,7 +1,7 @@
 [[installation]]
 == Installation
 
-[NOTE]
+[IMPORTANT]
 Valid credentials (username and password) are **required** in order to retrieve On-Premises services images from our Docker Registry.
 link:https://www.tiny.cloud/contact/[Contact {companyname} Support] to request credentials.
 

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
@@ -88,7 +88,6 @@ spelling-service/
   └── hunspell-dictionaries
 └── application.conf
 └── docker-compose.yaml
-
 ----
 
 Here is an example of the `application.conf` file with the basic configurations: 

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
@@ -2,8 +2,8 @@
 == Installation
 
 [IMPORTANT]
-Valid credentials (username and password) are **required** in order to retrieve On-Premises services images from our Docker Registry.
-link:https://www.tiny.cloud/contact/[Contact {companyname} Support] to request credentials.
+A valid access token is **required** in order to retrieve On-Premises services images from {companyname} Cloud Docker Registry.
+link:https://www.tiny.cloud/contact/[Contact {companyname} Support] to request the access token.
 
 === Retrieve Docker Image
 
@@ -11,7 +11,7 @@ link:https://www.tiny.cloud/contact/[Contact {companyname} Support] to request c
 +
 [source, sh, subs="attributes+"]
 ----
-docker login -u tiny -p [password] registry.containers.tiny.cloud
+docker login -u tiny -p [access-token] registry.containers.tiny.cloud
 ----
 
 . Pull the Docker Image from the Docker registry:
@@ -20,6 +20,11 @@ docker login -u tiny -p [password] registry.containers.tiny.cloud
 ----
 docker pull registry.containers.tiny.cloud/spelling-tiny:<VERSION>
 ----
+
++
+[NOTE]
+Currently, the Docker images are only supported on x86-64 (also known as AMD64) architecture processors.
+
 +
 Replace `<VERSION>` with `latest` or the specific version number.
 
@@ -63,22 +68,30 @@ This configuration file requires at least the following information:
 
 * `allowed-origins`: Specifies the domains allowed to communicate with server-side editor features. This is **mandatory** for all server-side components.
 
-By default, the {pluginname} plugin comes with Hunspell dictionaries for link:https://www.tiny.cloud/docs/tinymce/latest/introduction-to-tiny-spellchecker/#supported-languages[supported languages]. For additional configurations, the service supports the following options:
+By default, the {pluginname} plugin comes with Hunspell dictionaries for link:https://www.tiny.cloud/docs/tinymce/latest/introduction-to-tiny-spellchecker/#supported-languages[supported languages]. For additional configurations, the service supports the following options in the `application.conf` file:
 
-==== Configure Custom Dictionaries 
+* `custom-dictionaries-path`: Sets the path to where the file or directory is mounted in the container. For more information on how to set up custom dictionaries, refer to link:https://www.tiny.cloud/docs/tinymce/latest/custom-dictionaries-for-tiny-spellchecker/[Adding custom dictionaries].  
+* `dynamic-custom-dictionaries`: When set to true, the {pluginname} service periodically checks the dictionary files in `custom-dictionaries-path` for changes and updates the custom dictionaries at runtime without requiring a service restart. The default value is `false`.
 
-To add custom dictionaries, create a folder on your machine and add the dictionary files. The custom dictionaries must conform to specific rules described in link:https://www.tiny.cloud/docs/tinymce/latest/custom-dictionaries-for-tiny-spellchecker/#creating-custom-dictionary-files[Adding custom dictionaries]. In the `application.conf` file, the `spelling` setting can be configured with the following parameters: 
+[NOTE]
+Enabling the `dynamic-custom-dictionaries` option introduces some performance overhead, which may result in a wait time for the custom dictionaries to load.
 
-* `custom-dictionaries-path`: Takes `<HOST_PATH_TO_CUSTOM_DICT_FOLDER>` as its value. Upon running the container, the specified folder is mapped to the target folder inside the container.
-* `dynamic-custom-dictionaries`: When set to true, the {pluginname} service periodically checks the dictionary files in `<HOST_PATH_TO_CUSTOM_DICT_FOLDER>` for changes and updates the custom dictionaries at runtime without requiring a service restart. Enabling this option introduces some performance overhead, which should be considered. The default value is `false`.
+=== Run the Docker Container 
 
-==== Configure Extra Hunspell Dictionaries
+The Docker container can also be run with `docker compose`. In this example, the following directory structure is assumed: 
 
-The default Hunspell dictionaries can also be replaced or extended. To do this, create a folder on your machine to store the Hunspell dictionary files. In the `application.conf` file, specify the following in the `spelling` setting:
+[source,sh]
+----
+spelling-service/
+└── resources/
+  ├── custom-dictionaries
+  └── hunspell-dictionaries
+└── application.conf
+└── docker-compose.yaml
 
-* `hunspell-dictionaries-path`: Takes `<HOST_PATH_TO_HUNSPELL_DICT_FOLDER>` as its value. Upon running the container, the specified folder is mapped to the target folder inside the container.
+----
 
-This is an example `application.conf` file with the basic configurations: 
+Here is an example of the `application.conf` file with the basic configurations: 
 
 [source, conf]
 ----
@@ -99,11 +112,10 @@ ephox {
 }
 ----
 
-=== Launch the Docker Container 
-
-Once the application configuration file is ready, proceed with the Docker Compose setup to configure and run the service.
-
 . Create the `docker-compose.yaml` file:
+
++
+Here is an example of how to set up the file given the above directory structure and `application.conf` file: 
 
 +
 [source, yaml]
@@ -117,18 +129,22 @@ services:
     init: true
     volumes:
       - type: bind
-        source: <PATH_TO_APPLICATION_CONF_FILE_IN_HOST_MACHINE>
+        source: ./application.conf
         target: /ephox-spelling/ephox-spelling-docker-env.conf 
         read_only: true
       - type: bind
-        source: <HOST_PATH_TO_CUSTOM_DICT_FOLDER>
+        source: ./resources/custom-dictionaries
         target: /app/resources/custom-dictionaries
         read_only: true
       - type: bind
-        source: <HOST_PATH_TO_HUNSPELL_DICT_FOLDER>
-        target: /app/resources/hunspell-dictionaries
+        source: ./resources/hunspell-dictionaries
+        target: /app/resources/custom-dictionaries
         read_only: true
 ----
+
++
+[NOTE]
+Ensure the `target` path in the `volumes` option matches the `custom-dictionaries-path` and `hunspell-dictionaries-path` in the `application.conf` file. 
 
 . Run the service (within the same directory where `docker-compose.yaml` was placed):
 
@@ -228,7 +244,10 @@ To do this, configure the link:https://www.tiny.cloud/docs/tinymce/latest/introd
 [source, js]
 ----
 tinymce.init({
-  …,
+  selector: 'textarea#spellchecker', // change this value according to your HTML
+  plugins: 'code tinymcespellchecker link',
+  toolbar: 'spellchecker language spellcheckdialog',
+  spellchecker_language: 'en_US',
   spellchecker_rpc_url: "http://localhost:18080"
 });
 ----

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
@@ -2,8 +2,8 @@
 == Installation
 
 [NOTE]
-A valid xref:license-key.adoc[License Key] is **required** in order to install {pluginname} On-Premises.
-link:https://www.tiny.cloud/contact/[Contact us] for a trial xref:license-key.adoc[License Key].
+Valid credentials (username and password) are **required** in order to retrieve On-Premises services images from our Docker Registry.
+link:https://www.tiny.cloud/contact/[Contact us] to request credentials.
 
 === Retrieve Docker Image
 
@@ -189,7 +189,7 @@ To check the service is running, use:
 +
 [source, sh]
 ----
-curl <http://localhost:18080/version>
+curl http://localhost:18080/version
 ----
 
 +
@@ -201,7 +201,7 @@ To confirm that a request is being sent to the {pluginname} service, use:
 +
 [source, sh]
 ----
-curl <http://localhost:18080/2/check> -d '{"words": ["teh"], "language": "en_US"}' -H "Origin: <http://good.com>" -H "Content-Type: application/json"
+curl http://localhost:18080/2/check -d '{"words": ["teh"], "language": "en_US"}' -H "Origin: http://good.com" -H "Content-Type: application/json"
 ----
 
 +
@@ -210,7 +210,7 @@ Finally, to verify if a request is unauthorized and originates from an incorrect
 +
 [source, sh]
 ----
-curl <http://localhost:18080/2/check> -d '{"words": ["teh"], "language": "en_US"}' -H "Origin: <http://bad.com>" -H "Content-Type: application/json"
+curl http://localhost:18080/2/check -d '{"words": ["teh"], "language": "en_US"}' -H "Origin: http://bad.com" -H "Content-Type: application/json"
 ----
 
 +

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
@@ -11,7 +11,7 @@ link:https://www.tiny.cloud/contact/[Contact {companyname} Support] to request c
 +
 [source, sh, subs="attributes+"]
 ----
-docker login -u [username] -p [password] registry.containers.tiny.cloud
+docker login -u tiny -p [password] registry.containers.tiny.cloud
 ----
 
 . Pull the Docker Image from the Docker registry:

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
@@ -7,7 +7,7 @@ link:https://www.tiny.cloud/contact/[Contact {companyname} Support] to request c
 
 === Retrieve Docker Image
 
-. Login into the {companyname} Cloud Docker Registry: 
+. Log into the {companyname} Cloud Docker Registry: 
 +
 [source, sh, subs="attributes+"]
 ----

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
@@ -1,0 +1,239 @@
+[[installation]]
+== Installation
+
+[NOTE]
+A valid xref:license-key.adoc[License Key] is **required** in order to install {pluginname} On-Premises.
+link:https://www.tiny.cloud/contact/[Contact us] for a trial xref:license-key.adoc[License Key].
+
+=== Retrieve Docker Image
+
+. Login into the {companyname} Cloud Docker Registry: 
++
+[source, sh, subs="attributes+"]
+----
+docker login -u [username] -p [password] registry.containers.tiny.cloud
+----
+
+. Pull the Docker Image from the Docker registry:
++
+[source, sh, subs="attributes+"]
+----
+docker pull registry.containers.tiny.cloud/spelling-tiny:[version]
+----
++
+Replace `version` with `latest` or the specific version number.
+
+=== Specify Configurations 
+
+After completing the previous steps, run the Docker container from the pulled image: 
+
+[source, sh, subs="attributes+"]
+----
+docker run -p 18080:18080 registry.containers.tiny.cloud/spelling-tiny:[version]
+----
+
+This triggers `-p 18080:18080`, exposing the service on `localhost:18080`. The service runs on port `18080` inside the Docker container, and this maps it to the same port on your localhost.
+
+If set up correctly, the logs should display output similar to the following: 
+
+[source, log]
+----
+2024-12-05 11:30:50.813Z [io-compute-9] INFO  ironbark - ironbark
+...
+2024-12-05 11:30:51.166Z [io-compute-blocker-9] INFO  ironbark - -> Raw Config assembled from various sources: ConfigOrigin(merge of /ephox-spelling/ephox-spelling-docker-env.conf: 1,system properties,reference.conf @ jar:file:/ephox-spelling/ephox-spelling.jar!/reference.conf: 1)
+2024-12-05 11:30:51.206Z [io-compute-blocker-9] WARN  c.e.d.config.AllowedOriginsConfig$ - No allowed-origins specified in config!
+2024-12-05 11:30:51.219Z [io-compute-blocker-9] INFO  ironbark - ironbark config loaded successfully: IronbarkConfig(Logger[ironbark],SpellingConfig(None,Some(200),None,false),OriginWhitelist(List(),OriginPrecision(true)),None,None,StaticCustomDictionaryScanConfig)
+2024-12-05 11:30:51.275Z [io-compute-blocker-9] INFO  com.ephox.nectar.data.Bees$ - Loading all dictionaries from WinterTree
+2024-12-05 11:30:51.677Z [io-compute-blocker-6] INFO  com.ephox.nectar.data.Bees$ - Loading all dictionaries from WinterTree
+2024-12-05 11:30:52.127Z [io-compute-7] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /0:0:0:0:0:0:0:0:18080
+2024-12-05 11:30:52.131Z [io-compute-7] INFO  o.h.blaze.server.BlazeServerBuilder - 
+  _   _   _        _ _
+ | |_| |_| |_ _ __| | | ___
+ | ' \\  _|  _| '_ \\_  _(_-<
+ |_||_\\__|\\__| .__/ |_|/__/
+             |_|
+2024-12-05 11:30:52.145Z [io-compute-7] INFO  o.h.blaze.server.BlazeServerBuilder - http4s v0.23.27 on blaze v0.23.16 started at http://[::]:18080/
+----
+
+Running this command will generate a log warning about `allowed-origins` not being configured. This is expected, as it will be set up in the next step.
+
+The {productname} server-side components require a configuration file to function correctly. By convention, this file is named `application.conf`. For more information, refer to link:https://www.tiny.cloud/docs/tinymce/latest/configure-required-services/[Required configuration for the server-side components]. 
+
+This configuration file requires at least the following information:
+
+* `allowed-origins`: Specifies the domains allowed to communicate with server-side editor features. This is **mandatory** for all server-side components.
+
+By default, the {pluginname} plugin comes with Hunspell dictionaries for link:https://www.tiny.cloud/docs/tinymce/latest/introduction-to-tiny-spellchecker/#supported-languages[supported languages]. For additional configurations, the service supports the following options:
+
+==== Configure Custom Dictionaries 
+
+To add custom dictionaries, create a folder on your machine and add the dictionary files. The custom dictionaries must conform to specific rules described in link:https://www.tiny.cloud/docs/tinymce/latest/custom-dictionaries-for-tiny-spellchecker/#creating-custom-dictionary-files[Adding custom dictionaries]. In the `application.conf` file, the `spelling` setting can be configured with the following parameters: 
+
+* `custom-dictionaries-path`: Takes `<HOST_PATH_TO_CUSTOM_DICT_FOLDER>` as its value. Upon running the container, the specified folder is mapped to the target folder inside the container.
+* `dynamic-custom-dictionaries`: When set to true, the {pluginname} service periodically checks the dictionary files in `<HOST_PATH_TO_CUSTOM_DICT_FOLDER>` for changes and updates the custom dictionaries at runtime without requiring a service restart. Enabling this option introduces some performance overhead, which should be considered. The default value is `false`.
+
+==== Configure Extra Hunspell Dictionaries
+
+The default Hunspell dictionaries can also be replaced or extended. To do this, create a folder on your machine to store the Hunspell dictionary files. In the `application.conf` file, specify the following in the `spelling` setting:
+
+* `hunspell-dictionaries-path`: Takes `<HOST_PATH_TO_HUNSPELL_DICT_FOLDER>` as its value. Upon running the container, the specified folder is mapped to the target folder inside the container.
+
+This is an example `application.conf` file with the basic configurations: 
+
+[source, conf]
+----
+ephox {
+
+  allowed-origins {
+    origins = [
+      "<http://example.com>",
+      "<http://good.com> ",
+      "*.my.company.org"
+    ]
+  }
+  
+  spelling {
+    custom-dictionaries-path = "/app/resources/custom-dictionaries"
+    hunspell-dictionaries-path = "/app/resources/hunspell-dictionaries"
+  }
+}
+----
+
+=== Launch the Docker Container 
+
+Once the application configuration file is ready, proceed with the Docker Compose setup to configure and run the service.
+
+. Create the `docker-compose.yml` file:
+
++
+[source, yml]
+----
+services:
+  spelling-tiny:
+    image: registry.containers.tiny.cloud/spelling-tiny:<VERSION>
+    ports:
+      - "18080:18080"
+    restart: always
+    init: true
+    volumes:
+      - type: bind
+        source: <PATH_TO_APPLICATION_CONF_FILE_IN_HOST_MACHINE>
+        target: /ephox-spelling/ephox-spelling-docker-env.conf 
+        read_only: true
+      - type: bind
+        source: <HOST_PATH_TO_CUSTOM_DICT_FOLDER>
+        target: /app/resources/custom-dictionaries
+        read_only: true
+      - type: bind
+        source: <HOST_PATH_TO_HUNSPELL_DICT_FOLDER>
+        target: /app/resources/hunspell-dictionaries
+        read_only: true
+----
+
+. Run the service (within the same directory where docker-compose.yaml was placed):
+
++
+[source, sh]
+----
+docker compose up
+----
+
++
+If the allowed origins, Hunspell, and custom dictionaries folders are configured correctly, the initiation logs should appear as follows:
+
++
+[source, log]
+----
+[+] Running 2/2
+ ✔ Network spelling-tiny_default            Created                                                                                                                                                                                               0.0s 
+ ✔ Container spelling-tiny-spelling-tiny-1  Created                                                                                                                                                                                               0.1s 
+Attaching to spelling-tiny-1
+spelling-tiny-1  | 2025-02-11 09:51:10.332Z [io-compute-5] INFO  ironbark - ironbark
+...
+spelling-tiny-1  | 2025-02-11 09:51:10.736Z [io-compute-blocker-5] INFO  ironbark - -> Raw Config assembled from various sources: ConfigOrigin(merge of /ephox-spelling/ephox-spelling-docker-env.conf: 1,system properties,reference.conf @ jar:file:/ephox-spelling/ephox-spelling.jar!/reference.conf: 1)
+spelling-tiny-1  | 2025-02-11 09:51:10.814Z [io-compute-blocker-5] INFO  c.e.d.config.AllowedOriginsConfig$ - Read allowed-origins config (ignoring ports = true) as:
+spelling-tiny-1  |  - example.com
+spelling-tiny-1  |  - good.com
+spelling-tiny-1  |  - my.company.org
+spelling-tiny-1  | 2025-02-11 09:51:10.822Z [io-compute-blocker-5] INFO  ironbark - ironbark config loaded successfully: IronbarkConfig(Logger[ironbark],SpellingConfig(None,Some(200),None,5,0.8),OriginWhitelist(List(example.com, good.com, my.company.org),OriginPrecision(true)),Some(CustomDictionaryPath(/app/resources/custom-dictionaries)),Some(HunspellDictionaryPath(/app/resources/hunspell-dictionaries)),StaticCustomDictionaryScanConfig)
+spelling-tiny-1  | 2025-02-11 09:51:11.101Z [io-compute-blocker-6] INFO  c.e.i.d.StaticCustomDictionaries$ - Using custom dictionary: [global] = 2 words in engine Hunspell
+spelling-tiny-1  | 2025-02-11 09:51:11.104Z [io-compute-blocker-6] INFO  c.e.i.d.StaticCustomDictionaries$ - Using custom dictionary: [global] = 2 words in engine WinterTree
+spelling-tiny-1  | 2025-02-11 09:51:11.161Z [io-compute-blocker-6] INFO  com.ephox.nectar.data.Bees$ - Loading all dictionaries from WinterTree
+spelling-tiny-1  | 2025-02-11 09:51:11.482Z [io-compute-blocker-5] INFO  c.e.nectar.hunspell.HunspellLoader$ - Loading hunspell dictionary from path: /app/resources/hunspell-dictionaries and locale es
+spelling-tiny-1  | 2025-02-11 09:51:11.536Z [io-compute-blocker-5] INFO  c.e.nectar.hunspell.HunspellLoader$ - Finished loading hunspell for es
+spelling-tiny-1  | 2025-02-11 09:51:11.537Z [io-compute-blocker-5] INFO  c.e.nectar.hunspell.HunspellLoader$ - Loading hunspell dictionary from path: /app/resources/hunspell-dictionaries and locale pt_BR
+spelling-tiny-1  | 2025-02-11 09:51:11.881Z [io-compute-blocker-5] INFO  c.e.nectar.hunspell.HunspellLoader$ - Finished loading hunspell for pt_BR
+...
+spelling-tiny-1  | 2025-02-11 09:51:13.593Z [io-compute-blocker-5] INFO  c.e.nectar.hunspell.HunspellLoader$ - Loading hunspell dictionary from path: /app/resources/hunspell-dictionaries and locale de_DE
+spelling-tiny-1  | 2025-02-11 09:51:13.651Z [io-compute-blocker-5] INFO  c.e.nectar.hunspell.HunspellLoader$ - Finished loading hunspell for de_DE
+spelling-tiny-1  | 2025-02-11 09:51:14.142Z [io-compute-9] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /0:0:0:0:0:0:0:0:18080
+spelling-tiny-1  | 2025-02-11 09:51:14.146Z [io-compute-9] INFO  o.h.blaze.server.BlazeServerBuilder - 
+spelling-tiny-1  |   _   _   _        _ _
+spelling-tiny-1  |  | |_| |_| |_ _ __| | | ___
+spelling-tiny-1  |  | ' \\  _|  _| '_ \\_  _(_-<
+spelling-tiny-1  |  |_||_\\__|\\__| .__/ |_|/__/
+spelling-tiny-1  |              |_|
+spelling-tiny-1  | 2025-02-11 09:51:14.162Z [io-compute-9] INFO  o.h.blaze.server.BlazeServerBuilder - http4s v0.23.27 on blaze v0.23.16 started at http://[::]:18080/
+----
+
+=== Next Steps 
+
+. Test the service via `cURL` command
+
++
+To verify that the {pluginname} service is set up and functioning correctly within the container, ensure the service is running on port `18080`. Once active, it should be ready to receive requests. The expected outputs below confirm proper configuration, assuming `http://good.com` is in the allowed origins and `http://bad.com` is not.
+
++
+To check the service is running, use:
+
++
+[source, sh]
+----
+curl <http://localhost:18080/version>
+----
+
++
+An example output is: `2.127.0`
+
++
+To confirm that a request is being sent to the {pluginname} service, use:
+
++
+[source, sh]
+----
+curl <http://localhost:18080/2/check> -d '{"words": ["teh"], "language": "en_US"}' -H "Origin: <http://good.com>" -H "Content-Type: application/json"
+----
+
++
+Finally, to verify if a request is unauthorized and originates from an incorrect origin, use:
+
++
+[source, sh]
+----
+curl <http://localhost:18080/2/check> -d '{"words": ["teh"], "language": "en_US"}' -H "Origin: <http://bad.com>" -H "Content-Type: application/json"
+----
+
++
+If an error occurs,  the expected message is: `{ "message": "The supplied authentication is not authorized to access this resource" }`.
+
+. Test directly in {productname}
+
++
+Before deploying, it is recommended to test this service within the {productname} editor itself.
+
++
+To do this, configure the link:https://www.tiny.cloud/docs/tinymce/latest/introduction-to-tiny-spellchecker/[{pluginname}] feature in the editor and call it via `tinymce.init`. If running locally on the default port `18080`, use the following settings:
+
++
+[source, js]
+----
+tinymce.init({
+  …,
+  spellchecker_rpc_url: "<http://localhost:18080>"
+});
+----
+
+
+
+
+

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
@@ -3,7 +3,7 @@
 
 [IMPORTANT]
 A valid access token is **required** in order to retrieve On-Premises services images from {companyname} Cloud Docker Registry.
-link:https://www.tiny.cloud/contact/[Contact {companyname} Support] to request the access token.
+link:https://www.tiny.cloud/contact/[Contact {companyname} Support^] to request the access token.
 
 === Retrieve Docker Image
 

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
@@ -22,11 +22,10 @@ docker pull registry.containers.tiny.cloud/spelling-tiny:<VERSION>
 ----
 
 +
+Replace `<VERSION>` with `latest` or the specific version number.
++
 [NOTE]
 Currently, the Docker images are only supported on x86-64 (also known as AMD64) architecture processors.
-
-+
-Replace `<VERSION>` with `latest` or the specific version number.
 
 === Specify Configurations 
 

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
@@ -3,7 +3,7 @@
 
 [NOTE]
 Valid credentials (username and password) are **required** in order to retrieve On-Premises services images from our Docker Registry.
-link:https://www.tiny.cloud/contact/[Contact us] to request credentials.
+link:https://www.tiny.cloud/contact/[Contact {companyname} Support] to request credentials.
 
 === Retrieve Docker Image
 
@@ -11,7 +11,7 @@ link:https://www.tiny.cloud/contact/[Contact us] to request credentials.
 +
 [source, sh, subs="attributes+"]
 ----
-docker login -u [username] -p [access-token] registry.containers.tiny.cloud
+docker login -u [username] -p [password] registry.containers.tiny.cloud
 ----
 
 . Pull the Docker Image from the Docker registry:

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-overview.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-overview.adoc
@@ -5,6 +5,6 @@ The On-Premises version of the link:https://www.tiny.cloud/tinymce/features/spel
 
 The only requirement to run these services On-Premises is a container runtime or orchestration tool e.g. Docker, Kubernetes, Podman.
 
-To get started, contact link:https://www.tiny.cloud/contact/[{companyname} Support] to enable the service. A username and password will be provided to access the {companyname} Cloud Docker registry and pull the Docker image.
+A valid access token is required to access the {companyname} Cloud Docker registry and pull the Docker image. Contact link:https://www.tiny.cloud/contact/[{companyname} Support] to request the access token. 
 
 include::partial$misc/admon-dont-push-docker-images.adoc[]

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-overview.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-overview.adoc
@@ -7,4 +7,6 @@ A valid xref:license-key.adoc[License Key] is required in order to install {plug
 
 The only requirement to run these services On-Premises is a container runtime or orchestration tool e.g. Docker, Kubernetes, Podman.
 
+Once your subscription is enabled for the service, an access token will be provided to access the Tiny Cloud Docker registry and pull the Docker image.
+
 include::partial$misc/admon-dont-push-docker-images.adoc[]

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-overview.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-overview.adoc
@@ -1,0 +1,10 @@
+[[overview]]
+== Overview
+
+The On-Premises version of the link:https://www.tiny.cloud/tinymce/features/spell-checker/[{pluginname}] is an application that can be installed and run on the customer’s in-house servers and computing infrastructure, including a private cloud.
+
+A valid xref:license-key.adoc[License Key] is required in order to install {pluginname} On-Premises. link:https://www.tiny.cloud/contact/[Contact Tiny Support] to request a trial xref:license-key.adoc[License Key].
+
+The only requirement to run these services On-Premises is a container runtime or orchestration tool e.g. Docker, Kubernetes, Podman.
+
+include::partial$misc/admon-dont-push-docker-images.adoc[]

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-overview.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-overview.adoc
@@ -3,8 +3,6 @@
 
 The On-Premises version of the link:https://www.tiny.cloud/tinymce/features/spell-checker/[{pluginname}] is an application that can be installed and run on the customer’s in-house servers and computing infrastructure, including a private cloud.
 
-A valid xref:license-key.adoc[License Key] is required in order to install {pluginname} On-Premises. link:https://www.tiny.cloud/contact/[Contact Tiny Support] to request a trial xref:license-key.adoc[License Key].
-
 The only requirement to run these services On-Premises is a container runtime or orchestration tool e.g. Docker, Kubernetes, Podman.
 
 Once your subscription is enabled for the service, an access token will be provided to access the Tiny Cloud Docker registry and pull the Docker image.

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-overview.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-overview.adoc
@@ -5,6 +5,6 @@ The On-Premises version of the link:https://www.tiny.cloud/tinymce/features/spel
 
 The only requirement to run these services On-Premises is a container runtime or orchestration tool e.g. Docker, Kubernetes, Podman.
 
-Once your subscription is enabled for the service, an access token will be provided to access the Tiny Cloud Docker registry and pull the Docker image.
+To get started, contact link:https://www.tiny.cloud/contact/[{companyname} Support] to enable the service. A username and password will be provided to access the {companyname} Cloud Docker registry and pull the Docker image.
 
 include::partial$misc/admon-dont-push-docker-images.adoc[]

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-overview.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-overview.adoc
@@ -1,10 +1,10 @@
 [[overview]]
 == Overview
 
-The On-Premises version of the link:https://www.tiny.cloud/tinymce/features/spell-checker/[{pluginname}] is an application that can be installed and run on the customer’s in-house servers and computing infrastructure, including a private cloud.
+The On-Premises version of the link:https://www.tiny.cloud/tinymce/features/spell-checker/[{pluginname}^] is an application that can be installed and run on the customer’s in-house servers and computing infrastructure, including a private cloud.
 
 The only requirement to run these services On-Premises is a container runtime or orchestration tool e.g. Docker, Kubernetes, Podman.
 
-A valid access token is required to access the {companyname} Cloud Docker registry and pull the Docker image. Contact link:https://www.tiny.cloud/contact/[{companyname} Support] to request the access token. 
+A valid access token is required to access the {companyname} Cloud Docker registry and pull the Docker image. Contact link:https://www.tiny.cloud/contact/[{companyname} Support^] to request the access token. 
 
 include::partial$misc/admon-dont-push-docker-images.adoc[]

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-requirements.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-requirements.adoc
@@ -5,4 +5,4 @@
 * The user has Administrative or Root user access to run the Docker commands.
 * The user is either:
 ** Using a Unix-like operating system, such as Linux or macOS.
-** Using Windows and has access to unix command line tools using link:https://gitforwindows.org/[Git for Windows], link:https://www.cygwin.com/[Cygwin], or the link:https://docs.microsoft.com/en-us/windows/wsl/install-win10[Windows Subsystem for Linux].
+** Using Windows and has access to unix command line tools using link:https://gitforwindows.org/[Git for Windows^], link:https://www.cygwin.com/[Cygwin^], or the link:https://docs.microsoft.com/en-us/windows/wsl/install-win10[Windows Subsystem for Linux^].

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-requirements.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-requirements.adoc
@@ -1,0 +1,8 @@
+[[requirements]]
+== Requirements
+
+* The link:https://docs.docker.com/engine/docker-overview/[Docker Engine] is installed and running.
+* The user has Administrative or Root user access to run the Docker commands.
+* The user is either:
+** Using a Linux, Unix or macOS operating system.
+** Using Windows and has access to unix command line tools using link:https://gitforwindows.org/[Git for Windows], link:https://www.cygwin.com/[Cygwin], or the link:https://docs.microsoft.com/en-us/windows/wsl/install-win10[Windows Subsystem for Linux].

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-requirements.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-requirements.adoc
@@ -1,7 +1,7 @@
 [[requirements]]
 == Requirements
 
-* The link:https://docs.docker.com/engine/docker-overview/[Docker Engine] is installed and running.
+* The link:https://docs.docker.com/engine/docker-overview/[Docker Engine^] is installed and running.
 * The user has Administrative or Root user access to run the Docker commands.
 * The user is either:
 ** Using a Unix-like operating system, such as Linux or macOS.

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-requirements.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-requirements.adoc
@@ -4,5 +4,5 @@
 * The link:https://docs.docker.com/engine/docker-overview/[Docker Engine] is installed and running.
 * The user has Administrative or Root user access to run the Docker commands.
 * The user is either:
-** Using a Linux, Unix or macOS operating system.
+** Using a Unix-like operating system, such as Linux or macOS.
 ** Using Windows and has access to unix command line tools using link:https://gitforwindows.org/[Git for Windows], link:https://www.cygwin.com/[Cygwin], or the link:https://docs.microsoft.com/en-us/windows/wsl/install-win10[Windows Subsystem for Linux].


### PR DESCRIPTION
Ticket: DOC-3136

Site: [Staging branch](http://docs-hotfix-7-doc-3136.staging.tiny.cloud/docs/tinymce/latest/individual-spelling-container/)

Changes:
* Updated documentation content for Spelling service using Docker (individually licensed) 

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed