### PR TITLE
DOC-3185: Add tips for viewing available Docker image versions and recommend using the `latest` tag in installation guides

### DIFF
--- a/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-installation.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-installation.adoc
@@ -35,6 +35,13 @@ Pull the Docker image:
 docker pull registry.containers.tiny.cloud/{dockerimageexporttopdf}:[version]
 ----
 
+[TIP]
+====
+To view all available Docker image versions, refer to the changelog at link:https://registry.containers.tiny.cloud/api/changelogs/pdf-converter-tiny[pdf-converter-tiny].
+
+To ensure access to the most recent version of the service, {companyname} **recommends** using the `latest` tag when pulling the image.
+====
+
 Launch the Docker container:
 
 [source, sh, subs="attributes+"]

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
@@ -35,6 +35,13 @@ Pull the Docker image:
 docker pull docker pull registry.containers.tiny.cloud/{dockerimageimportfromwordexporttoword}:[version]
 ----
 
+[TIP]
+====
+To view all available Docker image versions, refer to the changelog at link:https://registry.containers.tiny.cloud/api/changelogs/docx-converter-tiny[docx-converter-tiny].
+
+To ensure access to the most recent version of the service, {companyname} recommends using the `latest` tag when pulling the image.
+====
+
 Launch the Docker container:
 
 [source, sh, subs="attributes+"]


### PR DESCRIPTION
Ticket: DOC-3185

Site: [Deploy the TinyMCE Import from Word and Export to Word service server-side component using Docker (individually licensed)](http://docs-hotfix-7-doc-3185.staging.tiny.cloud/docs/tinymce/latest/individual-import-from-word-and-export-to-word-on-premises/)

Site: [Deploy the TinyMCE Export to PDF service server-side component using Docker (individually licensed)](http://docs-hotfix-7-doc-3185.staging.tiny.cloud/docs/tinymce/latest/individual-export-to-pdf-on-premises/)

Changes:
* Add tip for viewing available Docker image versions and recommend using the `latest` tag in installation guides

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed