### PR TITLE
DOC-3188: Update various script URLs in live-demos to use `cdn.skypack.dev` and `jsdelivr` for improved reliability.

### DIFF
--- a/modules/ROOT/examples/live-demos/ai/example.js
+++ b/modules/ROOT/examples/live-demos/ai/example.js
@@ -1,6 +1,6 @@
-const fetchApi = import(
-    'https://unpkg.com/@microsoft/fetch-event-source@2.0.1/lib/esm/index.js'
-).then((module) => module.fetchEventSource);
+const fetchApi = import('https://cdn.skypack.dev/@microsoft/fetch-event-source@2.0.1')
+  .then((module) => module.fetchEventSource);
+ 
 
 // This example stores the API key in the client side integration. This is not recommended for any purpose.
 // Instead, an alternate method for retrieving the API key should be used.

--- a/modules/ROOT/examples/live-demos/ai/index.js
+++ b/modules/ROOT/examples/live-demos/ai/index.js
@@ -1,6 +1,6 @@
-const fetchApi = import(
-    'https://unpkg.com/@microsoft/fetch-event-source@2.0.1/lib/esm/index.js'
-).then((module) => module.fetchEventSource);
+const fetchApi = import('https://cdn.skypack.dev/@microsoft/fetch-event-source@2.0.1')
+  .then((module) => module.fetchEventSource);
+ 
 
 const ai_request = (request, respondWith) => {
     respondWith.stream((signal, streamMessage) => {

--- a/modules/ROOT/examples/live-demos/comments-callback/index.js
+++ b/modules/ROOT/examples/live-demos/comments-callback/index.js
@@ -1,9 +1,9 @@
 tinymce.ScriptLoader.loadScripts(
   // Update to use UMD for broader compatibility browser support.
   [
-    '//unpkg.com/@pollyjs/core@5.1.1/dist/umd/pollyjs-core.js',
-    '//unpkg.com/@pollyjs/adapter-fetch@5.1.1/dist/umd/pollyjs-adapter-fetch.js',
-    '//unpkg.com/@pollyjs/persister-local-storage@5.1.1/dist/umd/pollyjs-persister-local-storage.js',
+    'https://cdn.jsdelivr.net/npm/@pollyjs/core@5.1.1/dist/umd/pollyjs-core.js',
+    'https://cdn.jsdelivr.net/npm/@pollyjs/adapter-fetch@5.1.1/dist/umd/pollyjs-adapter-fetch.js',
+    'https://cdn.jsdelivr.net/npm/@pollyjs/persister-local-storage@5.1.1/dist/umd/pollyjs-persister-local-storage.js',
   ]
 ).then(() => {
   /******************************

--- a/modules/ROOT/examples/live-demos/full-featured/example.js
+++ b/modules/ROOT/examples/live-demos/full-featured/example.js
@@ -1,6 +1,6 @@
-const fetchApi = import(
-  "https://unpkg.com/@microsoft/fetch-event-source@2.0.1/lib/esm/index.js"
-).then((module) => module.fetchEventSource);
+const fetchApi = import('https://cdn.skypack.dev/@microsoft/fetch-event-source@2.0.1')
+  .then((module) => module.fetchEventSource);
+
 
 // This example stores the OpenAI API key in the client side integration. This is not recommended for any purpose.
 // Instead, an alternate method for retrieving the API key should be used.

--- a/modules/ROOT/examples/live-demos/full-featured/index.js
+++ b/modules/ROOT/examples/live-demos/full-featured/index.js
@@ -1,6 +1,7 @@
-const fetchApi = import(
-  "https://unpkg.com/@microsoft/fetch-event-source@2.0.1/lib/esm/index.js"
-).then((module) => module.fetchEventSource);
+const fetchApi = import('https://cdn.skypack.dev/@microsoft/fetch-event-source@2.0.1')
+  .then((module) => module.fetchEventSource);
+
+
 
 /* Script to import faker.js for generating random data for demonstration purposes */
 tinymce.ScriptLoader.loadScripts(['https://cdn.jsdelivr.net/npm/faker@5/dist/faker.min.js']).then(() => {

--- a/modules/ROOT/examples/live-demos/premiumskinsandicons-material-classic/index.html
+++ b/modules/ROOT/examples/live-demos/premiumskinsandicons-material-classic/index.html
@@ -1,5 +1,5 @@
-<script src="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.js"></script>
-<link rel="stylesheet" href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css">
+<script src="https://cdn.jsdelivr.net/npm/material-components-web@latest/dist/material-components-web.min.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/material-components-web@latest/dist/material-components-web.min.css">
 <link href="https://fonts.googleapis.com/css?family=Roboto:400,400i,700,700i" rel="stylesheet">
 
 <div class="mdc-layout-grid">

--- a/modules/ROOT/examples/live-demos/premiumskinsandicons-material-outline/index.html
+++ b/modules/ROOT/examples/live-demos/premiumskinsandicons-material-outline/index.html
@@ -1,5 +1,5 @@
-<script src="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.js"></script>
-<link rel="stylesheet" href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css">
+<script src="https://cdn.jsdelivr.net/npm/material-components-web@latest/dist/material-components-web.min.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/material-components-web@latest/dist/material-components-web.min.css">
 <link href="https://fonts.googleapis.com/css?family=Roboto:400,400i,700,700i" rel="stylesheet">
 
 <div class="mdc-layout-grid">

--- a/modules/ROOT/pages/ai-azure.adoc
+++ b/modules/ROOT/pages/ai-azure.adoc
@@ -78,7 +78,7 @@ This example demonstrates how to integrate the {pluginname} plugin with the http
 
 [source,js]
 ----
-const fetchApi = import("https://unpkg.com/@microsoft/fetch-event-source@2.0.1/lib/esm/index.js").then(module => module.fetchEventSource);
+const fetchApi = import("https://cdn.skypack.dev/@microsoft/fetch-event-source@2.0.1").then(module => module.fetchEventSource);
 
 // This example stores the API key in the client side integration. This is not recommended for any purpose.
 // Instead, an alternate method for retrieving the API key should be used.

--- a/modules/ROOT/pages/ai-gemini.adoc
+++ b/modules/ROOT/pages/ai-gemini.adoc
@@ -101,7 +101,7 @@ tinymce.init({
 This example demonstrates how to integrate the {pluginname} plugin with the Vertex AI API to generate streaming responses.
 [source,js]
 ----
-const fetchApi = import("https://unpkg.com/@microsoft/fetch-event-source@2.0.1/lib/esm/index.js").then(module => module.fetchEventSource);
+const fetchApi = import("https://cdn.skypack.dev/@microsoft/fetch-event-source@2.0.1").then(module => module.fetchEventSource);
 
 // Providing access credentials within the integration is not recommended for production use.
 // It is recommended to set up a proxy server to authenticate requests and provide access.

--- a/modules/ROOT/pages/ai-openai.adoc
+++ b/modules/ROOT/pages/ai-openai.adoc
@@ -78,7 +78,7 @@ This example demonstrates how to integrate the {pluginname} plugin with the Open
 
 [source,js]
 ----
-const fetchApi = import("https://unpkg.com/@microsoft/fetch-event-source@2.0.1/lib/esm/index.js").then(module => module.fetchEventSource);
+const fetchApi = import("https://cdn.skypack.dev/@microsoft/fetch-event-source@2.0.1").then(module => module.fetchEventSource);
 
 // This example stores the API key in the client side integration. This is not recommended for any purpose.
 // Instead, an alternate method for retrieving the API key should be used.


### PR DESCRIPTION
Ticket: DOC-3188

Site: [full-feature-demo](http://docs-hotfix-7-doc-3188.staging.tiny.cloud/docs/tinymce/latest/full-featured-premium-demo/)
Site: [material-outline-demo](http://docs-hotfix-7-doc-3188.staging.tiny.cloud/docs/tinymce/latest/material-outline-demo/)
Site: [AI-Assistant](http://docs-hotfix-7-doc-3188.staging.tiny.cloud/docs/tinymce/latest/ai/#interactive-example)
Site: [comments-callback-live-demo](http://docs-hotfix-7-doc-3188.staging.tiny.cloud/docs/tinymce/latest/comments-callback-mode/#comments-callback-live-demo)


Changes:
* [UNPKG](https://x.com/unpkg/status/1904454221614739820) now servers all traffic over HTTP/3
* Other [issues](https://github.com/unpkg/unpkg/issues/412)
* We should consider replacement for Pollyjs in the future.

* Update AI-Assistant, Material Outline Demo, and Full feature demo to use `cdn.skypack.dev` as `jsDelivr` failed to find resource after many attempts.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed