### PR TITLE
DOC-3197: mark export plugin as deprecated

### DIFF
--- a/modules/ROOT/pages/export.adoc
+++ b/modules/ROOT/pages/export.adoc
@@ -6,6 +6,8 @@
 :plugincode: export
 :pluginminimumplan: tiertwo
 
+IMPORTANT: The Export plugin has been marked as *deprecated*. It will be completely removed from the upcoming TinyMCE 9.0 release. As an alternative solution, we recommend the link:https://www.tiny.cloud/docs/tinymce/latest/exportpdf/[Export to PDF^] Premium plugin.
+
 include::partial$misc/admon-premium-plugin.adoc[]
 
 The {pluginname} plugin adds the ability to export content from the editor to a user's local machine in various formats. For a list of available exporters and information on what they support, see the xref:exporters[Exporters section].


### PR DESCRIPTION
Ticket: DOC-3197

Site: [Staging branch](http://docs-<hotfix|feature>-<version>-doc-<num>.staging.tiny.cloud/docs/tinymce/<version>/)

Changes:
* Mark export plugin as deprecated

Pre-checks:
- [ ] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [ ] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [ ] Included a `release note` entry for any `New product features`.
- [ ] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [ ] Documentation Team Lead has reviewed