### PR TITLE
DOC-3162: TinyMCE 7.7.2 Release Documentation

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -422,7 +422,6 @@
 *** {productname} 7.7.2
 **** xref:7.7.2-release-notes.adoc#overview[Overview]
 **** xref:7.7.2-release-notes.adoc#bug-fixes[Bug fixes]
-**** xref:7.7.2-release-notes.adoc#security-fixes[Security fixes]
 *** {productname} 7.7.1
 **** xref:7.7.1-release-notes.adoc#overview[Overview]
 **** xref:7.7.1-release-notes.adoc#accompanying-premium-self-hosted-server-side-component-changes[Accompanying Premium self-hosted server-side component changes]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -419,6 +419,10 @@
 ** xref:tinymce-and-cors.adoc[Cross-Origin Resource Sharing (CORS)]
 * Release information
 ** xref:release-notes.adoc[Release notes for {productname}]
+*** {productname} 7.7.2
+**** xref:7.7.2-release-notes.adoc#overview[Overview]
+**** xref:7.7.2-release-notes.adoc#bug-fixes[Bug fixes]
+**** xref:7.7.2-release-notes.adoc#security-fixes[Security fixes]
 *** {productname} 7.7.1
 **** xref:7.7.1-release-notes.adoc#overview[Overview]
 **** xref:7.7.1-release-notes.adoc#accompanying-premium-self-hosted-server-side-component-changes[Accompanying Premium self-hosted server-side component changes]

--- a/modules/ROOT/pages/7.7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.2-release-notes.adoc
@@ -2,7 +2,7 @@
 :release-version: 7.7.2
 :navtitle: {productname} {release-version}
 :description: Release notes for {productname} {release-version}
-:keywords: releasenotes, bugfixes, security
+:keywords: releasenotes, bugfixes
 :page-toclevels: 1
 
 include::partial$misc/admon-releasenotes-for-stable.adoc[]
@@ -11,30 +11,41 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 [[overview]]
 == Overview
 
-{productname} {release-version} was released for {enterpriseversion} and {cloudname} on <weekday>, <month> <DD>^<st|nd|rd|th>^, <YYYY>. These release notes provide an overview of the changes for {productname} {release-version}, including:
+{productname} {release-version} was released for {enterpriseversion} and {cloudname} on Wednesday, March 19^th^, 2025. These release notes provide an overview of the changes for {productname} {release-version}, including:
 
-// Remove sections and section boilerplates as necessary.
-// Pluralise as necessary or remove the placeholder plural marker.
 * xref:bug-fixes[Bug fixes]
-* xref:security-fixes[Security fixes]
 
 [[bug-fixes]]
 == Bug fixes
 
-{productname} {release-version} also includes the following bug fix<es>:
+{productname} {release-version} also includes the following bug fixes:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Error was thrown when pressing `tab` in the last cell of a non-editable table.
+// #TINY-11797
 
-// CCFR here.
+Previously in {productname}, an issue was identified where pressing `Tab` in the last cell of a non-editable table attempted to insert a new row and move the selection to it. This behavior resulted in an infinite loop. Additionally, if `Tab` was pressed in an editable cell and the next cell was a `contentEditable="false"` (`CEF`) cell, with a `contenteditable="true"` element inside, the focus would skip the `CEF` cell.
 
+This issue also triggered error messages when pressing `Tab` in the last cell of a non-editable table, negatively impacting page performance.
 
-[[security-fixes]]
-== Security fixes
+{productname} {release-version} resolves this issue by refining the tab navigation behavior:
 
-{productname} {release-version} includes <a fix | fixes for the following security issue<s>:
+* Pressing `Tab` in the last cell of a non-editable table now has no effect.
+* When `Tab` is pressed in an editable cell, and the next cell is a `CEF` cell with an editable element inside, the cursor is moved to an editable element within the `CEF` cell.
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+These improvements enhance table navigation, prevent unnecessary error messages, and optimize performance when working with non-editable tables.
 
-// CCFR here.
+=== Error was thrown when trying to use the context form API after a component was detached.
+// #TINY-11781
+
+Previously, an error occurred when the `setValue` function from the xref:contextform.adoc#formapi[Context Form API] was called after the toolbar had been detached from the DOM. As a result, developers were unable to retrieve the value of the Context Form when using the API after the form had been closed.
+
+{productname} {release-version} resolves this issue by ensuring that developers can now reliably get and set the value of the Context Form even after it has been detached.
+
+=== Deleting an empty block within an `<li>` element would move cursor to the end of the `<li>`.
+// #TINY-11763
+
+In previous versions of {productname}, an issue was identified where deleting an empty block within an `<li>` element would unexpectedly reposition the cursor at the end of the `<li>` element. Additionally, deleting an empty block located between two lists could trigger an error if all elements were nested within the same `<li>` element.
+
+These issues led to confusing behavior, as users experienced unintended cursor movement and encountered error messages.
+
+{productname} {release-version} resolves these issues by improving the list behavior. As a result, the cursor remains stable, and users no longer experience unexpected movements or error messages.

--- a/modules/ROOT/pages/7.7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.2-release-notes.adoc
@@ -23,7 +23,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 === Error was thrown when pressing `Tab` in the last cell of a non-editable table.
 // #TINY-11797
 
-Previously in {productname}, an issue was identified where pressing `Tab` in the last cell of a non-editable table attempted to insert a new row and move the selection to it. This behavior resulted in an infinite loop. Additionally, if `Tab` was pressed in an editable cell and the next cell was a `contentEditable="false"` (`CEF`) cell, with a `contenteditable="true"` element inside, the focus would skip the `CEF` cell.
+Previously in {productname}, an issue was identified where pressing `Tab` in the last cell of a non-editable table attempted to insert a new row and move the selection to it. This behavior resulted in an infinite loop. Additionally, if `Tab` was pressed in an editable cell and the next cell was a `contenteditable="false"` (`CEF`) cell, with a `contenteditable="true"` element inside, the focus would skip the `CEF` cell.
 
 This issue also triggered error messages when pressing `Tab` in the last cell of a non-editable table, negatively impacting page performance.
 

--- a/modules/ROOT/pages/7.7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.2-release-notes.adoc
@@ -1,0 +1,40 @@
+= {productname} {release-version}
+:release-version: 7.7.2
+:navtitle: {productname} {release-version}
+:description: Release notes for {productname} {release-version}
+:keywords: releasenotes, bugfixes, security
+:page-toclevels: 1
+
+include::partial$misc/admon-releasenotes-for-stable.adoc[]
+
+
+[[overview]]
+== Overview
+
+{productname} {release-version} was released for {enterpriseversion} and {cloudname} on <weekday>, <month> <DD>^<st|nd|rd|th>^, <YYYY>. These release notes provide an overview of the changes for {productname} {release-version}, including:
+
+// Remove sections and section boilerplates as necessary.
+// Pluralise as necessary or remove the placeholder plural marker.
+* xref:bug-fixes[Bug fixes]
+* xref:security-fixes[Security fixes]
+
+[[bug-fixes]]
+== Bug fixes
+
+{productname} {release-version} also includes the following bug fix<es>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[security-fixes]]
+== Security fixes
+
+{productname} {release-version} includes <a fix | fixes for the following security issue<s>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.

--- a/modules/ROOT/pages/7.7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.2-release-notes.adoc
@@ -20,7 +20,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 {productname} {release-version} also includes the following bug fixes:
 
-=== Error was thrown when pressing `tab` in the last cell of a non-editable table.
+=== Error was thrown when pressing `Tab` in the last cell of a non-editable table.
 // #TINY-11797
 
 Previously in {productname}, an issue was identified where pressing `Tab` in the last cell of a non-editable table attempted to insert a new row and move the selection to it. This behavior resulted in an infinite loop. Additionally, if `Tab` was pressed in an editable cell and the next cell was a `contentEditable="false"` (`CEF`) cell, with a `contenteditable="true"` element inside, the focus would skip the `CEF` cell.

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -4,6 +4,18 @@
 
 NOTE: This is the {productname} Community version changelog. For information about the latest {cloudname} or {enterpriseversion} Release, see: xref:release-notes.adoc[{productname} Release Notes].
 
+== xref:7.7.2-release-notes.adoc[7.7.2 - 2025-03-19]
+
+=== Fixed
+* Error was thrown when pressing tab in the last cell of a non-editable table.
+// #TINY-11797
+* Error was thrown when trying to use the context form API after a component was detached.
+// #TINY-11781
+* Deleting an empty block within an <li> element would move cursor to the end of the <li>.
+// #TINY-11763
+* Deleting an empty block that was between two lists would throw an Error when all three elements were nested inside a list.
+// #TINY-11763
+
 == xref:7.7.1-release-notes.adoc[7.7.1 - 2025-03-05]
 
 === Fixed

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -11,7 +11,7 @@ This section lists the releases for {productname} 7 and the changes made in each
 
 a|
 [.lead]
-xref:7.0.0-release-notes.adoc#overview[{productname} 7.7.2]
+xref:7.7.2-release-notes.adoc#overview[{productname} 7.7.2]
 
 Release notes for {productname} 7.7.2
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -11,6 +11,12 @@ This section lists the releases for {productname} 7 and the changes made in each
 
 a|
 [.lead]
+xref:7.0.0-release-notes.adoc#overview[{productname} 7.7.2]
+
+Release notes for {productname} 7.7.2
+
+a|
+[.lead]
 xref:7.7.1-release-notes.adoc#overview[{productname} 7.7.1]
 
 Release notes for {productname} 7.7.1


### PR DESCRIPTION
Ticket: DOC-3162

Site: [Staging branch](http://docs-release-772.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* TinyMCE 7.7.2 Release Documentation

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.

Review:
- [x] Documentation Team Lead has reviewed