### PR TITLE
DOC-3218: Add tinymce/8 to branch to antora-playbook.yml for v6.

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -8,7 +8,7 @@ content:
     branches: [ HEAD ]
     start_path: ./
   - url: https://github.com/tinymce/tinymce-docs.git
-    branches: [ tinymce/5, tinymce/7 ]
+    branches: [ tinymce/5, tinymce/7, tinymce/8 ]
 urls:
   html_extension_style: indexify
   latest_version_segment: latest


### PR DESCRIPTION
Ticket: DOC-3218

Site: [Staging branch](http://docs-feature-6-doc-3218updatev8.staging.tiny.cloud/docs/tinymce/6/)

Changes:
* add `tinymce/8` to `antora-playbook.yml` file.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [ ] Documentation Team Lead has reviewed