### PR TITLE
DOC-3131: The `editor.selection.scrollIntoView()` method now pads the target scroll area with a small margin, ensuring content doesn't sit at the very edge of the viewport.

### DIFF
--- a/modules/ROOT/pages/7.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.8.0-release-notes.adoc
@@ -114,6 +114,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== The `+editor.selection.scrollIntoView()+` method now pads the target scroll area with a small margin, ensuring content doesn't sit at the very edge of the viewport.
+// #TINY-11786
+
+Previously, when cycling through accessibility issues in the a11y checker dialog, the highlighted content could appear aligned to the very edge of the viewport, making it difficult to identify and visually track. This behavior impacted usability by reducing the effectiveness of the a11y checker tool.
+
+In {productname} {release-version}, the `+editor.selection.scrollIntoView()+` method was updated to include a top margin, aligning the highlighted content to a fixed 30px from the top of the viewport. Additionally, a visual overlay was introduced to draw attention to the selected element. These changes improve visibility, provide smoother and more intuitive scroll positioning, and enhance the overall user experience when navigating accessibility issues in {productname}.
+
 
 [[additions]]
 == Additions

--- a/modules/ROOT/pages/7.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.8.0-release-notes.adoc
@@ -119,7 +119,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 Previously, when cycling through accessibility issues in the a11y checker dialog, the highlighted content could appear aligned to the very edge of the viewport, making it difficult to identify and visually track. This behavior impacted usability by reducing the effectiveness of the a11y checker tool.
 
-In {productname} {release-version}, the `+editor.selection.scrollIntoView()+` method was updated to include a top margin, aligning the highlighted content to a fixed 30px from the top of the viewport. Additionally, a visual overlay was introduced to draw attention to the selected element. These changes improve visibility, provide smoother and more intuitive scroll positioning, and enhance the overall user experience when navigating accessibility issues in {productname}.
+In {productname} {release-version}, the `+editor.selection.scrollIntoView()+` method was updated to include a top and bottom margin, aligning the highlighted content to a fixed `30px` from the edge of the viewport. Additionally, a visual overlay was introduced to draw attention to the selected element. These changes improve visibility, provide smoother and more intuitive scroll positioning, and enhance the overall user experience when navigating accessibility issues in {productname}.
 
 
 [[additions]]


### PR DESCRIPTION
Ticket: DOC-3131

Site: [Staging branch](http://docs-feature-780-doc-3131tiny-11786.staging.tiny.cloud/docs/tinymce/latest/7.8.0-release-notes/#the-editor-selection-scrollintoview-method-now-pads-the-target-scroll-area-with-a-small-margin-ensuring-content-doesnt-sit-at-the-very-edge-of-the-viewport)

Changes:
* add improvement for TINY-11786

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed