### PR TITLE
DOC-3131: Non-uploadcare image URLs would be altered by color adjustments even when they failed to upload.

### DIFF
--- a/modules/ROOT/pages/7.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.8.0-release-notes.adoc
@@ -70,6 +70,19 @@ The {productname} {release-version} release includes an accompanying release of 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
 
+=== Image Optimizer (Powered by Uploadcare)
+
+{productname} {release-version} introduces the **Image Optimizer (Powered by Uploadcare)** plugin.
+
+**Image Optimizer** includes the following fix.
+
+=== Non-uploadcare image URLs would be altered by color adjustments even when they failed to upload.
+// #TINY-11761
+
+Previously, applying color filters to images that had not yet been successfully uploaded to Uploadcare could result in broken image links if the server returned an error. This occurred because the original image was modified before confirming a successful upload. With this update, {productname} now preserves the original image until a successful upload is completed, ensuring that image functionality remains intact even if an upload fails. This change improves the reliability of the image upload and editing workflow in {release-version}.
+
+For information on the **Image Optimizer (Powered by Uploadcare)** plugin, see xref:uploadcare.adoc[Image Optimizer (Powered by Uploadcare)].
+
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement
 


### PR DESCRIPTION
Ticket: DOC-3131

Site: [Staging branch](http://docs-feature-780-doc-3131tiny-11761.staging.tiny.cloud/docs/tinymce/latest/7.8.0-release-notes/#non-uploadcare-image-urls-would-be-altered-by-color-adjustments-even-when-they-failed-to-upload)

Changes:
* fix documentation for TINY-11761

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed