### PR TITLE
DOC-3151: the toolbar did not consider the entire space in some cases if there was a horizontal scroll.

### DIFF
--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -153,10 +153,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-// === <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== The toolbar did not always account for the full available space during horizontal scrolling.
+// #TINY-11549
 
-// CCFR here.
+In previous versions of {productname}, the toolbar did not accurately account for the actual available space. As a result, the layout area allocated for the toolbar was smaller than the effective free space, leading to inconsistent resizing and positioning during horizontal scrolling.
+
+This issue has been addressed in {release-version}. The toolbar now correctly utilizes the available area, ensuring stable and consistent rendering within the intended layout.
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-3151

Site: [Staging branch](http://docs-feature-790-doc-3151tiny-11549.staging.tiny.cloud/docs/tinymce/latest/7.9.0-release-notes/#the-toolbar-did-not-always-account-for-the-full-available-space-during-horizontal-scrolling)

Changes:
* Documented the bug fix for TINY-11549.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed