### PR TITLE
DOC-3151: Update default list icons with new asset files.

### DIFF
--- a/modules/ROOT/images/icons/list-bull-circle.svg
+++ b/modules/ROOT/images/icons/list-bull-circle.svg
@@ -1,15 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="48px" height="48px" viewBox="0 0 48 48" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 51.2 (57519) - http://www.bohemiancoding.com/sketch -->
-    <title>icon-list-bull-circle</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <path d="M11,16 C12.1045695,16 13,15.1045695 13,14 C13,12.8954305 12.1045695,12 11,12 C9.8954305,12 9,12.8954305 9,14 C9,15.1045695 9.8954305,16 11,16 Z M11,17 C9.34314575,17 8,15.6568542 8,14 C8,12.3431458 9.34314575,11 11,11 C12.6568542,11 14,12.3431458 14,14 C14,15.6568542 12.6568542,17 11,17 Z" fill="#000000" fill-rule="nonzero"></path>
-        <path d="M11,26 C12.1045695,26 13,25.1045695 13,24 C13,22.8954305 12.1045695,22 11,22 C9.8954305,22 9,22.8954305 9,24 C9,25.1045695 9.8954305,26 11,26 Z M11,27 C9.34314575,27 8,25.6568542 8,24 C8,22.3431458 9.34314575,21 11,21 C12.6568542,21 14,22.3431458 14,24 C14,25.6568542 12.6568542,27 11,27 Z" fill="#000000" fill-rule="nonzero"></path>
-        <path d="M11,36 C12.1045695,36 13,35.1045695 13,34 C13,32.8954305 12.1045695,32 11,32 C9.8954305,32 9,32.8954305 9,34 C9,35.1045695 9.8954305,36 11,36 Z M11,37 C9.34314575,37 8,35.6568542 8,34 C8,32.3431458 9.34314575,31 11,31 C12.6568542,31 14,32.3431458 14,34 C14,35.6568542 12.6568542,37 11,37 Z" fill="#000000" fill-rule="nonzero"></path>
-        <rect fill="#000000" opacity="0.2" x="18" y="12" width="22" height="4"></rect>
-        <rect fill="#000000" opacity="0.2" x="18" y="22" width="22" height="4"></rect>
-        <rect fill="#000000" opacity="0.2" x="18" y="32" width="22" height="4"></rect>
-    </g>
-</svg>
+<svg fill="none" height="48" viewBox="0 0 48 48" width="48" xmlns="http://www.w3.org/2000/svg"><g fill="#222f3e"><path d="m8 14a3 3 0 1 0 6 0 3 3 0 0 0 -6 0zm5 0a2 2 0 1 1 -4 0 2 2 0 0 1 4 0zm-5 10a3 3 0 1 0 6 0 3 3 0 0 0 -6 0zm5 0a2 2 0 1 1 -4 0 2 2 0 0 1 4 0zm-5 10a3 3 0 1 0 6 0 3 3 0 0 0 -6 0zm5 0a2 2 0 1 1 -4 0 2 2 0 0 1 4 0z" fill-rule="evenodd"/><path d="m18 12h22v4h-22zm0 10h22v4h-22zm0 10h22v4h-22z" opacity=".2"/></g></svg>

--- a/modules/ROOT/images/icons/list-bull-default.svg
+++ b/modules/ROOT/images/icons/list-bull-default.svg
@@ -1,15 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="48px" height="48px" viewBox="0 0 48 48" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 51.2 (57519) - http://www.bohemiancoding.com/sketch -->
-    <title>icon-list-bull-default</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <circle fill="#000000" cx="11" cy="14" r="3"></circle>
-        <circle fill="#000000" cx="11" cy="24" r="3"></circle>
-        <circle fill="#000000" cx="11" cy="34" r="3"></circle>
-        <rect fill="#000000" opacity="0.2" x="18" y="12" width="22" height="4"></rect>
-        <rect fill="#000000" opacity="0.2" x="18" y="22" width="22" height="4"></rect>
-        <rect fill="#000000" opacity="0.2" x="18" y="32" width="22" height="4"></rect>
-    </g>
-</svg>
+<svg fill="none" height="48" viewBox="0 0 48 48" width="48" xmlns="http://www.w3.org/2000/svg"><g fill="#222f3e"><path d="m14 14a3 3 0 1 1 -6 0 3 3 0 0 1 6 0z"/><path d="m12 24a3 3 0 1 0 6 0 3 3 0 0 0 -6 0zm5 0a2 2 0 1 1 -4 0 2 2 0 0 1 4 0z" fill-rule="evenodd"/><path d="m16 31h6v6h-6z"/><path d="m16 31h6v6h-6z"/><path d="m18 12h22v4h-22zm4 10h18v4h-18zm4 10h14v4h-14z" opacity=".2"/></g></svg>

--- a/modules/ROOT/images/icons/list-bull-disc.svg
+++ b/modules/ROOT/images/icons/list-bull-disc.svg
@@ -1,0 +1,1 @@
+<svg fill="none" height="48" viewBox="0 0 48 48" width="48" xmlns="http://www.w3.org/2000/svg"><g fill="#222f3e"><path d="m14 14a3 3 0 1 1 -6 0 3 3 0 0 1 6 0zm0 10a3 3 0 1 1 -6 0 3 3 0 0 1 6 0zm0 10a3 3 0 1 1 -6 0 3 3 0 0 1 6 0z"/><path d="m18 12h22v4h-22zm0 10h22v4h-22zm0 10h22v4h-22z" opacity=".2"/></g></svg>

--- a/modules/ROOT/images/icons/list-bull-square.svg
+++ b/modules/ROOT/images/icons/list-bull-square.svg
@@ -1,15 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="48px" height="48px" viewBox="0 0 48 48" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 51.2 (57519) - http://www.bohemiancoding.com/sketch -->
-    <title>icon-list-bull-square</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <rect fill="#000000" x="8" y="11" width="6" height="6"></rect>
-        <rect fill="#000000" x="8" y="21" width="6" height="6"></rect>
-        <rect fill="#000000" x="8" y="31" width="6" height="6"></rect>
-        <rect fill="#000000" opacity="0.2" x="18" y="12" width="22" height="4"></rect>
-        <rect fill="#000000" opacity="0.2" x="18" y="22" width="22" height="4"></rect>
-        <rect fill="#000000" opacity="0.2" x="18" y="32" width="22" height="4"></rect>
-    </g>
-</svg>
+<svg fill="none" height="48" viewBox="0 0 48 48" width="48" xmlns="http://www.w3.org/2000/svg"><g fill="#222f3e"><path d="m8 21h6v6h-6zm0 10h6v6h-6zm0-20h6v6h-6z"/><path d="m18 12h22v4h-22zm0 10h22v4h-22zm0 10h22v4h-22z" opacity=".2"/></g></svg>

--- a/modules/ROOT/partials/configuration/icon_list.adoc
+++ b/modules/ROOT/partials/configuration/icon_list.adoc
@@ -107,9 +107,10 @@
 | `+line-height+` | image:icons/line-height.svg[line-height.svg] | `+line-height.svg+`
 | `+line+` | image:icons/line.svg[line.svg] | `+line.svg+`
 | `+link+` | image:icons/link.svg[link.svg] | `+link.svg+`
-| `+list-bull-circle+` | image:icons/list-bull-circle.svg[list-bull-circle.svg] | `+list-bull-circle.svg+`
 | `+list-bull-default+` | image:icons/list-bull-default.svg[list-bull-default.svg] | `+list-bull-default.svg+`
+| `+list-bull-circle+` | image:icons/list-bull-circle.svg[list-bull-circle.svg] | `+list-bull-circle.svg+`
 | `+list-bull-square+` | image:icons/list-bull-square.svg[list-bull-square.svg] | `+list-bull-square.svg+`
+| `+list-bull-disc+` | image:icons/list-bull-disc.svg[list-bull-disc.svg] | `+list-bull-disc.svg+`
 | `+list-num-default-rtl+` | image:icons/list-num-default-rtl.svg[list-num-default-rtl.svg] | `+list-num-default-rtl.svg+`
 | `+list-num-default+` | image:icons/list-num-default.svg[list-num-default.svg] | `+list-num-default.svg+`
 | `+list-num-lower-alpha-rtl+` | image:icons/list-num-lower-alpha-rtl.svg[list-num-lower-alpha-rtl.svg] | `+list-num-lower-alpha-rtl.svg+`


### PR DESCRIPTION
Ticket: DOC-3151

Site: [Staging branch](http://docs-feature-790-doc-3151tiny-12014.staging.tiny.cloud/docs/tinymce/latest/editor-icon-identifiers/#:~:text=list%2Dbull%2Ddefault,bull%2Ddisc.svg)

Changes:
* Update default list icons with new asset files to support TINY-12014 changes.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.


Review:
- [x] Documentation Team Lead has reviewed