### PR TITLE
DOC-3151: Changed word-capture regex for abbreviations to allow larger abbreviations.

### DIFF
--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -170,7 +170,7 @@ This behavior was caused by insufficient overlap detection when identifying matc
 <p>D. dd.DDD.</p>
 ----
 
-.Example after the fix
+.Example after the fix:
 [source,html]
 ----
 <!-- Original content typed by the user -->

--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -153,11 +153,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-// === <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Changed word-capture regular expression for abbreviations to allow larger abbreviations.
+// #TINY-11560
 
-// CCFR here.
+Previously in {productname}, an issue was identified where words or letters were inadvertently duplicated during pattern matching. This behavior particularly affected the handling of acronyms, resulting in inconsistent behavior.
 
+With the release of {productname} {release-version}, this issue has been resolved. Pattern matching now performs as expected, ensuring text is processed accurately without unintended duplication.
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -153,12 +153,32 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-=== Changed word-capture regular expression for abbreviations to allow larger abbreviations.
+=== Improved handling of overlapping matches in abbreviation detection
 // #TINY-11560
 
-Previously in {productname}, an issue was identified where words or letters were inadvertently duplicated during pattern matching. This behavior particularly affected the handling of acronyms, resulting in inconsistent behavior.
+Previously in {productname}, an issue occurred during pattern matching where overlapping regular expression matches caused duplicated content when processing abbreviations. For example, in the string `D. dd.D.`, multiple overlapping patterns such as `D.`, `dd.D`, and a final `D.` could be incorrectly matched and processed more than once. This resulted in unexpected duplication in the editor, such as `D. dd.DDD.`.
 
-With the release of {productname} {release-version}, this issue has been resolved. Pattern matching now performs as expected, ensuring text is processed accurately without unintended duplication.
+This behavior was caused by insufficient overlap detection when identifying match regions, leading to multiple reinsertions of already matched substrings. The issue has now been resolved in {productname} {release-version} by refining the pattern-matching logic to accurately detect and avoid overlapping matches. The updated implementation ensures that each abbreviation is matched and processed only once, eliminating duplicated insertions and preserving the original content structure.
+
+.Example before the fix:
+[source,html]
+----
+<!-- Original content typed by the user -->
+<p>D. dd.D.</p>
+
+<!-- Result after pattern matching (incorrect behavior) -->
+<p>D. dd.DDD.</p>
+----
+
+.Example after the fix
+[source,html]
+----
+<!-- Original content typed by the user -->
+<p>D. dd.D.</p>
+
+<!-- Result after pattern matching (correct behavior) -->
+<p>D. dd.D.</p>
+----
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-3151

Site: [Staging branch](http://docs-feature-790-doc-3151tiny-11560.staging.tiny.cloud/docs/tinymce/latest/7.9.0-release-notes/#changed-word-capture-regular-expression-for-abbreviations-to-allow-larger-abbreviations)

Changes:
* Documented the bug fix for TINY-11560.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed