### PR TITLE
DOC-3183: Updated jQuery integration quick start documentation.

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -13,7 +13,7 @@ asciidoc:
     tinymce_live_demo_url: https://cdn.tiny.cloud/1/qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc/tinymce/7/tinymce.min.js
     tinydrive_live_demo_url: https://cdn.tiny.cloud/1/qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc/tinydrive/7/tinydrive.min.js
     webcomponent_url: https://cdn.jsdelivr.net/npm/@tinymce/tinymce-webcomponent@2/dist/tinymce-webcomponent.min.js
-    jquery_url: https://cdn.jsdelivr.net/npm/@tinymce/tinymce-jquery@2/dist/tinymce-jquery.min.js
+    jquery_url: https://cdn.jsdelivr.net/npm/@tinymce/tinymce-jquery/dist/tinymce-jquery.min.js
     openai_proxy_url: https://openai.ai-demo-proxy.tiny.cloud/v1/chat/completions
     openai_proxy_token: eyJhbGciOiJFUzM4NCJ9.eyJhdWQiOlsiaHR0cHM6Ly9vcGVuYWkuYWktZGVtby1wcm94eS50aW55LmNsb3VkLyJdLCJleHAiOjE3NTEzMjgwMDAsImh0dHBzOi8vb3BlbmFpLmFpLWRlbW8tcHJveHkudGlueS5jbG91ZC9yb2xlIjoicHVibGljLWRlbW8iLCJpc3MiOiJodHRwczovL2FpLWRlbW8tcHJveHkudGlueS5jbG91ZC8iLCJqdGkiOiJmOGFmY2EyNC1mN2FhLTQxMjktYTc2Yy02YThlZDU3YjAyZjYiLCJzdWIiOiJhaS1hc3Npc3RhbnQtZGVtbyJ9.Xu0apHCbxgmRQTeTqrTIDFFhh2CgKeARRXa3mCxSGoCwZqkoQaFRZBCzDo8Xz7DuUa5mW2XHl-HYcYiXJM9ly16d0oY7lJefHBeLlmJEBE1CSttHBkCRWZS8eFLCasL6
     default_meta_keywords: tinymce, documentation, docs, plugins, customizable skins, configuration, examples, html, php, java, javascript, image editor, inline editor, distraction-free editor, classic editor, wysiwyg

--- a/modules/ROOT/partials/integrations/jquery-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/jquery-quick-start.adoc
@@ -99,12 +99,33 @@ endif::[]
 in the jQuery prefix, and any other settings are defined in the object passed to
 the `tinymce` method.
 +
+ifeval::["{productSource}" == "cloud"]
 [source,html]
 ----
 <script>
-  $('textarea#tiny').tinymce({ height: 500, /* other settings... */ });
+  $('textarea#tiny').tinymce({
+    height: 500,
+    api_key: '<your api key>',
+    /* other settings... */,
+  });
 </script>
 ----
+. Update the `+api_key+` property to include your link:{accountsignup}/[{cloudname} API key].
+endif::[]
+
+ifeval::["{productSource}" == "package-manager"]
+[source,html]
+----
+<script>
+  $('textarea#tiny').tinymce({
+    height: 500,
+    license_key: '<your license key>',
+    /* other settings... */,
+  });
+</script>
+----
+. Update the `+license_key+` property and include your xref:license-key.adoc[License Key].
+endif::[]
 
 == Example jQuery integration
 
@@ -128,6 +149,7 @@ ifeval::["{productSource}" == "package-manager"]
     <script>
       $('textarea#tiny').tinymce({
         height: 500,
+        license_key: '<your-license-key>',
         menubar: false,
         plugins: [
           'advlist', 'autolink', 'lists', 'link', 'image', 'charmap', 'preview',
@@ -169,6 +191,7 @@ ifeval::["{productSource}" == "cloud"]
     <script>
       $('textarea#tiny').tinymce({
         height: 500,
+        api_key: '<your api key>',
         menubar: false,
         plugins: [
           'advlist', 'autolink', 'lists', 'link', 'image', 'charmap', 'preview',


### PR DESCRIPTION
Ticket: DOC-3183

Site: [Staging branch](http://docs-hotfix-7-doc-3183.staging.tiny.cloud/docs/tinymce/latest/jquery-cloud/)

Changes:
* Updated `jquery_url` attribute in the `antora.yml` file with the url that points to the latest stable version of `tinymce-jquery`.
* Included `license_key` and `api_key` in the examples

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed