### PR TITLE
DOC-3131: It wasn't possible to add comments to selected footnotes elements.

### DIFF
--- a/modules/ROOT/pages/7.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.8.0-release-notes.adoc
@@ -165,7 +165,7 @@ In previous versions of {productname}, it was not possible to add comments to fo
 
 As a result, attempting to add a comment would result in the comment being attached to a word outside the footnote as they were not considered valid block elements.
 
-{productname} {release-version} addresses this issue. Now, comments can now be added directly to the entire footnote element, similar to how comments are handled for figures and other comparable elements.
+{productname} {release-version} addresses this issue. Comments can now be added directly to the entire footnote element, similar to how comments are handled for figures and other comparable elements.
 
 
 [[security-fixes]]

--- a/modules/ROOT/pages/7.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.8.0-release-notes.adoc
@@ -70,22 +70,6 @@ The {productname} {release-version} release includes an accompanying release of 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
 
-=== Image Optimizer (Powered by Uploadcare)
-
-{productname} {release-version} introduces the **Image Optimizer (Powered by Uploadcare)** plugin.
-
-**Image Optimizer** includes the following fix.
-
-==== Dragging and dropping image files onto the placeholder was not possible if the files had the correct extension but an incorrect MIME type.
-// #TINY-11842
-
-In previous versions of the **Image Optimizer** premium plugin, dragging and dropping supported image files onto the placeholder could fail due to inconsistent file type detection. The issue occurred because only the MIME type or the file extension was checked, resulting in discrepancies when handling certain image files.
-
-{productname} {release-version} resolves this issue by updating file type detection to consider both the MIME type and the file extension when verifying supported formats. This enhancement ensures more reliable and consistent behavior when dragging and dropping image files.
-
-For information on the **Image Optimizer (Powered by Uploadcare)** plugin, see xref:uploadcare.adoc[Image Optimizer (Powered by Uploadcare)].
-
-
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement
 

--- a/modules/ROOT/pages/7.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.8.0-release-notes.adoc
@@ -161,7 +161,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === It wasn't possible to add comments to selected footnotes elements.
 // #TINY-11842
 
-In previous versions of {productname}, it was not possible to add comments to footnotes when selecting the footnote element.
+In previous versions of {productname}, it was not possible to add comments to footnotes (created by the xref:footnotes.adoc[Footnotes] plugin) when selecting the footnote element.
 
 As a result, attempting to add a comment would result in the comment being attached to a word outside the footnote as they were not considered valid block elements.
 

--- a/modules/ROOT/pages/7.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.8.0-release-notes.adoc
@@ -70,6 +70,22 @@ The {productname} {release-version} release includes an accompanying release of 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
 
+=== Image Optimizer (Powered by Uploadcare)
+
+{productname} {release-version} introduces the **Image Optimizer (Powered by Uploadcare)** plugin.
+
+**Image Optimizer** includes the following fix.
+
+==== Dragging and dropping image files onto the placeholder was not possible if the files had the correct extension but an incorrect MIME type.
+// #TINY-11842
+
+In previous versions of the **Image Optimizer** premium plugin, dragging and dropping supported image files onto the placeholder could fail due to inconsistent file type detection. The issue occurred because only the MIME type or the file extension was checked, resulting in discrepancies when handling certain image files.
+
+{productname} {release-version} resolves this issue by updating file type detection to consider both the MIME type and the file extension when verifying supported formats. This enhancement ensures more reliable and consistent behavior when dragging and dropping image files.
+
+For information on the **Image Optimizer (Powered by Uploadcare)** plugin, see xref:uploadcare.adoc[Image Optimizer (Powered by Uploadcare)].
+
+
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement
 

--- a/modules/ROOT/pages/7.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.8.0-release-notes.adoc
@@ -158,6 +158,15 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== It wasn't possible to add comments to selected footnotes elements.
+// #TINY-11842
+
+In previous versions of {productname}, it was not possible to add comments to footnotes when selecting the footnote element.
+
+As a result, attempting to add a comment would result in the comment being attached to a word outside the footnote as they where not considered valid block elements.
+
+{productname} {release-version} addresses this issue. Now, comments can now be added directly to the entire footnote element, similar to how comments are handled for figures and other comparable elements.
+
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/pages/7.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.8.0-release-notes.adoc
@@ -163,7 +163,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 In previous versions of {productname}, it was not possible to add comments to footnotes when selecting the footnote element.
 
-As a result, attempting to add a comment would result in the comment being attached to a word outside the footnote as they where not considered valid block elements.
+As a result, attempting to add a comment would result in the comment being attached to a word outside the footnote as they were not considered valid block elements.
 
 {productname} {release-version} addresses this issue. Now, comments can now be added directly to the entire footnote element, similar to how comments are handled for figures and other comparable elements.
 


### PR DESCRIPTION
Ticket: DOC-3131

Site: [Staging branch](http://docs-feature-780-doc-3131tiny-11842.staging.tiny.cloud/docs/tinymce/latest/7.8.0-release-notes/#it-wasnt-possible-to-add-comments-to-selected-footnotes-elements)

Changes:
* added fix for TINY-11842

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed