### PR TITLE
DOC-3151: If `style_formats` is empty the button is now disabled.

### DIFF
--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -160,7 +160,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === If `style_formats` is empty the button is now disabled.
 // #TINY-12005
 
-Previously, when the xref:user-formatting-options.adoc#style_formats[style_formats] configuration was empty or undefined, the **Formats** toolbar button remained active, resulting in a dropdown menu that appeared empty and non-functional. This behavior caused confusion, as users were presented with an unresponsive interface element that suggested available formatting options when none existed.
+Previously, when the xref:user-formatting-options.adoc#style_formats[style_formats] configuration was explicitly set to an empty list, the **Formats** toolbar button remained enabled, displaying an empty and non-functional dropdown menu. This led to confusion, as the button appeared interactive and suggested available formatting options, despite none being configured.
 
 In {release-version}, the {productname} editor now disables the **Formats** button entirely when no style formats are defined. This change improves usability by clearly signaling that there are no available style options, preventing unnecessary interaction and enhancing clarity for end users.
 

--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -157,7 +157,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 // #TINY-vwxyz1
 
 // CCFR here.
+=== If `style_formats` is empty the button is now disabled.
+// #TINY-12005
 
+Previously, when the xref:user-formatting-options.adoc#style_formats[style_formats] configuration was empty or undefined, the **Formats** toolbar button remained active, resulting in a dropdown menu that appeared empty and non-functional. This behavior caused confusion, as users were presented with an unresponsive interface element that suggested available formatting options when none existed.
+
+In {release-version}, the {productname} editor now disables the **Formats** button entirely when no style formats are defined. This change improves usability by clearly signaling that there are no available style options, preventing unnecessary interaction and enhancing clarity for end users.
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-3151

Site: [Staging branch](http://docs-feature-790-doc-3151tiny-12005.staging.tiny.cloud/docs/tinymce/latest/7.9.0-release-notes/#if-style_formats-is-empty-the-button-is-now-disabled)

Changes:
* fix documentation for TINY-12005

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed