### PR TITLE
DOC-3165: Update documentation for Import from Word and Export to Word services using Docker (Individually licensed) 

### DIFF
--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
@@ -28,6 +28,13 @@ Login to Docker registry:
 docker login -u [username] -p [password] registry.containers.tiny.cloud
 ----
 
+Pull the Docker image: 
+
+[source, sh, subs="attributes+"]
+----
+docker pull docker pull registry.containers.tiny.cloud/{dockerimageimportfromwordexporttoword}:[version]
+----
+
 Launch the Docker container:
 
 [source, sh, subs="attributes+"]
@@ -59,7 +66,7 @@ services:
     restart: always
     init: true
     environment:
-      LICENSE_KEY: "licensekey"
+      LICENSE_KEY: "license_key"
       # Secret Key is optional
       SECRET_KEY: "secret_key"
 ----
@@ -70,7 +77,7 @@ For details on `SECRET_KEY` usage check the xref:individual-import-from-word-and
 
 [source, bash]
 ----
-docker-compose up
+docker compose up
 ----
 
 [NOTE]

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
@@ -25,7 +25,7 @@ Login to Docker registry:
 
 [source, sh, subs="attributes+"]
 ----
-docker login -u [username] -p [password] registry.containers.tiny.cloud
+docker login -u tiny -p [access-token] registry.containers.tiny.cloud
 ----
 
 Pull the Docker image: 

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-overview-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-overview-on-premises.adoc
@@ -3,7 +3,9 @@
 
 {pluginname} is a set of two converter services that allow for both exporting a structured HTML content (e.g. created with {productname} WYSIWYG editor) into a `.docx` Microsoft Word file and for importing content from `.docx` and `.dotx` files and converting it into a styled HTML document.
 
-A valid license key is needed in order to install {pluginname} On-Premises. link:https://www.tiny.cloud/contact/[Contact us] for a trial license key.
+A valid license key is needed in order to install {pluginname} On-Premises. You will also need login credentials to access the Tiny Cloud Docker registry and pull the Docker image. 
+
+To get started, link:https://www.tiny.cloud/contact/[Contact Tiny Support] for a trial license key and Docker login credentials.
 
 The documentation in this section refers to a simplified version of the {pluginname} On-Premises which was designed to be easy to set up and maintain (while preserving all the features). It also lowers the running costs by reducing the number of servers required to run the whole application to the minimum.
 

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-overview-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-overview-on-premises.adoc
@@ -3,9 +3,9 @@
 
 {pluginname} is a set of two converter services that allow for both exporting a structured HTML content (e.g. created with {productname} WYSIWYG editor) into a `.docx` Microsoft Word file and for importing content from `.docx` and `.dotx` files and converting it into a styled HTML document.
 
-A valid license key is needed in order to install {pluginname} On-Premises. You will also need login credentials to access the Tiny Cloud Docker registry and pull the Docker image. 
+A valid license key is needed in order to install {pluginname} On-Premises. You will also need an access token to access the Tiny Cloud Docker registry and pull the Docker image. 
 
-To get started, link:https://www.tiny.cloud/contact/[Contact Tiny Support] for a trial license key and Docker login credentials.
+To get started, link:https://www.tiny.cloud/contact/[Contact Tiny Support] for a trial license key and Docker access token.
 
 The documentation in this section refers to a simplified version of the {pluginname} On-Premises which was designed to be easy to set up and maintain (while preserving all the features). It also lowers the running costs by reducing the number of servers required to run the whole application to the minimum.
 


### PR DESCRIPTION
Ticket: DOC-3165

Site: [Staging branch](http://docs-hotfix-7-doc-3165.staging.tiny.cloud/docs/tinymce/latest/individual-import-from-word-and-export-to-word-on-premises/)

Changes:
* Update Overview section to include Docker login credentials requirement
* Add step for pulling the Docker image in the example scripts 

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed