### PR TITLE
DOC-3188: Update Polly.js script imports to use UMD for broader browser compatibility

### DIFF
--- a/modules/ROOT/examples/live-demos/comments-callback/index.js
+++ b/modules/ROOT/examples/live-demos/comments-callback/index.js
@@ -1,8 +1,9 @@
 tinymce.ScriptLoader.loadScripts(
+  // Update to use UMD for broader compatibility browser support.
   [
-    '//unpkg.com/@pollyjs/core@5.1.1',
-    '//unpkg.com/@pollyjs/adapter-fetch@5.1.1',
-    '//unpkg.com/@pollyjs/persister-local-storage@5.1.1',
+    '//unpkg.com/@pollyjs/core@5.1.1/dist/umd/pollyjs-core.js',
+    '//unpkg.com/@pollyjs/adapter-fetch@5.1.1/dist/umd/pollyjs-adapter-fetch.js',
+    '//unpkg.com/@pollyjs/persister-local-storage@5.1.1/dist/umd/pollyjs-persister-local-storage.js',
   ]
 ).then(() => {
   /******************************


### PR DESCRIPTION

Ticket: DOC-3188

Site: [Staging branch](http://docs-hotfix-7-doc-3188.staging.tiny.cloud/docs/tinymce/latest/comments-callback-mode/#comments-callback-live-demo/)

Changes:
* Update to use UMD for broader compatibility browser support as previous working URLs stopped working.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed