### PR TITLE
DOC-3147: Deleting a whole element would sometimes modify nearby content

### DIFF
--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -151,7 +151,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Deleting a whole element would sometimes modify nearby content
 // #TINY-11868
 
-Previously, deleting a complete HTML element using the "Source Code" editor either by cutting `+Ctrl+X+` or `+Cmd+X+`, backspacing, or pressing delete could inadvertently modify surrounding content. For example, removing a `<div>` element that precedes a `<p>` tag could cause the `<p>` to be transformed into a `<div>`, resulting in unintended structural changes. This behavior was inconsistent and particularly noticeable outside of test environments such as the Fiddle editor.
+Previously, deleting a complete HTML element using the "Source Code" editor either by cutting `+Ctrl+X+` or `+Cmd+X+`, backspacing, or pressing delete could inadvertently modify surrounding content. For example, removing a `<div>` element that precedes a `<p>` tag could cause the `<p>` to be transformed into a `<div>`, resulting in unintended structural changes.
 
 This issue has been resolved in {productname} {release-version} by improving how element deletions are handled within the editor's DOM logic. Cutting or deleting a selected element now preserves the integrity and tag type of adjacent elements. Users can expect consistent and predictable editing behavior when modifying HTML source content.
 


### PR DESCRIPTION
Ticket: DOC-3147

Site: [Staging branch](http://docs-feature-800-doc-3147tiny-11868.staging.tiny.cloud/docs/tinymce/latest/8.0-release-notes/#deleting-a-whole-element-would-sometimes-modify-nearby-content)

Changes:
* Fix documentation for TINY-11868

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed