### PR TITLE
DOC-3211: add 'readonly' property to angular-tech-ref docs

### DIFF
--- a/modules/ROOT/partials/integrations/angular-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/angular-tech-ref.adoc
@@ -8,6 +8,7 @@
 ** xref:licensekey[`+licenseKey+`]
 ** xref:cloudchannel[`+cloudChannel+`]
 ** xref:disabled[`+disabled+`]
+** xref:readonly[`+readonly+`]
 ** xref:id[`+id+`]
 ** xref:init[`+init+`]
 ** xref:initialvalue[`+initialValue+`]
@@ -182,7 +183,7 @@ For information {productname} development channels, see: xref:editor-plugin-vers
 [[disabled]]
 === `+disabled+`
 
-The `+disabled+` property can dynamically switch the editor between a "disabled" (read-only) mode (`+true+`) and the standard editable mode (`+false+`).
+The `+disabled+` property can dynamically switch the editor's `disabled` option.
 
 *Type:* `+Boolean+`
 
@@ -194,9 +195,25 @@ The `+disabled+` property can dynamically switch the editor between a "disabled"
 
 [source,html]
 ----
-<editor
-  [disabled]="true"
-></editor>
+<editor [disabled]="true" />
+----
+
+[[readonly]]
+=== `+readonly+`
+
+The `+readonly+` property can dynamically switch the editor between a "readonly" mode (`+true+`) and the standard editable mode (`+false+`).
+
+*Type:* `+Boolean+`
+
+*Default value:* `+false+`
+
+*Possible values:* `+true+`, `+false+`
+
+==== Example: using `+readonly+`
+
+[source,html]
+----
+<editor [readonly]="true" />
 ----
 
 [[id]]


### PR DESCRIPTION
Ticket: DOC-<num>

Site: [Staging branch](http://docs-hotifx-7-doc-3211.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* add 'readonly' property to angular-tech-ref docs

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [ ] Documentation Team Lead has reviewed