### PR TITLE
DOC-3152: Fixed typos in 7.7.0 release docs and import/export word docker setup docs.

### DIFF
--- a/modules/ROOT/pages/7.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.7.0-release-notes.adoc
@@ -372,7 +372,7 @@ This issue has been resolved in {productname} {release-version}. Input elements 
 
 This section describes issues that users of {productname} {release-version} may encounter and possible workarounds for these issues.
 
-There one known issue in {productname} {release-version}.
+There is one known issue in {productname} {release-version}.
 
 === Missing Hebrew translation for Blockquote toolbar button tooltip
 // #TINY-11732

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-autorization-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-autorization-on-premises.adoc
@@ -6,7 +6,7 @@ To enable authorization, set the `SECRET_KEY` environment variable during the xr
 If the `SECRET_KEY` variable is set, then all requests must have a header with a JWT (JSON Web Token) signed with this key. The token should be passed as a value of the `Authorization` header for each request sent to the {pluginname} REST API.
 
 [NOTE]
-If the `SECRET_KEY` is not setup during the installation, then {pluginname} On-Premises will not require any headers with tokens when sending requests to the {pluginname} REST API. However, this it is not recommend to skip the authorization when running {pluginname} On-Premises in a public network.
+If the `SECRET_KEY` is not setup during the installation, then {pluginname} On-Premises will not require any headers with tokens when sending requests to the {pluginname} REST API. However, it is **not** recommended to skip the authorization when running {pluginname} On-Premises in a public network.
 
 === Generating the token
 


### PR DESCRIPTION
Ticket: DOC-3152

Site: [7.7.0 Release Docs](http://docs-hotfix-7-doc-3152.staging.tiny.cloud/docs/tinymce/latest/7.7.0-release-notes/#known-issues)

Site: [Import From Word and Export to Word Docker docs](http://docs-hotfix-7-doc-3152.staging.tiny.cloud/docs/tinymce/latest/individual-import-from-word-and-export-to-word-on-premises/#authorization)

Changes:
* In the 7.7.0 docs known issues section, fixed the following typo: "There one known issue in TinyMCE 7.7.0." to "There **is** one known issue in TinyMCE 7.7.0.""

* In the Import from Word and Export to Word Docker docs authorization NOTE section, fixed the following typo: ""However, this it is not recommend to skip the authorization when running Import from Word and Export to Word On-Premises in a public network."" to ""However, **it is not recommended** to skip the authorization when running Import from Word and Export to Word On-Premises in a public network."".

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed