### PR TITLE
DOC-3189: Refactor promotion documentation and update references to new promotions page

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -239,7 +239,7 @@
 ** xref:editor-important-options.adoc[Integration options]
 ** xref:editor-size-options.adoc[Size]
 ** xref:editor-save-and-submit.adoc[Save and submit]
-** xref:editor-premium-upgrade-promotion.adoc[Premium upgrade promotion]
+** xref:promotions.adoc[Promotions]
 * Interface
 ** Editor modes
 *** xref:use-tinymce-classic.adoc[Classic editing mode]

--- a/modules/ROOT/pages/initial-configuration.adoc
+++ b/modules/ROOT/pages/initial-configuration.adoc
@@ -29,7 +29,7 @@ Editor options related to saving or submitting editor content.
 
 |
 [.lead]
-xref:editor-premium-upgrade-promotion.adoc[Premium upgrade promotion]
+xref:promotions.adoc[Promotions]
 
 Editor options related to turning the Premium promotion display off.
 

--- a/modules/ROOT/pages/promotions.adoc
+++ b/modules/ROOT/pages/promotions.adoc
@@ -6,7 +6,7 @@
 include::partial$misc/premium-upgrade-promotion-option.adoc[]
 
 [[premium-upgrade-promotion-defaults]]
-=== Premium upgrade promotion defaults
+== Premium upgrade promotion defaults
 
 When the Community distribution of {productname} 6.2 is running as a self-hosted instance, an *Upgrade* promotion button appears in the unused corner of the editor menu bar by default. The button does not appear when Community distributions of {productname} are running on the {cloudname}.
 

--- a/modules/ROOT/pages/promotions.adoc
+++ b/modules/ROOT/pages/promotions.adoc
@@ -4,24 +4,3 @@
 :keywords: upgrade, promotion, premium, button, lightning bolt
 
 include::partial$misc/premium-upgrade-promotion-option.adoc[]
-
-[[premium-upgrade-promotion-defaults]]
-== Premium upgrade promotion defaults
-
-When the Community distribution of {productname} 6.2 is running as a self-hosted instance, an *Upgrade* promotion button appears in the unused corner of the editor menu bar by default. The button does not appear when Community distributions of {productname} are running on the {cloudname}.
-
-This promotion button redirects to a link:{companyurl}/tinymce-self-hosted-premium-features/[promotion page], showcasing the benefits of the variety of xref:plugins.adoc#premium-plugins[Premium Plugins] available for {productname}.
-
-When {productname} 6.2 or later is running as part of a Premium plan, the *Upgrade* promotion button is disabled. And it is disabled when running with a Premium plan whether {productname} is running in the {cloudname} or as a self-hosted instance.
-
-The {productname} Community distribution displays the promotion button when running as a self-hosted instance because the `promotion` option is set to `true` by default. To turn this button off in the Community distribution, set the `promotion` option to `false`.
-
-[source,js]
-----
-tinymce.init({
-  selector: "textarea",  // change this value according to your HTML
-  promotion: false
-});
-----
-
-IMPORTANT: It is not necessary to set `promotion` to `false` when {productname} is running as part of a Premium plan. Running {productname} as part of a Premium plan automatically disables the *Upgrade* promotion button.

--- a/modules/ROOT/partials/configuration/onboarding.adoc
+++ b/modules/ROOT/partials/configuration/onboarding.adoc
@@ -1,5 +1,3 @@
-= Cloud promotion
-
 [[onboarding]]
 == `+onboarding+`
 
@@ -13,8 +11,7 @@ The promotion will automatically disappear when the trial ends.
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: using cloud `+onboarding+`
-
+.Example: using cloud `+onboarding+`
 [source,js]
 ----
 tinymce.init({

--- a/modules/ROOT/partials/configuration/onboarding.adoc
+++ b/modules/ROOT/partials/configuration/onboarding.adoc
@@ -1,4 +1,4 @@
-= Open source promotion
+= Cloud promotion
 
 [[onboarding]]
 == `+onboarding+`

--- a/modules/ROOT/partials/configuration/onboarding.adoc
+++ b/modules/ROOT/partials/configuration/onboarding.adoc
@@ -1,0 +1,22 @@
+[[onboarding]]
+== `+onboarding+`
+
+The cloud version of {productname} contains a promotion for paid features included in the 14-day trial. This promotion can be toggled on or off with the onboarding option.
+
+The promotion will automatically disappear when the trial ends.
+
+*Type:* `+Boolean+`
+
+*Default value:* `+true+` for cloud instances; otherwise `+false+`.
+
+*Possible values:* `+true+`, `+false+`
+
+=== Example: using cloud `+onboarding+`
+
+[source,js]
+----
+tinymce.init({
+  selector: "textarea",  // change this value according to your HTML
+  onboarding: false
+});
+----

--- a/modules/ROOT/partials/configuration/onboarding.adoc
+++ b/modules/ROOT/partials/configuration/onboarding.adoc
@@ -1,7 +1,9 @@
+= Open source promotion
+
 [[onboarding]]
 == `+onboarding+`
 
-The cloud version of {productname} contains a promotion for paid features included in the 14-day trial. This promotion can be toggled on or off with the onboarding option.
+The cloud version of {productname} contains a promotion for paid features included in the 14-day trial. This promotion can be toggled on or off with the `+onboarding+` option.
 
 The promotion will automatically disappear when the trial ends.
 

--- a/modules/ROOT/partials/configuration/promotion.adoc
+++ b/modules/ROOT/partials/configuration/promotion.adoc
@@ -1,4 +1,4 @@
-= Cloud promotion
+= Open source promotion
 
 [[promotion]]
 == `+promotion+`

--- a/modules/ROOT/partials/configuration/promotion.adoc
+++ b/modules/ROOT/partials/configuration/promotion.adoc
@@ -1,15 +1,15 @@
+= Cloud promotion
+
 [[promotion]]
 == `+promotion+`
 
-{productname} 6.2 and later includes the `promotion` option. It controls the presentation or otherwise of a Tiny-specific promotion button.
+The open source version of {productname} contains a promotion for paid features. This promotion can be toggled on or off with the `+promotion+` option.
 
 *Type:* `+Boolean+`
 
 *Default value:* `+true+` in Community self-hosted instances; otherwise `+false+`.
 
 *Possible values:* `+true+`, `+false+`
-
-See xref:promotions.adoc#premium-upgrade-promotion-defaults[Premium upgrade promotion defaults] for details.
 
 === Example: using open source `+promotion+`
 
@@ -20,7 +20,3 @@ tinymce.init({
   promotion: true
 });
 ----
-
-The *Upgrade* promotion appears in the unused corner of the {productname} menu bar. Consequently it does not appear if the menu bar is disabled.
-
-NOTE: The distribution-specific defaults are not fixed. Someone running {productname} as part of a Premium plan can turn this option on. And someone running the Community distribution of {productname} as a self-hosted instance can turn this option off.

--- a/modules/ROOT/partials/configuration/promotion.adoc
+++ b/modules/ROOT/partials/configuration/promotion.adoc
@@ -1,7 +1,5 @@
-= Open source promotion
-
 [[promotion]]
-== `+promotion+`
+== `+promotion+`  
 
 The open source version of {productname} contains a promotion for paid features. This promotion can be toggled on or off with the `+promotion+` option.
 
@@ -11,8 +9,7 @@ The open source version of {productname} contains a promotion for paid features.
 
 *Possible values:* `+true+`, `+false+`
 
-=== Example: using open source `+promotion+`
-
+.Example: using open source `+promotion+`
 [source,js]
 ----
 tinymce.init({

--- a/modules/ROOT/partials/configuration/promotion.adoc
+++ b/modules/ROOT/partials/configuration/promotion.adoc
@@ -9,9 +9,9 @@
 
 *Possible values:* `+true+`, `+false+`
 
-See xref:editor-premium-upgrade-promotion.adoc#premium-upgrade-promotion-defaults[Premium upgrade promotion defaults] for details.
+See xref:promotions.adoc#premium-upgrade-promotion-defaults[Premium upgrade promotion defaults] for details.
 
-=== Example: using `+promotion+`
+=== Example: using open source `+promotion+`
 
 [source,js]
 ----

--- a/modules/ROOT/partials/misc/premium-upgrade-promotion-option.adoc
+++ b/modules/ROOT/partials/misc/premium-upgrade-promotion-option.adoc
@@ -1,6 +1,7 @@
-[[options]]
-== Options
+== Open source promotion
 
 include::partial$configuration/promotion.adoc[leveloffset=+1]
+
+== Cloud promotion
 
 include::partial$configuration/onboarding.adoc[leveloffset=+1]

--- a/modules/ROOT/partials/misc/premium-upgrade-promotion-option.adoc
+++ b/modules/ROOT/partials/misc/premium-upgrade-promotion-option.adoc
@@ -1,4 +1,6 @@
-[[premium-upgrade-promotion-option]]
-== Premium upgrade promotion option
+[[options]]
+== Options
 
 include::partial$configuration/promotion.adoc[leveloffset=+1]
+
+include::partial$configuration/onboarding.adoc[leveloffset=+1]


### PR DESCRIPTION
Ticket: DOC-3131

Site: [Staging branch](http://docs-feature-780-doc-3131doc-3191.staging.tiny.cloud/docs/tinymce/latest/promotions/)

Changes:
* Refactor promotion documentation and update references to new promotions page.
* Re-name previous page to align with changes.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.

Review:
- [x] Documentation Team Lead has reviewed