### PR TITLE
DOC-3202: Add migration guides for users migrating from TinyMCE `4 | 5` to `v7`

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -209,6 +209,8 @@
 **** xref:bundling-localization.adoc[UI localizations]
 **** xref:bundling-themes.adoc[Themes]
 ** xref:upgrading.adoc[Upgrading {productname}]
+** xref:migration-from-4x.adoc[Migrating from {productname} 4]
+** xref:migration-from-5x.adoc[Migrating from {productname} 5]
 ** xref:migration-from-6x.adoc[Migrating from {productname} 6]
 ** xref:migration-from-froala.adoc[Migrating from Froala]
 ** xref:generate-rsa-key-pairs.adoc[Generate public key pairs]

--- a/modules/ROOT/pages/migration-from-4x.adoc
+++ b/modules/ROOT/pages/migration-from-4x.adoc
@@ -1,0 +1,7 @@
+= Migrating from {productname} 4 to {productname} 7
+:navtitle: Migrating from TinyMCE 4
+:description: Guidance for migrating from TinyMCE 4 to TinyMCE 7
+:keywords: migration, considerations, premigration, pre-migration
+:release-version: 7.0
+
+// Todo

--- a/modules/ROOT/pages/migration-from-5x.adoc
+++ b/modules/ROOT/pages/migration-from-5x.adoc
@@ -1,0 +1,7 @@
+= Migrating from {productname} 5 to {productname} 7
+:navtitle: Migrating from TinyMCE 5
+:description: Guidance for migrating from TinyMCE 5 to TinyMCE 7
+:keywords: migration, considerations, premigration, pre-migration
+:release-version: 7.0
+
+// Todo


### PR DESCRIPTION
Ticket: DOC-3202
Ticket: TINY-12035

Site: [Staging branch](http://docs-hotfix-7-doc-3202.staging.tiny.cloud/docs/tinymce/latest/migration-from-4x/)
Site: [Staging branch](http://docs-hotfix-7-doc-3202.staging.tiny.cloud/docs/tinymce/latest/migration-from-5x/)

Changes:
* Add new guides to assist users wanting to migrate from v4 and v5 version of TinyMCE.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.

Review:
- [ ] Documentation Team Lead has reviewed