### PR TITLE
DOC-3149: TinyMCE 7.7.1 Release Documentation.

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -419,6 +419,12 @@
 ** xref:tinymce-and-cors.adoc[Cross-Origin Resource Sharing (CORS)]
 * Release information
 ** xref:release-notes.adoc[Release notes for {productname}]
+*** {productname} 7.7.1
+**** xref:7.7.1-release-notes.adoc#overview[Overview]
+**** xref:7.7.0-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
+**** xref:7.7.0-release-notes.adoc#improvements[Improvements]
+**** xref:7.7.0-release-notes.adoc#bug-fixes[Bug fixes]
+**** xref:7.7.0-release-notes.adoc#known-issues[Known issues]
 *** {productname} 7.7.0
 **** xref:7.7.0-release-notes.adoc#overview[Overview]
 **** xref:7.7.0-release-notes.adoc#accompanying-premium-self-hosted-server-side-component-changes[Accompanying Premium self-hosted server-side component changes]

--- a/modules/ROOT/pages/7.7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.1-release-notes.adoc
@@ -1,0 +1,78 @@
+= {productname} {release-version}
+:release-version: 7.7.1
+:navtitle: {productname} {release-version}
+:description: Release notes for {productname} {release-version}
+:keywords: releasenotes, new, changes, bugfixes
+:page-toclevels: 1
+
+include::partial$misc/admon-releasenotes-for-stable.adoc[]
+
+
+[[overview]]
+== Overview
+
+{productname} {release-version} was released for {enterpriseversion} and {cloudname} on <weekday>, <month> <DD>^<st|nd|rd|th>^, <YYYY>. These release notes provide an overview of the changes for {productname} {release-version}, including:
+
+// Remove sections and section boilerplates as necessary.
+// Pluralise as necessary or remove the placeholder plural marker.
+* xref:accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
+* xref:accompanying-open-source-plugin-end-of-life-announcement[Accompanying open source plugin end-of-life-announcement]
+* xref:accompanying-enhanced-skins-and-icon-packs-changes[Accompanying Enhanced Skins & Icon Packs changes]
+* xref:bug-fixes[Bug fixes]
+* xref:known-issues[Known issues]
+
+
+[[accompanying-premium-plugin-changes]]
+== Accompanying Premium plugin changes
+
+The following premium plugin updates were released alongside {productname} {release-version}.
+
+=== <Premium plugin name 1> <Premium plugin name 1 version>
+
+The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+
+**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+
+==== <Premium plugin name 1 change 1>
+
+// CCFR here.
+
+For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+
+
+[[accompanying-enhanced-skins-and-icon-packs-changes]]
+== Accompanying Enhanced Skins & Icon Packs changes
+
+The {productname} {release-version} release includes an accompanying release of the **Enhanced Skins & Icon Packs**.
+
+=== Enhanced Skins & Icon Packs
+
+The **Enhanced Skins & Icon Packs** release includes the following updates:
+
+The **Enhanced Skins & Icon Packs** were rebuilt to pull in the changes also incorporated into the default {productname} {release-version} skin, Oxide.
+
+For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-and-icon-packs.adoc[Enhanced Skins & Icon Packs].
+
+
+[[bug-fixes]]
+== Bug fixes
+
+{productname} {release-version} also includes the following bug fix<es>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[known-issues]]
+== Known issues
+
+This section describes issues that users of {productname} {release-version} may encounter and possible workarounds for these issues.
+
+There <is one | are <number> known issue<s> in {productname} {release-version}.
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -11,6 +11,12 @@ This section lists the releases for {productname} 7 and the changes made in each
 
 a|
 [.lead]
+xref:7.7.1-release-notes.adoc#overview[{productname} 7.7.1]
+
+Release notes for {productname} 7.7.1
+
+a|
+[.lead]
 xref:7.7.0-release-notes.adoc#overview[{productname} 7.7.0]
 
 Release notes for {productname} 7.7.0


### PR DESCRIPTION
Ticket: DOC-3149

Site: [Staging branch](http://docs-release-771.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* TinyMCE 7.7.1 Release Documentation

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.

Review:
- [ ] Documentation Team Lead has reviewed