### PR TITLE
DOC-3151: Pressing `enter` before a floating image sometimes duplicated the image.

### DIFF
--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -156,7 +156,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Pressing `enter` before a floating image sometimes duplicated the image.
 // #TINY-1676
 
-Previously, An issue in **Firefox** previously caused lines containing floating images to be handled incorrectly during deletion, resulting in content not being cleared properly and images being duplicated.
+Previously, An issue in **Firefox** caused lines containing floating images to be handled incorrectly during deletion, resulting in content not being cleared properly and images being duplicated.
 
 With the release of {productname} {release-version}, this behavior has been resolved. Deleting lines with floating images now works as expected, ensuring that duplicate images no longer appear.
 

--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -153,10 +153,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-// === <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Pressing `enter` before a floating image sometimes duplicated the image.
+// #TINY-1676
 
-// CCFR here.
+Previously, An issue in **Firefox** previously caused lines containing floating images to be handled incorrectly during deletion, resulting in content not being cleared properly and images being duplicated.
+
+With the release of {productname} {release-version}, this behavior has been resolved. Deleting lines with floating images now works as expected, ensuring that duplicate images no longer appear.
 
 
 [[security-fixes]]

--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -156,7 +156,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Pressing `enter` before a floating image sometimes duplicated the image.
 // #TINY-1676
 
-Previously, An issue in **Firefox** caused lines containing floating images to be handled incorrectly during deletion, resulting in content not being cleared properly and images being duplicated.
+Previously, when pressing `Enter` before a floating image, the image could be duplicated instead of a new line being correctly inserted. This issue was due to limitations in the native content-editable behavior of **Firefox**, which {productname} previously relied on for handling new lines. In particular, Firefox did not clear line content correctly when it included floated elements, resulting in duplicated images.
 
 With the release of {productname} {release-version}, this behavior has been resolved. Deleting lines with floating images now works as expected, ensuring that duplicate images no longer appear.
 

--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -158,7 +158,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 Previously, when pressing `Enter` before a floating image, the image could be duplicated instead of a new line being correctly inserted. This issue was due to limitations in the native content-editable behavior of **Firefox**, which {productname} previously relied on for handling new lines. In particular, Firefox did not clear line content correctly when it included floated elements, resulting in duplicated images.
 
-With the release of {productname} {release-version}, this behavior has been resolved. Deleting lines with floating images now works as expected, ensuring that duplicate images no longer appear.
+With the release of {productname} {release-version}, an internal new line mechanism has been introduced to replace the unreliable browser behavior. This ensures consistent and correct handling of new lines around floating content. Pressing `Enter` before a floating image now behaves as expected, and duplicate images no longer appear.
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-3151

Site: [Staging branch](http://docs-feature-790-doc-3151tiny-11676.staging.tiny.cloud/docs/tinymce/latest/7.9.0-release-notes/#pressing-enter-before-a-floating-image-sometimes-duplicated-the-image)

Changes:
* Documented the bug fix for TINY-11676.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed