### PR TITLE
TINY-11908: Add new `readonly` prop to Vue integration.

### DIFF
--- a/modules/ROOT/partials/integrations/vue-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/vue-tech-ref.adoc
@@ -7,6 +7,7 @@
 ** xref:license-key[`+licenseKey+`]
 ** xref:cloud-channel[`+cloud-channel+`]
 ** xref:disabled[`+disabled+`]
+** xref:readonly[`+readonly+`]
 ** xref:id[`+id+`]
 ** xref:init[`+init+`]
 ** xref:initial-value[`+initial-value+`]
@@ -99,6 +100,7 @@ The editor accepts the following properties:
   api-key="no-api-key"
   cloud-channel="{productmajorversion}"
   :disabled=false
+  :readonly=false
   id="uuid"
   :init= "{ }"
   initial-value=""
@@ -202,6 +204,26 @@ The `+disabled+` property can dynamically switch the editor between a "disabled"
 ----
 <editor
   :disabled=true
+/>
+----
+
+[[readonly]]
+=== `+readonly+`
+
+The `+readonly+` property can dynamically switch the editor between a "read-only" mode (`+true+`) and the standard editable mode (`+false+`).
+
+*Type:* `+Boolean+`
+
+*Default value:* `+false+`
+
+*Possible values:* `+true+`, `+false+`
+
+==== Example: using `+readonly+`
+
+[source,html]
+----
+<editor
+  :readonly=true
 />
 ----
 


### PR DESCRIPTION
Ticket: TINY-11908

Site: [Staging branch](http://docs-hotfix-7-tiny-11908.staging.tiny.cloud/docs/tinymce/latest/vue-ref/#readonly)

Changes:
* Update documentation to include new `readonly` prop for integrations wrapper.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed