### PR TITLE
DOC-3147: Resize handles are more accessible with `role` and `aria-valuetext` attributes.

### DIFF
--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -99,10 +99,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following improvement<s>:
 
-// === <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Resize handles are more accessible with `role` and `aria-valuetext` attributes.
+// #TINY-11421
 
-// CCFR here.
+In previous versions of {productname}, the editor's resize handle lacked a `role` attribute, raising accessibility concerns.
+
+In {productname} {release-version}, the resize handle now includes a `role` seperator and an `aria-valuetext` attribute that dynamically reflects the current dimensions of the editor. These improvements enhance accessibility and ensure more accurate announcements by screen readers.
 
 
 [[additions]]


### PR DESCRIPTION
Ticket: DOC-3147

Site: [Staging branch](http://docs-feature-800-doc-3147tiny-11421.staging.tiny.cloud/docs/tinymce/latest/8.0-release-notes/#resize-handles-are-more-accessible-with-role-and-aria-valuetext-attributes)

Changes:
* Documented the improvement for TINY-11421.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed