### PR TITLE
DOC-3131: A confirmation dialog now appears when resolving conversation to match the UX of deleting a conversation.

### DIFF
--- a/modules/ROOT/pages/7.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.8.0-release-notes.adoc
@@ -69,6 +69,21 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Comments
+
+The {productname} {release-version} release includes an accompanying release of the **Comments** premium plugin.
+
+**Comments** includes the following change.
+
+=== A confirmation dialog now appears when resolving conversation to match the UX of deleting a conversation.
+// #TINY-11324
+
+Previously, resolving a conversation did not trigger a confirmation dialog, unlike the behavior when deleting a conversation. Selecting *Resolve conversation* from the conversation kebab menu would immediately perform the action without user confirmation.
+
+{productname} {release-version} introduces a confirmation dialog for resolving conversations, ensuring a consistent user experience and helping prevent unintentional resolutions.
+
+For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to {companyname} Comments].
+
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement


### PR DESCRIPTION
Ticket: DOC-

Site: [Staging branch](http://docs-feature-780-doc-3131tiny-11324.staging.tiny.cloud/docs/tinymce/latest/7.8.0-release-notes/#a-confirmation-dialog-now-appears-when-resolving-conversation-to-match-the-ux-of-deleting-a-conversation)

Changes:
* added change for TINY-11324

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed