### PR TITLE
DOC-3151: Select UI elements was not properly styled on Chrome version 136.

### DIFF
--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -298,7 +298,7 @@ Previously, when the xref:user-formatting-options.adoc#style_formats[style_forma
 
 In {release-version}, the {productname} editor now disables the **Formats** button entirely when no style formats are defined. This change improves usability by clearly signaling that there are no available style options, preventing unnecessary interaction and enhancing clarity for end users.
 
-=== Select UI elements was not properly styled on Chrome version 136.
+=== Select UI elements were not properly styled on Chrome version 136.
 // #TINY-12131
 
 Previously, the `Select` UI elements were not properly styled in Chrome version 136, resulting in no visual indication of the currently selected option, which lead to usability issues.

--- a/modules/ROOT/pages/7.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.0-release-notes.adoc
@@ -297,3 +297,10 @@ Key Improvements/Benefits:
 Previously, when the xref:user-formatting-options.adoc#style_formats[style_formats] configuration was explicitly set to an empty list, the **Formats** toolbar button remained enabled, displaying an empty and non-functional dropdown menu. This led to confusion, as the button appeared interactive and suggested available formatting options, despite none being configured.
 
 In {release-version}, the {productname} editor now disables the **Formats** button entirely when no style formats are defined. This change improves usability by clearly signaling that there are no available style options, preventing unnecessary interaction and enhancing clarity for end users.
+
+=== Select UI elements was not properly styled on Chrome version 136.
+// #TINY-12131
+
+Previously, the `Select` UI elements were not properly styled in Chrome version 136, resulting in no visual indication of the currently selected option, which lead to usability issues.
+
+{productname} {release-version} addresses this issue. Now, the styling for `Select` UI elements had been updated to ensure the selected option is clearly displayed, restoring proper visual feedback. This improvement ensures consistent and intuitive styling for Chrome 136 and earlier versions.

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -41,6 +41,8 @@ NOTE: This is the {productname} Community version changelog. For information abo
 // #TINY-11676
 * Editor did not scroll into viewport on receiving focus on Chrome and Safari.
 // #TINY-12017
+* Select UI elements was not properly styled on Chrome version 136.
+// #TINY-12131
 
 == xref:7.8.0-release-notes.adoc[7.8.0 - 2025-04-9]
 

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -41,7 +41,7 @@ NOTE: This is the {productname} Community version changelog. For information abo
 // #TINY-11676
 * Editor did not scroll into viewport on receiving focus on Chrome and Safari.
 // #TINY-12017
-* Select UI elements was not properly styled on Chrome version 136.
+* Select UI elements were not properly styled on Chrome version 136.
 // #TINY-12131
 
 == xref:7.8.0-release-notes.adoc[7.8.0 - 2025-04-9]


### PR DESCRIPTION
Ticket: DOC-3151

Site: [Staging branch](http://docs-feature-790-doc-3151tiny-12131.staging.tiny.cloud/docs/tinymce/latest/7.9.0-release-notes/#select-ui-elements-was-not-properly-styled-on-chrome-version-136)

Changes:
* added fix documentation for TINY-12131
* included changelog entry also.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed