### PR TITLE
DOC-3172: Update Full Screen plugin documentation to clarify classic mode requirement.

### DIFF
--- a/modules/ROOT/pages/editor-command-identifiers.adoc
+++ b/modules/ROOT/pages/editor-command-identifiers.adoc
@@ -372,7 +372,7 @@ include::partial$commands/formatpainter-cmds.adoc[leveloffset=+3]
 [[fullscreen]]
 ==== Full Screen
 
-The following command requires the xref:fullscreen.adoc[Full Screen (`+fullscreen+`)] plugin and is **only** applicable when the editor is in Classic mode.
+The following command requires the xref:fullscreen.adoc[Full Screen (`+fullscreen+`)] plugin and is **only** applicable when the editor is in classic mode.
 
 include::partial$commands/fullscreen-cmds.adoc[leveloffset=+3]
 

--- a/modules/ROOT/pages/editor-command-identifiers.adoc
+++ b/modules/ROOT/pages/editor-command-identifiers.adoc
@@ -372,7 +372,7 @@ include::partial$commands/formatpainter-cmds.adoc[leveloffset=+3]
 [[fullscreen]]
 ==== Full Screen
 
-The following command requires the xref:fullscreen.adoc[Full Screen (`+fullscreen+`)] plugin.
+The following command requires the xref:fullscreen.adoc[Full Screen (`+fullscreen+`)] plugin and is **only** applicable when the editor is in Classic mode.
 
 include::partial$commands/fullscreen-cmds.adoc[leveloffset=+3]
 

--- a/modules/ROOT/pages/fullscreen.adoc
+++ b/modules/ROOT/pages/fullscreen.adoc
@@ -5,12 +5,12 @@
 :pluginname: Full Screen
 :plugincode: fullscreen
 
-This plugin adds full screen editing capabilities to {productname}. When the toolbar button is pressed the editable area will fill the browser's viewport. The plugin adds a toolbar button and a menu item `+Fullscreen+` under the `+View+` menu.
+The {pluginname} plugin enables fullscreen editing in {productname} when using classic mode. Activating the toolbar button expands the editable area to fill the browser viewport. The plugin adds a `+Fullscreen+` toolbar button and a corresponding menu item under the `+View+` menu.
 
 Full screen mode can be toggled using the following keyboard shortcuts:
 
 * macOS: Command+Shift+F
-* Most other operating systems (such as Windows or Linux): Ctrl+Shift+F
+* Windows or Linux: Ctrl+Shift+F
 
 == Basic setup
 
@@ -22,6 +22,9 @@ tinymce.init({
   toolbar: 'fullscreen'
 });
 ----
+
+[NOTE]
+This feature is supported only when {productname} is operating in classic mode. It is **not supported** in inline mode. For details on the differences between editing modes, refer to xref:use-tinymce-classic.adoc[Classic editing mode].
 
 == Options
 

--- a/modules/ROOT/pages/fullscreen.adoc
+++ b/modules/ROOT/pages/fullscreen.adoc
@@ -7,7 +7,7 @@
 
 The {pluginname} plugin enables fullscreen editing in {productname} when using classic mode. Activating the toolbar button expands the editable area to fill the browser viewport. The plugin adds a `+Fullscreen+` toolbar button and a corresponding menu item under the `+View+` menu.
 
-Full screen mode can be toggled using the following keyboard shortcuts:
+Fullscreen mode can be toggled using the following keyboard shortcuts:
 
 * macOS: Command+Shift+F
 * Windows or Linux: Ctrl+Shift+F

--- a/modules/ROOT/partials/commands/fullscreen-cmds.adoc
+++ b/modules/ROOT/partials/commands/fullscreen-cmds.adoc
@@ -1,7 +1,7 @@
 [cols="1,3",options="header"]
 |===
 |Command |Description
-|mceFullScreen |Toggles full screen mode.
+|mceFullScreen |Toggles full screen mode when the editor is in Classic mode.
 |===
 
 .Example

--- a/modules/ROOT/partials/commands/fullscreen-cmds.adoc
+++ b/modules/ROOT/partials/commands/fullscreen-cmds.adoc
@@ -1,7 +1,7 @@
 [cols="1,3",options="header"]
 |===
 |Command |Description
-|mceFullScreen |Toggles full screen mode when the editor is in Classic mode.
+|mceFullScreen |Toggles fullscreen mode
 |===
 
 .Example

--- a/modules/ROOT/partials/commands/fullscreen-cmds.adoc
+++ b/modules/ROOT/partials/commands/fullscreen-cmds.adoc
@@ -1,7 +1,7 @@
 [cols="1,3",options="header"]
 |===
 |Command |Description
-|mceFullScreen |Toggles fullscreen mode
+|mceFullScreen |Toggles fullscreen mode.
 |===
 
 .Example

--- a/modules/ROOT/partials/configuration/fullscreen_native.adoc
+++ b/modules/ROOT/partials/configuration/fullscreen_native.adoc
@@ -13,6 +13,9 @@ The `+fullscreen_native+` option allows the editor to use the browser full scree
 
 *Possible values:* `+true+`, `+false+`
 
+[NOTE]
+This option is only supported when {productname} is in classic mode. It is not supported in inline mode.
+
 === Example: using `+fullscreen_native+`
 
 To use the browser-native full screen mode for the {productname} editor, set `+fullscreen_native+` to `+true+`. For example:

--- a/modules/ROOT/partials/index-pages/opensource-plugins.adoc
+++ b/modules/ROOT/partials/index-pages/opensource-plugins.adoc
@@ -67,7 +67,7 @@ a|
 [.lead]
 xref:fullscreen.adoc[Full Screen]
 
-Expand {productname} to fill the entire screen when using classic mode.
+Expand {productname} to fill the entire screen
 
 a|
 [.lead]

--- a/modules/ROOT/partials/index-pages/opensource-plugins.adoc
+++ b/modules/ROOT/partials/index-pages/opensource-plugins.adoc
@@ -67,7 +67,7 @@ a|
 [.lead]
 xref:fullscreen.adoc[Full Screen]
 
-Zoom {productname} up to the whole screen.
+Expand {productname} to fill the entire screen when using classic mode.
 
 a|
 [.lead]

--- a/modules/ROOT/partials/index-pages/opensource-plugins.adoc
+++ b/modules/ROOT/partials/index-pages/opensource-plugins.adoc
@@ -67,7 +67,7 @@ a|
 [.lead]
 xref:fullscreen.adoc[Full Screen]
 
-Expand {productname} to fill the entire screen
+Expand {productname} to fill the entire screen.
 
 a|
 [.lead]


### PR DESCRIPTION
Ticket: DOC-3172

Site: [Staging branch](http://docs-hotfix-7-doc-3172.staging.tiny.cloud/docs/tinymce/latest/fullscreen/#:~:text=This%20feature%20is%20supported%20only%20when%20TinyMCE%20is%20operating%20in%20classic%20mode.%20It%20is%20not%20supported%20in%20inline%20mode.%20For%20details%20on%20the%20differences%20between%20editing%20modes%2C%20refer%20to%20Classic%20editing%20mode.)
Site: [Opensource plugins](http://docs-hotfix-7-doc-3172.staging.tiny.cloud/docs/tinymce/latest/plugins/#:~:text=Expand%20TinyMCE%20to%20fill%20the%20entire%20screen%20when%20using%20classic%20mode.)
Site: [Fullscreen_native](http://docs-hotfix-7-doc-3172.staging.tiny.cloud/docs/tinymce/latest/fullscreen/#fullscreen_native:~:text=This%20option%20is%20only%20supported%20when%20TinyMCE%20is%20in%20classic%20mode.%20It%20is%20not%20supported%20in%20inline%20mode.)

Changes:
* Update various pages and table to mention supported mode for FullScreen plugin.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed