### PR TITLE
DOC-3154: Clarify skin creation instructions in UI customization documentation (TinyMCE v7).

### DIFF
--- a/modules/ROOT/pages/creating-a-skin.adoc
+++ b/modules/ROOT/pages/creating-a-skin.adoc
@@ -1,83 +1,108 @@
-= Create a skin for {productname}
-:navtitle: Create a skin
-:description_short: Introducing skin creation.
-:description: Introducing skin creation, less and icon modification.
-:keywords: create, creator, skin, icon
+= Create a Skin for {productname}
+:navtitle: Create a Skin
+:description_short: Introduction to skin creation.
+:description: Learn how to create a custom skin, modify Less variables, and update icons for {productname}.
+:keywords: create, skin, customization, icon, Less
 
-This section provides information on how to manually create a new skin to customize the appearance of {productname} {productmajorversion}.
+This guide explains how to manually create a new skin to customize the appearance of {productname} {productmajorversion}.
 
 == Prerequisites
 
-This guide assumes:
+Before beginning, ensure that:
 
-* Familiarity with the command line and running simple commands.
-* https://nodejs.org/en/[Node.js], https://yarnpkg.com/en/[Yarn] and https://gulpjs.com[Gulp] are already installed.
-* Basic understanding of http://lesscss.org[Less], the CSS preprocessor we use to build the skins. More specifically, http://lesscss.org/features/#variables-feature[read the section about variables].
+* Familiarity with the command line and basic commands is established.
+* link:https://nodejs.org/en/[Node.js] and link:https://yarnpkg.com/en/[Yarn] are already installed.
+* A basic understanding of link:http://lesscss.org[Less], the CSS preprocessor used to build skins, is required. Specifically, review the link:http://lesscss.org/features/#variables-feature[section on variables].
 
 == Preparation
 
-The CSS that goes with a theme is called a skin. The default skin for {productname} {productmajorversion} is named Oxide and is written in http://lesscss.org[Less], a popular CSS preprocessor. With Oxide we introduced a concept we call the *Style API*. This API consists of around 300 variables which you use to modify the appearance of {productname}. You never touch the underlying CSS. The benefit of this approach is that improvements we make to the CSS and HTML won't break your custom skin. This also means that if things don't work as expected, we can provide support and bug fixes, something that was virtually impossible before.
+The CSS associated with a theme is called a skin. The default skin for {productname} {productmajorversion} is **Oxide**, written in link:http://lesscss.org[Less]. Oxide introduces the *Style API*, which consists of approximately 300 variables that allow customization of {productname} without modifying the underlying CSS. This approach ensures compatibility with future updates and provides continued support for bug fixes.
 
-IMPORTANT: We do not recommend modifying or overriding CSS rules directly.
+[IMPORTANT]
+{companyname} recommends not modifying or overriding CSS rules directly.
 
-To set up the skin development environment, begin with the following steps:
+Follow these steps to set up the skin development environment:
 
-. Download (or `+git clone+`) the https://github.com/tinymce/tinymce[{productname} source code].
-. Open the terminal and navigate to the folder you just downloaded.
-. Install dependencies with the command:
+. Download (or `+git clone+`) the link:https://github.com/tinymce/tinymce[{productname} source code].
+. Open a terminal and navigate to the folder you just downloaded.
+. Install dependencies and build the project using the following commands:
 +
 [source,sh]
 ----
-yarn install
+yarn && yarn dev && yarn build
 ----
-. Launch the web server to preview the skins using the command:
+. Start the development server to preview skins:
 +
 [source,sh]
 ----
 yarn oxide-start
 ----
+. Once the server starts, open a browser and navigate to the displayed URL, typically `+http://localhost:3000+`.
 
-You should now be able to open a web browser and point it to the url displayed in the terminal, usually `+http://localhost:3000+`.
-
-The development environment is set up and ready to work.
+The development environment is now setup and should look similar to the following:
 
 image::SDK-for-silver.png[{productname} skin SDK for Silver theme]
 
-If you just need to build the skins without launching a web server, run:
+[NOTE]
+If required to modify the skin without launching a web server, run **`+yarn oxide-build+`** instead of **`+yarn oxide-start+`**.
 
-[source,sh]
-----
-yarn oxide-build
-----
+== Creating or Editing a Skin
 
-== Making or editing a skin
+Ensure completion of the preparation steps before proceeding.
 
-Make sure you have performed the preparation steps above.
+=== Directory Structure
 
