### PR TITLE
DOC-3155: Remove references to skin tool from the `tinymce/6` documentation content.

### DIFF
--- a/modules/ROOT/pages/creating-a-skin.adoc
+++ b/modules/ROOT/pages/creating-a-skin.adoc
@@ -6,8 +6,6 @@
 
 This section provides information on how to manually create a new skin to customize the appearance of {productname} {productmajorversion}.
 
-The {productname} Skin Tool provides an interactive method for designing and creating a skin for {productname}, visit: http://skin.tiny.cloud/[http://skin.tiny.cloud/].
-
 == Prerequisites
 
 This guide assumes:

--- a/modules/ROOT/pages/customize-ui.adoc
+++ b/modules/ROOT/pages/customize-ui.adoc
@@ -35,7 +35,7 @@ tinymce.init({
 });
 ----
 
-To create a skin interactively, visit http://skin.tiny.cloud/t5/[the {productname} 6 Skin Tool]. For information on manually creating skins for {productname}, see xref:creating-a-skin.adoc[Creating a skin].
+For information on manually creating skins for {productname}, see xref:creating-a-skin.adoc[Creating a skin].
 
 NOTE: Developers often confuse the difference between {productname} "themes" and "skins". A *Skin* in {productname} is used to make changes to the appearance of the editor, for example, colors, margins, padding, fonts, icons, etc. A *Theme* creates the editor construction (left, top, bottom, or right of the editing area - vertical or horizontal, inline or outside, etc.). A skin usually changes the color scheme of a button, dialog, etc. while the theme applies to the whole editor including its functionality and has child skins to change the appearance.
 


### PR DESCRIPTION
Ticket: DOC-3155

Site: [Staging branch](http://docs-hotfix-7-doc-3155.staging.tiny.cloud/docs/tinymce/6/creating-a-skin/)

Changes:
* <placeholder-text>

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [ ] Documentation Team Lead has reviewed