### PR TITLE
DOC-3196: Fix typo in Docker pull command for import/export installation instructions.

### DIFF
--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
@@ -32,7 +32,7 @@ Pull the Docker image:
 
 [source, sh, subs="attributes+"]
 ----
-docker pull docker pull registry.containers.tiny.cloud/{dockerimageimportfromwordexporttoword}:[version]
+docker pull registry.containers.tiny.cloud/{dockerimageimportfromwordexporttoword}:[version]
 ----
 
 [TIP]


### PR DESCRIPTION
Ticket: DOC-3196

Site: [Staging branch](http://docs-hotfix-7-doc-3196.staging.tiny.cloud/docs/tinymce/latest/individual-import-from-word-and-export-to-word-on-premises/#:~:text=docker%20login%20%2Du%20tiny%20%2Dp%20%5Baccess%2Dtoken%5D%20registry.containers.tiny.cloud)

Changes:
* FIX duplication error.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed