### PR TITLE
DOC-3200: Fixed typo in TinyMCE util tools documentation.

### DIFF
--- a/modules/ROOT/pages/apis/tinymce.util.tools.adoc
+++ b/modules/ROOT/pages/apis/tinymce.util.tools.adoc
@@ -4,7 +4,7 @@
 :keywords: each, explode, grep, hasOwnProperty, inArray, is, isArray, makeMap, map, resolve, toArray, trim, walk
 :moxie-type: api
 
-This class contains various utlity functions. These are also exposed directly on the tinymce namespace.
+This class contains various utility functions. These are also exposed directly on the tinymce namespace.
 
 [[summary]]
 == Summary


### PR DESCRIPTION
Ticket: DOC-3200

Site: [Staging branch](http://docs-hotfix-7-doc-3200.staging.tiny.cloud/docs/tinymce/latest/apis/tinymce.util.tools/)

Changes:
* Fixed typo in the first sentence of page: Changed **utlity** to **utility**.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [ ] Documentation Team Lead has reviewed