### PR TITLE
DOC-3218: Add `tinymce/8` to `antora-playbook.yml` file for v7

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -8,7 +8,7 @@ content:
     branches: HEAD
     start_path: ./
   - url: https://github.com/tinymce/tinymce-docs.git
-    branches: [ tinymce/5, tinymce/6 ]
+    branches: [ tinymce/5, tinymce/6, tinymce/8 ]
 urls:
   html_extension_style: indexify
   latest_version_segment: latest

--- a/modules/ROOT/partials/integrations/blazor-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/blazor-quick-start.adoc
@@ -113,7 +113,7 @@ endif::[]
 dotnet watch run
 ----
 +
-This will start a local development server accessible at `http://localhost:{PORT}`, where `{PORT}` is specified in the project's `+Properties/launchSettings.json+` file.
+This will start a local development server accessible at `+http://localhost:{PORT}+`, where `+{PORT}+` is specified in the project's `+Properties/launchSettings.json+` file.
 * To stop the development server, select on the command line or command prompt and press _Ctrl+C_.
 
 

--- a/modules/ROOT/partials/integrations/vue-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/vue-quick-start.adoc
@@ -241,7 +241,7 @@ import Editor from '@tinymce/tinymce-vue'
 ----
 +
 . {productname} can be self-hosted by either:
-** xref:deploying-tinymce-independent[Deploying {productname} independent of the Vue.js application],
+** xref:#deploying-tinymce-independent[Deploying {productname} independent of the Vue.js application],
 ** xref:zip-install.adoc[{productname} .zip deployments].
 
 * [[deploying-tinymce-independent]] Deploying {productname} independent of the Vue.js application. To use a {productname} instance that has been deployed independent of the Vue.js application, use an HTML `+<script>+` tag.

--- a/modules/ROOT/partials/integrations/vue-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/vue-quick-start.adoc
@@ -241,7 +241,7 @@ import Editor from '@tinymce/tinymce-vue'
 ----
 +
 . {productname} can be self-hosted by either:
-** xref:deploying-tinymce-independent.adoc[Deploying {productname} independent of the Vue.js application],
+** xref:deploying-tinymce-independent[Deploying {productname} independent of the Vue.js application],
 ** xref:zip-install.adoc[{productname} .zip deployments].
 
 * [[deploying-tinymce-independent]] Deploying {productname} independent of the Vue.js application. To use a {productname} instance that has been deployed independent of the Vue.js application, use an HTML `+<script>+` tag.


### PR DESCRIPTION
Ticket: DOC-3218

Site: [Staging branch](http://docs-feature-8-doc-3218updatev8.staging.tiny.cloud/docs/tinymce/7/)

Changes:
* Update `antora-playbook.yml` to include `tinymce/8` branch.
* Fix console errors.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed