### PR TITLE
DOC-3143: Update key information about trial period behaviour for document converters on Tiny Cloud.

### DIFF
--- a/modules/ROOT/examples/live-demos/full-featured/example.js
+++ b/modules/ROOT/examples/live-demos/full-featured/example.js
@@ -6,7 +6,6 @@ const fetchApi = import(
 // Instead, an alternate method for retrieving the API key should be used.
 const openai_api_key = "<INSERT_OPENAI_API_KEY_HERE>";
 
-const useDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
 const isSmallScreen = window.matchMedia('(max-width: 1023.5px)').matches;
 
 tinymce.init({
@@ -111,8 +110,7 @@ tinymce.init({
   content_style: '.mymention{ color: gray; }',
   contextmenu: 'link image editimage table configurepermanentpen',
   a11y_advanced_options: true,
-  skin: useDarkMode ? 'oxide-dark' : 'oxide',
-  content_css: useDarkMode ? 'dark' : 'default',
+  skin: 'oxide-dark',
   autocorrect_capitalize: true,
   mergetags_list: [
     {

--- a/modules/ROOT/examples/live-demos/full-featured/index.js
+++ b/modules/ROOT/examples/live-demos/full-featured/index.js
@@ -141,7 +141,6 @@ tinymce.ScriptLoader.loadScripts(['https://cdn.jsdelivr.net/npm/faker@5/dist/fak
     });
   };
 
-  const useDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
   const isSmallScreen = window.matchMedia('(max-width: 1023.5px)').matches;
 
   const ai_request = (request, respondWith) => {
@@ -523,8 +522,7 @@ tinymce.ScriptLoader.loadScripts(['https://cdn.jsdelivr.net/npm/faker@5/dist/fak
     'body { font-family:Helvetica,Arial,sans-serif; font-size:16px }',
     contextmenu: 'link image editimage table spellchecker configurepermanentpen',
     a11y_advanced_options: true,
-    skin: useDarkMode ? 'oxide-dark' : 'oxide',
-    content_css: useDarkMode ? 'dark' : 'default',
+    skin: 'oxide-dark',
     mentions_selector: '.mymention',
     mentions_fetch: mentions_fetch,
     mentions_menu_hover: mentions_menu_hover,

--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -242,7 +242,7 @@ For information on the **Accessibility Checker** plugin, see: xref:a11ychecker.a
 
 {productname} {release-version} also includes the following improvements:
 
-==== Improved visual indication of keyboard focus for a comment annotation when there is an image inside.
+=== Improved visual indication of keyboard focus for a comment annotation when there is an image inside.
 // #TINY-11596
 
 In previous versions of **Comments**, annotated non-text elements occasionally displayed a double bottom border when selected, leading to a visual inconsistency that appeared buggy and clashed with existing border styles.

--- a/modules/ROOT/pages/exportpdf.adoc
+++ b/modules/ROOT/pages/exportpdf.adoc
@@ -30,14 +30,37 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'exportpdf',
   toolbar: 'exportpdf',
+  exportpdf_token_provider: () => { // required when using the Export to PDF plugin with Tiny Cloud.
+    return fetch('http://localhost:3000/jwt', { // specify your token endpoint
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    }).then(response => response.json());
+  },
 });
 ----
 
-[IMPORTANT]
-When using the {pluginname} plugin with the {companyname} Cloud service, JWT authentication is required to use the service. For more information on how to set up JWT authentication with {pluginname}, see examples:
+[NOTE]
+For more infomation on the exportpdf_token_provider option, see xref:exportpdf.adoc#exportpdf-token-provider[exportpdf_token_provider].
 
-* xref:export-to-pdf-with-jwt-authentication-nodejs.adoc[{pluginname} with JWT authentication (Node.js)]
-* xref:export-to-pdf-with-jwt-authentication-php.adoc[{pluginname} with JWT authentication (PHP)]
+[IMPORTANT]
+====
+The {pluginname} plugin **requires** JWT authentication when using the {companyname} Cloud service.
+
+* Configure the `{plugincode}_token_provider` option to specify the endpoint for retrieving a valid JWT token.
+* If hosting locally, use the format `+http://localhost:[port]/jwt+`, ensuring the endpoint returns a JSON object containing the token.
+
+For more information on how to set up JWT authentication with {pluginname}, see examples:
+
+* xref:export-to-pdf-with-jwt-authentication-nodejs.adoc[Export to PDF with JWT authentication (Node.js)]
+* xref:export-to-pdf-with-jwt-authentication-php.adoc[Export to PDF with JWT authentication (PHP)]
+
+**Trial period behavior:**
+
+* The {pluginname} plugin runs in evaluation mode and adds a watermark to exported content.
+* The `{plugincode}_token_provider` option is "not required" during the trial period.
+* If the trial period "expires" or the plugin lacks the necessary entitlement, it becomes _non-functional_.
+* Attempting to use JWT authentication during the trial will result in an _error_.
+====
 
 == Basic setup using the self-hosted service
 

--- a/modules/ROOT/pages/exportword.adoc
+++ b/modules/ROOT/pages/exportword.adoc
@@ -36,14 +36,42 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'exportword',
   toolbar: 'exportword',
+  exportword_token_provider: () => { // required when using the Export to Word plugin with Tiny Cloud.
+    return fetch('http://localhost:3000/jwt', { // specify your token endpoint
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    }).then(response => response.json());
+  },
 });
 ----
 
+[NOTE]
+For more infomation on the exportword_token_provider option, see xref:exportword.adoc#exportword-token-provider[exportword_token_provider]
+
 [IMPORTANT]
-When using the {pluginname} plugin with the {companyname} Cloud service, JWT authentication is required to use the service. For more information on how to set up JWT authentication with {pluginname}, see examples:
+====
+The {pluginname} plugin **requires** JWT authentication when using the {companyname} Cloud service.
+
+* Configure the `{plugincode}_token_provider` option to specify the endpoint for retrieving a valid JWT token.
+* If hosting locally, use the format `+http://localhost:[port]/jwt+`, ensuring the endpoint returns a JSON object containing the token.
+
+For more information on how to set up JWT authentication with {pluginname}, see examples:
 
 * xref:export-to-word-with-jwt-authentication-nodejs.adoc[{pluginname} with JWT authentication (Node.js)]
 * xref:export-to-word-with-jwt-authentication-php.adoc[{pluginname} with JWT authentication (PHP)]
+
+**Trial period behavior:**
+
+* The {pluginname} plugin runs in evaluation mode and adds a watermark to exported content.
+* The `{plugincode}_token_provider` option is "not required" during the trial period.
+* If the trial period "expires" or the plugin lacks the necessary entitlement, it becomes _non-functional_.
+* Attempting to use JWT authentication during the trial will result in an _error_.
+====
+
+
+
+
+
 
 == Basic setup using the self-hosted service
 

--- a/modules/ROOT/pages/importword.adoc
+++ b/modules/ROOT/pages/importword.adoc
@@ -31,14 +31,37 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'importword',
   toolbar: 'importword',
+  importword_token_provider: () => { // required when using the Import from Word plugin with Tiny Cloud.
+    return fetch('http://localhost:3000/jwt', { // specify your token endpoint
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    }).then(response => response.json());
+  },
 });
 ----
 
+[NOTE]
+For more infomation on the importword_token_provider option, see xref:importword.adoc#importword-token-provider[importword_token_provider].
+
 [IMPORTANT]
-When using the {pluginname} plugin with the {companyname} Cloud service, JWT authentication is required to use the service. For more information on how to set up JWT authentication with {pluginname}, see examples:
+====
+The {pluginname} plugin **requires** JWT authentication when using the {companyname} Cloud service.
+
+* Configure the `{plugincode}_token_provider` option to specify the endpoint for retrieving a valid JWT token.
+* If hosting locally, use the format `+http://localhost:[port]/jwt+`, ensuring the endpoint returns a JSON object containing the token.
+
+For more information on how to set up JWT authentication with {pluginname}, see examples:
 
 * xref:import-from-word-with-jwt-authentication-nodejs.adoc[{pluginname} with JWT authentication (Node.js)]
 * xref:import-from-word-with-jwt-authentication-php.adoc[{pluginname} with JWT authentication (PHP)]
+
+**Trial period behavior:**
+
+* The {pluginname} plugin runs in evaluation mode and adds a watermark to exported content.
+* The `{plugincode}_token_provider` option is "not required" during the trial period.
+* If the trial period "expires" or the plugin lacks the necessary entitlement, it becomes _non-functional_.
+* Attempting to use JWT authentication during the trial will result in an _error_.
+====
 
 == Basic setup using the self-hosted service
 

--- a/modules/ROOT/partials/configuration/exportpdf_token_provider.adoc
+++ b/modules/ROOT/partials/configuration/exportpdf_token_provider.adoc
@@ -15,7 +15,7 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'exportpdf',
   toolbar: 'exportpdf',
-  exportpdf_token_provider: () => {
+  exportpdf_token_provider: () => { // required when using the Export to PDF plugin with Tiny Cloud.
     return fetch('http://localhost:3000/jwt', { // specify your token endpoint
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -23,9 +23,3 @@ tinymce.init({
   },
 });
 ----
-
-[NOTE]
-The `exportpdf_token_provider` option is required when using the {companyname} Cloud service. For more information on how to set up JWT authentication with {pluginname}, see examples:
-
-* xref:export-to-pdf-with-jwt-authentication-nodejs.adoc[Export to PDF with JWT authentication (Node.js)]
-* xref:export-to-pdf-with-jwt-authentication-php.adoc[Export to PDF with JWT authentication (PHP)]

--- a/modules/ROOT/partials/configuration/exportword_token_provider.adoc
+++ b/modules/ROOT/partials/configuration/exportword_token_provider.adoc
@@ -15,7 +15,7 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'exportword',
   toolbar: 'exportword',
-  exportword_token_provider: () => {
+  exportword_token_provider: () => { // required when using the Export to Word plugin with Tiny Cloud.
     return fetch('http://localhost:3000/jwt', { // specify your token endpoint
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -23,10 +23,3 @@ tinymce.init({
   },
 });
 ----
-
-
-[NOTE]
-The `exportword_token_provider` option is required when using the {companyname} Cloud service. For more information on how to set up JWT authentication with {pluginname}, see examples:
-
-* xref:export-to-word-with-jwt-authentication-nodejs.adoc[Export to Word with JWT authentication (Node.js)]
-* xref:export-to-word-with-jwt-authentication-php.adoc[Export to Word with JWT authentication (PHP)]

--- a/modules/ROOT/partials/configuration/importword_token_provider.adoc
+++ b/modules/ROOT/partials/configuration/importword_token_provider.adoc
@@ -15,7 +15,7 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'importword',
   toolbar: 'importword',
-  importword_token_provider: () => {
+  importword_token_provider: () => { // required when using the Import from Word plugin with Tiny Cloud.
     return fetch('http://localhost:3000/jwt', { // specify your token endpoint
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -23,9 +23,3 @@ tinymce.init({
   },
 });
 ----
-
-[NOTE]
-The `importword_token_provider` option is required when using the {companyname} Cloud service. For more information on how to set up JWT authentication with {pluginname}, see examples:
-
-* xref:import-from-word-with-jwt-authentication-nodejs.adoc[Import to Word with JWT authentication (Node.js)]
-* xref:import-from-word-with-jwt-authentication-php.adoc[Import to Word with JWT authentication (PHP)]


### PR DESCRIPTION
Ticket: DOC-3143

Site: [Staging branch: exportword](http://docs-hotfix-7-doc-3143.staging.tiny.cloud/docs/tinymce/latest/exportword/)
Site: [Staging branch: exportpdf](http://docs-hotfix-7-doc-3143.staging.tiny.cloud/docs/tinymce/latest/exportpdf/)
Site: [Staging branch: importword](http://docs-hotfix-7-doc-3143.staging.tiny.cloud/docs/tinymce/latest/importword/)

Changes:
* Update `Basic setup using the Tiny Cloud service` for each service
* Improved JWT authentication details for the `{pluginname}` plugin, and trial behavior.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [ ] Documentation Team Lead has reviewed