-=== Overview
+Navigate to `+modules/oxide/src/less/skins/+`. This folder contains:
 
-Navigate to `+modules/oxide/src/less/skins/+`. There are two folders in this location:
+. `+/ui+`: Contains editor UI skins. The main file here is `+skin.less+`.
+. `+/content+`: Contains skins for the content inside the editor.
 
-* `+/ui+` - which is the skins for the editor. The important file here is `+skin.less+`.
-* `+/content+` - which is the skins for the content within the editor.
+The `+modules/oxide/src/less/theme/+` folder contains Less files defining global styles. Most files list available variables at the top, such as colors, margins, and fonts. Variables are prefixed with `@` (e.g., `@background-color`).
 
-The folder `+modules/oxide/src/less/theme/+` contains the Less files. At the top of most files you'll find the available variables that defines the default colors, margins, fonts etc (variables are the strings that starts with an at-character, for example `+@background-color+`). _Do not edit these files_, instead use them as a reference when creating your skin. We recommend starting with the two files containing global variables: `+modules/oxide/src/less/theme/globals/global-variables.less+` and the toolbar buttons: `+modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less+`.
+[IMPORTANT]
+====
+_Do not edit these files directly_. Instead, use them as references when creating a custom skin. Start by reviewing:
 
-The general workflow is that you look inside the less files within the theme folder and copy the variables you like to change into your skin's `+skin.less+` file.
+* `+modules/oxide/src/less/theme/globals/global-variables.less+`
+* `+modules/oxide/src/less/theme/components/toolbar-button/toolbar-button.less+`
 
-NOTE: The skin *only* changes the visual presentation of the UI and *not* the placement of elements. Placement of elements is done by the {productname} UI framework. This framework makes it possible to do complex UI layouts on all browsers without touching any CSS when plugins are created.
+The typical workflow involves copying variables from the theme folder into the skins `skin.less` file and modifying them as needed.
+====
+
+[NOTE]
+Skins **only** affect the visual appearance of the UI. Element positioning is managed by {productname}'s UI framework.
 
 [[creating-a-skin]]
-=== Creating a skin
+=== Creating a Skin
 
-. Begin by duplicating the `+default+` folder located in `+modules/oxide/src/less/skins/ui/+` and rename it to the name of your skin.
-. Start the development server using the terminal command `+yarn oxide-start+`. If you already have the server running, you need to restart it to make it recognize your new skin using `+ctrl-c+` and then start it again.
-. Open the file `+modules/oxide/src/less/skin/ui/<your-skin-name>/skin.less+`.
-. Open any less file located in the theme folder, for example `+modules/oxide/src/less/theme/globals/global-variables.less+` and copy a variable you like to change, it's easiest to copy the whole line. Let's copy the `+@background-color+` variable to start with.
-. Paste the variable into the `+skin.less+` file you opened in step 2. For a striking look, change the variable value to be red, like this: `+@background-color: red;+`. Then save the file.
+. Duplicate the `+default+` folder in `+modules/oxide/src/less/skins/ui/+` and rename it.
+. Rebuild the project to recognize the newly created skins by running:
++
+[source,sh]
+----
+yarn build
+----
+. Start the development server by running:
++
+[source,sh]
+----
+yarn oxide-start
+----
++
+[TIP]
+If the server is already running, restart it (`+Ctrl+C+`) and run the command again.
 
-Your skin.less file should now look like this:
-
+. Open `+modules/oxide/src/less/skin/ui/<your-skin-name>/skin.less+`.
+. Open a Less file from the theme folder (e.g., `+modules/oxide/src/less/theme/globals/global-variables.less+`) and copy a variable to modify. For example:
++
+[source,less]
+----
+@background-color: red;
+----
+. Paste the variable into the `skin.less` file.
++
+The updated `skin.less` should look like this:
++
 [source,less]
 ----
 @import 'src/less/theme/theme';
@@ -88,30 +113,60 @@ Your skin.less file should now look like this:
 
 @background-color: red;
 ----
++
+. Save the file and check the changes in a browser. Select the skin from the _Skin menu_.
+. The editor should now display with a red background.
 
-Switch to the web browser. Select your skin from the _Skin menu_. It should show a fiery red editor
+image::SDK-for-silver-custom-example.png[{productname} Skin SDK for the Silver theme]
 
-image::SDK-for-silver-custom-example.png[{productname} skin SDK for Silver theme]
+This method allows customization of {productname} by modifying predefined variables, such as toolbar spacing or letter spacing.
 
-This is how you skin {productname}: copy variables from the files in the theme folder and paste them into your skin file. There are variables for most things, like spacing between toolbar buttons to letter spacing. Simple yet powerful.
+[TIP]
+Adjust {productname} configurations in `+modules/oxide/src/demo/index.html+` to match specific use cases.
 
-TIP: You can change the {productname} config in `+modules/oxide/src/demo/index.html+` to suit your particular use case.
+== Creating a Content CSS File
 
-== Creating a content CSS file
+To modify the appearance of content inside the editor (e.g., headings, lists, quotes), create a content CSS file:
 
-To update the appearance of the content within the editor, such as headings, quotes, lists, etc... you create a content css. These are located in `+modules/oxide/src/less/skin/content/+`
+. Create a folder in `+modules/oxide/src/less/skins/content/+` and add a `content.less` file. Alternatively, duplicate an existing content CSS file.
+. Rebuild the project to recognize the newly created content skin.
++
+[source,sh]
+----
+yarn build
+----
+. Start the development server:
++
+[source,sh]
+----
+yarn oxide-start
+----
++
+[TIP]
+If the server is already running, restart it (`+Ctrl+C+`) and run the command again.
 
-. Create a folder in `+modules/oxide/src/less/skins/content/+` and create a `+content.less+` file in it. Alternatively, you can duplicate any of the existing content css.
-. Start the development server using the terminal command yarn oxide-start. If you already have the server running, you need to restart it to make it recognize your new skin using ctrl-c and then start it again.
-. Add the relevant element selectors for the desired use case such as `+h1+` to `+h6+`, `+a+`, `+blockquote+`, `+code+`, `+table+`, etc...
+. Add styles for relevant elements (`h1` to `h6`, `a`, `blockquote`, `code`, `table`, etc.). For example:
++
+[source,less]
+----
+h1 {
+  color: red;
+}
+----
++
+. Save the file and check the changes in a browser.
+. The editor should now display with red headings.
 
-== Moving the skin into {productname}
+== Moving the Skin into {productname}
 
-. Copy the skin and/or content CSS from `+modules/oxide/build/skins/+` to the corresponding folders in your production {productname} folder.
-. Update the {productname} init function with the xref:editor-skin.adoc#skin[skin] option and/or the xref:add-css-options.adoc#content_css[content_css] option.
+. Copy the skin and/or content CSS from `+modules/oxide/build/skins/+` to the appropriate folders in the production {productname} setup.
+. Update {productname}'s initialization options:
 
-For more information on how to specify the location of the skin file, see xref:editor-skin.adoc#skin_url[this] section.
+* Use the xref:editor-skin.adoc#skin[skin] option for UI skins.
+* Use the xref:add-css-options.adoc#content_css[content_css] option for content styles.
 
-== Modifying the icons
+For details on specifying the skin file location, see xref:editor-skin.adoc#skin_url[this section].
 
-For information on adding custom icons, see: xref:creating-an-icon-pack.adoc[Create an icon pack for {productname}].
+== Modifying Icons
+
+For details on adding custom icons, see: xref:creating-an-icon-pack.adoc[Create an Icon Pack for {productname}].

--- a/modules/ROOT/pages/customize-ui.adoc
+++ b/modules/ROOT/pages/customize-ui.adoc
@@ -35,7 +35,7 @@ tinymce.init({
 });
 ----
 
-To create a skin interactively, visit http://skin.tiny.cloud/t5/[the {productname} 6 Skin Tool]. For information on manually creating skins for {productname}, see xref:creating-a-skin.adoc[Creating a skin].
+For information on manually creating skins for {productname}, see xref:creating-a-skin.adoc[Creating a skin].
 
 NOTE: Developers often confuse the difference between {productname} "themes" and "skins". A *Skin* in {productname} is used to make changes to the appearance of the editor, for example, colors, margins, padding, fonts, icons, etc. A *Theme* creates the editor construction (left, top, bottom, or right of the editing area - vertical or horizontal, inline or outside, etc.). A skin usually changes the color scheme of a button, dialog, etc. while the theme applies to the whole editor including its functionality and has child skins to change the appearance.
 


### PR DESCRIPTION
Ticket: DOC-3154

Site: [Staging branch](http://docs-hotfix-7-doc-3154.staging.tiny.cloud/docs/tinymce/latest/creating-a-skin/)

Changes:
* improve documentation for skin creation.
* removal of links to skin.tiny.cloud/5t

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed