### PR TITLE
DOC-3151: Spellchecking with a language that does not match the content no longer overloads the spelling server.

### DIFF
--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -69,6 +69,19 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Spell Checker
+
+The {productname} {release-version} includes an accompanying release of the **Spell Checker** premium plugin.
+
+**Spell Checker** includes the following improvement.
+
+==== Spellchecking with a language that does not match the content no longer overloads the spelling server.
+// #TINY-12061
+
+Previously, using the spellchecker with a language that did not match the document content could cause server overload due to the large volume of unrecognized words. This issue led to excessive CPU usage on the spelling server. In {release-version}, {productname} now processes words in manageable chunks, reducing the load on the server and preventing performance degradation during spellchecking operations with mismatched language settings.
+
+For information on the **Spell Checker** premium plugin, see: xref:introduction-to-tiny-spellchecker.adoc[Spell Checker plugin].
+
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement


### PR DESCRIPTION
Ticket: DOC-3151

Site: [Staging branch](http://docs-feature-790-doc-3151tiny-12061.staging.tiny.cloud/docs/tinymce/latest/7.9.0-release-notes/#spellchecking-with-a-language-that-does-not-match-the-content-no-longer-overloads-the-spelling-server)

Changes:
* Documentation fix for TINY-12061

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed