### PR TITLE
DOC-3151: Japanese keyboard could insert content while the editor was in `readonly` mode

### DIFF
--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -156,9 +156,9 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Japanese keyboard could insert content while the editor was in `readonly` mode
 // #TINY-11363
 
-In previous versions of {productname}, an issue was identified where the editor permitted content insertion via IME (Input Method Editor) input, such as using a Japanese keyboard even when the editor was configured with `readonly: true`. This behavior allowed users to bypass standard input restrictions, potentially compromising content protection and data integrity.
+In previous versions of {productname}, an issue was identified where the editor permitted content insertion via IME (Input Method Editor) input, such as using a Japanese keyboard even when the editor was configured with `readonly: true`. 
 
-With the release of {productname} {release-version}, this issue has been addressed by implementing event handlers that intercept and block IME-related input events and their default behaviors while in read-only mode. This enhancement ensures that the readonly setting is strictly enforced, preventing content modifications from all input sources, including IME. As a result, data integrity is preserved, and the editor's reliability in multilingual environments is significantly improved.
+With the release of {productname} {release-version}, this issue has been addressed by implementing event handlers that intercept and block IME-related input events and their default behaviors while in read-only mode. This enhancement ensures that the readonly setting is strictly enforced, preventing content modifications from all input sources, including IME. 
 
 
 [[security-fixes]]

--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -153,10 +153,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-// === <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Japanese keyboard could insert content while the editor was in `readonly` mode
+// #TINY-11363
 
-// CCFR here.
+In previous versions of {productname}, an issue was identified where the editor permitted content insertion via IME (Input Method Editor) input, such as using a Japanese keyboard even when the editor was configured with `readonly: true`. This behavior allowed users to bypass standard input restrictions, potentially compromising content protection and data integrity.
+
+With the release of {productname} {release-version}, this issue has been addressed by implementing event handlers that intercept and block IME-related input events and their default behaviors while in read-only mode. This enhancement ensures that the readonly setting is strictly enforced, preventing content modifications from all input sources, including IME. As a result, data integrity is preserved, and the editor's reliability in multilingual environments is significantly improved.
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-3151

Site: [Staging branch](http://docs-feature-790-doc-3151tiny-11363.staging.tiny.cloud/docs/tinymce/latest/7.9.0-release-notes/#japanese-keyboard-could-insert-content-while-the-editor-was-in-readonly-mode)

Changes:
* Documented the bug fix for TINY-11363.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed