### PR TITLE
DOC-3149: TinyMCE 7.7.1 Release Documentation.

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -419,6 +419,11 @@
 ** xref:tinymce-and-cors.adoc[Cross-Origin Resource Sharing (CORS)]
 * Release information
 ** xref:release-notes.adoc[Release notes for {productname}]
+*** {productname} 7.7.1
+**** xref:7.7.1-release-notes.adoc#overview[Overview]
+**** xref:7.7.1-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
+**** xref:7.7.1-release-notes.adoc#bug-fixes[Bug fixes]
+**** xref:7.7.1-release-notes.adoc#known-issues[Known issues]
 *** {productname} 7.7.0
 **** xref:7.7.0-release-notes.adoc#overview[Overview]
 **** xref:7.7.0-release-notes.adoc#accompanying-premium-self-hosted-server-side-component-changes[Accompanying Premium self-hosted server-side component changes]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -421,9 +421,9 @@
 ** xref:release-notes.adoc[Release notes for {productname}]
 *** {productname} 7.7.1
 **** xref:7.7.1-release-notes.adoc#overview[Overview]
-**** xref:7.7.1-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
+**** xref:7.7.1-release-notes.adoc#accompanying-premium-self-hosted-server-side-component-changes[Accompanying Premium self-hosted server-side component changes]
 **** xref:7.7.1-release-notes.adoc#bug-fixes[Bug fixes]
-**** xref:7.7.1-release-notes.adoc#known-issues[Known issues]
+**** xref:7.7.1-release-notes.adoc#security-fixes[Security fixes]
 *** {productname} 7.7.0
 **** xref:7.7.0-release-notes.adoc#overview[Overview]
 **** xref:7.7.0-release-notes.adoc#accompanying-premium-self-hosted-server-side-component-changes[Accompanying Premium self-hosted server-side component changes]

--- a/modules/ROOT/pages/7.7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.1-release-notes.adoc
@@ -2,7 +2,7 @@
 :release-version: 7.7.1
 :navtitle: {productname} {release-version}
 :description: Release notes for {productname} {release-version}
-:keywords: releasenotes, new, changes, bugfixes
+:keywords: releasenotes, bugfixes, security
 :page-toclevels: 1
 
 include::partial$misc/admon-releasenotes-for-stable.adoc[]
@@ -11,64 +11,88 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 [[overview]]
 == Overview
 
-{productname} {release-version} was released for {enterpriseversion} and {cloudname} on <weekday>, <month> <DD>^<st|nd|rd|th>^, <YYYY>. These release notes provide an overview of the changes for {productname} {release-version}, including:
+{productname} {release-version} was released for {enterpriseversion} and {cloudname} on Wednesday, March 05^st^, 2025. These release notes provide an overview of the changes for {productname} {release-version}, including:
 
-// Remove sections and section boilerplates as necessary.
-// Pluralise as necessary or remove the placeholder plural marker.
-* xref:accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
-* xref:accompanying-enhanced-skins-and-icon-packs-changes[Accompanying Enhanced Skins & Icon Packs changes]
+* xref:accompanying-premium-self-hosted-server-side-component-changes[Accompanying Premium self-hosted server-side component changes]
 * xref:bug-fixes[Bug fixes]
-* xref:known-issues[Known issues]
+* xref:security-fixes[Security fixes]
 
+[[accompanying-premium-self-hosted-server-side-component-changes]]
+== Accompanying Premium self-hosted server-side component changes
 
-[[accompanying-premium-plugin-changes]]
-== Accompanying Premium plugin changes
+The {productname} {release-version} release includes accompanying changes affecting the {productname} **self-hosted** services for the following plugins:
 
-The following premium plugin updates were released alongside {productname} {release-version}.
+* **Enhanced Media Embed** plugin `mediaembed`.
+* **Image Editing** plugin `editimage`.
+* **Link Checker** plugin `linkchecker`.
+* **Spell Checker** plugin `tinymcespellchecker`.
+* **Spelling Autocorrect** plugin `autocorrect`.
 
-=== <Premium plugin name 1> <Premium plugin name 1 version>
+For information on:
 
-The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+* The **Enhanced Media Embed** plugin, see: xref:introduction-to-mediaembed.adoc[Enhanced Media Embed plugin].
+* The **Image Editing** plugin, see: xref:editimage.adoc[Image Editing plugin].
+* The **Link Checker** plugin, see: xref:linkchecker.adoc[Link Checker plugin].
+* The **Spell Checker** plugin, see: xref:introduction-to-tiny-spellchecker.adoc[Spell Checkerplugin].
+* The **Spelling Autocorrect** plugin, see: xref:autocorrect.adoc[Spelling Autocorrect plugin].
+* Deploying the **server-side** components, see: xref:introduction-to-premium-selfhosted-services.adoc[Server-side component installation].
 
-**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+The Java server-side components have been updated to the following versions:
 
-==== <Premium plugin name 1 change 1>
+* `ephox-hyperlinking.war`: 2.109.5
+* `ephox-image-proxy.war`: 2.111.6
+* `ephox-spelling.war`: 2.128.4
 
-// CCFR here.
+=== Updating the self-hosted server-side components
 
-For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+The new versions of the server-side services provide updates for the Java-based server-side components. To deploy the updated version of the server-side components:
 
+. Update your Java Application Server to the minimum required version:
 
-[[accompanying-enhanced-skins-and-icon-packs-changes]]
-== Accompanying Enhanced Skins & Icon Packs changes
+include::partial$misc/supported-application-servers.adoc[]
 
-The {productname} {release-version} release includes an accompanying release of the **Enhanced Skins & Icon Packs**.
+. Replace the existing server-side `.war` files with the `.war` files bundled with {productname} {release-version} or later.
 
-=== Enhanced Skins & Icon Packs
+For information on:
 
-The **Enhanced Skins & Icon Packs** release includes the following updates:
+* Deploying the server-side components, see: xref:introduction-to-premium-selfhosted-services.adoc[Server-side component installation].
+* Deploying the server-side components using Docker, see: xref:bundle-intro-setup.adoc[Containerized service deployments].
 
-The **Enhanced Skins & Icon Packs** were rebuilt to pull in the changes also incorporated into the default {productname} {release-version} skin, Oxide.
-
-For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-and-icon-packs.adoc[Enhanced Skins & Icon Packs].
-
+include::partial$misc/admon-no-functionality-changes-in-updated-server-side-components.adoc[]
 
 [[bug-fixes]]
 == Bug fixes
 
-{productname} {release-version} also includes the following bug fix<es>:
+{productname} {release-version} also includes the following bug fixes:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Skin UI content CSS was truncated when bundling, causing CSS styles to be missing.
+// #TINY-11875
 
-// CCFR here.
+Previously in {productname}, an issue was identified where skin content CSS was truncated during the build process when bundling CSS files into JavaScript resources. This caused invalid styles, leading to partial or complete loss of CSS in the editor UI for self-hosted setups, which resulted in broken styling and reduced usability.
 
+This issue has been resolved in {productname} {release-version}. The bundling process now correctly incorporates CSS styles into the generated JavaScript resources, preventing truncation and ensuring consistent styling across the editor UI.
 
-[[known-issues]]
-== Known issues
+=== Context forms used to disappear if their input was disabled in the `onSetup` API.
+// #TINY-11890
 
-This section describes issues that users of {productname} {release-version} may encounter and possible workarounds for these issues.
+Previously, an issue was identified where disabling a context form's input in the `onSetup` function caused the form to disappear due to focus being set on a non-focusable element.
 
-There one known issue in {productname} {release-version}.
+In {productname} {release-version}, this issue has been resolved by ensuring that the fallback focus is directed to a focusable element. As a result, even when the input is disabled, the focus remains intact, preventing the context form from disappearing.
 
-=== <TINY-vwxyz 1 changelog entry>
+For more information on the `onSetup` function and context forms, see: xref:contextform.adoc[Context Forms]
+
+[[security-fixes]]
+== Security fixes
+
+{productname} {release-version} includes two fixes for the following security issue:
+
+The following server-side component has been updated to include dependency updates addressing the following security issues. 
+
+* https://nvd.nist.gov/vuln/detail/CVE-2025-25193[CVE-2025-25193]
+* https://nvd.nist.gov/vuln/detail/CVE-2025-24970[CVE-2025-24970]
+
+This update is considered as a **Medium** & *High* severity vulnerability fix.
+
+For information on the server-side components updates, see: xref:#accompanying-premium-self-hosted-server-side-component-changes[Accompanying Premium self-hosted server-side component changes].
+
+include::partial$misc/admon-no-functionality-changes-in-updated-server-side-components.adoc[]

--- a/modules/ROOT/pages/7.7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.1-release-notes.adoc
@@ -1,0 +1,74 @@
+= {productname} {release-version}
+:release-version: 7.7.1
+:navtitle: {productname} {release-version}
+:description: Release notes for {productname} {release-version}
+:keywords: releasenotes, new, changes, bugfixes
+:page-toclevels: 1
+
+include::partial$misc/admon-releasenotes-for-stable.adoc[]
+
+
+[[overview]]
+== Overview
+
+{productname} {release-version} was released for {enterpriseversion} and {cloudname} on <weekday>, <month> <DD>^<st|nd|rd|th>^, <YYYY>. These release notes provide an overview of the changes for {productname} {release-version}, including:
+
+// Remove sections and section boilerplates as necessary.
+// Pluralise as necessary or remove the placeholder plural marker.
+* xref:accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
+* xref:accompanying-enhanced-skins-and-icon-packs-changes[Accompanying Enhanced Skins & Icon Packs changes]
+* xref:bug-fixes[Bug fixes]
+* xref:known-issues[Known issues]
+
+
+[[accompanying-premium-plugin-changes]]
+== Accompanying Premium plugin changes
+
+The following premium plugin updates were released alongside {productname} {release-version}.
+
+=== <Premium plugin name 1> <Premium plugin name 1 version>
+
+The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+
+**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+
+==== <Premium plugin name 1 change 1>
+
+// CCFR here.
+
+For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+
+
+[[accompanying-enhanced-skins-and-icon-packs-changes]]
+== Accompanying Enhanced Skins & Icon Packs changes
+
+The {productname} {release-version} release includes an accompanying release of the **Enhanced Skins & Icon Packs**.
+
+=== Enhanced Skins & Icon Packs
+
+The **Enhanced Skins & Icon Packs** release includes the following updates:
+
+The **Enhanced Skins & Icon Packs** were rebuilt to pull in the changes also incorporated into the default {productname} {release-version} skin, Oxide.
+
+For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-and-icon-packs.adoc[Enhanced Skins & Icon Packs].
+
+
+[[bug-fixes]]
+== Bug fixes
+
+{productname} {release-version} also includes the following bug fix<es>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[known-issues]]
+== Known issues
+
+This section describes issues that users of {productname} {release-version} may encounter and possible workarounds for these issues.
+
+There one known issue in {productname} {release-version}.
+
+=== <TINY-vwxyz 1 changelog entry>

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -4,6 +4,14 @@
 
 NOTE: This is the {productname} Community version changelog. For information about the latest {cloudname} or {enterpriseversion} Release, see: xref:release-notes.adoc[{productname} Release Notes].
 
+== xref:7.7.1-release-notes.adoc[7.7.1 - 2025-03-05]
+
+=== Fixed
+* Skin UI content CSS was truncated when bundling, causing CSS styles to be missing.
+// #TINY-11875
+* Context forms used to disappear if their input were disabled on `onSetup`.
+// #TINY-11890
+
 == xref:7.7.0-release-notes.adoc[7.7.0 - 2025-02-20]
 
 === Added

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -11,6 +11,12 @@ This section lists the releases for {productname} 7 and the changes made in each
 
 a|
 [.lead]
+xref:7.7.1-release-notes.adoc#overview[{productname} 7.7.1]
+
+Release notes for {productname} 7.7.1
+
+a|
+[.lead]
 xref:7.7.0-release-notes.adoc#overview[{productname} 7.7.0]
 
 Release notes for {productname} 7.7.0

--- a/modules/ROOT/pages/support.adoc
+++ b/modules/ROOT/pages/support.adoc
@@ -42,11 +42,6 @@ Java Development Kit::
 Java (J2EE) Application Servers::
 include::partial$misc/supported-application-servers.adoc[]
 
-Operating Systems::
-* Windows Server 2008 SP2
-* Red Hat Enterprise Linux v6
-* Red Hat Enterprise Linux v5
-
 Minimum Hardware Requirements::
 * CPU: Dual Core Processor ~ 2Ghz. For higher loads, a quad core or higher is recommended.
 * RAM: 4 Gigabytes of RAM available for services

--- a/modules/ROOT/partials/misc/supported-application-servers.adoc
+++ b/modules/ROOT/partials/misc/supported-application-servers.adoc
@@ -1,5 +1,5 @@
 * Eclipse Jetty:
-** 9.4+
+** 9.4+ (with extended support)
 * WebSphere Application Server (WAS) 8 or later
 * Apache Tomcat:
 +


### PR DESCRIPTION
Ticket: DOC-3149

Site: [Staging branch](http://docs-release-771.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* TinyMCE 7.7.1 Release Documentation

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.

Review:
- [x] Documentation Team Lead has reviewed