### PR TITLE
TINY-11911: Add disabled and readonly webComponent tech ref

### DIFF
--- a/modules/ROOT/partials/integrations/webcomponent-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/webcomponent-tech-ref.adoc
@@ -8,6 +8,8 @@
 ** xref:loading-plugins[Loading plugins]
 ** xref:setting-the-editor-width[Setting the editor width]
 ** xref:setting-the-editor-height[Setting the editor height]
+** xref:setting-readonly[Setting the editor to readonly]
+** xref:setting-disabled[Setting the editor to disabled]
 ** xref:setting-the-toolbar[Setting the toolbar]
 ** xref:setting-the-toolbar-mode[Setting the toolbar mode]
 ** xref:setting-the-menu-bar[Setting the menu bar]
@@ -144,6 +146,26 @@ To set the height of the editor (content area and user interface), use the `+hei
 [source,html]
 ----
 <tinymce-editor height="15em"></tinymce-editor>
+----
+
+
+[[setting-readonly]]
+=== Setting readonly mode
+
+To set the editor's mode to `readonly`.
+
+[source,html]
+----
+<tinymce-editor readonly></tinymce-editor>
+----
+
+[[setting-disaled-state]]
+=== Setting disabled state
+To set the editor to a disabled state.
+
+[source,html]
+----
+<tinymce-editor disabled></tinymce-editor>
 ----
 
 [[setting-the-toolbar]]


### PR DESCRIPTION
Ticket: TINY-11911

Site: [Staging branch](http://docs-hotfix-7-tiny-1911.staging.tiny.cloud/docs/tinymce/7/)

Changes:
* Added `disabled` and `readonly` attributes to the web component tech

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.
- [x] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [ ] Documentation Team Lead has reviewed