### PR TITLE
DOC-3151: Tabbing inside a `figcaption` element no longer shows two text insertion carets.

### DIFF
--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -157,6 +157,14 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 // #TINY-vwxyz1
 
 // CCFR here.
+=== Tabbing inside a `figcaption` element no longer shows two text insertion carets.
+// #TINY-11997
+
+Previously, when tabbing within a `figcaption` element, the fake text caret was not properly hidden, resulting in both the browser’s native caret and the fake caret being rendered simultaneously. This visual duplication caused confusion for users during text navigation and editing. The issue occurred because the focus event inside editable captions did not trigger logic to hide the fake caret.
+
+This has been resolved by updating the focus handling behavior to detect whether the focused element is within an editable context and hide the fake caret accordingly.
+
+As a result, only a single, correct text caret is displayed when tabbing inside `figcaption` elements, improving editing clarity and user experience.
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-3151

Site: [Staging branch](http://docs-feature-790-doc-3151tiny-11997.staging.tiny.cloud/docs/tinymce/latest/7.9.0-release-notes/#tabbing-inside-a-figcaption-element-no-longer-shows-two-text-insertion-carets)

Changes:
* fix documentation for TINY-11997

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.


Review:
- [x] Documentation Team Lead has reviewed