### PR TITLE
DOC-3199: Fixed Image Optimizer filters in the demo.

### DIFF
--- a/modules/ROOT/examples/live-demos/uploadcare/index.js
+++ b/modules/ROOT/examples/live-demos/uploadcare/index.js
@@ -5,18 +5,15 @@ tinymce.init({
 	uploadcare_cdn_base_url: 'https://tiny.ucarecdn.com',
 	uploadcare_store_type: 'temporary',
   uploadcare_filters: [
-    { name: 'none' }, // No filter applied
     { name: 'adaris', amount: -100 }, // Adaris with inverted effect (amount -100), label defaults to 'adaris'
-    { name: 'adaris', amount: -100, label: 'Vintage Fade' }, // Adaris with inverted effect (amount -100), label reads 'Vintage Fade'
+    { name: 'adaris', amount: -100, label: 'Vintage' }, // Adaris with inverted effect (amount -100), label reads 'Vintage'
     { name: 'adaris', amount: 0, label: 'Base' }, // Adaris with neutral effect (amount 0), label reads 'Base'
     { name: 'adaris', amount: 50, label: 'Light' }, // Adaris with light effect (amount 50), label reads 'Light'
-    { name: 'adaris', amount: 100, label: 'Standard' }, // Adaris with standard effect (amount 100), label reads 'Standard'
     { name: 'adaris', amount: 200, label: 'Intense' }, // Adaris with intense effect (amount 200), label reads 'Intense'
-    { name: 'zevcen', amount: 200, label: 'Glow Boost' }, // Zevcen with intense effect (amount 200), label reads 'Glow Boost'
-    { name: 'galen', amount: 80, label: 'Soft Focus' }, // Galen with softening effect (amount 80), label reads 'Soft Focus'
-    { name: 'carris', amount: 120, label: 'Sharp Contrast' }, // Carris with high contrast (amount 120), label reads 'Sharp Contrast'
-    { name: 'ferand', amount: 60, label: 'Light Touch' }, // Ferand with light enhancement (amount 60), label reads 'Light Touch'
-    { name: 'sorahel', amount: -50, label: 'Night Mood' } // Sorahel with darkened effect (amount -50), label reads 'Night Mood'
+    { name: 'galen', amount: 80, label: 'Soft' }, // Galen with softening effect (amount 80), label reads 'Soft'
+    { name: 'carris', amount: 120, label: 'Sharp' }, // Carris with high contrast (amount 120), label reads 'Sharp'
+    { name: 'sorahel', amount: -50, label: 'Night' }, // Sorahel with darkened effect (amount -50), label reads 'Night'
+    { name: 'none' }, // No filter applied
   ],
   a11y_advanced_options: true,
   toolbar: "undo redo | styles | bold italic underline | forecolor | bullist numlist| link uploadcare | code preview",

--- a/modules/ROOT/partials/configuration/uploadcare_filters.adoc
+++ b/modules/ROOT/partials/configuration/uploadcare_filters.adoc
@@ -55,6 +55,7 @@ tinymce.init({
 ====
 * Filter names must be selected from the supported set:
 ** `adaris`, `briaril`, `calarel`, `carris`, `cynarel`, `cyren`, `elmet`, `elonni`, `enzana`, `erydark`, `fenralan`, `ferand`, `galen`, `gavin`, `gethriel`, `iorill`, `iothari`, `iselva`, `jadis`, `lavra`, `misiara`, `namala`, `nerion`, `nethari`, `pamaya`, `sarnar`, `sedis`, `sewen`, `sorahel`, `sorlen`, `tarian`, `thellassan`, `varriel`, `varven`, `vevera`, `virkas`, `yedis`, `yllara`, `zatvel`, `zevcen`.
+* The `{ name: 'none' }` option adds a "No filter" or "Remove filter" choice to the list of available filters. This allows end users to remove any applied filter. If this option is **not** included, users will **not** have a way to remove a filter once it's been applied.
 * If the amount is not set, it defaults to 100.
 * Some filters may behave unpredictably outside the 0–100 range.
 * Applying negative amount values inverts the filter, useful for creative effects.

--- a/modules/ROOT/partials/configuration/uploadcare_filters.adoc
+++ b/modules/ROOT/partials/configuration/uploadcare_filters.adoc
@@ -51,11 +51,15 @@ tinymce.init({
 });
 ----
 
+[IMPORTANT]
+====
+The `{ name: 'none' }` option adds a "No filter" or "Remove filter" choice to the list of available filters. This allows end users to remove any applied filter. If this option is **not** included, users will **not** have a way to remove a filter once it's been applied.
+====
+
 [NOTE]
 ====
 * Filter names must be selected from the supported set:
 ** `adaris`, `briaril`, `calarel`, `carris`, `cynarel`, `cyren`, `elmet`, `elonni`, `enzana`, `erydark`, `fenralan`, `ferand`, `galen`, `gavin`, `gethriel`, `iorill`, `iothari`, `iselva`, `jadis`, `lavra`, `misiara`, `namala`, `nerion`, `nethari`, `pamaya`, `sarnar`, `sedis`, `sewen`, `sorahel`, `sorlen`, `tarian`, `thellassan`, `varriel`, `varven`, `vevera`, `virkas`, `yedis`, `yllara`, `zatvel`, `zevcen`.
-* The `{ name: 'none' }` option adds a "No filter" or "Remove filter" choice to the list of available filters. This allows end users to remove any applied filter. If this option is **not** included, users will **not** have a way to remove a filter once it's been applied.
 * If the amount is not set, it defaults to 100.
 * Some filters may behave unpredictably outside the 0–100 range.
 * Applying negative amount values inverts the filter, useful for creative effects.


### PR DESCRIPTION
Ticket: DOC-3199

Site: [Updated demo](http://docs-hotfix-7-doc-3199.staging.tiny.cloud/docs/tinymce/latest/uploadcare/#interactive-example)
Site: [{name: 'none'} explanation](http://docs-hotfix-7-doc-3199.staging.tiny.cloud/docs/tinymce/latest/uploadcare/#example-setting-uploadcare_filters) - The explanation is in the **Important** section.

Changes:
* Updated the demo to have 9 filter options including the `{name: 'none'}` option.
* Added an explanation about `{name: 'none'}` option and what happens if this option is not set during setup.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed