### PR TITLE
DOC-3131: The tooltip for the `blockquote` button was not translated in Hebrew.

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -379,4 +379,4 @@ There one known issue in {productname} {release-version}.
 
 The Blockquote toolbar button tooltip does not display a translation for Hebrew. This issue affects users who rely on localized tooltips for accessibility and usability.
 
-**Status**: Currently under investigation.
+**Status**: This issue has been resolved in xref:7.8.0-release-notes.adoc#the-tooltip-for-the-blockquote-button-was-not-translated-in-hebrew[TinyMCE 7.8.0]

--- a/modules/ROOT/pages/7.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.8.0-release-notes.adoc
@@ -359,6 +359,11 @@ In previous versions of {productname}, the keyboard focus styles were not proper
 
 Previously, when the editor height was set using relative units such as `pt` or `em`, the editor was unable to parse and evaluate these values correctly. As a result, it would bypass the `min_height` and `max_height` checks, leading to unpredictable layout behavior. This issue was especially noticeable during initialization, although resizing later used the browser-calculated content box height, which partially masked the problem. In {release-version}, {productname} now attempts to compute height values from additional unit types to better enforce minimum and maximum height constraints. Some units, such as percentages (`%`), may still override explicit height values due to browser limitations in determining the final rendered size. This update ensures that `min_height` and `max_height` settings are more reliably applied across a wider range of unit types.
 
+=== The tooltip for the `blockquote` button was not translated in Hebrew.
+// #TINY-11732
+
+Previously, the tooltip for the `blockquote` button was not translated in Hebrew. {productname} {release-version} addresses this by adding a new Hebrew translation to the tooltip for the `blockquote` button.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-3131

Site: [Staging branch](http://docs-feature-780-doc-3131tiny-11732.staging.tiny.cloud/docs/tinymce/latest/7.8.0-release-notes/#the-tooltip-for-the-blockquote-button-was-not-translated-in-hebrew)

Changes:
* Documented the bug fix for TINY-11732

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed