### PR TITLE
DOC-3163: Deleting an empty block within `<li>` would move cursor at the end of the `<li>`.

### DIFF
--- a/modules/ROOT/pages/7.7.2-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.2-release-notes.adoc
@@ -23,10 +23,14 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 {productname} {release-version} also includes the following bug fixes:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Deleting an empty block within an `<li>` element would move the cursor at the end of the `<li>` element.
+// #TINY-11763
 
-// CCFR here.
+In previous versions of {productname}, an issue was identified where deleting an empty block within an `<li>` element would unexpectedly reposition the cursor at the end of the `<li>` element. Additionally, deleting an empty block located between two lists could trigger an error if all elements were nested within the same `<li>` element.
+
+These issues led to confusing behavior, as users experienced unintended cursor movement and encountered error messages.
+
+{productname} {release-version} resolves these issues by improving the list behavior. As a result, the cursor remains stable, and users no longer experience unexpected movements or error messages.
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-3163

Site: [Staging branch](http://docs-feature-772-doc-3163tiny-11763.staging.tiny.cloud/docs/tinymce/latest/7.7.2-release-notes/#deleting-an-empty-block-within-an-li-element-would-move-the-cursor-at-the-end-of-the-li-element)

Changes:
* Documented the bug fix for TINY-11763

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed