### PR TITLE
DOC-3163: Exception when pressing tab in the last cell of a non-editable table.

### DIFF
--- a/modules/ROOT/pages/7.7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.2-release-notes.adoc
@@ -23,10 +23,19 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 {productname} {release-version} also includes the following bug fixes:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Exception occurs when pressing `tab` in the last cell of a non-editable table
+// #TINY-11797
 
-// CCFR here.
+Previously in {productname}, an issue was identified where pressing `Tab` in the last cell of a non-editable table attempted to insert a new row and move the selection to it. This behavior resulted in an infinite loop. Additionally, if `Tab` was pressed in an editable cell and the next cell was a content-editable false (`CEF`) cell, the focus would skip the `CEF` cell.
+
+This issue also triggered error messages when pressing `Tab` in the last cell of a non-editable table, negatively impacting page performance.
+
+{productname} {release-version} resolves this issue by refining the tab navigation behavior:
+
+* Pressing `Tab` in the last cell of a non-editable table now has no effect.
+* When `Tab` is pressed in an editable cell, and the next cell is a `CEF` cell, the cursor remains in the editable cell.
+
+These improvements enhance table navigation, prevent unnecessary error messages, and optimize performance when working with non-editable tables.
 
 
 [[security-fixes]]

--- a/modules/ROOT/pages/7.7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.2-release-notes.adoc
@@ -33,7 +33,7 @@ This issue also triggered error messages when pressing `Tab` in the last cell of
 {productname} {release-version} resolves this issue by refining the tab navigation behavior:
 
 * Pressing `Tab` in the last cell of a non-editable table now has no effect.
-* When `Tab` is pressed in an editable cell, and the next cell is a `CEF` cell, the cursor remains in the editable cell.
+* When `Tab` is pressed in an editable cell, and the next cell is a `CEF` cell with an editable element inside, the cursor is moved to an editable element within the `CEF` cell.
 
 These improvements enhance table navigation, prevent unnecessary error messages, and optimize performance when working with non-editable tables.
 

--- a/modules/ROOT/pages/7.7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.2-release-notes.adoc
@@ -26,7 +26,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 === Exception occurs when pressing `tab` in the last cell of a non-editable table
 // #TINY-11797
 
-Previously in {productname}, an issue was identified where pressing `Tab` in the last cell of a non-editable table attempted to insert a new row and move the selection to it. This behavior resulted in an infinite loop. Additionally, if `Tab` was pressed in an editable cell and the next cell was a `contentEditable="false"` (`CEF`) cell, the focus would skip the `CEF` cell.
+Previously in {productname}, an issue was identified where pressing `Tab` in the last cell of a non-editable table attempted to insert a new row and move the selection to it. This behavior resulted in an infinite loop. Additionally, if `Tab` was pressed in an editable cell and the next cell was a `contentEditable="false"` (`CEF`) cell, with a `contenteditable="true"` element inside, the focus would skip the `CEF` cell.
 
 This issue also triggered error messages when pressing `Tab` in the last cell of a non-editable table, negatively impacting page performance.
 

--- a/modules/ROOT/pages/7.7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.2-release-notes.adoc
@@ -26,7 +26,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 === Exception occurs when pressing `tab` in the last cell of a non-editable table
 // #TINY-11797
 
-Previously in {productname}, an issue was identified where pressing `Tab` in the last cell of a non-editable table attempted to insert a new row and move the selection to it. This behavior resulted in an infinite loop. Additionally, if `Tab` was pressed in an editable cell and the next cell was a content-editable false (`CEF`) cell, the focus would skip the `CEF` cell.
+Previously in {productname}, an issue was identified where pressing `Tab` in the last cell of a non-editable table attempted to insert a new row and move the selection to it. This behavior resulted in an infinite loop. Additionally, if `Tab` was pressed in an editable cell and the next cell was a `contentEditable="false"` (`CEF`) cell, the focus would skip the `CEF` cell.
 
 This issue also triggered error messages when pressing `Tab` in the last cell of a non-editable table, negatively impacting page performance.
 


### PR DESCRIPTION
Ticket: DOC-3163

Site: [Staging branch](http://docs-feature-772-doc-3163tiny-11797.staging.tiny.cloud/docs/tinymce/latest/7.7.2-release-notes/#exception-occurs-when-pressing-tab-in-the-last-cell-of-a-non-editable-table)

Changes:
* Documented the bug fix for TINY-11797

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed