### PR TITLE
DOC-3151: `ContextFormSizeInput` lock button has been repositioned beteen the "width" and "height" inputs.

### DIFF
--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -136,6 +136,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== `ContextFormSizeInput` lock button has been repositioned between the "width" and "height" inputs.
+// TINY-11916
+
+In previous versions of {productname}, the "lock aspect ratio" button in the `ContextFormSizeInput` component was positioned at the end of the "width" and "height" input fields. This placement made it difficult to understand the relationship between the inputs and the lock functionality. 
+
+{productname} {release-version} addresses this issue. Now, the lock button has been repositioned between the "width" and "height" inputs.
 
 [[removed]]
 == Removed


### PR DESCRIPTION
Ticket: DOC-3151

Site: [Staging branch](http://docs-feature-790-doc-3151tiny-11916.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* Add change documentation for TINY-11916

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.


Review:
- [x] Documentation Team Lead has reviewed