### PR TITLE
DOC-3131: Source Code editor was not scrolling to the editor's caret position in Firefox.

### DIFF
--- a/modules/ROOT/pages/7.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.8.0-release-notes.adoc
@@ -57,17 +57,20 @@ For information on the **<Open source plugin name>** plugin, see xref:<plugincod
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
-=== <Premium plugin name 1> <Premium plugin name 1 version>
+=== Enhanced Code Editor
 
-The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+The {productname} {release-version} release includes an accompanying release of the **Enhanced Code Editor** premium plugin.
 
-**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+**Enhanced Code Editor includes the following fix**.
 
-==== <Premium plugin name 1 change 1>
+==== Source Code editor was not scrolling to the editor's caret position in Firefox.
+// #TINY-11811
 
-// CCFR here.
+Previously, an issue was identified where the source code editor in Firefox did not automatically scroll to the caret's relative position within the editor. As a result, users were required to manually scroll to locate the corresponding element, leading to a suboptimal user experience.
 
-For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+With the release of {productname} {release-version}, this issue has been resolved. The source code editor in Firefox now exhibits consistent behavior with other browsers, automatically scrolling to the caret's position when the editor is opened. This enhancement significantly improves the user experience by eliminating the need for manual navigation.
+
+For information on the **Enhanced Code Editor** plugin, see: xref:advcode.adoc[Enhanced Code Editor].
 
 
 [[accompanying-premium-plugin-end-of-life-announcement]]

--- a/modules/ROOT/pages/7.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.8.0-release-notes.adoc
@@ -66,7 +66,7 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== Source Code editor was not scrolling to the editor's caret position in Firefox.
 // #TINY-11811
 
-Previously, an issue was identified where the source code editor in Firefox did not automatically scroll to the caret's relative position within the editor. As a result, users were required to manually scroll to locate the corresponding element, leading to a suboptimal user experience.
+Previously, an issue was identified where the Enhanced Code Editor in Firefox did not automatically scroll to the caret's relative position within the editor. As a result, users were required to manually scroll to locate the corresponding element, leading to a suboptimal user experience.
 
 With the release of {productname} {release-version}, this issue has been resolved. The source code editor in Firefox now exhibits consistent behavior with other browsers, automatically scrolling to the caret's position when the editor is opened. This enhancement significantly improves the user experience by eliminating the need for manual navigation.
 

--- a/modules/ROOT/pages/7.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.8.0-release-notes.adoc
@@ -68,7 +68,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 Previously, an issue was identified where the Enhanced Code Editor in Firefox did not automatically scroll to the caret's relative position within the editor. As a result, users were required to manually scroll to locate the corresponding element, leading to a suboptimal user experience.
 
-With the release of {productname} {release-version}, this issue has been resolved. The source code editor in Firefox now exhibits consistent behavior with other browsers, automatically scrolling to the caret's position when the editor is opened. This enhancement significantly improves the user experience by eliminating the need for manual navigation.
+With the release of {productname} {release-version}, this issue has been resolved. The Enhanced Code Editor in Firefox now exhibits consistent behavior with other browsers, automatically scrolling to the caret's position when the editor is opened. This enhancement significantly improves the user experience by eliminating the need for manual navigation.
 
 For information on the **Enhanced Code Editor** plugin, see: xref:advcode.adoc[Enhanced Code Editor].
 


### PR DESCRIPTION

Ticket: DOC-3131

Site: [Staging branch](http://docs-feature-780-doc-3131tiny-11811.staging.tiny.cloud/docs/tinymce/latest/7.8.0-release-notes/#source-code-editor-was-not-scrolling-to-the-editors-caret-position-in-firefox/)

Changes:
* Documented the bug fix for TINY-11811

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed