### PR TITLE
DOC-3151: Resize cursor is now the correct direction for each resize mode.

### DIFF
--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -119,7 +119,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 Previously, when the {productname} editor was configured with `resize: true`, which restricts resizing to the vertical axis, the editor incorrectly displayed a diagonal resize cursor. This was misleading, as the visual cue did not match the actual resizing behavior. In {release-version}, the cursor style now accurately reflects the resizing direction: a vertical resize cursor is shown when `resize: true` is used, and a diagonal cursor remains for `resize: 'both'`, which allows resizing in both horizontal and vertical directions.
 
-{productname} would like to thank link:https://github.com/daniloff200[daniloff200] for their contribution to this improvement.
+NOTE: {companyname} Technologies would like to thank link:https://github.com/daniloff200[daniloff200] for contributing to this improvement.
 
 
 [[additions]]

--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -114,6 +114,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Resize cursor is now the correct direction for each resize mode.
+// #TINY-12036 || #GH-10189
+
+Previously, when the {productname} editor was configured with `resize: true`, which restricts resizing to the vertical axis, the editor incorrectly displayed a diagonal resize cursor. This was misleading, as the visual cue did not match the actual resizing behavior. In {release-version}, the cursor style now accurately reflects the resizing direction: a vertical resize cursor is shown when `resize: true` is used, and a diagonal cursor remains for `resize: 'both'`, which allows resizing in both horizontal and vertical directions.
+
+{productname} would like to thank link:https://github.com/daniloff200[daniloff200] for their contribution to this improvement.
+
 
 [[additions]]
 == Additions


### PR DESCRIPTION
Ticket: DOC-3151

Site: [Staging branch](http://docs-feature-790-doc-3151tiny-12036.staging.tiny.cloud/docs/tinymce/latest/7.9.0-release-notes/#resize-cursor-is-now-the-correct-direction-for-each-resize-mode)

Changes:
* Improvement for TINY-12036 and GH-10189

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed