### PR TITLE
DOC-3164: Update documentation for Export to PDF service using Docker (Individually licensed)

### DIFF
--- a/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-installation.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-installation.adoc
@@ -15,7 +15,7 @@ Refer to the xref:individual-export-to-pdf-on-premises.adoc#requirements[Require
 
 === Setting up the application using a Docker container
 
-. The username and password credentials supplied by {companyname} are utilized for logging into the Docker registry and retrieving the Docker image.
+. Log into the Docker registry and retrieve the Docker image using the provided access token.
 . Containerize the application using `docker` or `docker-compose`.
 . Use a demo page to verify if the application works properly.
 
@@ -25,7 +25,7 @@ Login to Docker registry:
 
 [source, sh, subs="attributes+"]
 ----
-docker login -u [username] -p [password] registry.containers.tiny.cloud
+docker login -u tiny -p [access-token] registry.containers.tiny.cloud
 ----
 
 Pull the Docker image: 

--- a/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-installation.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-installation.adoc
@@ -15,7 +15,7 @@ Refer to the xref:individual-export-to-pdf-on-premises.adoc#requirements[Require
 
 === Setting up the application using a Docker container
 
-. The username and password credentials supplied by Tiny are utilized for logging into the Docker registry and retrieving the Docker image.
+. The username and password credentials supplied by {companyname} are utilized for logging into the Docker registry and retrieving the Docker image.
 . Containerize the application using `docker` or `docker-compose`.
 . Use a demo page to verify if the application works properly.
 
@@ -26,6 +26,13 @@ Login to Docker registry:
 [source, sh, subs="attributes+"]
 ----
 docker login -u [username] -p [password] registry.containers.tiny.cloud
+----
+
+Pull the Docker image: 
+
+[source, sh, subs="attributes+"]
+----
+docker pull registry.containers.tiny.cloud/{dockerimageexporttopdf}:[version]
 ----
 
 Launch the Docker container:
@@ -72,7 +79,7 @@ For details on `SECRET_KEY` usage check the xref:individual-export-to-pdf-on-pre
 
 [source, bash]
 ----
-docker-compose up
+docker compose up
 ----
 
 [NOTE]

--- a/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-overview.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-overview.adoc
@@ -3,8 +3,8 @@
 
 The On-Premises version of the {pluginname} Converter is an application that can be installed and run on the customer’s in-house servers and computing infrastructure, including a private cloud. It contains all the features of the {pluginname} Converter available as SaaS.
 
-A valid license key is required in order to install {pluginname} Converter On-Premises. You will also need login credentials to access the {companyname} Cloud Docker registry and pull the Docker image. 
+A valid license key is required in order to install {pluginname} Converter On-Premises. You will also need an access token to access the {companyname} Cloud Docker registry and pull the Docker image. 
 
-To get started, link:https://www.tiny.cloud/contact/[Contact Tiny Support] for a trial license key and Docker login credentials. 
+To get started, link:https://www.tiny.cloud/contact/[Contact Tiny Support] for a trial license key and Docker access token. 
 
 The only requirement to run {pluginname} On-Premises is a container runtime or orchestration tool e.g. Docker, Kubernetes, Podman. 

--- a/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-overview.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-overview.adoc
@@ -3,8 +3,8 @@
 
 The On-Premises version of the {pluginname} Converter is an application that can be installed and run on the customer’s in-house servers and computing infrastructure, including a private cloud. It contains all the features of the {pluginname} Converter available as SaaS.
 
-A valid license key is required in order to install {pluginname} Converter On-Premises.
-link:https://www.tiny.cloud/contact/[Contact us] for a trial license key.
+A valid license key is required in order to install {pluginname} Converter On-Premises. You will also need login credentials to access the {companyname} Cloud Docker registry and pull the Docker image. 
 
+To get started, link:https://www.tiny.cloud/contact/[Contact Tiny Support] for a trial license key and Docker login credentials. 
 
-The only requirement to run {pluginname} On-Premises is a container runtime or orchestration tool e.g. Docker, Kubernetes, Podman.
+The only requirement to run {pluginname} On-Premises is a container runtime or orchestration tool e.g. Docker, Kubernetes, Podman. 


### PR DESCRIPTION
Ticket: DOC-3164

Site: [Staging branch](http://docs-hotfix-7-doc-3164.staging.tiny.cloud/docs/tinymce/latest/individual-export-to-pdf-on-premises/)

Changes:
* Update Overview section to include Docker login credentials requirement
* Add step for pulling the Docker image in the example scripts

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed