### PR TITLE
DOC-3189: Add new options for preserving MathML elements and attributes in the Math plugin

### DIFF
--- a/modules/ROOT/pages/7.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.8.0-release-notes.adoc
@@ -73,7 +73,7 @@ For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode
 
 The {productname} {release-version} release includes an accompanying release of the **Math** premium plugin.
 
-**Math** includes the following fix.
+**Math** includes the following addition.
 
 ==== New `extended_mathml_attributes` and `extended_mathml_elements` options.
 // #TINY-11756

--- a/modules/ROOT/pages/7.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.8.0-release-notes.adoc
@@ -84,8 +84,8 @@ Prior to {release-version}, MathML elements and attributes could be configured i
 
 The new options allow users to define lists of MathML elements and attributes that should be preserved, even if DOMPurify does not currently recognize them. This enables quicker user-side updates in response to evolving MathML specifications without disabling sanitization or waiting for upstream changes.
 
-**`+extended_mathml_elements+`**: allows a list of additional MathML elements to be preserved.
-**`+extended_mathml_attributes+`**: allows a list of additional MathML attributes to be preserved.
+* **`+extended_mathml_elements+`**: allows a list of additional MathML elements to be preserved.
+* **`+extended_mathml_attributes+`**: allows a list of additional MathML attributes to be preserved.
 
 These options apply only within MathML contexts and do not affect general HTML content. They enable use cases such as preserving `+<mn>+` elements and attributes like `linebreak` in MathML expressions.
 

--- a/modules/ROOT/pages/7.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.8.0-release-notes.adoc
@@ -80,7 +80,9 @@ The {productname} {release-version} release includes an accompanying release of 
 
 To improve flexibility when working with MathML content, especially in cases where new attributes or elements are not yet supported by DOMPurify, two new configuration options have been introduced: xref:math.adoc#extended-mathml-elements[extended_mathml_elements] and xref:math.adoc#extended-mathml-attributes[extended_mathml_attributes].
 
-Prior to {release-version}, MathML elements and attributes could be configured informally, but were not officially supported. With enhanced security measures introduced in {productname} {release-version}, MathML content is now filtered separately from HTML using DOMPurify, and any unsupported elements or attributes are stripped from the editor content. This change increased security but removed the ability to allow certain MathML-specific content.
+Prior to {release-version}, MathML elements and attributes were treated the same as all other content, with no special handling for MathML-specific structures. As a result, unsupported elements and attributes were either retained without validation or stripped without regard to their MathML context.
+
+In {productname} {release-version}, MathML content is now filtered separately from general HTML using DOMPurify. As part of this change, support has been added to selectively allow specific elements and attributes *within* a `<math>` element using the new configuration options.
 
 The new options allow users to define lists of MathML elements and attributes that should be preserved, even if DOMPurify does not currently recognize them. This enables quicker user-side updates in response to evolving MathML specifications without disabling sanitization or waiting for upstream changes.
 

--- a/modules/ROOT/pages/7.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.8.0-release-notes.adoc
@@ -69,6 +69,54 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Math
+
+The {productname} {release-version} release includes an accompanying release of the **Math** premium plugin.
+
+**Math** includes the following fix.
+
+==== New `extended_mathml_attributes` and `extended_mathml_elements` options.
+// #TINY-11756
+
+== New options for customizing allowed MathML elements and attributes
+
+To improve flexibility when working with MathML content, especially in cases where new attributes or elements are not yet supported by DOMPurify, two new configuration options have been introduced: xref:math.adoc#extended-mathml-elements[extended_mathml_elements] and xref:math.adoc#extended-mathml-attributes[extended_mathml_attributes].
+
+Prior to {release-version}, MathML elements and attributes could be configured informally, but were not officially supported. With enhanced security measures introduced in {productname} {release-version}, MathML content is now filtered separately from HTML using DOMPurify, and any unsupported elements or attributes are stripped from the editor content. This change increased security but removed the ability to allow certain MathML-specific content.
+
+The new options allow users to define lists of MathML elements and attributes that should be preserved, even if DOMPurify does not currently recognize them. This enables quicker user-side updates in response to evolving MathML specifications without disabling sanitization or waiting for upstream changes.
+
+**`+extended_mathml_elements+`**: allows a list of additional MathML elements to be preserved.
+**`+extended_mathml_attributes+`**: allows a list of additional MathML attributes to be preserved.
+
+These options apply only within MathML contexts and do not affect general HTML content. They enable use cases such as preserving `+<mn>+` elements and attributes like `linebreak` in MathML expressions.
+
+.Example of MathML with preserved elements and attributes
+[source,js]
+----
+tinymce.init({
+  selector: "textarea",
+  extended_mathml_elements: [ "mn" ],
+  extended_mathml_attributes: [ "linebreak" ]
+});
+----
+
+.Example of MathML with preserved elements and attributes
+[source,html]
+----
+<p>
+  <math xmlns="http://www.w3.org/1998/Math/MathML">
+    <mrow><mn>0.196</mn></mrow>
+    <mspace linebreak="newline"></mspace>
+    <mrow><mo>=</mo></mrow>
+    <mspace linebreak="newline"></mspace>
+    <mrow><mn>0.196</mn></mrow>
+  </math>
+</p>
+----
+
+For information on the **Math** premium plugin, see: xref:math.adoc[Math].
+
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement

--- a/modules/ROOT/pages/7.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.8.0-release-notes.adoc
@@ -78,8 +78,6 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== New `extended_mathml_attributes` and `extended_mathml_elements` options.
 // #TINY-11756
 
-== New options for customizing allowed MathML elements and attributes
-
 To improve flexibility when working with MathML content, especially in cases where new attributes or elements are not yet supported by DOMPurify, two new configuration options have been introduced: xref:math.adoc#extended-mathml-elements[extended_mathml_elements] and xref:math.adoc#extended-mathml-attributes[extended_mathml_attributes].
 
 Prior to {release-version}, MathML elements and attributes could be configured informally, but were not officially supported. With enhanced security measures introduced in {productname} {release-version}, MathML content is now filtered separately from HTML using DOMPurify, and any unsupported elements or attributes are stripped from the editor content. This change increased security but removed the ability to allow certain MathML-specific content.

--- a/modules/ROOT/pages/math.adoc
+++ b/modules/ROOT/pages/math.adoc
@@ -72,6 +72,12 @@ include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
+== Options
+
+include::partial$configuration/extended_mathml_elements.adoc[leveloffset=+1]
+
+include::partial$configuration/extended_mathml_attributes.adoc[leveloffset=+1]
+
 == Commands
 
 The {pluginname} plugin provides the following {productname} commands.

--- a/modules/ROOT/partials/configuration/extended_mathml_attributes.adoc
+++ b/modules/ROOT/partials/configuration/extended_mathml_attributes.adoc
@@ -1,0 +1,57 @@
+[[extended-mathml-attributes]]
+== `+extended_mathml_attributes+`
+
+This option allows a specific list of additional MathML attributes to be preserved in the editor content, even if they are not included in the default DOMPurify allowlist. This setting only affects attributes used within MathML markup and has no effect on general HTML content.
+
+*Type:* `+Array+` of `+Strings+`
+
+*Default value:* `+[]+` (empty array)
+
+=== Example: using `+extended_mathml_attributes+`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',
+  extended_mathml_attributes: [ 'linebreak', 'encoding' ]
+});
+----
+
+.Example of MathML with preserved attributes
+[source,html]
+----
+<p>
+  <math xmlns="http://www.w3.org/1998/Math/MathML">
+    <mrow linebreak="newline" encoding="utf8">
+      <mi>x</mi>
+      <mo>=</mo>
+      <mfrac>
+        <mrow>
+          <mo>&#x2212;</mo>
+          <mi>b</mi>
+          <mo>&#x00B1;</mo>
+          <msqrt>
+            <mrow>
+              <msup>
+                <mi>b</mi>
+                <mn>2</mn>
+              </msup>
+              <mo>&#x2212;</mo>
+              <mn>4</mn>
+              <mo>&#x2062;</mo>
+              <mi>a</mi>
+              <mo>&#x2062;</mo>
+              <mi>c</mi>
+            </mrow>
+          </msqrt>
+        </mrow>
+        <mrow>
+          <mn>2</mn>
+          <mo>&#x2062;</mo>
+          <mi>a</mi>
+        </mrow>
+      </mfrac>
+    </mrow>
+  </math>
+</p>
+----

--- a/modules/ROOT/partials/configuration/extended_mathml_elements.adoc
+++ b/modules/ROOT/partials/configuration/extended_mathml_elements.adoc
@@ -1,0 +1,46 @@
+[[extended-mathml-elements]]
+== `+extended_mathml_elements+`
+
+This option allows a specific list of additional MathML elements to be preserved in the editor content, even if they are not included in the default DOMPurify allowlist. This setting only affects elements used within MathML markup and has no effect on general HTML content.
+
+*Type:* `+Array+` of `+Strings+`
+
+*Default value:* `+[]+` (empty array)
+
+=== Example: using `+extended_mathml_elements+`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',
+  extended_mathml_elements: [ 'mn', 'mspace' ]
+});
+----
+
+.Example of MathML with preserved elements
+[source,html]
+----
+<p>
+  <math xmlns="http://www.w3.org/1998/Math/MathML">
+    <mrow>
+      <mi>a</mi>
+      <mo>=</mo>
+      <mfrac>
+        <mrow>
+          <mn>1</mn>
+          <mo>+</mo>
+          <mn>√2</mn>
+        </mrow>
+        <mn>3</mn>
+      </mfrac>
+      <mspace width="1em"></mspace>
+      <mo>&#x222A;</mo>
+      <mspace width="1em"></mspace>
+      <msup>
+        <mn>5</mn>
+        <mn>2</mn>
+      </msup>
+    </mrow>
+  </math>
+</p>
+----


### PR DESCRIPTION
Ticket: DOC-3131

Site: [Staging branch-release notes](http://docs-feature-780-doc-3131tiny-11756.staging.tiny.cloud/docs/tinymce/latest/7.8.0-release-notes/#new-options-for-customizing-allowed-mathml-elements-and-attributes)
Site: [Staging branch-#extended-mathml-elements](http://docs-feature-780-doc-3131tiny-11756.staging.tiny.cloud/docs/tinymce/latest/math/#extended-mathml-elements)
Site: [Staging branch-#extended-mathml-attributes](http://docs-feature-780-doc-3131tiny-11756.staging.tiny.cloud/docs/tinymce/latest/math/#extended-mathml-attributes)

Changes:
* <placeholder-text>

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] Included a `release note` entry for any `New product features`.

Review:
- [x] Documentation Team Lead has reviewed