### PR TITLE
DOC-3143: Update key information about trial period behaviour for document converters on Tiny Cloud. 

### DIFF
--- a/modules/ROOT/pages/exportpdf.adoc
+++ b/modules/ROOT/pages/exportpdf.adoc
@@ -30,14 +30,37 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'exportpdf',
   toolbar: 'exportpdf',
+  exportpdf_token_provider: () => { // required when using the Export to PDF plugin with Tiny Cloud.
+    return fetch('http://localhost:3000/jwt', { // specify your token endpoint
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    }).then(response => response.json());
+  },
 });
 ----
 
-[IMPORTANT]
-When using the {pluginname} plugin with the {companyname} Cloud service, JWT authentication is required to use the service. For more information on how to set up JWT authentication with {pluginname}, see examples:
+[NOTE]
+For more infomation on the exportpdf_token_provider option, see xref:exportpdf.adoc#exportpdf-token-provider[exportpdf_token_provider].
 
-* xref:export-to-pdf-with-jwt-authentication-nodejs.adoc[{pluginname} with JWT authentication (Node.js)]
-* xref:export-to-pdf-with-jwt-authentication-php.adoc[{pluginname} with JWT authentication (PHP)]
+[IMPORTANT]
+====
+The {pluginname} plugin **requires** JWT authentication when using the {companyname} Cloud service.
+
+* Configure the `{plugincode}_token_provider` option to specify the endpoint for retrieving a valid JWT token.
+* If hosting locally, use the format `+http://localhost:[port]/jwt+`, ensuring the endpoint returns a JSON object containing the token.
+
+For more information on how to set up JWT authentication with {pluginname}, see examples:
+
+* xref:export-to-pdf-with-jwt-authentication-nodejs.adoc[Export to PDF with JWT authentication (Node.js)]
+* xref:export-to-pdf-with-jwt-authentication-php.adoc[Export to PDF with JWT authentication (PHP)]
+
+**Trial period behavior:**
+
+* The {pluginname} plugin runs in evaluation mode and adds a watermark to exported content.
+* The `{plugincode}_token_provider` option is "not required" during the trial period.
+* If the trial period "expires" or the plugin lacks the necessary entitlement, it becomes _non-functional_.
+* Attempting to use JWT authentication during the trial will result in an _error_.
+====
 
 == Basic setup using the self-hosted service
 

--- a/modules/ROOT/pages/exportpdf.adoc
+++ b/modules/ROOT/pages/exportpdf.adoc
@@ -30,7 +30,9 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'exportpdf',
   toolbar: 'exportpdf',
-  exportpdf_token_provider: () => { // required when using the Export to PDF plugin with Tiny Cloud.
+// Below option is only required when using the cloud-based Export to PDF plugin from Tiny.Cloud.
+// Avoid setting it up during the trial period.
+  exportpdf_token_provider: () => { 
     return fetch('http://localhost:3000/jwt', { // specify your token endpoint
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/modules/ROOT/pages/exportpdf.adoc
+++ b/modules/ROOT/pages/exportpdf.adoc
@@ -49,7 +49,7 @@ For more infomation on the exportpdf_token_provider option, see xref:exportpdf.a
 The {pluginname} plugin **requires** JWT authentication when using the {companyname} Cloud service.
 
 * Configure the `{plugincode}_token_provider` option to specify the endpoint for retrieving a valid JWT token.
-* If hosting locally, use the format `+http://localhost:[port]/jwt+`, ensuring the endpoint returns a JSON object containing the token.
+* If hosting locally, use the format `+http://localhost:[port]/jwt+`, ensuring the endpoint returns a xref:importword.adoc#data-structure[valid JSON object] containing the token.
 
 For more information on how to set up JWT authentication with {pluginname}, see examples:
 
@@ -63,6 +63,8 @@ For more information on how to set up JWT authentication with {pluginname}, see 
 * If the trial period "expires" or the plugin lacks the necessary entitlement, it becomes _non-functional_.
 * Attempting to use JWT authentication during the trial will result in an _error_.
 ====
+
+include::partial$misc/admon-document-converters-jwt-expected-data-structure.adoc[]
 
 == Basic setup using the self-hosted service
 

--- a/modules/ROOT/pages/exportpdf.adoc
+++ b/modules/ROOT/pages/exportpdf.adoc
@@ -49,7 +49,7 @@ For more infomation on the exportpdf_token_provider option, see xref:exportpdf.a
 The {pluginname} plugin **requires** JWT authentication when using the {companyname} Cloud service.
 
 * Configure the `{plugincode}_token_provider` option to specify the endpoint for retrieving a valid JWT token.
-* If hosting locally, use the format `+http://localhost:[port]/jwt+`, ensuring the endpoint returns a xref:importword.adoc#data-structure[valid JSON object] containing the token.
+* If hosting locally, use the format `+http://localhost:[port]/jwt+`, ensuring the endpoint returns a xref:importword.adoc#data-structure[JSON] containing the token.
 
 For more information on how to set up JWT authentication with {pluginname}, see examples:
 

--- a/modules/ROOT/pages/exportpdf.adoc
+++ b/modules/ROOT/pages/exportpdf.adoc
@@ -1,6 +1,7 @@
 = {pluginname} plugin
 :plugincode: exportpdf
 :pluginname: Export to PDF
+:pluginfilename: export-to-pdf
 :navtitle: {pluginname}
 :description: The {pluginname} feature provides the ability to generate a PDF file directly from the editor.
 :description_short: Generate a PDF file directly from the editor.
@@ -22,8 +23,7 @@ liveDemo::exportpdf[]
 
 To add the {pluginname} plugin to the editor, add `{plugincode}` to the `plugins` option in the editor configuration.
 
-For example:
-
+.Example:
 [source,js]
 ----
 tinymce.init({
@@ -41,37 +41,16 @@ tinymce.init({
 });
 ----
 
-[NOTE]
 For more infomation on the exportpdf_token_provider option, see xref:exportpdf.adoc#exportpdf-token-provider[exportpdf_token_provider].
 
-[IMPORTANT]
-====
-The {pluginname} plugin **requires** JWT authentication when using the {companyname} Cloud service.
+include::partial$misc/admon-jwt-authentication-requirements.adoc[]
 
-* Configure the `{plugincode}_token_provider` option to specify the endpoint for retrieving a valid JWT token.
-* If hosting locally, use the format `+http://localhost:[port]/jwt+`, ensuring the endpoint returns a xref:importword.adoc#data-structure[JSON] containing the token.
-
-For more information on how to set up JWT authentication with {pluginname}, see examples:
-
-* xref:export-to-pdf-with-jwt-authentication-nodejs.adoc[Export to PDF with JWT authentication (Node.js)]
-* xref:export-to-pdf-with-jwt-authentication-php.adoc[Export to PDF with JWT authentication (PHP)]
-
-**Trial period behavior:**
-
-* The {pluginname} plugin runs in evaluation mode and adds a watermark to exported content.
-* The `{plugincode}_token_provider` option is "not required" during the trial period.
-* If the trial period "expires" or the plugin lacks the necessary entitlement, it becomes _non-functional_.
-* Attempting to use JWT authentication during the trial will result in an _error_.
-====
-
-include::partial$misc/admon-document-converters-jwt-expected-data-structure.adoc[]
 
 == Basic setup using the self-hosted service
 
 To use the self-hosted version of the {pluginname} plugin, you need to set the `exportpdf_service_url` option to the URL of the service.
 
-For example:
-
+.Example:
 [source,js]
 ----
 tinymce.init({

--- a/modules/ROOT/pages/exportword.adoc
+++ b/modules/ROOT/pages/exportword.adoc
@@ -36,14 +36,42 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'exportword',
   toolbar: 'exportword',
+  exportword_token_provider: () => { // required when using the Export to Word plugin with Tiny Cloud.
+    return fetch('http://localhost:3000/jwt', { // specify your token endpoint
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    }).then(response => response.json());
+  },
 });
 ----
 
+[NOTE]
+For more infomation on the exportword_token_provider option, see xref:exportword.adoc#exportword-token-provider[exportword_token_provider]
+
 [IMPORTANT]
-When using the {pluginname} plugin with the {companyname} Cloud service, JWT authentication is required to use the service. For more information on how to set up JWT authentication with {pluginname}, see examples:
+====
+The {pluginname} plugin **requires** JWT authentication when using the {companyname} Cloud service.
+
+* Configure the `{plugincode}_token_provider` option to specify the endpoint for retrieving a valid JWT token.
+* If hosting locally, use the format `+http://localhost:[port]/jwt+`, ensuring the endpoint returns a JSON object containing the token.
+
+For more information on how to set up JWT authentication with {pluginname}, see examples:
 
 * xref:export-to-word-with-jwt-authentication-nodejs.adoc[{pluginname} with JWT authentication (Node.js)]
 * xref:export-to-word-with-jwt-authentication-php.adoc[{pluginname} with JWT authentication (PHP)]
+
+**Trial period behavior:**
+
+* The {pluginname} plugin runs in evaluation mode and adds a watermark to exported content.
+* The `{plugincode}_token_provider` option is "not required" during the trial period.
+* If the trial period "expires" or the plugin lacks the necessary entitlement, it becomes _non-functional_.
+* Attempting to use JWT authentication during the trial will result in an _error_.
+====
+
+
+
+
+
 
 == Basic setup using the self-hosted service
 

--- a/modules/ROOT/pages/exportword.adoc
+++ b/modules/ROOT/pages/exportword.adoc
@@ -1,6 +1,7 @@
 = {pluginname} plugin
 :plugincode: exportword
 :pluginname: Export to Word
+:pluginfilename: export-to-word
 :navtitle: {pluginname}
 :description: The {pluginname} feature lets you generate a .docx (Microsoft Word document) file directly from the editor.
 :description_short: Generate a .docx file directly from the editor.
@@ -47,41 +48,16 @@ tinymce.init({
 });
 ----
 
-[NOTE]
 For more infomation on the exportword_token_provider option, see xref:exportword.adoc#exportword-token-provider[exportword_token_provider]
 
-[IMPORTANT]
-====
-The {pluginname} plugin **requires** JWT authentication when using the {companyname} Cloud service.
-
-* Configure the `{plugincode}_token_provider` option to specify the endpoint for retrieving a valid JWT token.
-* If hosting locally, use the format `+http://localhost:[port]/jwt+`, ensuring the endpoint returns a xref:exportword.adoc#data-structure[JSON] containing the token.
-
-For more information on how to set up JWT authentication with {pluginname}, see examples:
-
-* xref:export-to-word-with-jwt-authentication-nodejs.adoc[{pluginname} with JWT authentication (Node.js)]
-* xref:export-to-word-with-jwt-authentication-php.adoc[{pluginname} with JWT authentication (PHP)]
-
-**Trial period behavior:**
-
-* The {pluginname} plugin runs in evaluation mode and adds a watermark to exported content.
-* The `{plugincode}_token_provider` option is "not required" during the trial period.
-* If the trial period "expires" or the plugin lacks the necessary entitlement, it becomes _non-functional_.
-* Attempting to use JWT authentication during the trial will result in an _error_.
-====
-
-include::partial$misc/admon-document-converters-jwt-expected-data-structure.adoc[]
-
-
-
-
+include::partial$misc/admon-jwt-authentication-requirements.adoc[]
 
 
 == Basic setup using the self-hosted service
 
 To use the self-hosted version of the {pluginname} plugin, you need to set the `exportword_service_url` option to the URL of the service.
 
-For example:
+.Example:
 [source,js]
 ----
 tinymce.init({

--- a/modules/ROOT/pages/exportword.adoc
+++ b/modules/ROOT/pages/exportword.adoc
@@ -36,7 +36,9 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'exportword',
   toolbar: 'exportword',
-  exportword_token_provider: () => { // required when using the Export to Word plugin with Tiny Cloud.
+// Below option is only required when using the cloud-based Export to Word plugin from Tiny.Cloud.
+// Avoid setting it up during the trial period.
+  exportword_token_provider: () => {
     return fetch('http://localhost:3000/jwt', { // specify your token endpoint
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/modules/ROOT/pages/exportword.adoc
+++ b/modules/ROOT/pages/exportword.adoc
@@ -55,7 +55,7 @@ For more infomation on the exportword_token_provider option, see xref:exportword
 The {pluginname} plugin **requires** JWT authentication when using the {companyname} Cloud service.
 
 * Configure the `{plugincode}_token_provider` option to specify the endpoint for retrieving a valid JWT token.
-* If hosting locally, use the format `+http://localhost:[port]/jwt+`, ensuring the endpoint returns a JSON object containing the token.
+* If hosting locally, use the format `+http://localhost:[port]/jwt+`, ensuring the endpoint returns a xref:exportword.adoc#data-structure[valid JSON object] containing the token.
 
 For more information on how to set up JWT authentication with {pluginname}, see examples:
 
@@ -69,6 +69,8 @@ For more information on how to set up JWT authentication with {pluginname}, see 
 * If the trial period "expires" or the plugin lacks the necessary entitlement, it becomes _non-functional_.
 * Attempting to use JWT authentication during the trial will result in an _error_.
 ====
+
+include::partial$misc/admon-document-converters-jwt-expected-data-structure.adoc[]
 
 
 

--- a/modules/ROOT/pages/exportword.adoc
+++ b/modules/ROOT/pages/exportword.adoc
@@ -55,7 +55,7 @@ For more infomation on the exportword_token_provider option, see xref:exportword
 The {pluginname} plugin **requires** JWT authentication when using the {companyname} Cloud service.
 
 * Configure the `{plugincode}_token_provider` option to specify the endpoint for retrieving a valid JWT token.
-* If hosting locally, use the format `+http://localhost:[port]/jwt+`, ensuring the endpoint returns a xref:exportword.adoc#data-structure[valid JSON object] containing the token.
+* If hosting locally, use the format `+http://localhost:[port]/jwt+`, ensuring the endpoint returns a xref:exportword.adoc#data-structure[JSON] containing the token.
 
 For more information on how to set up JWT authentication with {pluginname}, see examples:
 

--- a/modules/ROOT/pages/importword.adoc
+++ b/modules/ROOT/pages/importword.adoc
@@ -50,7 +50,7 @@ For more infomation on the importword_token_provider option, see xref:importword
 The {pluginname} plugin **requires** JWT authentication when using the {companyname} Cloud service.
 
 * Configure the `{plugincode}_token_provider` option to specify the endpoint for retrieving a valid JWT token.
-* If hosting locally, use the format `+http://localhost:[port]/jwt+`, ensuring the endpoint returns a xref:importword.adoc#data-structure[valid JSON object] containing the token.
+* If hosting locally, use the format `+http://localhost:[port]/jwt+`, ensuring the endpoint returns a xref:importword.adoc#data-structure[JSON] containing the token.
 
 For more information on how to set up JWT authentication with {pluginname}, see examples:
 

--- a/modules/ROOT/pages/importword.adoc
+++ b/modules/ROOT/pages/importword.adoc
@@ -2,6 +2,7 @@
 = {pluginname} plugin
 :plugincode: importword
 :pluginname: Import from Word
+:pluginfilename: import-from-word
 :navtitle: {pluginname}
 :description: Provides a way to import .docx (Microsoft Word documents) or .dotx (Microsoft Word templates) files into the editor.
 :description_short: Import .docx or .dotx files into the editor.
@@ -42,37 +43,16 @@ tinymce.init({
 });
 ----
 
-[NOTE]
 For more infomation on the importword_token_provider option, see xref:importword.adoc#importword-token-provider[importword_token_provider].
 
-[IMPORTANT]
-====
-The {pluginname} plugin **requires** JWT authentication when using the {companyname} Cloud service.
+include::partial$misc/admon-jwt-authentication-requirements.adoc[]
 
-* Configure the `{plugincode}_token_provider` option to specify the endpoint for retrieving a valid JWT token.
-* If hosting locally, use the format `+http://localhost:[port]/jwt+`, ensuring the endpoint returns a xref:importword.adoc#data-structure[JSON] containing the token.
-
-For more information on how to set up JWT authentication with {pluginname}, see examples:
-
-* xref:import-from-word-with-jwt-authentication-nodejs.adoc[{pluginname} with JWT authentication (Node.js)]
-* xref:import-from-word-with-jwt-authentication-php.adoc[{pluginname} with JWT authentication (PHP)]
-
-**Trial period behavior:**
-
-* The {pluginname} plugin runs in evaluation mode and adds a watermark to exported content.
-* The `{plugincode}_token_provider` option is "not required" during the trial period.
-* If the trial period "expires" or the plugin lacks the necessary entitlement, it becomes _non-functional_.
-* Attempting to use JWT authentication during the trial will result in an _error_.
-====
-
-include::partial$misc/admon-document-converters-jwt-expected-data-structure.adoc[]
 
 == Basic setup using the self-hosted service
 
 To use the self-hosted version of the {pluginname} plugin, you need to set the `importword_service_url` option to the URL of the service.
 
-For example:
-
+.Example:
 [source,js]
 ----
 tinymce.init({

--- a/modules/ROOT/pages/importword.adoc
+++ b/modules/ROOT/pages/importword.adoc
@@ -31,14 +31,37 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'importword',
   toolbar: 'importword',
+  importword_token_provider: () => { // required when using the Import from Word plugin with Tiny Cloud.
+    return fetch('http://localhost:3000/jwt', { // specify your token endpoint
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    }).then(response => response.json());
+  },
 });
 ----
 
+[NOTE]
+For more infomation on the importword_token_provider option, see xref:importword.adoc#importword-token-provider[importword_token_provider].
+
 [IMPORTANT]
-When using the {pluginname} plugin with the {companyname} Cloud service, JWT authentication is required to use the service. For more information on how to set up JWT authentication with {pluginname}, see examples:
+====
+The {pluginname} plugin **requires** JWT authentication when using the {companyname} Cloud service.
+
+* Configure the `{plugincode}_token_provider` option to specify the endpoint for retrieving a valid JWT token.
+* If hosting locally, use the format `+http://localhost:[port]/jwt+`, ensuring the endpoint returns a JSON object containing the token.
+
+For more information on how to set up JWT authentication with {pluginname}, see examples:
 
 * xref:import-from-word-with-jwt-authentication-nodejs.adoc[{pluginname} with JWT authentication (Node.js)]
 * xref:import-from-word-with-jwt-authentication-php.adoc[{pluginname} with JWT authentication (PHP)]
+
+**Trial period behavior:**
+
+* The {pluginname} plugin runs in evaluation mode and adds a watermark to exported content.
+* The `{plugincode}_token_provider` option is "not required" during the trial period.
+* If the trial period "expires" or the plugin lacks the necessary entitlement, it becomes _non-functional_.
+* Attempting to use JWT authentication during the trial will result in an _error_.
+====
 
 == Basic setup using the self-hosted service
 

--- a/modules/ROOT/pages/importword.adoc
+++ b/modules/ROOT/pages/importword.adoc
@@ -31,6 +31,8 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'importword',
   toolbar: 'importword',
+// Below option is only required when using the cloud-based Import from Word plugin from Tiny.Cloud.
+// Avoid setting it up during the trial period.
   importword_token_provider: () => { // required when using the Import from Word plugin with Tiny Cloud.
     return fetch('http://localhost:3000/jwt', { // specify your token endpoint
       method: 'POST',

--- a/modules/ROOT/pages/importword.adoc
+++ b/modules/ROOT/pages/importword.adoc
@@ -50,7 +50,7 @@ For more infomation on the importword_token_provider option, see xref:importword
 The {pluginname} plugin **requires** JWT authentication when using the {companyname} Cloud service.
 
 * Configure the `{plugincode}_token_provider` option to specify the endpoint for retrieving a valid JWT token.
-* If hosting locally, use the format `+http://localhost:[port]/jwt+`, ensuring the endpoint returns a JSON object containing the token.
+* If hosting locally, use the format `+http://localhost:[port]/jwt+`, ensuring the endpoint returns a xref:importword.adoc#data-structure[valid JSON object] containing the token.
 
 For more information on how to set up JWT authentication with {pluginname}, see examples:
 
@@ -64,6 +64,8 @@ For more information on how to set up JWT authentication with {pluginname}, see 
 * If the trial period "expires" or the plugin lacks the necessary entitlement, it becomes _non-functional_.
 * Attempting to use JWT authentication during the trial will result in an _error_.
 ====
+
+include::partial$misc/admon-document-converters-jwt-expected-data-structure.adoc[]
 
 == Basic setup using the self-hosted service
 

--- a/modules/ROOT/partials/configuration/exportpdf_token_provider.adoc
+++ b/modules/ROOT/partials/configuration/exportpdf_token_provider.adoc
@@ -7,6 +7,8 @@ The `exportpdf_token_provider` option enables integration with a token-based aut
 
 *Default value:* `undefined`
 
+*Return data:* xref:exportpdf.adoc#data-structure[`Token` object]
+
 === Example: using `exportpdf_token_provider`
 
 [source,js]
@@ -23,3 +25,5 @@ tinymce.init({
   },
 });
 ----
+
+include::partial$misc/admon-document-converters-jwt-expected-data-structure.adoc[]

--- a/modules/ROOT/partials/configuration/exportpdf_token_provider.adoc
+++ b/modules/ROOT/partials/configuration/exportpdf_token_provider.adoc
@@ -15,7 +15,7 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'exportpdf',
   toolbar: 'exportpdf',
-  exportpdf_token_provider: () => {
+  exportpdf_token_provider: () => { // required when using the Export to PDF plugin with Tiny Cloud.
     return fetch('http://localhost:3000/jwt', { // specify your token endpoint
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -23,9 +23,3 @@ tinymce.init({
   },
 });
 ----
-
-[NOTE]
-The `exportpdf_token_provider` option is required when using the {companyname} Cloud service. For more information on how to set up JWT authentication with {pluginname}, see examples:
-
-* xref:export-to-pdf-with-jwt-authentication-nodejs.adoc[Export to PDF with JWT authentication (Node.js)]
-* xref:export-to-pdf-with-jwt-authentication-php.adoc[Export to PDF with JWT authentication (PHP)]

--- a/modules/ROOT/partials/configuration/exportword_token_provider.adoc
+++ b/modules/ROOT/partials/configuration/exportword_token_provider.adoc
@@ -7,6 +7,8 @@ The `exportword_token_provider` option enables integration with a token-based au
 
 *Default value:* `undefined`
 
+*Return data:* xref:exportword.adoc#data-structure[`Token` object]
+
 === Example: using `exportword_token_provider`
 
 [source,js]
@@ -23,3 +25,5 @@ tinymce.init({
   },
 });
 ----
+
+include::partial$misc/admon-document-converters-jwt-expected-data-structure.adoc[]

--- a/modules/ROOT/partials/configuration/exportword_token_provider.adoc
+++ b/modules/ROOT/partials/configuration/exportword_token_provider.adoc
@@ -15,7 +15,7 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'exportword',
   toolbar: 'exportword',
-  exportword_token_provider: () => {
+  exportword_token_provider: () => { // required when using the Export to Word plugin with Tiny Cloud.
     return fetch('http://localhost:3000/jwt', { // specify your token endpoint
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -23,10 +23,3 @@ tinymce.init({
   },
 });
 ----
-
-
-[NOTE]
-The `exportword_token_provider` option is required when using the {companyname} Cloud service. For more information on how to set up JWT authentication with {pluginname}, see examples:
-
-* xref:export-to-word-with-jwt-authentication-nodejs.adoc[Export to Word with JWT authentication (Node.js)]
-* xref:export-to-word-with-jwt-authentication-php.adoc[Export to Word with JWT authentication (PHP)]

--- a/modules/ROOT/partials/configuration/importword_token_provider.adoc
+++ b/modules/ROOT/partials/configuration/importword_token_provider.adoc
@@ -7,6 +7,8 @@ The `importword_token_provider` option enables integration with a token-based au
 
 *Default value:* `undefined`
 
+*Return data:* xref:importword.adoc#data-structure[`Token` object]
+
 === Example: using `importword_token_provider`
 
 [source,js]
@@ -23,3 +25,5 @@ tinymce.init({
   },
 });
 ----
+
+include::partial$misc/admon-document-converters-jwt-expected-data-structure.adoc[]

--- a/modules/ROOT/partials/configuration/importword_token_provider.adoc
+++ b/modules/ROOT/partials/configuration/importword_token_provider.adoc
@@ -15,7 +15,7 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'importword',
   toolbar: 'importword',
-  importword_token_provider: () => {
+  importword_token_provider: () => { // required when using the Import from Word plugin with Tiny Cloud.
     return fetch('http://localhost:3000/jwt', { // specify your token endpoint
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -23,9 +23,3 @@ tinymce.init({
   },
 });
 ----
-
-[NOTE]
-The `importword_token_provider` option is required when using the {companyname} Cloud service. For more information on how to set up JWT authentication with {pluginname}, see examples:
-
-* xref:import-from-word-with-jwt-authentication-nodejs.adoc[Import to Word with JWT authentication (Node.js)]
-* xref:import-from-word-with-jwt-authentication-php.adoc[Import to Word with JWT authentication (PHP)]

--- a/modules/ROOT/partials/misc/admon-document-converters-jwt-expected-data-structure.adoc
+++ b/modules/ROOT/partials/misc/admon-document-converters-jwt-expected-data-structure.adoc
@@ -1,0 +1,16 @@
+== Data structure
+
+The JSON data containing the valid encoded token must match the following structure:
+
+[source,json]
+----
+{
+  "token": "<encoded JWT string>"
+}
+----
+
+[cols="1,1,1,3",options="header"]
+|===
+|Field |Type |Required? |Description
+|`+token+` |`+string+` |required |A Base64-encoded JSON Web Token (JWT) used for authentication and authorization.
+|===

--- a/modules/ROOT/partials/misc/admon-document-converters-jwt-expected-data-structure.adoc
+++ b/modules/ROOT/partials/misc/admon-document-converters-jwt-expected-data-structure.adoc
@@ -1,11 +1,12 @@
-== Data structure
+[[data-structure]]
+=== Data structure for the JWT token
 
-The JSON data containing the valid encoded token must match the following structure:
+The object containing the valid encoded token must match the following structure:
 
-[source,json]
+[source,js]
 ----
 {
-  "token": "<encoded JWT string>"
+  token: "<encoded JWT string>"
 }
 ----
 

--- a/modules/ROOT/partials/misc/admon-jwt-authentication-requirements.adoc
+++ b/modules/ROOT/partials/misc/admon-jwt-authentication-requirements.adoc
@@ -1,0 +1,18 @@
+[IMPORTANT]
+====
+The {pluginname} plugin **requires** JWT authentication when using the {companyname} Cloud service.
+
+* Configure the `{plugincode}_token_provider` option to specify the endpoint for retrieving a valid JWT token.
+
+For more information on how to set up JWT authentication with {pluginname}, see examples:
+
+* xref:{pluginfilename}-with-jwt-authentication-nodejs.adoc[{pluginname} with JWT authentication (Node.js)]
+* xref:{pluginfilename}-with-jwt-authentication-php.adoc[{pluginname} with JWT authentication (PHP)]
+
+**Trial period behavior:**
+
+* The {pluginname} plugin runs in evaluation mode and adds a watermark to exported content.
+* The `{plugincode}_token_provider` option is "not required" during the trial period.
+* If the trial period "expires" or the plugin lacks the necessary entitlement, it becomes _non-functional_.
+* Attempting to use JWT authentication during the trial will result in an _error_.
+====


### PR DESCRIPTION
Ticket: DOC-3143

Site: [Staging branch: exportword](http://docs-hotfix-7-doc-3143.staging.tiny.cloud/docs/tinymce/latest/exportword/)
Site: [Staging branch: exportpdf](http://docs-hotfix-7-doc-3143.staging.tiny.cloud/docs/tinymce/latest/exportpdf/)
Site: [Staging branch: importword](http://docs-hotfix-7-doc-3143.staging.tiny.cloud/docs/tinymce/latest/importword/)

Changes:
* Update `Basic setup using the Tiny Cloud service` for each service
* Improved JWT authentication details for the `{pluginname}` plugin, and trial behavior.
* Updated partials, and minor copy edits.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed