### PR TITLE
DOC-3186: Update Blazor public documentation

### DIFF
--- a/modules/ROOT/partials/integrations/blazor-postinstall.adoc
+++ b/modules/ROOT/partials/integrations/blazor-postinstall.adoc
@@ -90,7 +90,7 @@ ifeval::["{productSource}" == "cloud"]
 +
 [source,cs]
 ----
-<Editor ApiKey="your-api-key" />
+<Editor ApiKey="no-api-key" />
 ---- 
 +
 endif::[]

--- a/modules/ROOT/partials/integrations/blazor-postinstall.adoc
+++ b/modules/ROOT/partials/integrations/blazor-postinstall.adoc
@@ -84,7 +84,26 @@ Welcome to your new app.
 In a Blazor Web App, different render modes determine how components are rendered and how interactivity is handled. To enable JavaScript interactivity, ensure that `+@rendermode InteractiveServer+` is specified in a page component. 
 +
 
+ifeval::["{productSource}" == "cloud"]
+. Update the `+ApiKey+` option in the editor element and include your link:{accountsignup}/[{cloudname} API key].
+
++
+[source,cs]
+----
+<Editor ApiKey="your-api-key" />
+---- 
++
+endif::[]
+
 ifeval::["{productSource}" != "cloud"]
+. Update the `+LicenseKey+` option in the editor element and include your and include your xref:license-key.adoc[License Key].
+
++
+[source,cs]
+----
+<Editor LicenseKey="your-license-key" />
+---- 
++
 
 . To load {productname} from the self-hosted package instead of the {cloudname}, configure the `+ScriptSrc+` property:
 +

--- a/modules/ROOT/partials/integrations/blazor-postinstall.adoc
+++ b/modules/ROOT/partials/integrations/blazor-postinstall.adoc
@@ -9,25 +9,38 @@ _File:_ `+BlazorApp.csproj+`
 </ItemGroup>
 ----
 . Add the `+tinymce-blazor.js+` script to the main page.
-* Using Blazor Server add the script in `+Pages/_Host.cshtml+`, for example:
+* If using the Blazor Web App, add the script in `+Components/App.razor+`, for example:
++
+[source,html]
+----
+<script src="_framework/blazor.web.js"></script>
+<script src="_content/TinyMCE.Blazor/tinymce-blazor.js"></script>
+----
+
+[NOTE]
+The location of the script depends on the type of Blazor app, including Blazor Server and Blazor WebAssembly (WASM) which are not covered in this guide. 
+
+* If using Blazor Server, add the script in `+Pages/_Host.cshtml+`, for example: 
 +
 [source,html]
 ----
 <script src="_framework/blazor.server.js"></script>
 <script src="_content/TinyMCE.Blazor/tinymce-blazor.js"></script>
 ----
-* Using WASM add the script in `+wwwroot/index.html+`, for example:
+* If using WASM, add the script in `+wwwroot/index.html+`, for example:
 +
 [source,html]
 ----
 <script src="_content/TinyMCE.Blazor/tinymce-blazor.js"></script>
 <script src="_framework/blazor.webassembly.js"></script>
 ----
-. Add the `+Editor+` component to a page by either:
+
+. Add the `+Editor+` component to a page by either: 
 * Using the `+using+` directive
 +
 [source,cs]
 ----
+@rendermode InteractiveServer
 @using TinyMCE.Blazor
 <Editor />
 ----
@@ -45,12 +58,15 @@ _File:_ `+Pages/Index.razor+`
 [source,cs]
 ----
 @page "/"
+@rendermode InteractiveServer
 @using TinyMCE.Blazor
 
 <h1>Hello, world!</h1>
 Welcome to your new app.
 <Editor />
 ----
+[IMPORTANT]
+In a Blazor Web App, different render modes determine how components are rendered and how interactivity is handled. To enable JavaScript interactivity, ensure that `+@rendermode InteractiveServer+` is specified in a page component.   
 
 ifeval::["{productSource}" != "cloud"]
 

--- a/modules/ROOT/partials/integrations/blazor-postinstall.adoc
+++ b/modules/ROOT/partials/integrations/blazor-postinstall.adoc
@@ -55,7 +55,7 @@ _File:_ `+Pages/Index.razor+`
 @using TinyMCE.Blazor
 
 <h1>Hello, world!</h1>
-Welcome to your new app.
+<h2>Welcome to your new app.</h2>
 <Editor />
 ----
 * Using the component with its namespace: 
@@ -76,7 +76,7 @@ _File:_ `+Pages/Index.razor+`
 @using TinyMCE.Blazor
 
 <h1>Hello, world!</h1>
-Welcome to your new app.
+<h2>Welcome to your new app.</h2>
 <Editor />
 ---- 
 +

--- a/modules/ROOT/partials/integrations/blazor-postinstall.adoc
+++ b/modules/ROOT/partials/integrations/blazor-postinstall.adoc
@@ -96,7 +96,7 @@ ifeval::["{productSource}" == "cloud"]
 endif::[]
 
 ifeval::["{productSource}" != "cloud"]
-. Update the `+LicenseKey+` option in the editor element and include your and include your xref:license-key.adoc[License Key].
+. Update the `+LicenseKey+` option in the editor element and include your xref:license-key.adoc[License Key].
 
 +
 [source,cs]

--- a/modules/ROOT/partials/integrations/blazor-postinstall.adoc
+++ b/modules/ROOT/partials/integrations/blazor-postinstall.adoc
@@ -1,6 +1,4 @@
-. Verify the installation by checking the `+ItemGroup+` references in `+BlazorApp.csproj+`, such as:
-+
-_File:_ `+BlazorApp.csproj+`
+. Verify the installation by checking the `+ItemGroup+` references in the project file. For example, if the project is named _BlazorApp_, the relevant file would be `+BlazorApp.csproj+` with the dependency referenced as follows: 
 +
 [source,xml]
 ----
@@ -8,16 +6,16 @@ _File:_ `+BlazorApp.csproj+`
   <PackageReference Include="TinyMCE.Blazor" Version="X.Y.Z" />
 </ItemGroup>
 ----
-. Add the `+tinymce-blazor.js+` script to the main page.
-* If using the Blazor Web App, add the script in `+Components/App.razor+`, for example:
+. Add the `+tinymce-blazor.js+` script to the main page. If using the Blazor Web App, add the script in `+Components/App.razor+`, for example:
 +
 [source,html]
 ----
 <script src="_framework/blazor.web.js"></script>
 <script src="_content/TinyMCE.Blazor/tinymce-blazor.js"></script>
 ----
-
++
 [NOTE]
+====
 The location of the script depends on the type of Blazor app, including Blazor Server and Blazor WebAssembly (WASM) which are not covered in this guide. 
 
 * If using Blazor Server, add the script in `+Pages/_Host.cshtml+`, for example: 
@@ -34,17 +32,33 @@ The location of the script depends on the type of Blazor app, including Blazor S
 <script src="_content/TinyMCE.Blazor/tinymce-blazor.js"></script>
 <script src="_framework/blazor.webassembly.js"></script>
 ----
+====
++
 
-. Add the `+Editor+` component to a page by either: 
-* Using the `+using+` directive
+. Add the `+Editor+` component to a page by either:  
+* Using the `+using+` directive:  
 +
 [source,cs]
 ----
-@rendermode InteractiveServer
 @using TinyMCE.Blazor
 <Editor />
 ----
-* Using the full component and package name
++
+For example: 
++
+_File:_ `+Pages/Index.razor+`
++
+[source,cs]
+----
+@page "/"
+@rendermode InteractiveServer
+@using TinyMCE.Blazor
+
+<h1>Hello, world!</h1>
+Welcome to your new app.
+<Editor />
+----
+* Using the component with its namespace: 
 +
 [source,cs]
 ----
@@ -64,9 +78,11 @@ _File:_ `+Pages/Index.razor+`
 <h1>Hello, world!</h1>
 Welcome to your new app.
 <Editor />
-----
+---- 
++
 [IMPORTANT]
-In a Blazor Web App, different render modes determine how components are rendered and how interactivity is handled. To enable JavaScript interactivity, ensure that `+@rendermode InteractiveServer+` is specified in a page component.   
+In a Blazor Web App, different render modes determine how components are rendered and how interactivity is handled. To enable JavaScript interactivity, ensure that `+@rendermode InteractiveServer+` is specified in a page component. 
++
 
 ifeval::["{productSource}" != "cloud"]
 

--- a/modules/ROOT/partials/integrations/blazor-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/blazor-quick-start.adoc
@@ -17,7 +17,7 @@ This procedure requires:
 * link:https://dotnet.microsoft.com/en-us/download[.NET SDK^]
 * link:https://learn.microsoft.com/en-us/visualstudio/subscriptions/vs-c-sharp-dev-kit[C# Dev Kit VS Code Extension^] 
 
-Alternatively, the https://learn.microsoft.com/en-us/dotnet/core/install/windows#install-with-visual-studio-code[.NET WinGet Configuration file^] can be downloaded to install the necessary dependencies. 
+Alternatively, the link:https://learn.microsoft.com/en-us/dotnet/core/install/windows#install-with-visual-studio-code[.NET WinGet Configuration file^] can be downloaded to install the necessary dependencies. 
 
 === Procedure
 

--- a/modules/ROOT/partials/integrations/blazor-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/blazor-quick-start.adoc
@@ -27,7 +27,7 @@ Alternatively, the link:https://learn.microsoft.com/en-us/dotnet/core/install/wi
 
 ifeval::["{productSource}" == "package-manager"]
 
-. To use the self-hosted version of `{productName}`, install the `{productname}` package from the Command Pallette.
+. To use the self-hosted version of `{productname}`, install the `{productname}` package from the Command Pallette.
 endif::[]
 
 [[using-visual-studio]]

--- a/modules/ROOT/partials/integrations/blazor-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/blazor-quick-start.adoc
@@ -62,7 +62,7 @@ Install-Package TinyMCE
 
 endif::[]
 
-. To test the application, run the application by pressing *Ctrl+F5*.
+. To test the application, run the application by pressing `+Ctrl+F5+`.
 
 [[using-a-command-prompt-or-terminal]]
 == Using a command prompt or terminal

--- a/modules/ROOT/partials/integrations/blazor-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/blazor-quick-start.adoc
@@ -2,8 +2,12 @@ The https://github.com/tinymce/tinymce-blazor[Official {productname} Blazor comp
 
 Select from the following guides:
 
+* xref:using-visual-studio-code[Using Visual Studio Code (VS Code)]
 * xref:using-visual-studio[Using Visual Studio]
 * xref:using-a-command-prompt-or-terminal[Using a command prompt or terminal]
+
+[[using-visual-studio-code]]
+== Using Visual Studio Code (VS Code)
 
 [[using-visual-studio]]
 == Using Visual Studio
@@ -18,7 +22,7 @@ This procedure requires:
 === Procedure
 
 . On the Visual Studio toolbar, click the https://docs.microsoft.com/en-us/visualstudio/ide/create-new-project[*New Project* button].
-. Select the *Blazor Server App* template.
+. Select the *Blazor Web App* template and name the project 'BlazorApp'.
 . Use the NuGet package manager console to install the `+TinyMCE.Blazor+` package, such as:
 +
 [source,sh]
@@ -55,7 +59,7 @@ This procedure requires:
 +
 [source,sh]
 ----
-dotnet new blazorserver -o BlazorApp --no-https
+dotnet new blazor -o BlazorApp --no-https
 ----
 . Change into the new application directory:
 +
@@ -90,7 +94,7 @@ include::partial$integrations/blazor-postinstall.adoc[]
 dotnet watch run
 ----
 +
-This will start a local development server, accessible at http://localhost:5000.
+This will start a local development server accessible at `http://localhost:{PORT}`, where `{PORT}` is specified in the project's `+Properties/launchSettings.json+` file.
 * To stop the development server, select on the command line or command prompt and press _Ctrl+C_.
 
 == Next Steps

--- a/modules/ROOT/partials/integrations/blazor-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/blazor-quick-start.adoc
@@ -42,7 +42,7 @@ This procedure requires:
 
 === Procedure
 
-. On the Visual Studio toolbar, click the https://docs.microsoft.com/en-us/visualstudio/ide/create-new-project[*New Project* button].
+. On the Visual Studio toolbar, click the link:https://docs.microsoft.com/en-us/visualstudio/ide/create-new-project[*New Project* button].
 . Select the *Blazor Web App* template and follow the steps to set up the project. 
 . Use the NuGet package manager console to install the `+TinyMCE.Blazor+` package, such as:
 +

--- a/modules/ROOT/partials/integrations/blazor-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/blazor-quick-start.adoc
@@ -119,7 +119,7 @@ This will start a local development server accessible at `http://localhost:{PORT
 
 ifeval::["{productSource}" == "zip"]
 
-== Download {productName} Zip
+== Download {productname} Zip
 
 To use the self-hosted version of `{productName}`, download the https://www.tiny.cloud/my-account/downloads/[{productname} zip^]. Unzip the content and place it in the project, such as in the `+wwwroot+` folder for storing public static assets.
 endif::[]

--- a/modules/ROOT/partials/integrations/blazor-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/blazor-quick-start.adoc
@@ -121,7 +121,7 @@ ifeval::["{productSource}" == "zip"]
 
 == Download {productname} Zip
 
-To use the self-hosted version of `{productName}`, download the https://www.tiny.cloud/my-account/downloads/[{productname} zip^]. Unzip the content and place it in the project, such as in the `+wwwroot+` folder for storing public static assets.
+To use the self-hosted version of `{productname}`, download the link:https://www.tiny.cloud/my-account/downloads/[{productname} zip^]. Unzip the content and place it in the project, such as in the `+wwwroot+` folder for storing public static assets.
 endif::[]
 
 == Post-installation

--- a/modules/ROOT/partials/integrations/blazor-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/blazor-quick-start.adoc
@@ -9,6 +9,29 @@ Select from the following guides:
 [[using-visual-studio-code]]
 == Using Visual Studio Code (VS Code)
 
+=== Prerequisites
+
+This procedure requires:
+
+* https://code.visualstudio.com/[Visual Studio Code (VS Code)^] 
+* https://dotnet.microsoft.com/en-us/download[.NET SDK^]
+* https://learn.microsoft.com/en-us/visualstudio/subscriptions/vs-c-sharp-dev-kit[C# Dev Kit VS Code Extension^] 
+
+Alternatively, the https://learn.microsoft.com/en-us/dotnet/core/install/windows#install-with-visual-studio-code[.NET WinGet Configuration file^] can be downloaded to install the necessary dependencies. 
+
+=== Procedure
+
+. In VS Code, open the Command Palette by pressing `+Ctrl+Shift+P+`. Find `.NET: New Project` and select it to create a new project.
+. Select *Blazor Web App* from the list of templates and follow the steps to set up the project. 
+. Using the Command Palette, find and select `.NuGet: Add NuGet Package`. Enter `+TinyMCE.Blazor+` and select the package along with the version to install. 
+
+ifeval::["{productSource}" == "package-manager"]
+
+. To use the self-hosted version of `{productName}`, install the `{productname}` package from the Command Pallette.
+endif::[]
+include::partial$integrations/blazor-postinstall.adoc[]
+
+
 [[using-visual-studio]]
 == Using Visual Studio
 
@@ -22,7 +45,7 @@ This procedure requires:
 === Procedure
 
 . On the Visual Studio toolbar, click the https://docs.microsoft.com/en-us/visualstudio/ide/create-new-project[*New Project* button].
-. Select the *Blazor Web App* template and name the project 'BlazorApp'.
+. Select the *Blazor Web App* template and follow the steps to set up the project. 
 . Use the NuGet package manager console to install the `+TinyMCE.Blazor+` package, such as:
 +
 [source,sh]

--- a/modules/ROOT/partials/integrations/blazor-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/blazor-quick-start.adoc
@@ -13,9 +13,9 @@ Select from the following guides:
 
 This procedure requires:
 
-* https://code.visualstudio.com/[Visual Studio Code (VS Code)^] 
-* https://dotnet.microsoft.com/en-us/download[.NET SDK^]
-* https://learn.microsoft.com/en-us/visualstudio/subscriptions/vs-c-sharp-dev-kit[C# Dev Kit VS Code Extension^] 
+* link:https://code.visualstudio.com/[Visual Studio Code (VS Code)^] 
+* link:https://dotnet.microsoft.com/en-us/download[.NET SDK^]
+* link:https://learn.microsoft.com/en-us/visualstudio/subscriptions/vs-c-sharp-dev-kit[C# Dev Kit VS Code Extension^] 
 
 Alternatively, the https://learn.microsoft.com/en-us/dotnet/core/install/windows#install-with-visual-studio-code[.NET WinGet Configuration file^] can be downloaded to install the necessary dependencies. 
 

--- a/modules/ROOT/partials/integrations/blazor-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/blazor-quick-start.adoc
@@ -29,8 +29,6 @@ ifeval::["{productSource}" == "package-manager"]
 
 . To use the self-hosted version of `{productName}`, install the `{productname}` package from the Command Pallette.
 endif::[]
-include::partial$integrations/blazor-postinstall.adoc[]
-
 
 [[using-visual-studio]]
 == Using Visual Studio
@@ -63,7 +61,6 @@ Install-Package TinyMCE
 ----
 
 endif::[]
-include::partial$integrations/blazor-postinstall.adoc[]
 
 . To test the application, run the application by pressing *Ctrl+F5*.
 
@@ -107,7 +104,6 @@ dotnet add package TinyMCE
 ----
 
 endif::[]
-include::partial$integrations/blazor-postinstall.adoc[]
 
 . Test the application using the .NET development server.
 * To start the development server, in the project's root directory, run:
@@ -119,6 +115,18 @@ dotnet watch run
 +
 This will start a local development server accessible at `http://localhost:{PORT}`, where `{PORT}` is specified in the project's `+Properties/launchSettings.json+` file.
 * To stop the development server, select on the command line or command prompt and press _Ctrl+C_.
+
+
+ifeval::["{productSource}" == "zip"]
+
+== Download {productName} Zip
+
+To use the self-hosted version of `{productName}`, download the https://www.tiny.cloud/my-account/downloads/[{productname} zip^]. Unzip the content and place it in the project, such as in the `+wwwroot+` folder for storing public static assets.
+endif::[]
+
+== Post-installation
+
+include::partial$integrations/blazor-postinstall.adoc[]
 
 == Next Steps
 

--- a/modules/ROOT/partials/integrations/blazor-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/blazor-quick-start.adoc
@@ -1,4 +1,4 @@
-The https://github.com/tinymce/tinymce-blazor[Official {productname} Blazor component] integrates {productname} into https://dotnet.microsoft.com/apps/aspnet/web-apps/blazor[Blazor applications]. This procedure creates a basic Blazor application and adds a {productname} editor using the {productname} Blazor integration. The basic Blazor application is based on the following tutorial: https://dotnet.microsoft.com/learn/aspnet/blazor-tutorial/[Microsoft .NET Blazor Tutorial - Build your first Blazor app].
+The link:https://github.com/tinymce/tinymce-blazor[Official {productname} Blazor component^] integrates {productname} into link:https://dotnet.microsoft.com/apps/aspnet/web-apps/blazor[Blazor applications^]. This procedure creates a basic Blazor application and adds a {productname} editor using the {productname} Blazor integration. The basic Blazor application is based on the following tutorial: link:https://dotnet.microsoft.com/learn/aspnet/blazor-tutorial/[Microsoft .NET Blazor Tutorial - Build your first Blazor app^].
 
 Select from the following guides:
 
@@ -37,12 +37,12 @@ endif::[]
 
 This procedure requires:
 
-* https://docs.microsoft.com/en-us/visualstudio/windows/[Microsoft Visual Studio]
-* https://docs.microsoft.com/en-us/dotnet/core/install/[Microsoft .NET]
+* link:https://docs.microsoft.com/en-us/visualstudio/windows/[Microsoft Visual Studio^]
+* link:https://docs.microsoft.com/en-us/dotnet/core/install/[Microsoft .NET^]
 
 === Procedure
 
-. On the Visual Studio toolbar, click the link:https://docs.microsoft.com/en-us/visualstudio/ide/create-new-project[*New Project* button].
+. On the Visual Studio toolbar, click the link:https://docs.microsoft.com/en-us/visualstudio/ide/create-new-project[*New Project* button^].
 . Select the *Blazor Web App* template and follow the steps to set up the project. 
 . Use the NuGet package manager console to install the `+TinyMCE.Blazor+` package, such as:
 +
@@ -71,7 +71,7 @@ endif::[]
 
 This procedure requires:
 
-* https://docs.microsoft.com/en-us/dotnet/core/install/[Microsoft .NET]
+* link:https://docs.microsoft.com/en-us/dotnet/core/install/[Microsoft .NET^]
 
 === Procedure
 

--- a/modules/ROOT/partials/integrations/blazor-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/blazor-tech-ref.adoc
@@ -18,7 +18,7 @@ The `+TinyMCE.Blazor+` `+Editor+` component accepts the following properties:
   Disable=false
   JsConfSrc="path_to_jsObj"
   Conf="@yourConf"
-  ApiKey="your-api-key"
+  ApiKey="no-api-key"
   LicenseKey="your-license-key"
   ScriptSrc="/path/to/tinymce.min.js"
   ClassName="tinymce-wrapper"
@@ -40,7 +40,7 @@ None of the configuration properties are required for the TinyMCE Blazor integra
 [source,cs]
 ----
 <Editor
-  ApiKey="your-api-key"
+  ApiKey="no-api-key"
 />
 ----
 


### PR DESCRIPTION
Ticket: DOC-3186

Site: [Staging branch](http://docs-hotfix-7-doc-3186.staging.tiny.cloud/docs/tinymce/latest/)
Site: [blazor-cloud](http://docs-hotfix-7-doc-3186.staging.tiny.cloud/docs/tinymce/latest/blazor-cloud/)
Site: [blazor-pm](http://docs-hotfix-7-doc-3186.staging.tiny.cloud/docs/tinymce/latest/blazor-pm/)
Site: [blazor-zip](http://docs-hotfix-7-doc-3186.staging.tiny.cloud/docs/tinymce/latest/blazor-zip/)

Changes:
* Update installation instruction to use Blazor Web App template for .NET 8 
* Add VS Code installation instruction 
* Add instruction for including TinyMCE Zip in self-hosted guide 

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed