### PR TITLE
DOC-3151: Aspect ratio was not properly calculated when uploading images wider than the editor.

### DIFF
--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -69,6 +69,23 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Image Optimizer
+
+The {productname} {release-version} release includes an accompanying release of the **Image Optimizer** premium plugin.
+
+**Image Optimizer** includes the following fix.
+
+==== Aspect ratio was not properly calculated when uploading images wider than the editor.
+// #TINY-11963
+
+Previous version of the **Image Optimizer** plugin, an issue would occur where images wider than the editor were distorted when uploaded to the CDN.
+
+This occurred when the image being uploaded replaced a resized version rendered from a `srcset` alternative, and the aspect ratio was incorrectly calculated using the `naturalWidth` of the original image and the `naturalHeight` of the new image. This mismatch led to a distorted aspect ratio post-upload.
+
+{productname} {release-version} addresses this issue. Now, the aspect ratio is now correctly calculated using both the `naturalWidth` and `naturalHeight` of the original image, ensuring consistent and undistorted rendering after upload.
+
+For information on the **Image Optimizer** plugin, see: xref:uploadcare.adoc[Image Optimizer].
+
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement


### PR DESCRIPTION
Ticket: DOC-3151

Site: [Staging branch](http://docs-feature-790-doc-3151tiny-11963.staging.tiny.cloud/docs/tinymce/latest/7.9.0-release-notes/#aspect-ratio-was-not-properly-calculated-when-uploading-images-wider-than-the-editor)

Changes:
* fix documentation for TINY-11963

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed