### PR TITLE
DOC-3151: The `mceInsertContent` command could delete the parent block element when an anchor was selected.

### DIFF
--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -237,7 +237,7 @@ In previous versions of {productname}, the "lock aspect ratio" button in the `Co
 
 The {productname} `mceInsertContent` command could inadvertently remove the parent block element when an anchor (`<a>`) tag was selected.
 
-In senarios such as when an anchor element was fully selected, the surrounding block-level parent tag, such as `<p>` or `<div>`, could be incorrectly removed, causing unexpected content structure changes. This issue primarily affected Chrome users, as it did not reproduce consistently in Safari or Firefox.
+In scenarios where an anchor element was fully selected, the surrounding block-level parent tag, such as `<p>` or `<div>`, could be incorrectly removed, leading to unexpected changes in the content structure. This issue primarily affected Chrome users and did not reproduce consistently in Safari or Firefox.
 
 The issue has been resolved in {release-version}. The `mceInsertContent` command now properly retains the parent block elements when inserting content into a selected anchor element.
 

--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -232,6 +232,15 @@ In previous versions of {productname}, the "lock aspect ratio" button in the `Co
 
 {productname} {release-version} also includes the following bug fix<es>:
 
+=== The `mceInsertContent` command could delete the parent block element when an anchor was selected.
+// #TINY-11953
+
+The {productname} `mceInsertContent` command could inadvertently remove the parent block element when an anchor (`<a>`) tag was selected.
+
+In senarios such as when an anchor element was fully selected, the surrounding block-level parent tag, such as `<p>` or `<div>`, could be incorrectly removed, causing unexpected content structure changes. This issue primarily affected Chrome users, as it did not reproduce consistently in Safari or Firefox.
+
+The issue has been resolved in {release-version}. The `mceInsertContent` command now properly retains the parent block elements when inserting content into a selected anchor element.
+
 === Japanese keyboard could insert content while the editor was in `readonly` mode
 // #TINY-11363
 

--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -239,7 +239,7 @@ The {productname} `mceInsertContent` command could inadvertently remove the pare
 
 In scenarios where an anchor element was fully selected, the surrounding block-level parent tag, such as `<p>` or `<div>`, could be incorrectly removed, leading to unexpected changes in the content structure. This issue primarily affected Chrome users and did not reproduce consistently in Safari or Firefox.
 
-The issue has been resolved in {release-version}. The `mceInsertContent` command now properly retains the parent block elements when inserting content into a selected anchor element.
+This issue has been resolved in {release-version}. The `mceInsertContent` command now properly retains the parent block elements when inserting content into a selected anchor element.
 
 === Japanese keyboard could insert content while the editor was in `readonly` mode
 // #TINY-11363


### PR DESCRIPTION
Ticket: DOC-3151

Site: [Staging branch](http://docs-feature-790-doc-3151tiny-11953.staging.tiny.cloud/docs/tinymce/latest/7.9.0-release-notes/#the-mceinsertcontent-command-could-delete-the-parent-block-element-when-an-anchor-was-selected)

Changes:
* fix documentation for TINY-11953

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed