### PR TITLE
DOC-3163: Exception was thrown when trying to use context form API after component was detached.

### DIFF
--- a/modules/ROOT/pages/7.7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.2-release-notes.adoc
@@ -26,7 +26,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 === Exception was thrown when trying to use the context form API after the toolbar was detached.
 // #TINY-11781
 
-Previously, an error occurred when the `setValue` function from the Context Form API was called after the toolbar had been detached from the DOM. As a result, developers were unable to retrieve the value of the Context Form when using the API after the form had been closed.
+Previously, an error occurred when the `setValue` function from the xref:contextform.adoc#formapi[Context Form API] was called after the toolbar had been detached from the DOM. As a result, developers were unable to retrieve the value of the Context Form when using the API after the form had been closed.
 
 {productname} {release-version} resolves this issue by ensuring that developers can now reliably get and set the value of the Context Form even after it has been detached.
 

--- a/modules/ROOT/pages/7.7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.2-release-notes.adoc
@@ -23,10 +23,14 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 {productname} {release-version} also includes the following bug fixes:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Exception was thrown when trying to use the context form API after the toolbar was detached.
+// #TINY-11781
 
-// CCFR here.
+Previously, an error occurred when the `setValue` function from the Context Form API was called after the toolbar had been detached from the DOM. As a result, developers were unable to retrieve the value of the Context Form when using the API after the form had been closed.
+
+{productname} {release-version} resolves this issue by ensuring that developers can now reliably get and set the value of the Context Form even after it has been detached.
+
+For more information on the Context Form API, see: xref:contextform.adoc[Context Forms]
 
 
 [[security-fixes]]

--- a/modules/ROOT/pages/7.7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.2-release-notes.adoc
@@ -30,7 +30,6 @@ Previously, an error occurred when the `setValue` function from the xref:context
 
 {productname} {release-version} resolves this issue by ensuring that developers can now reliably get and set the value of the Context Form even after it has been detached.
 
-For more information on the Context Form API, see: xref:contextform.adoc[Context Forms]
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-3163

Site: [Staging branch](http://docs-feature-772-doc-3163tiny-11781.staging.tiny.cloud/docs/tinymce/latest/7.7.2-release-notes/#exception-was-thrown-when-trying-to-use-the-context-form-api-after-the-toolbar-was-detached)

Changes:
* Documented the bug fix for TINY-11781

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed