### PR TITLE
DOC-3198: Omit onboarding UI from promotions page.

### DIFF
--- a/modules/ROOT/pages/7.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.8.0-release-notes.adoc
@@ -257,12 +257,12 @@ tinymce.init({
 </p>
 ----
 
-=== New `onboarding` option
-// #TINY-11931
+// === New `onboarding` option
+// // #TINY-11931
 
-{productname} {release-version} introduces a new `+onboarding+` option to enhance the developer experience during the 14-day trial period. This option controls the display of a cloud promotion banner highlighting paid features available during the trial. The banner is automatically hidden when the trial ends or when the editor is correctly configured, ensuring a smoother and less intrusive setup experience.
+// {productname} {release-version} introduces a new `+onboarding+` option to enhance the developer experience during the 14-day trial period. This option controls the display of a cloud promotion banner highlighting paid features available during the trial. The banner is automatically hidden when the trial ends or when the editor is correctly configured, ensuring a smoother and less intrusive setup experience.
 
-For more information, see xref:promotions.adoc#onboarding[onboarding].
+// For more information, see xref:promotions.adoc#onboarding[onboarding].
 
 
 [[bug-fixes]]

--- a/modules/ROOT/partials/misc/premium-upgrade-promotion-option.adoc
+++ b/modules/ROOT/partials/misc/premium-upgrade-promotion-option.adoc
@@ -2,6 +2,6 @@
 
 include::partial$configuration/promotion.adoc[leveloffset=+1]
 
-== Cloud promotion
+// == Cloud promotion
 
-include::partial$configuration/onboarding.adoc[leveloffset=+1]
+// include::partial$configuration/onboarding.adoc[leveloffset=+1]


### PR DESCRIPTION
Ticket: DOC-3198

Site: [promotions](http://docs-hotfix-7-doc-3198.staging.tiny.cloud/docs/tinymce/latest/promotions/)
Site: [content-appearance/#onboarding](http://docs-hotfix-7-doc-3198.staging.tiny.cloud/docs/tinymce/latest/content-appearance/#onboarding)
Site: [customize-ui/#onboarding](http://docs-hotfix-7-doc-3198.staging.tiny.cloud/docs/tinymce/latest/customize-ui/#onboarding)
Site: [7.8.0 Release notes](http://docs-hotfix-7-doc-3198.staging.tiny.cloud/docs/tinymce/latest/7.8.0-release-notes/#overview)

Changes:
* Hide inclusion of new `onboarding` UI until re-launch.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed