### PR TITLE
DOC-3205: Update docs with Blazor changes

### DIFF
--- a/modules/ROOT/partials/integrations/blazor-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/blazor-tech-ref.adoc
@@ -123,7 +123,7 @@ Set the editor to inline mode.
 
 === `Disable`
 
-Set the editor to readonly mode.
+Sets the editor to a disable state.
 
 *Type:* `+Boolean+`
 
@@ -137,6 +137,24 @@ Set the editor to readonly mode.
   Disable=@disable
 />
 <button @onclick="@(() => disable = !disable)">Toggle</button>
+----
+
+=== `Readonly`
+
+Sets the editor to readonly mode.
+
+*Type:* `+Boolean+`
+
+*Default value:* `+false+`
+
+==== Example using Readonly
+
+[source,cs]
+----
+<Editor
+  Readonly=@readonly
+/>
+<button @onclick="@(() => readonly = !readonly)">Toggle</button>
 ----
 
 === `JsConfSrc`


### PR DESCRIPTION
Ticket: DOC-3205

Site: [Staging branch](http://docs-hotfix-7-doc-3205.staging.tiny.cloud/docs/tinymce/7/)

Changes:
* Adds docs for the new Readonly property and the change to how the Disable works.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] ~~`modules/ROOT/nav.adoc` has been updated `(if applicable)`.~~
- [x] ~~Included a `release note` entry for any `New product features`.~~
- [x] ~~If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.~~

- [x] Don't merge until we merge and release the new Blazor integration

Review:
- [x] Documentation Team Lead has reviewed