### PR TITLE
DOC-3197: mark export plugin as deprecated

### DIFF
--- a/modules/ROOT/pages/export.adoc
+++ b/modules/ROOT/pages/export.adoc
@@ -6,6 +6,8 @@
 :pluginname: Export
 :plugincode: export
 
+IMPORTANT: The {pluginname} plugin is now *deprecated* and will be permanently removed in the upcoming {productname} 9.0 release. To ensure continued access to similar functionality, consider using the link:https://www.tiny.cloud/docs/tinymce/latest/exportpdf/[Export to PDF^] Premium plugin as an alternative.
+
 include::partial$misc/requires_5_5v.adoc[]
 
 include::partial$misc/premiumplugin.adoc[]


### PR DESCRIPTION
Ticket: DOC-3197

Site: [Staging branch](http://docs-feature-5-doc-3197.staging.tiny.cloud/docs/tinymce/5/)

Changes:
* DOC-3197

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed