### PR TITLE
DOC-3151: Spelling Autocorrect no longer requires the spelling service.

### DIFF
--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -69,6 +69,19 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== **Spelling Autocorrect**
+
+The {productname} {release-version} release includes an accompanying release of the **Spelling Autocorrect** premium plugin.
+
+**Spelling Autocorrect** includes the following improvements.
+
+==== Spelling Autocorrect no longer requires the spelling service.
+// #TINY-12041
+
+Previously, the {productname} autocorrect plugin depended on a server-side spelling service to retrieve its list of autocorrect entries. This setup increased server load and introduced latency due to REST API calls. As of {release-version}, the autocorrect list has been relocated to the client side, eliminating the need for a spellchecker server. This change improves performance by enabling caching and bundling of the autocorrect functionality with other client-side assets, resulting in faster load times and reduced backend dependencies.
+
+For information on the **Spelling Autocorrect** plugin, see: xref:autocorrect.adoc[Spelling Autocorrect plugin].
+
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement


### PR DESCRIPTION
Ticket: DOC-3151

Site: [Staging branch](http://docs-feature-790-doc-3151tiny-12041.staging.tiny.cloud/docs/tinymce/latest/7.9.0-release-notes/#spelling-autocorrect)

Changes:
* Documentation improvement for TINY-12041

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.


Review:
- [x] Documentation Team Lead has reviewed