### PR TITLE
DOC-3131: Setting editor height to a `pt` or `em` value was ignoring min/max height settings.

### DIFF
--- a/modules/ROOT/pages/7.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.8.0-release-notes.adoc
@@ -158,6 +158,11 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Setting editor height to a `pt` or `em` value was ignoring min/max height settings.
+// #TINY-11108
+
+Previously, when the editor height was set using relative units such as `pt` or `em`, the editor was unable to parse and evaluate these values correctly. As a result, it would bypass the `min_height` and `max_height` checks, leading to unpredictable layout behavior. This issue was especially noticeable during initialization, although resizing later used the browser-calculated content box height, which partially masked the problem. In {release-version}, {productname} now attempts to compute height values from additional unit types to better enforce minimum and maximum height constraints. Some units, such as percentages (`%`), may still override explicit height values due to browser limitations in determining the final rendered size. This update ensures that `min_height` and `max_height` settings are more reliably applied across a wider range of unit types.
+
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/partials/configuration/height.adoc
+++ b/modules/ROOT/partials/configuration/height.adoc
@@ -3,7 +3,13 @@
 
 `+height+` sets the height of the entire editor, including the menu bar, toolbars, and status bar.
 
-NOTE: If a number is provided, {productname} sets the height in pixels. If a string is provided, {productname} assumes the value is valid CSS and sets the editor's height as the string value. This allows for alternate units such as `+%+`, `+em+`, and `+vh+`.
+[NOTE]
+====
+* If a number is provided, {productname} sets the height in pixels by defult.
+* If a string is provided, {productname} assumes the value is valid CSS and sets the editor's height as the string value such as `+300px+`, `+50pt+`, or `+10em+`.
+
+Note: that values such as `+100%+`, `+10vh+` and `auto` are not currently supported.
+====
 
 *Type:* `+Number+` or `+String+`
 


### PR DESCRIPTION
Ticket: DOC-3131

Site: [release notes](http://docs-feature-780-doc-3131tiny-11108.staging.tiny.cloud/docs/tinymce/latest/7.8.0-release-notes/#setting-editor-height-to-a-pt-or-em-value-was-ignoring-minmax-height-settings)
Site: [height](http://docs-feature-780-doc-3131tiny-11108.staging.tiny.cloud/docs/tinymce/latest/editor-size-options/#height)

Changes:
* add fix documentation for TINY-11108

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed