### PR TITLE
DOC-3151: Inline dialog dropdowns reposition when the dialog is dragged or the window is scrolled.

### DIFF
--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -157,6 +157,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 // #TINY-vwxyz1
 
 // CCFR here.
+=== Inline dialog dropdowns reposition when the dialog is dragged or the window is scrolled.
+// TINY-11368 sub TINY-11823, TINY-11832
+
+Prior to {productname} {release-version}, opening the preferences menu from within the **Search and Replace** dialog in inline mode caused the dropdown to remain fixed in its original position, even when the dialog was moved or the window was scrolled. This resulted in the dropdown becoming visually detached from its associated button and dialog, leading to a disjointed and confusing user experience.
+
+In {productname} {release-version}, this issue has been resolved. The dropdown menu now remains visually and functionally anchored to the dialog when it is dragged or when the window is scrolled. This ensures consistent and intuitive behavior, aligned with the handling of other dropdowns across the application.
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-3151

Site: [Staging branch](http://docs-feature-790-doc-3151tiny-11368.staging.tiny.cloud/docs/tinymce/latest/7.9.0-release-notes/#inline-dialog-dropdowns-reposition-when-the-dialog-is-dragged-or-the-window-is-scrolled)

Changes:
* Fix documentation for TINY-11368 including (TINY-11823 & TINY-11832) as child tickets.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed