### PR TITLE
DOC-3226: Update licensing information and examples for TinyMCE 8

### DIFF
--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -136,7 +136,6 @@ The license key system in {productname} 8 has been enhanced to provide improved 
 Key changes for self-hosted deployments:
 
 * New `T8LK:` prefix requirement for all commercial license keys.
-* Enhanced JWT-based validation that runs entirely in the browser
 * No server communication or "phone home" checks required
 * Support for both date-based and version-locked keys
 * Streamlined hybrid deployment configuration

--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -153,6 +153,20 @@ Key changes for self-hosted deployments:
 * Commercial use: Contact your account manager or visit link:https://www.tiny.cloud/my-account[Tiny Cloud Account] to obtain a T8LK-prefixed license key
 * GPL use: Set `license_key: 'gpl'` (case insensitive)
 * Open source projects using premium features: Use the combined format `license_key: 'GPL+T8LK:...'`
+
+*Required License Key Manager Setup for Self-hosted Commercial Deployments:*
+
+For commercial license keys to function, the license key manager must be properly configured. **The editor will not work without this setup.**
+
+* **Standalone hosting** (e.g., in a `/public` folder): The `+licensekeymanager+` folder is **required** to be located within the `+plugins+` folder alongside all other plugins.
+* **Bundled applications**: The `+licensekeymanager/index.js+` file is **required** to be imported, otherwise the editor will result in a disabled state.
+
+.Example: Importing the License Key Manager in a bundled application
+[source,javascript]
+----
+import 'tinymce/plugins/licensekeymanager';
+----
+
 ====
 
 === Upgrading from TinyMCE 7

--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -124,11 +124,18 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 === Enhanced license key system with T8LK prefix
 
-The license key system in {productname} 8 has been enhanced to provide improved subscription access control and streamlined renewal processes. All commercial license keys for self-hosted deployments now require the `T8LK:` prefix to indicate version 8 compatibility.
+The license key system in {productname} 8 has been enhanced to provide improved subscription access control and streamlined renewal processes. This change primarily affects self-hosted deployments, as cloud users ({cloudname}) do not require a license key.
 
-Key changes include:
+[IMPORTANT]
+====
+* If you use {cloudname}, no license key is required - your cloud subscription automatically includes the commercial license.
+* For self-hosted deployments, all commercial license keys must use the new `T8LK:` prefix format.
+* Existing TinyMCE 7 license keys cannot be made compatible with TinyMCE 8 by adding the T8LK prefix.
+====
 
-* All commercial license keys must start with `"T8LK:"` prefix
+Key changes for self-hosted deployments:
+
+* New `T8LK:` prefix requirement for all commercial license keys.
 * Enhanced JWT-based validation that runs entirely in the browser
 * No server communication or "phone home" checks required
 * Support for both date-based and version-locked keys
@@ -137,10 +144,22 @@ Key changes include:
 
 [IMPORTANT]
 ====
-* GPL usage still requires setting `license_key: 'gpl'` (case insensitive)
-* For open source projects using premium features, use the combined format: `license_key: 'GPL+T8LK:...'`
-* The license key is not required when using {cloudname} with an API key
+*Cloud Deployments:*
+
+* When using {cloudname}, only an API key is required - no license key needed
+* Your cloud subscription automatically includes the commercial license
+
+*Self-hosted Deployments:*
+
+* Commercial use: Contact your account manager or visit link:https://www.tiny.cloud/my-account[Tiny Cloud Account] to obtain a T8LK-prefixed license key
+* GPL use: Set `license_key: 'gpl'` (case insensitive)
+* Open source projects using premium features: Use the combined format `license_key: 'GPL+T8LK:...'`
 ====
+
+=== Upgrading from TinyMCE 7
+
+* *Cloud Users ({cloudname})*: No license key changes needed - simply update your {productname} version.
+* *Self-hosted Users*: Contact your account manager to obtain a new T8LK-prefixed license key.
 
 For more information on the new license key system, see: xref:license-key.adoc[License Key].
 

--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -1,4 +1,3 @@
-
 = {productname} {release-version}
 :release-version: 8.0.0
 :navtitle: {productname} {release-version}
@@ -27,8 +26,10 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 * xref:deprecated[Deprecated]
 * xref:known-issues[Known issues]
 
-[NOTE]
-For additional details on {productname} {release-version} breaking changes when considering upgrading, see xref:migration-from-7x.adoc[Migrating from {productname} 7 to {productname} {release-version}].
+[IMPORTANT]
+====
+This release includes breaking changes to the license key system. All commercial self-hosted deployments must update their license keys to use the new `T8LK:` prefix format. For details on this and other breaking changes when considering upgrading, see xref:migration-from-7x.adoc[Migrating from {productname} 7 to {productname} {release-version}].
+====
 
 [[new-premium-plugin<s>]]
 New Premium plugin<s>
@@ -119,7 +120,30 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 [[changes]]
 == Changes
 
-{productname} {release-version} also includes the following change<s>:
+{productname} {release-version} includes the following changes:
+
+=== Enhanced license key system with T8LK prefix
+
+The license key system in {productname} 8 has been enhanced to provide improved subscription access control and streamlined renewal processes. All commercial license keys for self-hosted deployments now require the `T8LK:` prefix to indicate version 8 compatibility.
+
+Key changes include:
+
+* All commercial license keys must start with `"T8LK:"` prefix
+* Enhanced JWT-based validation that runs entirely in the browser
+* No server communication or "phone home" checks required
+* Support for both date-based and version-locked keys
+* Streamlined hybrid deployment configuration
+* Improved support for air-gapped and offline environments
+
+[IMPORTANT]
+====
+* GPL usage still requires setting `license_key: 'gpl'` (case insensitive)
+* For open source projects using premium features, use the combined format: `license_key: 'GPL+T8LK:your-license-key'`
+* The license key is not required when using {cloudname} with an API key
+====
+
+For more information on the new license key system, see: xref:license-key.adoc[License Key].
+
 
 // === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1

--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -138,7 +138,7 @@ Key changes include:
 [IMPORTANT]
 ====
 * GPL usage still requires setting `license_key: 'gpl'` (case insensitive)
-* For open source projects using premium features, use the combined format: `license_key: 'GPL+T8LK:your-license-key'`
+* For open source projects using premium features, use the combined format: `license_key: 'GPL+T8LK:...'`
 * The license key is not required when using {cloudname} with an API key
 ====
 

--- a/modules/ROOT/pages/license-key.adoc
+++ b/modules/ROOT/pages/license-key.adoc
@@ -4,85 +4,115 @@
 :keywords: {productname}, cloud, script, textarea, apiKey, faq, license key, frequently asked questions,
 
 == Overview
-
-{productname} 8 introduces an enhanced license key system that provides improved subscription access control and streamlined renewal processes. This system includes both date-based and version-locked keys, supporting various deployment scenarios including cloud, self-hosted, and hybrid configurations.
+{productname} 8 uses an enhanced license key system that provides improved subscription access control and streamlined renewal processes. This system includes both **date-based** and **version-locked** keys, supporting various deployment scenarios including cloud, self-hosted, hybrid and offline (air-gapped) environment configurations.
 
 [IMPORTANT]
 ====
-If you are using {productname} 7, it is licensed under the GNU General Public License Version 2 or later. A configuration option called 'license_key' requires developers to make a conscious decision to use {productname} with the GPLv2+ license or with a commercial license.
+{productname} is licensed under the GNU General Public License Version 2 or later. A configuration option called 'license_key' introduced in v7 required developers to make a conscious decision to use {productname} with the GPLv2+ license or with a commercial license.
+
+For {productname} 8, self-hosted, hybrid, and offline deployments require a valid license key with the `+"T8LK:"+` prefix such as `+license_key: "T8LK:your-license-key"+`. This prefix indicates that the key is for version 8 and provides enhanced validation and management features.
 
 If you are using {productname} in a self-hosted environment, a console log warning message will display if the license key config option is missing or invalid. This message aims to ensure compliance with licensing requirements and provide transparency during the evaluation period.
 
 This message will not be shown when loading {productname} from {cloudname}, as it is already under a commercial license.
-
-For {productname} 8, license keys use the `+"T8LK:"+` prefix and provide enhanced validation and management features. These keys support both online and offline validation modes.
 ====
 
 include::partial$misc/setting-the-license.adoc[]
 
 == License Types and Deployment Options
 
-=== Date-based Keys (Standard)
+=== License Key Types
 
-The standard license key type in {productname} 8 is date-based, meaning:
+[cols="1,2,2", options="header"]
+|===
+| **Type** | **Key Features** | **Best For**
 
-* The key has a soft expiration date that matches your subscription end date.
-* After the soft expiration, the editor enters a grace period in `read-only` mode.
-* After the grace period expires, the editor becomes completely disabled.
-* Premium plugins are disabled at the soft expiration date.
-* In-editor messaging will notify users about approaching expiration.
+| Date-based Keys (Standard)
+a|
+* Time-based subscription:
+  ** Automatic version updates
+  ** 30-day grace period
+  ** Premium plugin access
+* Flexible usage:
+  ** Works with cloud features
+  ** Compatible with hybrid setups
+a|
+* Common scenarios:
+  ** Most deployments
+  ** Development teams 
+  ** Cloud integrations
 
-=== Version-locked Keys (Alternative)
+| Version-locked Keys
+a|
+* Fixed version access:
+  ** Specific version only
+  ** No expiration date
+  ** Domain restrictions
+* Security focused:
+  ** Offline validation
+  ** No cloud dependencies
+a|
+* Security-focused scenarios:
+  ** Air-gapped systems
+  ** Regulated industries
+  ** Government deployments
+  ** Security-critical systems
+|===
 
-For customers who cannot use date-based keys, version-locked keys are available:
+=== Deployment Types
 
-* The key is locked to specific {productname} versions.
-* No expiration date - the key continues working for allowed versions.
-* Cannot be used with versions released after your subscription ends.
-* Must contact account manager to get access to newer versions.
-* Suitable for air-gapped environments or strict deployment policies.
+[cols="1,2,2", options="header"]
+|===
+| **Type** | **Key Configuration** | **Capabilities**
 
-=== Deployment Patterns
+| Cloud-only
+a|
+* API key required for:
+  ** Cloud services access
+  ** Premium plugin access
+  ** Automatic updates
+a|
+* Fully managed service:
+  ** No local deployment needed
+  ** Automatic updates and CDN delivery
+  ** Cloud storage features
+  ** Real-time collaboration
 
-==== Cloud-only
+| Self-hosted
+a|
+* License key required with:
+  ** `T8LK` prefix
+  ** Domain validation
+a|
+* Complete local control:
+  ** Self-hosted premium plugins
+  ** Custom deployment options
+  ** No cloud dependencies
 
-* Use API key.
-* Premium features via subscription.
-* CDN-hosted resources.
-* Automatic updates.
+| Hybrid
+a|
+* Both keys required:
+  ** API key for cloud features
+  ** License key for local fallback
+* Optional failover configuration
+a|
+* Best of both worlds:
+  ** Cloud features when online
+  ** Local fallback when needed
+  ** High availability options
 
-==== Self-hosted
-
-* Use license key with `T8LK` prefix.
-* Local premium plugins.
-* Manual updates.
-* Full control over assets.
-
-==== Hybrid
-
-* Both API key and license key.
-* Mix of cloud and local features.
-* Flexible deployment options.
-* Fallback capabilities.
-
-=== Offline Mode
-
-For air-gapped environments or offline usage:
-
-* Supports environments without internet connectivity
-* Compatible with strict network security policies
-* Maintains license compliance through client-side JWT validation
-* Enforces version and domain restrictions without server connection
-* Works with standard security controls and firewalls
-* Requires version-locked keys for maximum compatibility
-
-[NOTE]
-====
-For air-gapped environments:
-* Use version-locked keys instead of date-based keys
-* Premium plugins must be downloaded and bundled locally
-* Updates require manual deployment of new versions
-====
+| Offline/Air-gapped
+a|
+* Version-locked key required:
+  ** `T8LK` prefix
+  ** Domain/environment locks
+  ** No internet connectivity needed
+a|
+* Completely offline operation:
+  ** Local resource bundling
+  ** Network isolation
+  ** Air-gap compliance
+|===
 
 == Configuration Examples
 
@@ -135,19 +165,29 @@ tinymce.init({
     "advlist", "anchor", "autolink", "charmap", "code", "fullscreen",
     "help", "image", "link", "lists",
     
-    // Premium plugins - available both via cloud and local fallback
+    // Premium plugins - ensure these are available both via cloud and locally
+    // Local versions should be downloaded and included in your bundle
     "powerpaste", "tinycomments", "tinydrive"
   ],
   toolbar: "undo redo | styles | bold italic | alignleft aligncenter alignright | bullist numlist | link image",
+  
   // Cloud configuration with local fallback
   api_key: "your-api-key",          // For cloud features
   license_key: "T8LK:your-license", // For local fallback
-  // Optional: Configure failover behavior
+  
+  // Failover configuration example
   serviceLoadFailbackTime: 5000,    // Wait 5s before falling back to local
+  
+  // Custom handler for image uploads with cloud/local failover
   images_upload_handler: function (blobInfo, progress) {
-    // Custom handler that tries cloud first, falls back to local
     return new Promise((resolve, reject) => {
-      // Implementation of cloud/local failover logic
+      // Example implementation:
+      // 1. Try uploading to cloud service first
+      // 2. If cloud upload fails or times out, fall back to local storage
+      // 3. Handle progress updates for both scenarios
+      // 4. Return the URL of the uploaded image
+      
+      // For detailed implementation, see the Image Upload documentation
     });
   }
 });
@@ -156,6 +196,7 @@ tinymce.init({
 [NOTE]
 ====
 For hybrid deployments:
+
 * Both `api_key` and `license_key` are used together
 * Configure appropriate timeouts for service failover
 * Consider implementing custom handlers for seamless fallback
@@ -188,32 +229,44 @@ tinymce.init({
 [NOTE]
 ====
 For offline deployments:
+
 * All assets must be available locally
 * Content delivery URLs should point to local resources
 * Premium plugins must be downloaded and included in your bundle
+* JWT validation is built into the {productname} core and works completely offline:
+  ** No internet connectivity required for license validation
+  ** No server communication or "phone home" checks
+  ** All validation is performed securely within the browser
 ====
 
 == License States
 
-=== Active
+[cols="1,2,1", options="header"]
+|===
+| State | Features & Behavior | Applicable To
 
-* Full editor and premium plugin functionality.
-* Regular version upgrades available (date-based keys).
-* No restrictions on features.
+| Active
+a|
+* Full editor and premium plugin functionality
+* Regular version upgrades available
+* No restrictions on features
+| All license types
 
-=== Grace Period (Date-based keys only)
+| Grace Period
+a|
+* All features remain functional
+* In-editor notifications about approaching expiration
+* Occurs 30 days before subscription end
+* Time to contact Tiny for renewal
+| Date-based keys only
 
-// TBA: Validate this date is correct
-* Occurs 30 days before subscription end.
-* All features remain functional.
-* In-editor notifications about approaching expiration.
-* Time to contact Tiny for renewal.
-
-=== Expired
-
-* Date-based keys: Editor disabled after grace period.
-* Version-locked keys: Cannot use new versions.
-* Must obtain new license key after renewal.
+| Expired
+a|
+* Date-based keys: Editor disabled
+* Version-locked keys: Cannot use new versions
+* Must obtain new license key after renewal
+| All license types
+|===
 
 == FAQ
 
@@ -225,21 +278,26 @@ The GPLv2+ license was chosen to provide the best compatibility with existing GP
 
 === What is the difference between a license key and the API key?
 
-The **API key** is used when loading {productname} from the {cloudname} and undergoes server-side validation. The **license key** (starting with T8LK: in version 8) is used to declare the license terms when self-hosting {productname} and uses client-side JWT validation in the browser.
+The **API key** is used when loading {productname} from the {cloudname} and undergoes server-side validation. The **license key** (starting with `T8LK:` in version 8) is used to declare the license terms when self-hosting {productname}. The license key contains a JSON Web Token (JWT) that enables secure client-side validation performed entirely within the browser, requiring no server communication or "phone home" checks.
 
 === Who needs to get a license key?
 
 Anyone who intends to self-host {productname} will need to:
+
 * For version 7: Provide a valid commercial license key or declare their intention to use {productname} under the GPLv2+ license
 * For version 8: Obtain a T8LK-prefixed commercial license key or use GPL mode
 
 === How will I know if this change affects me?
 
-If {productname} detects that the `license_key` configuration is missing or invalid, it will display a console log warning message. These warnings are designed to ensure compliance and provide transparency during evaluation periods. If you have actively suppressed or hidden these messages, please remove those overrides to maintain proper license validation. If no notification appears, you are not affected.
+If {productname} detects that the `license_key` configuration is missing or invalid, it will display a console log warning message. These warnings are designed to ensure compliance and provide transparency during evaluation periods.
+
+[TIP]
+If you have actively suppressed or hidden these messages, please remove those overrides to maintain proper license validation. If no notification appears, you are not affected.
 
 === Should I be using both an API key and a license key?
 
 For standard deployments, use only one of the following:
+
 * *API key* - For cloud deployments
 ** Server-side validation
 ** Automatic updates and CDN delivery
@@ -247,17 +305,20 @@ For standard deployments, use only one of the following:
 ** No client-side validation required
 
 * *License key* - For self-hosted deployments
-** Client-side JWT validation
+** Client-side JWT validation is automatically performed
 ** T8LK prefix required for version 8
 ** Supports air-gapped environments
 ** Local premium plugin validation
 
 *Hybrid Deployment Cases:*
+
 * Using both keys together requires specific configuration:
-** Set up cloud services with API key
-** Configure local fallback with license key
-** Enable high availability features
-** Access both cloud and local premium plugins
+** Set up cloud services with API key for primary cloud access
+** Configure local fallback with license key for offline operation
+** Configure service failover timeouts (e.g., `serviceLoadFailbackTime`)
+** Ensure premium plugins are available both via cloud and locally
+** Implement custom handlers for seamless cloud/local failover
+** Test both online and offline scenarios thoroughly
 
 [IMPORTANT]
 ====

--- a/modules/ROOT/pages/license-key.adoc
+++ b/modules/ROOT/pages/license-key.adoc
@@ -86,7 +86,7 @@ a|
   ** Cloud services access
   ** Premium plugin access
   ** Automatic updates
-* No license key required (defaults to a commercial license)
+* No license key required as its automatically issued. (defaults to a commercial license)
 a|
 * Fully managed service:
   ** No local deployment needed
@@ -189,6 +189,37 @@ In addition to the editor being readonly, a console log warning message and/or e
 === Why is a license key required?
 
 The license key ensures compliance with {productname} licensing terms. It's part of our efforts to refine the license key system and may have additional functionalities in the future.
+
+=== How do I obtain a TinyMCE 8 license key?
+
+To obtain a new TinyMCE 8 license key (T8LK-prefixed):
+
+* *Existing customers*: Contact your account manager or visit link:https://www.tiny.cloud/my-account[Tiny Cloud Account] to upgrade your subscription.
+* *New customers*: Visit link:https://www.tiny.cloud/pricing[Tiny Cloud Pricing] to purchase a new license.
+
+[IMPORTANT]
+====
+Existing TinyMCE 7 license keys cannot be modified to work with TinyMCE 8 by adding the T8LK prefix. A new TinyMCE 8 license must be obtained through the proper channels listed above.
+====
+
+=== I'm upgrading from {productname} 7 - how do I get a {productname} 8 license key?
+
+If you are using {cloudname} (cloud-hosted):
+
+* No license key is required - simply update your {productname} version as your cloud subscription includes the commercial license.
+
+If you are an existing {productname} 7 self-hosted customer upgrading to {productname} 8:
+
+. *Active Subscription*:
+* Contact your account manager or visit link:https://www.tiny.cloud/my-account[Tiny Cloud Account] to obtain a new T8LK-prefixed license key.
+. *Expired Subscription*:
+* Contact your account manager or visit link:https://www.tiny.cloud/pricing[Tiny Cloud Pricing] to renew your subscription.
+* A new T8LK-prefixed license key will be provided as part of the renewal process.
+
+[NOTE]
+====
+Your existing {productname} 7 license key will continue to work with TinyMCE 7 self-hosted installations. But, you will require a separate T8LK-prefixed license key for {productname} 8 editor instances for self-hosted installations.
+====
 
 === How can I get further assistance?
 

--- a/modules/ROOT/pages/license-key.adoc
+++ b/modules/ROOT/pages/license-key.adoc
@@ -154,7 +154,7 @@ The GPLv2+ license was chosen to provide the best compatibility with existing GP
 
 === What is the difference between a license key and the API key?
 
-The **API key** is used when loading TinyMCE from the {cloudname}. The license key is used to declare the license terms when self-hosting {productname}.
+The **API key** is used when loading {productname} from the {cloudname}. The license key is used to declare the license terms when self-hosting {productname}.
 
 === Who needs to get a license key?
 
@@ -190,19 +190,19 @@ In addition to the editor being readonly, a console log warning message and/or e
 
 The license key ensures compliance with {productname} licensing terms. It's part of our efforts to refine the license key system and may have additional functionalities in the future.
 
-=== How do I obtain a TinyMCE 8 license key?
+=== How do I obtain a {productname} 8 license key?
 
-To obtain a new TinyMCE 8 license key (T8LK-prefixed):
+To obtain a new {productname} 8 license key (T8LK-prefixed):
 
 * *Existing customers*: Contact your account manager or visit link:https://www.tiny.cloud/my-account[Tiny Cloud Account] to upgrade your subscription.
 * *New customers*: Visit link:https://www.tiny.cloud/pricing[Tiny Cloud Pricing] to purchase a new license.
 
 [IMPORTANT]
 ====
-Existing TinyMCE 7 license keys cannot be modified to work with TinyMCE 8 by adding the T8LK prefix. A new TinyMCE 8 license must be obtained through the proper channels listed above.
+Existing {productname} 7 license keys cannot be modified to work with {productname} 8 by adding the T8LK prefix. A new {productname} 8 license must be obtained through the proper channels listed above.
 ====
 
-=== I'm upgrading from {productname} 7 - how do I get a {productname} 8 license key?
+=== If im upgrading from TinyMCE 7 how do I get a TinyMCE 8 license key?
 
 If you are using {cloudname} (cloud-hosted):
 
@@ -218,7 +218,7 @@ If you are an existing {productname} 7 self-hosted customer upgrading to {produc
 
 [NOTE]
 ====
-Your existing {productname} 7 license key will continue to work with TinyMCE 7 self-hosted installations. But, you will require a separate T8LK-prefixed license key for {productname} 8 editor instances for self-hosted installations.
+Your existing {productname} 7 license key will continue to work with {productname} 7 self-hosted installations. But, you will require a separate T8LK-prefixed license key for {productname} 8 editor instances for self-hosted installations.
 ====
 
 === How can I get further assistance?
@@ -229,6 +229,107 @@ For any licensing or technical support questions, see our available options on t
 
 For licensing or technical support:
 * API key issues: Visit link:https://www.tiny.cloud/my-account[Tiny Cloud Account]
-* License key issues: Contact your account manager
+* License key issues: Visit link:https://www.tiny.cloud/my-account[Tiny Cloud Account] or contact your account manager
 * Technical support: Visit link:https://support.tiny.cloud[Support Portal]
-* Documentation: See link:https://www.tiny.cloud/docs/tinymce/latest/[TinyMCE Docs]
+* Documentation: See link:https://www.tiny.cloud/docs/tinymce/latest/[{productname} Docs]
+
+== License Key Error Messages
+
+The following table lists common license key error messages that may appear in the console or editor, along with their descriptions and solutions:
+
+[cols="1,2,2,2", options="header"]
+|===
+| Error Type | Console Message | Editor Notifications | Solution
+
+| xref:invalid-license-key[Invalid license key (General)]
+| The editor is disabled because the license key provided is invalid [+${errorType}+]
+| The editor is disabled because the license key provided is invalid.
+a| * Verify that the license key is correctly copied from your link:https://www.tiny.cloud/my-account[Tiny Cloud Account]
+* Ensure there are no extra spaces or characters in the key
+* Check if the key matches your deployment type (Cloud vs Self-hosted)
+
+| xref:hard-expired[Hard expired]
+| The editor is disabled because the license key has expired and is no longer valid
+| The editor is disabled because the license key has expired and is no longer valid.
+a| * Visit link:https://www.tiny.cloud/my-account[Tiny Cloud Account] to obtain a new license key
+* Update your configuration with the new key
+* Visit the link:https://support.tiny.cloud[Support Portal] if you believe your license should still be valid
+
+| xref:soft-expired[Soft expired]
+| The editor will be disabled in the near future because the license key has expired
+| The editor will be disabled in the near future because the license key has expired.
+a| * Visit link:https://www.tiny.cloud/my-account[Tiny Cloud Account] to obtain a new license key
+* Update your configuration before the grace period ends
+* Visit the link:https://support.tiny.cloud[Support Portal] if you need assistance with license renewal
+
+| xref:invalid-editor-version[Invalid editor version]
+| The editor is disabled because the license key is not valid with this version of {productname}
+| The editor is disabled because the license key is not valid with this version of {productname}.
+a| * Verify that your {productname} version matches the license key version
+* Update either your {productname} version or obtain a new license key
+* For version-locked keys, ensure you're using the correct patch version
+
+| xref:no-license-key[No license key]
+| The editor is disabled because a {productname} license key has not been provided. Provide a valid license key or add license_key: 'gpl' to the init config to agree to the open source license terms.
+| The editor is disabled because a {productname} license key has not been provided.
+a| * Add the `license_key` parameter to your {productname} configuration
+* For GPL usage, set `license_key: 'gpl'`
+* For commercial usage, enter your valid commercial license key
+
+| xref:invalid-plugin[Invalid plugin]
+| The "+${pluginCode}+" plugin requires a valid {productname} license key
+| _No editor message_
+a| * Verify that your license includes access to the premium plugin
+* Check if your license key is valid and not expired
+* Visit the link:https://support.tiny.cloud[Support Portal] if you believe you should have access to this plugin
+
+| xref:online-api-key-error-fallback[Online API Key Error (5xx - Fallback)]
+| The API key could not be validated by the API key validation server [type: +${errorType}${statusMsg}+]. Attempting fallback to provided license key.
+| The editor is disabled because the API key could not be validated by the API key validation server.
+a| * Check your internet connection
+* Verify your firewall settings allow access to the validation server
+* The editor will attempt to use the provided license key as fallback
+
+| xref:online-api-key-error-disable[Online API Key Error (4xx - Disable)]
+| The editor is disabled because the API key could not be validated by the API key validation server [type: +${errorType}${statusMsg}+]
+| The editor is disabled because the API key could not be validated by the API key validation server.
+a| * Verify that your API key is valid
+* Check if your subscription is active
+* Visit the link:https://support.tiny.cloud[Support Portal] if the issue persists
+|===
+
+=== Detailed Error Descriptions
+
+[[invalid-license-key]]
+==== Invalid license key (General)
+The provided license key is not recognized as a valid {productname} license key. This can occur if the key is malformed, expired, or doesn't match your deployment type. For self-hosted installations, ensure you're using a valid T8LK-prefixed license key. Visit the link:https://www.tiny.cloud/my-account[Tiny Cloud Account] to verify your license key.
+
+[[hard-expired]]
+==== Hard expired
+The license key has reached its expiration date and is no longer valid for use. The editor will be disabled until a new valid license key is provided. For time-based keys, refer to the <<License Key Types>> section. To renew your license, visit link:https://www.tiny.cloud/pricing[Tiny Cloud Pricing] or contact your account manager.
+
+[[soft-expired]]
+==== Soft expired
+The license key has reached its initial expiration date but is still within the grace period. The editor will continue to function but will be disabled when the grace period ends. See the <<License States>> section for more information about grace periods. Contact your account manager or visit link:https://www.tiny.cloud/my-account[Tiny Cloud Account] to renew your license before the grace period expires.
+
+[[invalid-editor-version]]
+==== Invalid editor version
+The license key is not compatible with the current version of {productname}. This typically occurs with version-locked keys when using a different patch version. Visit link:https://www.tiny.cloud/docs/tinymce/latest/[TinyMCE Documentation] to check your editor version. Review the <<License Key Types>> section about version-locked keys. If you're upgrading from {productname} 7, visit link:https://www.tiny.cloud/my-account[Tiny Cloud Account] to obtain a new license key or see <<If im upgrading from TinyMCE 7 how do I get a TinyMCE 8 license key?>> for guidance. For new licenses, visit link:https://www.tiny.cloud/pricing[Tiny Cloud Pricing].
+
+[[no-license-key]]
+==== No license key
+No license key has been provided in the {productname} configuration. For self-hosted installations, you must either provide a valid commercial license key or explicitly opt into GPL usage. See the <<Setting up the Commercial License Key Manager>> section for implementation details and the "<<What does the GPL license mean?>>" section for GPL licensing information.
+
+[[invalid-plugin]]
+==== Invalid plugin
+The attempted use of a premium plugin without a valid commercial license key. This occurs when trying to use premium features with a GPL license or an invalid commercial license. Review your subscription details in your link:https://www.tiny.cloud/my-account[Tiny Cloud Account] to verify plugin access. See the <<License Types and Deployment Options>> section for more information about license types and plugin access.
+
+[[online-api-key-error-fallback]]
+==== Online API Key Error (5xx - Fallback)
+A server-side error occurred while validating the API key. The editor will attempt to use the provided license key as a fallback mechanism. This typically occurs in hybrid deployments - see the <<Deployment Types>> section for proper configuration. If the issue persists, visit link:https://support.tiny.cloud[Support Portal] for assistance.
+
+[[online-api-key-error-disable]]
+==== Online API Key Error (4xx - Disable)
+The API key validation failed due to an invalid key or inactive subscription. The editor will be disabled until a valid API key is provided. For API key issues, visit link:https://www.tiny.cloud/my-account[Tiny Cloud Account] or see the "<<What is the difference between a license key and the API key?>>" section for clarification.
+
+For additional assistance, visit our link:https://support.tiny.cloud[Support Portal] or contact your link:https://www.tiny.cloud/my-account[Tiny Cloud Account] manager.

--- a/modules/ROOT/pages/license-key.adoc
+++ b/modules/ROOT/pages/license-key.adoc
@@ -10,7 +10,7 @@
 ====
 {productname} is licensed under the GNU General Public License Version 2 or later. A configuration option called `+'license_key'+` introduced in {productname} 7 requires developers to make a conscious decision to use {productname} with the GPLv2+ license or with a commercial license.
 
-When using {productname} 8 in a self-hosted environment, a license key must be provided and it must be valid. Otherwise, the editor will be set to readonly. A license key is not required when loading {productname} from {cloudname}, as it is already under a commercial license.
+When using {productname} 8 in a self-hosted environment, a license key must be provided and it must be valid. Otherwise, the editor will be disabled. A license key is not required when loading {productname} from {cloudname}, as it is already under a commercial license.
 
 In addition, when using {productname} 8 in a self-hosted environment for commercial use, a commercial license key manager addon is required in order for the editor to operate.
 ====
@@ -134,12 +134,12 @@ a|
 
 | Expired
 a|
-* Editor is set to readonly
+* Editor is disabled
 * Must obtain a new license key to continue using {productname}
 | Time-based keys only
 | Invalid
 a|
-* Editor is set to readonly
+* Editor is disabled
 * Editor notifications notifying that the license key is not valid
 | All license types
 |===
@@ -162,7 +162,7 @@ Anyone who intends to self-host {productname} will need to obtain a T8LK-prefixe
 
 === How will I know if this change affects me?
 
-If {productname} detects that the `license_key` configuration is missing or invalid, it will display a console log warning message and/or editor notification and set the editor to readonly. These warnings and restrictions are designed to ensure compliance and provide transparency during evaluation periods.
+If {productname} detects that the `license_key` configuration is missing or invalid, it will display a console log warning message and/or editor notification and set the editor to disabled. These warnings and restrictions are designed to ensure compliance and provide transparency during evaluation periods.
 
 [TIP]
 If you have actively suppressed or hidden these messages, please remove those overrides to maintain proper license validation. If no notification appears, you are not affected.
@@ -184,7 +184,7 @@ If using a cloud or hybrid deployment configuration, the license key may be chec
 
 === What happens if I don't provide a valid license key?
 
-In addition to the editor being readonly, a console log warning message and/or editor notification will persist until a valid license key or 'gpl' is provided.
+In addition to the editor being disabled, a console log warning message and/or editor notification will persist until a valid license key or 'gpl' is provided.
 
 === Why is a license key required?
 
@@ -248,14 +248,27 @@ a| * Verify that the license key is correctly copied from your link:https://www.
 * Ensure there are no extra spaces or characters in the key
 * Check if the key matches your deployment type (Cloud vs Self-hosted)
 
-| xref:hard-expired[Hard expired]
+| xref:load-error[Load error (Cloud)]
+| The editor is disabled because the TinyMCE API key could not be validated. The TinyMCE Commercial License Key Manager plugin is required for the provided API key to be validated but could not be loaded.
+| The editor is disabled because the TinyMCE API key could not be validated.
+a| * Verify that your API key is valid
+* Check if your subscription is active
+* Visit the link:https://support.tiny.cloud[Support Portal] if the issue persists
+
+| xref:load-error[Load error (Self-Hosted)]
+| The editor is disabled because the license key provided is invalid. The TinyMCE Commercial License Key Manager plugin is required for the provided license key to be validated but could not be loaded.
+| The editor is disabled because the TinyMCE license key could not be validated.
+a| * Check if the license key matches your deployment type: GPL or commercial, Cloud or Self-hosted
+* Ensure the license key manager is set up correctly: <<Setting up the Commercial License Key Manager>>
+
+| xref:expired[Expired]
 | The editor is disabled because the license key has expired and is no longer valid
 | The editor is disabled because the license key has expired and is no longer valid.
 a| * Visit link:https://www.tiny.cloud/my-account[Tiny Cloud Account] to obtain a new license key
 * Update your configuration with the new key
 * Visit the link:https://support.tiny.cloud[Support Portal] if you believe your license should still be valid
 
-| xref:soft-expired[Soft expired]
+| xref:grace-period[Grace period]
 | The editor will be disabled in the near future because the license key has expired
 | The editor will be disabled in the near future because the license key has expired.
 a| * Visit link:https://www.tiny.cloud/my-account[Tiny Cloud Account] to obtain a new license key
@@ -270,7 +283,7 @@ a| * Verify that your {productname} version matches the license key version
 * For version-locked keys, ensure you're using the correct patch version
 
 | xref:no-license-key[No license key]
-| The editor is disabled because a {productname} license key has not been provided. Provide a valid license key or add license_key: 'gpl' to the init config to agree to the open source license terms.
+| The editor is disabled because a {productname} license key has not been provided. Make sure to provide a valid license key or add license_key: 'gpl' to the init config to agree to the open source license terms.
 | The editor is disabled because a {productname} license key has not been provided.
 a| * Add the `license_key` parameter to your {productname} configuration
 * For GPL usage, set `license_key: 'gpl'`
@@ -285,7 +298,7 @@ a| * Verify that your license includes access to the premium plugin
 
 | xref:online-api-key-error-fallback[Online API Key Error (5xx - Fallback)]
 | The API key could not be validated by the API key validation server [type: +${errorType}${statusMsg}+]. Attempting fallback to provided license key.
-| The editor is disabled because the API key could not be validated by the API key validation server.
+|
 a| * Check your internet connection
 * Verify your firewall settings allow access to the validation server
 * The editor will attempt to use the provided license key as fallback
@@ -304,12 +317,20 @@ a| * Verify that your API key is valid
 ==== Invalid license key (General)
 The provided license key is not recognized as a valid {productname} license key. This can occur if the key is malformed, expired, or doesn't match your deployment type. For self-hosted installations, ensure you're using a valid T8LK-prefixed license key. Visit the link:https://www.tiny.cloud/my-account[Tiny Cloud Account] to verify your license key.
 
-[[hard-expired]]
-==== Hard expired
+[[load-error-cloud]]
+==== Load error (Cloud)
+The TinyMCE Commercial License Key Manager plugin is automatically loaded from the Tiny Cloud CDN for cloud deployments. If it cannot be loaded, the editor will be disabled. Review your subscription details in your link:https://www.tiny.cloud/my-account[Tiny Cloud Account] to check its status.
+
+[[load-error-selfhosted]]
+==== Load error (Self-hosted)
+For self-hosted installations, the TinyMCE Commercial License Key Manager plugin is required for commercial license keys otherwise the editor will be disabled. If it cannot be loaded, see the <<Setting up the Commercial License Key Manager>> section for implementation details
+
+[[expired]]
+==== Expired
 The license key has reached its expiration date and is no longer valid for use. The editor will be disabled until a new valid license key is provided. For time-based keys, refer to the <<License Key Types>> section. To renew your license, visit link:https://www.tiny.cloud/pricing[Tiny Cloud Pricing] or contact your account manager.
 
-[[soft-expired]]
-==== Soft expired
+[[grace-period]]
+==== Grace period
 The license key has reached its initial expiration date but is still within the grace period. The editor will continue to function but will be disabled when the grace period ends. See the <<License States>> section for more information about grace periods. Contact your account manager or visit link:https://www.tiny.cloud/my-account[Tiny Cloud Account] to renew your license before the grace period expires.
 
 [[invalid-editor-version]]

--- a/modules/ROOT/pages/license-key.adoc
+++ b/modules/ROOT/pages/license-key.adoc
@@ -3,16 +3,217 @@
 :description: Learn how to configure license key and stop {productname} from running in the evaluation mode.
 :keywords: {productname}, cloud, script, textarea, apiKey, faq, license key, frequently asked questions,
 
+== Overview
+
+{productname} 8 introduces an enhanced license key system that provides improved subscription access control and streamlined renewal processes. This system includes both date-based and version-locked keys, supporting various deployment scenarios including cloud, self-hosted, and hybrid configurations.
+
 [IMPORTANT]
 ====
-{productname} 7 is licensed under the GNU General Public License Version 2 or later. A new configuration option called 'license_key' requires developers to make a conscious decision to use {productname} with the GPLv2+ license or with a commercial license.
+If you are using {productname} 7, it is licensed under the GNU General Public License Version 2 or later. A configuration option called 'license_key' requires developers to make a conscious decision to use {productname} with the GPLv2+ license or with a commercial license.
 
 If you are using {productname} in a self-hosted environment, a console log warning message will display if the license key config option is missing or invalid. This message aims to ensure compliance with licensing requirements and provide transparency during the evaluation period.
 
 This message will not be shown when loading {productname} from {cloudname}, as it is already under a commercial license.
+
+For {productname} 8, license keys use the `+"T8LK:"+` prefix and provide enhanced validation and management features. These keys support both online and offline validation modes.
 ====
 
 include::partial$misc/setting-the-license.adoc[]
+
+== License Types and Deployment Options
+
+=== Date-based Keys (Standard)
+
+The standard license key type in {productname} 8 is date-based, meaning:
+
+* The key has a soft expiration date that matches your subscription end date.
+* After the soft expiration, the editor enters a grace period in `read-only` mode.
+* After the grace period expires, the editor becomes completely disabled.
+* Premium plugins are disabled at the soft expiration date.
+* In-editor messaging will notify users about approaching expiration.
+
+=== Version-locked Keys (Alternative)
+
+For customers who cannot use date-based keys, version-locked keys are available:
+
+* The key is locked to specific {productname} versions.
+* No expiration date - the key continues working for allowed versions.
+* Cannot be used with versions released after your subscription ends.
+* Must contact account manager to get access to newer versions.
+* Suitable for air-gapped environments or strict deployment policies.
+
+=== Deployment Patterns
+
+==== Cloud-only
+
+* Use API key.
+* Premium features via subscription.
+* CDN-hosted resources.
+* Automatic updates.
+
+==== Self-hosted
+
+* Use license key with `T8LK` prefix.
+* Local premium plugins.
+* Manual updates.
+* Full control over assets.
+
+==== Hybrid
+
+* Both API key and license key.
+* Mix of cloud and local features.
+* Flexible deployment options.
+* Fallback capabilities.
+
+=== Offline Mode
+
+For air-gapped environments or offline usage:
+
+* Supports environments without internet connectivity
+* Compatible with strict network security policies
+* Maintains license compliance through client-side JWT validation
+* Enforces version and domain restrictions without server connection
+* Works with standard security controls and firewalls
+* Requires version-locked keys for maximum compatibility
+
+[NOTE]
+====
+For air-gapped environments:
+* Use version-locked keys instead of date-based keys
+* Premium plugins must be downloaded and bundled locally
+* Updates require manual deployment of new versions
+====
+
+== Configuration Examples
+
+=== Cloud Deployment
+
+[source,javascript]
+----
+tinymce.init({
+  selector: "textarea",
+  plugins: [
+    // Core plugins
+    "advlist", "anchor", "autolink", "charmap", "code", "fullscreen",
+    "help", "image", "insertdatetime", "link", "lists", "media",
+    "preview", "searchreplace", "table", "visualblocks",
+    
+    // Premium plugins (requires valid subscription)
+    "powerpaste", "tinycomments", "tinydrive"
+  ],
+  toolbar: "undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
+  api_key: "no-api-key"
+});
+----
+
+=== Self-hosted Commercial
+
+[source,javascript]
+----
+tinymce.init({
+  selector: "textarea",
+  plugins: [
+    "advlist", "anchor", "autolink", "charmap", "code", "fullscreen",
+    "help", "image", "insertdatetime", "link", "lists", "media",
+    "preview", "searchreplace", "table", "visualblocks",
+    // Premium plugins need to be separately downloaded and included
+    "powerpaste", "tinycomments", "tinydrive"
+  ],
+  toolbar: "undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
+  license_key: "T8LK:your-license-key"  // Your commercial license key
+});
+----
+
+=== Hybrid Deployment
+
+[source,javascript]
+----
+tinymce.init({
+  selector: "textarea",
+  plugins: [
+    // Core plugins
+    "advlist", "anchor", "autolink", "charmap", "code", "fullscreen",
+    "help", "image", "link", "lists",
+    
+    // Premium plugins - available both via cloud and local fallback
+    "powerpaste", "tinycomments", "tinydrive"
+  ],
+  toolbar: "undo redo | styles | bold italic | alignleft aligncenter alignright | bullist numlist | link image",
+  // Cloud configuration with local fallback
+  api_key: "your-api-key",          // For cloud features
+  license_key: "T8LK:your-license", // For local fallback
+  // Optional: Configure failover behavior
+  serviceLoadFailbackTime: 5000,    // Wait 5s before falling back to local
+  images_upload_handler: function (blobInfo, progress) {
+    // Custom handler that tries cloud first, falls back to local
+    return new Promise((resolve, reject) => {
+      // Implementation of cloud/local failover logic
+    });
+  }
+});
+----
+
+[NOTE]
+====
+For hybrid deployments:
+* Both `api_key` and `license_key` are used together
+* Configure appropriate timeouts for service failover
+* Consider implementing custom handlers for seamless fallback
+* Test both online and offline scenarios
+====
+
+=== Offline/Air-gapped Deployment
+
+[source,javascript]
+----
+tinymce.init({
+  selector: "textarea",
+  plugins: [
+    // Core plugins included in your local bundle
+    "advlist", "anchor", "autolink", "charmap", "code", "fullscreen",
+    "help", "image", "link", "lists",
+    
+    // Premium plugins downloaded and bundled locally
+    "powerpaste", "spelling", "a11ychecker"
+  ],
+  toolbar: "undo redo | styles | bold italic | alignleft aligncenter alignright | bullist numlist outdent indent | link image",
+  // Version-locked key for offline environments
+  license_key: "T8LK:your-version-locked-key",
+  // Ensure all resources are loaded locally
+  skin_url: "/path/to/local/skin",
+  content_css: "/path/to/local/content.css"
+});
+----
+
+[NOTE]
+====
+For offline deployments:
+* All assets must be available locally
+* Content delivery URLs should point to local resources
+* Premium plugins must be downloaded and included in your bundle
+====
+
+== License States
+
+=== Active
+
+* Full editor and premium plugin functionality.
+* Regular version upgrades available (date-based keys).
+* No restrictions on features.
+
+=== Grace Period (Date-based keys only)
+
+// TBA: Validate this date is correct
+* Occurs 30 days before subscription end.
+* All features remain functional.
+* In-editor notifications about approaching expiration.
+* Time to contact Tiny for renewal.
+
+=== Expired
+
+* Date-based keys: Editor disabled after grace period.
+* Version-locked keys: Cannot use new versions.
+* Must obtain new license key after renewal.
 
 == FAQ
 
@@ -24,21 +225,46 @@ The GPLv2+ license was chosen to provide the best compatibility with existing GP
 
 === What is the difference between a license key and the API key?
 
-The **API key** is used when loading {productname} from the {cloudname}. The **license key** is used to declare the license terms when self-hosting {productname}.
+The **API key** is used when loading {productname} from the {cloudname} and undergoes server-side validation. The **license key** (starting with T8LK: in version 8) is used to declare the license terms when self-hosting {productname} and uses client-side JWT validation in the browser.
 
 === Who needs to get a license key?
 
-Anyone who intends to self-host {productname} will need to provide a valid commercial license key or declare their intention to use {productname} under the GPLv2+ license.
+Anyone who intends to self-host {productname} will need to:
+* For version 7: Provide a valid commercial license key or declare their intention to use {productname} under the GPLv2+ license
+* For version 8: Obtain a T8LK-prefixed commercial license key or use GPL mode
 
 === How will I know if this change affects me?
 
-If {productname} detects that the `license_key` configuration is missing or invalid, it will display a console log warning. If you have actively suppressed or hidden this message, please remove those overrides. If no notification appears, you are not affected.
+If {productname} detects that the `license_key` configuration is missing or invalid, it will display a console log warning message. These warnings are designed to ensure compliance and provide transparency during evaluation periods. If you have actively suppressed or hidden these messages, please remove those overrides to maintain proper license validation. If no notification appears, you are not affected.
 
 === Should I be using both an API key and a license key?
 
-No, an API key and a license key should not be used simultaneously. The API key should only be used if {productname} is loaded from the {cloudname}. If {productname} is being self-hosted, the license key option should be used instead.
+For standard deployments, use only one of the following:
+* *API key* - For cloud deployments
+** Server-side validation
+** Automatic updates and CDN delivery
+** Premium plugin access via subscription
+** No client-side validation required
 
-=== Will {productname} “phone home” to check the license key?
+* *License key* - For self-hosted deployments
+** Client-side JWT validation
+** T8LK prefix required for version 8
+** Supports air-gapped environments
+** Local premium plugin validation
+
+*Hybrid Deployment Cases:*
+* Using both keys together requires specific configuration:
+** Set up cloud services with API key
+** Configure local fallback with license key
+** Enable high availability features
+** Access both cloud and local premium plugins
+
+[IMPORTANT]
+====
+Only use both keys in properly configured hybrid deployments where you need cloud features with local fallback. Using both keys without proper hybrid deployment configuration **may cause** validation conflicts and unexpected behavior.
+====
+
+=== Will {productname} "phone home" to check the license key?
 
 No. {productname} does not contact any server to validate the license key.
 
@@ -53,3 +279,11 @@ The license key ensures compliance with {productname} licensing terms. It's part
 === How can I get further assistance?
 
 For any licensing or technical support questions, see our available options on the https://www.tiny.cloud/docs/tinymce/latest/support/[support page.]
+
+=== Technical Support
+
+For licensing or technical support:
+* API key issues: Visit link:https://www.tiny.cloud/my-account[Tiny Cloud Account]
+* License key issues: Contact your account manager
+* Technical support: Visit link:https://support.tiny.cloud[Support Portal]
+* Documentation: See link:https://www.tiny.cloud/docs/tinymce/latest/[TinyMCE Docs]

--- a/modules/ROOT/pages/license-key.adoc
+++ b/modules/ROOT/pages/license-key.adoc
@@ -32,10 +32,16 @@ The commercial license key manager is available:
 * in a purchased self-hosted addon - a `licensekeymanager` folder will be present in addition to the purchased addon.
 * as a standalone addon - a `licensekeymanager` folder will be present.
 
-If hosting {productname} standalone, for example, in a `/public` folder, ensure the `+licensekeymanager+` folder is included in the `+plugins+` folder with all of the other plugins.
+[IMPORTANT]
+====
+The following setup steps are **required** for the editor to function with commercial license keys. The editor will not work without proper license key manager configuration.
+====
 
-If bundling {productname} as part of an application ensure to import the `+licensekeymanager/index.js+` file. For example:
+If hosting {productname} standalone, for example, in a `/public` folder, **ensure** the `+licensekeymanager+` folder is included in the `+plugins+` folder with all of the other plugins. The editor will not function without this.
 
+If bundling {productname} as part of an application **ensure** the `+licensekeymanager/index.js+` file is imported, otherwise the editor will not function without this.
+
+.Example importing the License Key Manager in a bundled application
 [source,javascript]
 ----
 import 'tinymce/plugins/licensekeymanager';

--- a/modules/ROOT/pages/license-key.adoc
+++ b/modules/ROOT/pages/license-key.adoc
@@ -1,62 +1,77 @@
 = License key
 :description_short: {productname} License Configuration Guide | {productname}
-:description: Learn how to configure license key and stop {productname} from running in the evaluation mode.
+:description: Learn how to configure a license key in {productname}.
 :keywords: {productname}, cloud, script, textarea, apiKey, faq, license key, frequently asked questions,
 
 == Overview
-{productname} 8 uses an enhanced license key system that provides improved subscription access control and streamlined renewal processes. This system includes both **date-based** and **version-locked** keys, supporting various deployment scenarios including cloud, self-hosted, hybrid and offline (air-gapped) environment configurations.
+{productname} 8 uses an enhanced license key system to ensure compliance with {productname} licensing terms.
 
 [IMPORTANT]
 ====
-{productname} is licensed under the GNU General Public License Version 2 or later. A configuration option called 'license_key' introduced in v7 required developers to make a conscious decision to use {productname} with the GPLv2+ license or with a commercial license.
+{productname} is licensed under the GNU General Public License Version 2 or later. A configuration option called `+'license_key'+` introduced in {productname} 7 requires developers to make a conscious decision to use {productname} with the GPLv2+ license or with a commercial license.
 
-For {productname} 8, self-hosted, hybrid, and offline deployments require a valid license key with the `+"T8LK:"+` prefix such as `+license_key: "T8LK:your-license-key"+`. This prefix indicates that the key is for version 8 and provides enhanced validation and management features.
+When using {productname} 8 in a self-hosted environment, a license key must be provided and it must be valid. Otherwise, the editor will be set to readonly. A license key is not required when loading {productname} from {cloudname}, as it is already under a commercial license.
 
-If you are using {productname} in a self-hosted environment, a console log warning message will display if the license key config option is missing or invalid. This message aims to ensure compliance with licensing requirements and provide transparency during the evaluation period.
-
-This message will not be shown when loading {productname} from {cloudname}, as it is already under a commercial license.
+In addition, when using {productname} 8 in a self-hosted environment for commercial use, a commercial license key manager addon is required in order for the editor to operate.
 ====
 
 include::partial$misc/setting-the-license.adoc[]
+
+== Setting up the Commercial License Key Manager
+
+[NOTE]
+====
+`+'licensekeymanager'+` does not need to be added to the `+plugins+` configuration option.
+====
+
+A commercial license key manager (`+licensekeymanager+`) is required to be loaded by the editor when using a commercial license key. The commercial license key manager can be set up like any other plugin for self-hosted installations. However, it does not need to be specified in the `+plugins+` configuration option as the editor will attempt to automatically load the license key manager when required.
+
+The commercial license key manager is available:
+
+* in a purchased self-hosted plan - a `licensekeymanager` folder will be present in the `plugins` folder of the {productname} `+.zip+`.
+* in a purchased self-hosted addon - a `licensekeymanager` folder will be present in addition to the purchased addon.
+* as a standalone addon - a `licensekeymanager` folder will be present.
+
+If hosting {productname} standalone, for example, in a `/public` folder, ensure the `+licensekeymanager+` folder is included in the `+plugins+` folder with all of the other plugins.
+
+If bundling {productname} as part of an application ensure to import the `+licensekeymanager/index.js+` file. For example:
+
+[source,javascript]
+----
+import 'tinymce/plugins/licensekeymanager';
+----
 
 == License Types and Deployment Options
 
 === License Key Types
 
+There are two different license types:
+
+. **GPL license**
+. **Commercial license**
+
+A commercial license can be broken down into sub-types:
+
 [cols="1,2,2", options="header"]
 |===
 | **Type** | **Key Features** | **Best For**
 
-| Date-based Keys (Standard)
+| Time-based Keys
 a|
-* Time-based subscription:
-  ** Automatic version updates
-  ** 30-day grace period
-  ** Premium plugin access
-* Flexible usage:
-  ** Works with cloud features
-  ** Compatible with hybrid setups
+* Expiry date
+* Optional grace period
+* Premium plugin access
+* No patch version locking
 a|
-* Common scenarios:
-  ** Most deployments
-  ** Development teams 
-  ** Cloud integrations
-
+  ** Developers that can perform regular license rotation.
+  ** Developers that want a license key to work across patch versions.
 | Version-locked Keys
 a|
-* Fixed version access:
-  ** Specific version only
-  ** No expiration date
-  ** Domain restrictions
-* Security focused:
-  ** Offline validation
-  ** No cloud dependencies
+* Specific patch version only
+* No expiration date
+* Premium plugin access
 a|
-* Security-focused scenarios:
-  ** Air-gapped systems
-  ** Regulated industries
-  ** Government deployments
-  ** Security-critical systems
+* Environments where regular license key rotation cannot be performed.
 |===
 
 === Deployment Types
@@ -71,173 +86,33 @@ a|
   ** Cloud services access
   ** Premium plugin access
   ** Automatic updates
+* No license key required (defaults to a commercial license)
 a|
 * Fully managed service:
   ** No local deployment needed
   ** Automatic updates and CDN delivery
-  ** Cloud storage features
-  ** Real-time collaboration
 
 | Self-hosted
 a|
-* License key required with:
-  ** `T8LK` prefix
-  ** Domain validation
+* A GPL or commercial license key is required
+* No API key required
 a|
 * Complete local control:
-  ** Self-hosted premium plugins
+  ** Self-hosted editor and premium plugins
   ** Custom deployment options
   ** No cloud dependencies
+  ** No internet connectivity needed
 
 | Hybrid
 a|
 * Both keys required:
   ** API key for cloud features
-  ** License key for local fallback
-* Optional failover configuration
+  ** License key for self-hosted editor and self-hosted premium plugins
 a|
 * Best of both worlds:
-  ** Cloud features when online
-  ** Local fallback when needed
-  ** High availability options
-
-| Offline/Air-gapped
-a|
-* Version-locked key required:
-  ** `T8LK` prefix
-  ** Domain/environment locks
-  ** No internet connectivity needed
-a|
-* Completely offline operation:
-  ** Local resource bundling
-  ** Network isolation
-  ** Air-gap compliance
+  ** Access to cloud features
+  ** Custom deployment options
 |===
-
-== Configuration Examples
-
-=== Cloud Deployment
-
-[source,javascript]
-----
-tinymce.init({
-  selector: "textarea",
-  plugins: [
-    // Core plugins
-    "advlist", "anchor", "autolink", "charmap", "code", "fullscreen",
-    "help", "image", "insertdatetime", "link", "lists", "media",
-    "preview", "searchreplace", "table", "visualblocks",
-    
-    // Premium plugins (requires valid subscription)
-    "powerpaste", "tinycomments", "tinydrive"
-  ],
-  toolbar: "undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
-  api_key: "no-api-key"
-});
-----
-
-=== Self-hosted Commercial
-
-[source,javascript]
-----
-tinymce.init({
-  selector: "textarea",
-  plugins: [
-    "advlist", "anchor", "autolink", "charmap", "code", "fullscreen",
-    "help", "image", "insertdatetime", "link", "lists", "media",
-    "preview", "searchreplace", "table", "visualblocks",
-    // Premium plugins need to be separately downloaded and included
-    "powerpaste", "tinycomments", "tinydrive"
-  ],
-  toolbar: "undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
-  license_key: "T8LK:your-license-key"  // Your commercial license key
-});
-----
-
-=== Hybrid Deployment
-
-[source,javascript]
-----
-tinymce.init({
-  selector: "textarea",
-  plugins: [
-    // Core plugins
-    "advlist", "anchor", "autolink", "charmap", "code", "fullscreen",
-    "help", "image", "link", "lists",
-    
-    // Premium plugins - ensure these are available both via cloud and locally
-    // Local versions should be downloaded and included in your bundle
-    "powerpaste", "tinycomments", "tinydrive"
-  ],
-  toolbar: "undo redo | styles | bold italic | alignleft aligncenter alignright | bullist numlist | link image",
-  
-  // Cloud configuration with local fallback
-  api_key: "your-api-key",          // For cloud features
-  license_key: "T8LK:your-license", // For local fallback
-  
-  // Failover configuration example
-  serviceLoadFailbackTime: 5000,    // Wait 5s before falling back to local
-  
-  // Custom handler for image uploads with cloud/local failover
-  images_upload_handler: function (blobInfo, progress) {
-    return new Promise((resolve, reject) => {
-      // Example implementation:
-      // 1. Try uploading to cloud service first
-      // 2. If cloud upload fails or times out, fall back to local storage
-      // 3. Handle progress updates for both scenarios
-      // 4. Return the URL of the uploaded image
-      
-      // For detailed implementation, see the Image Upload documentation
-    });
-  }
-});
-----
-
-[NOTE]
-====
-For hybrid deployments:
-
-* Both `api_key` and `license_key` are used together
-* Configure appropriate timeouts for service failover
-* Consider implementing custom handlers for seamless fallback
-* Test both online and offline scenarios
-====
-
-=== Offline/Air-gapped Deployment
-
-[source,javascript]
-----
-tinymce.init({
-  selector: "textarea",
-  plugins: [
-    // Core plugins included in your local bundle
-    "advlist", "anchor", "autolink", "charmap", "code", "fullscreen",
-    "help", "image", "link", "lists",
-    
-    // Premium plugins downloaded and bundled locally
-    "powerpaste", "spelling", "a11ychecker"
-  ],
-  toolbar: "undo redo | styles | bold italic | alignleft aligncenter alignright | bullist numlist outdent indent | link image",
-  // Version-locked key for offline environments
-  license_key: "T8LK:your-version-locked-key",
-  // Ensure all resources are loaded locally
-  skin_url: "/path/to/local/skin",
-  content_css: "/path/to/local/content.css"
-});
-----
-
-[NOTE]
-====
-For offline deployments:
-
-* All assets must be available locally
-* Content delivery URLs should point to local resources
-* Premium plugins must be downloaded and included in your bundle
-* JWT validation is built into the {productname} core and works completely offline:
-  ** No internet connectivity required for license validation
-  ** No server communication or "phone home" checks
-  ** All validation is performed securely within the browser
-====
 
 == License States
 
@@ -248,23 +123,24 @@ For offline deployments:
 | Active
 a|
 * Full editor and premium plugin functionality
-* Regular version upgrades available
 * No restrictions on features
 | All license types
 
 | Grace Period
 a|
 * All features remain functional
-* In-editor notifications about approaching expiration
-* Occurs 30 days before subscription end
-* Time to contact Tiny for renewal
-| Date-based keys only
+* Warnings that the license key is in grace period and will be not work in the future
+| Time-based keys only
 
 | Expired
 a|
-* Date-based keys: Editor disabled
-* Version-locked keys: Cannot use new versions
-* Must obtain new license key after renewal
+* Editor is set to readonly
+* Must obtain a new license key to continue using {productname}
+| Time-based keys only
+| Invalid
+a|
+* Editor is set to readonly
+* Editor notifications notifying that the license key is not valid
 | All license types
 |===
 
@@ -272,66 +148,43 @@ a|
 
 === What does the GPL license mean?
 
-{productname} 7 is licensed under the GNU General Public License Version 2 or later, often abbreviated to GPLv2+. https://www.gnu.org/licenses/old-licenses/gpl-2.0.html[Read more about the license terms here.^]
+{productname} 8 is licensed under the GNU General Public License Version 2 or later, often abbreviated to GPLv2+. https://www.gnu.org/licenses/old-licenses/gpl-2.0.html[Read more about the license terms here.^]
 
 The GPLv2+ license was chosen to provide the best compatibility with existing GPL licensed open source projects.
 
 === What is the difference between a license key and the API key?
 
-The **API key** is used when loading {productname} from the {cloudname} and undergoes server-side validation. The **license key** (starting with `T8LK:` in version 8) is used to declare the license terms when self-hosting {productname}. The license key contains a JSON Web Token (JWT) that enables secure client-side validation performed entirely within the browser, requiring no server communication or "phone home" checks.
+The **API key** is used when loading TinyMCE from the {cloudname}. The license key is used to declare the license terms when self-hosting {productname}.
 
 === Who needs to get a license key?
 
-Anyone who intends to self-host {productname} will need to:
-
-* For version 7: Provide a valid commercial license key or declare their intention to use {productname} under the GPLv2+ license
-* For version 8: Obtain a T8LK-prefixed commercial license key or use GPL mode
+Anyone who intends to self-host {productname} will need to obtain a T8LK-prefixed commercial license key or use GPL mode
 
 === How will I know if this change affects me?
 
-If {productname} detects that the `license_key` configuration is missing or invalid, it will display a console log warning message. These warnings are designed to ensure compliance and provide transparency during evaluation periods.
+If {productname} detects that the `license_key` configuration is missing or invalid, it will display a console log warning message and/or editor notification and set the editor to readonly. These warnings and restrictions are designed to ensure compliance and provide transparency during evaluation periods.
 
 [TIP]
 If you have actively suppressed or hidden these messages, please remove those overrides to maintain proper license validation. If no notification appears, you are not affected.
 
 === Should I be using both an API key and a license key?
 
-For standard deployments, use only one of the following:
-
-* *API key* - For cloud deployments
-** Server-side validation
-** Automatic updates and CDN delivery
-** Premium plugin access via subscription
-** No client-side validation required
-
-* *License key* - For self-hosted deployments
-** Client-side JWT validation is automatically performed
-** T8LK prefix required for version 8
-** Supports air-gapped environments
-** Local premium plugin validation
-
-*Hybrid Deployment Cases:*
-
-* Using both keys together requires specific configuration:
-** Set up cloud services with API key for primary cloud access
-** Configure local fallback with license key for offline operation
-** Configure service failover timeouts (e.g., `serviceLoadFailbackTime`)
-** Ensure premium plugins are available both via cloud and locally
-** Implement custom handlers for seamless cloud/local failover
-** Test both online and offline scenarios thoroughly
+See the <<Deployment Types>> section above for more information.
 
 [IMPORTANT]
 ====
-Only use both keys in properly configured hybrid deployments where you need cloud features with local fallback. Using both keys without proper hybrid deployment configuration **may cause** validation conflicts and unexpected behavior.
+Only use both keys in properly configured hybrid deployments. Using both keys without proper hybrid deployment configuration **may cause** validation conflicts and unexpected behavior.
 ====
 
 === Will {productname} "phone home" to check the license key?
 
-No. {productname} does not contact any server to validate the license key.
+No, {productname} does not contact any server to validate the license key for self-hosted deployments.
+
+If using a cloud or hybrid deployment configuration, the license key may be checked by {cloudname}.
 
 === What happens if I don't provide a valid license key?
 
-The console log message or notification will persist until a valid license key or 'gpl' is provided. 
+In addition to the editor being readonly, a console log warning message and/or editor notification will persist until a valid license key or 'gpl' is provided.
 
 === Why is a license key required?
 

--- a/modules/ROOT/pages/vite-es6-npm.adoc
+++ b/modules/ROOT/pages/vite-es6-npm.adoc
@@ -15,7 +15,17 @@ This guide requires the following:
 
 * Node.js and npm.
 * Basic knowledge of how to use https://vitejs.dev[Vite].
+* For self-hosted deployments: A valid license key starting with `T8LK:` from your link:{accountpageurl}/[{accountpage}]
 * (Optional: For premium features) The latest premium .zip bundle of TinyMCE that includes premium plugins.
+
+[IMPORTANT]
+====
+When self-hosting TinyMCE 8:
+
+* A license key is required for commercial deployments
+* Keys must start with the `T8LK:` prefix
+* For hybrid deployments that need both cloud features and local fallback, you can use both `license_key` and `api_key`
+====
 
 == Procedures
 
@@ -71,5 +81,7 @@ npx vite build
 npx vite preview
 ----
 :!is_zip_install:
+
+
 
 include::partial$module-loading/bundling-next-steps.adoc[]

--- a/modules/ROOT/partials/install/basic-quickstart-base.adoc
+++ b/modules/ROOT/partials/install/basic-quickstart-base.adoc
@@ -182,7 +182,7 @@ ifeval::["{productSource}" != "cloud"]
     <script>
       tinymce.init({
         selector: '#mytextarea',
-        license_key: 'gpl|T8LK:your-license-key' //gpl for open source, T8LK:your-license-key for commercial
+        license_key: 'gpl' // gpl for open source, T8LK:... for commercial
       });
     </script>
   </head>

--- a/modules/ROOT/partials/install/basic-quickstart-base.adoc
+++ b/modules/ROOT/partials/install/basic-quickstart-base.adoc
@@ -182,7 +182,7 @@ ifeval::["{productSource}" != "cloud"]
     <script>
       tinymce.init({
         selector: '#mytextarea',
-        license_key: 'gpl|<your-license-key>'
+        license_key: 'gpl|T8LK:your-license-key' //gpl for open source, T8LK:your-license-key for commercial
       });
     </script>
   </head>

--- a/modules/ROOT/partials/integrations/angular-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/angular-tech-ref.adoc
@@ -132,7 +132,7 @@ include::partial$misc/get-an-api-key.adoc[]
 
 {cloudname} License key.
 
-Use this when self-hosting {productname} instead of loading from {cloudname}. License keys must start with the "T8LK:" prefix and use client-side JWT validation. For more information, see: xref:license-key.adoc[License Key].
+Use this when self-hosting {productname} instead of loading from {cloudname}. License keys must start with the "T8LK:" prefix and use client-side JWT validation that runs entirely in the browser, requiring no server communication or "phone home" checks. For more information, see: xref:license-key.adoc[License Key].
 
 *Type:* `+String+`
 

--- a/modules/ROOT/partials/integrations/angular-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/angular-tech-ref.adoc
@@ -130,18 +130,7 @@ include::partial$misc/get-an-api-key.adoc[]
 [[licensekey]]
 === `+licenseKey+`
 
-{cloudname} License key.
-
-Use this when self-hosting {productname} instead of loading from {cloudname}. For more information, see: xref:license-key.adoc[License Key].
-
-*Type:* `+String+`
-
-*Default value:* `+undefined+`
-
-*Possible values:*
-* `undefined` - Use this when loading from {cloudname} with an API key
-* `'gpl'` - For open source projects using GPL license
-* `'T8LK:...'` - For commercial {productname} installations
+include::partial$integrations/common/license-key-property.adoc[]
 
 ==== Example: Commercial license
 [source,html]

--- a/modules/ROOT/partials/integrations/angular-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/angular-tech-ref.adoc
@@ -132,21 +132,21 @@ include::partial$misc/get-an-api-key.adoc[]
 
 {cloudname} License key.
 
-Use this when self-hosting {productname} instead of loading from {cloudname}. License keys must start with the "T8LK:" prefix and use client-side JWT validation that runs entirely in the browser, requiring no server communication or "phone home" checks. For more information, see: xref:license-key.adoc[License Key].
+Use this when self-hosting {productname} instead of loading from {cloudname}. For more information, see: xref:license-key.adoc[License Key].
 
 *Type:* `+String+`
 
 *Default value:* `+undefined+`
 
-*Possible values:* 
+*Possible values:*
 * `undefined` - Use this when loading from {cloudname} with an API key
 * `'gpl'` - For open source projects using GPL license
-* `'T8LK:your-license-key'` - For commercial {productname} installations
+* `'T8LK:...'` - For commercial {productname} installations
 
 ==== Example: Commercial license
 [source,html]
 ----
-<editor licenseKey="T8LK:your-license-key" />
+<editor licenseKey="T8LK:..." />
 ----
 
 ==== Example: using `+licenseKey+` with GPL

--- a/modules/ROOT/partials/integrations/angular-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/angular-tech-ref.adoc
@@ -132,19 +132,27 @@ include::partial$misc/get-an-api-key.adoc[]
 
 {cloudname} License key.
 
-Use this when self-hosting {productname} instead of loading from {cloudname}. For more information, see: xref:license-key.adoc[License Key].
+Use this when self-hosting {productname} instead of loading from {cloudname}. License keys must start with the "T8LK:" prefix and use client-side JWT validation. For more information, see: xref:license-key.adoc[License Key].
 
 *Type:* `+String+`
 
 *Default value:* `+undefined+`
 
-*Possible values:* `undefined`, `'gpl'` or a valid {productname} license key
+*Possible values:* 
+* `undefined` - Use this when loading from {cloudname} with an API key
+* `'gpl'` - For open source projects using GPL license
+* `'T8LK:your-license-key'` - For commercial {productname} installations
 
-==== Example: using `+licenseKey+`
-
-[source,jsx]
+==== Example: Commercial license
+[source,html]
 ----
-<editor licenseKey='your-license-key' />
+<editor licenseKey="T8LK:your-license-key" />
+----
+
+==== Example: using `+licenseKey+` with GPL
+[source,html]
+----
+<editor licenseKey="gpl" />
 ----
 
 [[cloudchannel]]

--- a/modules/ROOT/partials/integrations/blazor-postinstall.adoc
+++ b/modules/ROOT/partials/integrations/blazor-postinstall.adoc
@@ -101,7 +101,6 @@ ifeval::["{productSource}" != "cloud"]
 +
 [source,cs]
 ----
-// gpl for open source, T8LK:... for commercial
 <Editor LicenseKey="gpl" />
 ----
 +

--- a/modules/ROOT/partials/integrations/blazor-postinstall.adoc
+++ b/modules/ROOT/partials/integrations/blazor-postinstall.adoc
@@ -1,4 +1,4 @@
-. Verify the installation by checking the `+ItemGroup+` references in the project file. For example, if the project is named _BlazorApp_, the relevant file would be `+BlazorApp.csproj+` with the dependency referenced as follows: 
+. Verify the installation by checking the `+ItemGroup+` references in the project file. For example, if the project is named _BlazorApp_, the relevant file would be `+BlazorApp.csproj+` with the dependency referenced as follows:
 +
 [source,xml]
 ----
@@ -16,9 +16,9 @@
 +
 [NOTE]
 ====
-The location of the script depends on the type of Blazor app, including Blazor Server and Blazor WebAssembly (WASM) which are not covered in this guide. 
+The location of the script depends on the type of Blazor app, including Blazor Server and Blazor WebAssembly (WASM) which are not covered in this guide.
 
-* If using Blazor Server, add the script in `+Pages/_Host.cshtml+`, for example: 
+* If using Blazor Server, add the script in `+Pages/_Host.cshtml+`, for example:
 +
 [source,html]
 ----
@@ -35,8 +35,8 @@ The location of the script depends on the type of Blazor app, including Blazor S
 ====
 +
 
-. Add the `+Editor+` component to a page by either:  
-* Using the `+using+` directive:  
+. Add the `+Editor+` component to a page by either:
+* Using the `+using+` directive:
 +
 [source,cs]
 ----
@@ -44,7 +44,7 @@ The location of the script depends on the type of Blazor app, including Blazor S
 <Editor />
 ----
 +
-For example: 
+For example:
 +
 _File:_ `+Pages/Index.razor+`
 +
@@ -58,7 +58,7 @@ _File:_ `+Pages/Index.razor+`
 <h2>Welcome to your new app.</h2>
 <Editor />
 ----
-* Using the component with its namespace: 
+* Using the component with its namespace:
 +
 [source,cs]
 ----
@@ -78,10 +78,10 @@ _File:_ `+Pages/Index.razor+`
 <h1>Hello, world!</h1>
 <h2>Welcome to your new app.</h2>
 <Editor />
----- 
+----
 +
 [IMPORTANT]
-In a Blazor Web App, different render modes determine how components are rendered and how interactivity is handled. To enable JavaScript interactivity, ensure that `+@rendermode InteractiveServer+` is specified in a page component. 
+In a Blazor Web App, different render modes determine how components are rendered and how interactivity is handled. To enable JavaScript interactivity, ensure that `+@rendermode InteractiveServer+` is specified in a page component.
 +
 
 ifeval::["{productSource}" == "cloud"]
@@ -91,7 +91,7 @@ ifeval::["{productSource}" == "cloud"]
 [source,cs]
 ----
 <Editor ApiKey="no-api-key" />
----- 
+----
 +
 endif::[]
 
@@ -101,8 +101,9 @@ ifeval::["{productSource}" != "cloud"]
 +
 [source,cs]
 ----
-<Editor LicenseKey="gpl|T8LK:your-license-key" />
----- 
+// gpl for open source, T8LK:... for commercial
+<Editor LicenseKey="gpl" />
+----
 +
 
 . To load {productname} from the self-hosted package instead of the {cloudname}, configure the `+ScriptSrc+` property:

--- a/modules/ROOT/partials/integrations/blazor-postinstall.adoc
+++ b/modules/ROOT/partials/integrations/blazor-postinstall.adoc
@@ -101,7 +101,7 @@ ifeval::["{productSource}" != "cloud"]
 +
 [source,cs]
 ----
-<Editor LicenseKey="your-license-key" />
+<Editor LicenseKey="gpl|T8LK:your-license-key" />
 ---- 
 +
 

--- a/modules/ROOT/partials/integrations/blazor-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/blazor-tech-ref.adoc
@@ -19,7 +19,7 @@ The `+TinyMCE.Blazor+` `+Editor+` component accepts the following properties:
   JsConfSrc="path_to_jsObj"
   Conf="@yourConf"
   ApiKey="no-api-key"
-  LicenseKey="gpl" // gpl for open source, T8LK:... for commercial
+  LicenseKey="gpl"
   ScriptSrc="/path/to/tinymce.min.js"
   ClassName="tinymce-wrapper"
 />

--- a/modules/ROOT/partials/integrations/blazor-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/blazor-tech-ref.adoc
@@ -188,18 +188,35 @@ In your component:
 
 === `LicenseKey`
 
-Specifies the {productname} license key. Required for self-hosted deployments of {productname}. This property is not required for deployments using the {cloudname}. For more information on licensing, see: xref:license-key.adoc[License key].
+Specifies the {productname} license key. Required for self-hosted deployments of {productname}. This property is not required for deployments using the {cloudname}.
+
+License keys must start with the "T8LK:" prefix and use client-side JWT validation. For more information, see: xref:license-key.adoc[License Key].
 
 *Type:* `+String+`
 
-==== Example using LicenseKey
+*Possible values:* 
+* `null` - Use this when loading from {cloudname} with an API key
+* `"gpl"` - For open source projects using GPL license
+* `"T8LK:your-license-key"` - For commercial {productname} installations
 
+==== Example: Commercial license (TinyMCE 8+)
 [source,cs]
 ----
 <Editor
-  LicenseKey="your-license-key"
+  LicenseKey="T8LK:your-license-key"
 />
 ----
+Use this example when you have a commercial license for TinyMCE 8 or newer. The T8LK prefix is required.
+
+==== Example: Open source GPL license
+[source,cs]
+----
+<Editor
+  LicenseKey="gpl"
+/>
+----
+
+Use this example when you're using TinyMCE under the open source GPL license in a self-hosted environment.
 
 === `ScriptSrc`
 

--- a/modules/ROOT/partials/integrations/blazor-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/blazor-tech-ref.adoc
@@ -19,7 +19,7 @@ The `+TinyMCE.Blazor+` `+Editor+` component accepts the following properties:
   JsConfSrc="path_to_jsObj"
   Conf="@yourConf"
   ApiKey="no-api-key"
-  LicenseKey="your-license-key"
+  LicenseKey="T8LK:your-license-key"
   ScriptSrc="/path/to/tinymce.min.js"
   ClassName="tinymce-wrapper"
 />

--- a/modules/ROOT/partials/integrations/blazor-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/blazor-tech-ref.adoc
@@ -19,7 +19,7 @@ The `+TinyMCE.Blazor+` `+Editor+` component accepts the following properties:
   JsConfSrc="path_to_jsObj"
   Conf="@yourConf"
   ApiKey="no-api-key"
-  LicenseKey="T8LK:your-license-key"
+  LicenseKey="gpl" // gpl for open source, T8LK:... for commercial
   ScriptSrc="/path/to/tinymce.min.js"
   ClassName="tinymce-wrapper"
 />
@@ -194,16 +194,16 @@ License keys must start with the "T8LK:" prefix and use client-side JWT validati
 
 *Type:* `+String+`
 
-*Possible values:* 
+*Possible values:*
 * `null` - Use this when loading from {cloudname} with an API key
 * `"gpl"` - For open source projects using GPL license
-* `"T8LK:your-license-key"` - For commercial {productname} installations
+* `"T8LK:..."` - For commercial {productname} installations
 
 ==== Example: Commercial license (TinyMCE 8+)
 [source,cs]
 ----
 <Editor
-  LicenseKey="T8LK:your-license-key"
+  LicenseKey="T8LK:..."
 />
 ----
 

--- a/modules/ROOT/partials/integrations/blazor-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/blazor-tech-ref.adoc
@@ -188,16 +188,8 @@ In your component:
 
 === `LicenseKey`
 
-Specifies the {productname} license key. Required for self-hosted deployments of {productname}. This property is not required for deployments using the {cloudname}.
 
-License keys must start with the "T8LK:" prefix and use client-side JWT validation that runs entirely in the browser, requiring no server communication or "phone home" checks. For more information, see: xref:license-key.adoc[License Key].
-
-*Type:* `+String+`
-
-*Possible values:*
-* `null` - Use this when loading from {cloudname} with an API key
-* `"gpl"` - For open source projects using GPL license
-* `"T8LK:..."` - For commercial {productname} installations
+include::partial$integrations/common/license-key-property.adoc[]
 
 ==== Example: Commercial license (TinyMCE 8+)
 [source,cs]

--- a/modules/ROOT/partials/integrations/blazor-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/blazor-tech-ref.adoc
@@ -190,7 +190,7 @@ In your component:
 
 Specifies the {productname} license key. Required for self-hosted deployments of {productname}. This property is not required for deployments using the {cloudname}.
 
-License keys must start with the "T8LK:" prefix and use client-side JWT validation. For more information, see: xref:license-key.adoc[License Key].
+License keys must start with the "T8LK:" prefix and use client-side JWT validation that runs entirely in the browser, requiring no server communication or "phone home" checks. For more information, see: xref:license-key.adoc[License Key].
 
 *Type:* `+String+`
 
@@ -206,6 +206,7 @@ License keys must start with the "T8LK:" prefix and use client-side JWT validati
   LicenseKey="T8LK:your-license-key"
 />
 ----
+
 Use this example when you have a commercial license for TinyMCE 8 or newer. The T8LK prefix is required.
 
 ==== Example: Open source GPL license

--- a/modules/ROOT/partials/integrations/common/license-key-property.adoc
+++ b/modules/ROOT/partials/integrations/common/license-key-property.adoc
@@ -1,0 +1,19 @@
+Specifies the {productname} license key. Required for self-hosted deployments of {productname}. This property is **not required** for cloud-only deployments using the {cloudname} as your cloud subscription automatically includes the commercial license. For more information, see: xref:license-key.adoc[License Key].
+
+*Type:* `+String+`
+
+*Default value:* `+undefined+`
+
+*Possible values:*
+* `undefined` - Use this when loading from {cloudname} with an API key
+* `'gpl'` - For open source projects using GPL license
+* `'T8LK:...'` - For commercial {productname} installations (must use this prefix for version 8+)
+
+[NOTE]
+====
+In hybrid deployments (using both cloud and self-hosted features):
+
+* You can provide both an API key and a license key
+* The editor will use cloud services when available
+* It will automatically fall back to the local license key if cloud services are not contactable
+====

--- a/modules/ROOT/partials/integrations/common/license-key-property.adoc
+++ b/modules/ROOT/partials/integrations/common/license-key-property.adoc
@@ -8,6 +8,7 @@ Specifies the {productname} license key. Required for self-hosted deployments of
 * `undefined` - Use this when loading from {cloudname} with an API key
 * `'gpl'` - For open source projects using GPL license
 * `'T8LK:...'` - For commercial {productname} installations (must use this prefix for version 8+)
+* `'GPL+T8LK:'` - For open source projects that require premium features while maintaining GPL compliance.
 
 [NOTE]
 ====

--- a/modules/ROOT/partials/integrations/jquery-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/jquery-quick-start.adoc
@@ -119,7 +119,7 @@ ifeval::["{productSource}" == "package-manager"]
 <script>
   $('textarea#tiny').tinymce({
     height: 500,
-    license_key: 'gpl|T8LK:your-license-key' //gpl for open source, T8LK:your-license-key for commercial
+    license_key: 'gpl' // gpl for open source, T8LK:... for commercial
     /* other settings... */,
   });
 </script>
@@ -149,7 +149,7 @@ ifeval::["{productSource}" == "package-manager"]
     <script>
       $('textarea#tiny').tinymce({
         height: 500,
-        license_key: 'gpl|T8LK:your-license-key' //gpl for open source, T8LK:your-license-key for commercial
+        license_key: 'gpl' // gpl for open source, T8LK:... for commercial
         menubar: false,
         plugins: [
           'advlist', 'autolink', 'lists', 'link', 'image', 'charmap', 'preview',

--- a/modules/ROOT/partials/integrations/jquery-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/jquery-quick-start.adoc
@@ -119,7 +119,7 @@ ifeval::["{productSource}" == "package-manager"]
 <script>
   $('textarea#tiny').tinymce({
     height: 500,
-    license_key: 'gpl' // gpl for open source, T8LK:... for commercial
+    license_key: 'gpl'
     /* other settings... */,
   });
 </script>
@@ -149,7 +149,7 @@ ifeval::["{productSource}" == "package-manager"]
     <script>
       $('textarea#tiny').tinymce({
         height: 500,
-        license_key: 'gpl' // gpl for open source, T8LK:... for commercial
+        license_key: 'gpl'
         menubar: false,
         plugins: [
           'advlist', 'autolink', 'lists', 'link', 'image', 'charmap', 'preview',

--- a/modules/ROOT/partials/integrations/jquery-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/jquery-quick-start.adoc
@@ -119,7 +119,7 @@ ifeval::["{productSource}" == "package-manager"]
 <script>
   $('textarea#tiny').tinymce({
     height: 500,
-    license_key: '<your license key>',
+    license_key: 'gpl|T8LK:your-license-key' //gpl for open source, T8LK:your-license-key for commercial
     /* other settings... */,
   });
 </script>
@@ -149,7 +149,7 @@ ifeval::["{productSource}" == "package-manager"]
     <script>
       $('textarea#tiny').tinymce({
         height: 500,
-        license_key: '<your-license-key>',
+        license_key: 'gpl|T8LK:your-license-key' //gpl for open source, T8LK:your-license-key for commercial
         menubar: false,
         plugins: [
           'advlist', 'autolink', 'lists', 'link', 'image', 'charmap', 'preview',

--- a/modules/ROOT/partials/integrations/react-bundling.adoc
+++ b/modules/ROOT/partials/integrations/react-bundling.adoc
@@ -41,7 +41,7 @@ import 'tinymce/skins/ui/oxide/content.js';
 export default function TinyEditorComponent(props) {
   return (
     <Editor
-      licenseKey='your-license-key'
+      licenseKey='gpl|T8LK:your-license-key' // gpl for open source, T8LK:your-license-key for commercial
       {...props}
     />
   );

--- a/modules/ROOT/partials/integrations/react-bundling.adoc
+++ b/modules/ROOT/partials/integrations/react-bundling.adoc
@@ -41,7 +41,7 @@ import 'tinymce/skins/ui/oxide/content.js';
 export default function TinyEditorComponent(props) {
   return (
     <Editor
-      licenseKey='gpl|T8LK:your-license-key' // gpl for open source, T8LK:your-license-key for commercial
+      licenseKey='gpl' // gpl for open source, T8LK:... for commercial
       {...props}
     />
   );

--- a/modules/ROOT/partials/integrations/react-bundling.adoc
+++ b/modules/ROOT/partials/integrations/react-bundling.adoc
@@ -41,7 +41,7 @@ import 'tinymce/skins/ui/oxide/content.js';
 export default function TinyEditorComponent(props) {
   return (
     <Editor
-      licenseKey='gpl' // gpl for open source, T8LK:... for commercial
+      licenseKey='gpl'
       {...props}
     />
   );

--- a/modules/ROOT/partials/integrations/react-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/react-quick-start.adoc
@@ -496,7 +496,7 @@ import './tinymce/skins/ui/oxide/content.js';
 export default function BundledEditor(props) {
   return (
     <Editor
-      licenseKey='gpl' // gpl for open source, T8LK:... for commercial
+      licenseKey='gpl'
       {...props}
     />
   );

--- a/modules/ROOT/partials/integrations/react-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/react-quick-start.adoc
@@ -149,7 +149,7 @@ export default function App() {
     <>
       <Editor
         tinymceScriptSrc='/tinymce/tinymce.min.js'
-        licenseKey='gpl' // gpl for open source, T8LK:... for commercial
+        licenseKey='gpl'
         onInit={(_evt, editor) => editorRef.current = editor}
         initialValue='<p>This is the initial content of the editor.</p>'
         init={{
@@ -243,7 +243,7 @@ import 'tinymce/skins/ui/oxide/content';
 export default function BundledEditor(props) {
   return (
     <Editor
-      licenseKey='gpl' // gpl for open source, T8LK:... for commercial
+      licenseKey='gpl'
       {...props}
     />
   );
@@ -358,7 +358,7 @@ export default function App() {
     <>
       <Editor
         tinymceScriptSrc='/tinymce/tinymce.min.js'
-        licenseKey='gpl' // gpl for open source, T8LK:... for commercial
+        licenseKey='gpl'
         onInit={(_evt, editor) => editorRef.current = editor}
         initialValue='<p>This is the initial content of the editor.</p>'
         init={{

--- a/modules/ROOT/partials/integrations/react-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/react-quick-start.adoc
@@ -149,7 +149,7 @@ export default function App() {
     <>
       <Editor
         tinymceScriptSrc='/tinymce/tinymce.min.js'
-        licenseKey='your-license-key'
+        licenseKey='gpl|T8LK:your-license-key' // gpl for open source, T8LK:your-license-key for commercial
         onInit={(_evt, editor) => editorRef.current = editor}
         initialValue='<p>This is the initial content of the editor.</p>'
         init={{
@@ -243,7 +243,7 @@ import 'tinymce/skins/ui/oxide/content';
 export default function BundledEditor(props) {
   return (
     <Editor
-      licenseKey='your-license-key'
+      licenseKey='gpl|T8LK:your-license-key' // gpl for open source, T8LK:your-license-key for commercial
       {...props}
     />
   );
@@ -358,7 +358,7 @@ export default function App() {
     <>
       <Editor
         tinymceScriptSrc='/tinymce/tinymce.min.js'
-        licenseKey='your-license-key'
+        licenseKey='gpl|T8LK:your-license-key' // gpl for open source, T8LK:your-license-key for commercial
         onInit={(_evt, editor) => editorRef.current = editor}
         initialValue='<p>This is the initial content of the editor.</p>'
         init={{
@@ -496,7 +496,7 @@ import './tinymce/skins/ui/oxide/content.js';
 export default function BundledEditor(props) {
   return (
     <Editor
-      licenseKey='your-lisense-key'
+      licenseKey='gpl|T8LK:your-license-key' // gpl for open source, T8LK:your-license-key for commercial
       {...props}
     />
   );

--- a/modules/ROOT/partials/integrations/react-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/react-quick-start.adoc
@@ -149,7 +149,7 @@ export default function App() {
     <>
       <Editor
         tinymceScriptSrc='/tinymce/tinymce.min.js'
-        licenseKey='gpl|T8LK:your-license-key' // gpl for open source, T8LK:your-license-key for commercial
+        licenseKey='gpl' // gpl for open source, T8LK:... for commercial
         onInit={(_evt, editor) => editorRef.current = editor}
         initialValue='<p>This is the initial content of the editor.</p>'
         init={{
@@ -243,7 +243,7 @@ import 'tinymce/skins/ui/oxide/content';
 export default function BundledEditor(props) {
   return (
     <Editor
-      licenseKey='gpl|T8LK:your-license-key' // gpl for open source, T8LK:your-license-key for commercial
+      licenseKey='gpl' // gpl for open source, T8LK:... for commercial
       {...props}
     />
   );
@@ -358,7 +358,7 @@ export default function App() {
     <>
       <Editor
         tinymceScriptSrc='/tinymce/tinymce.min.js'
-        licenseKey='gpl|T8LK:your-license-key' // gpl for open source, T8LK:your-license-key for commercial
+        licenseKey='gpl' // gpl for open source, T8LK:... for commercial
         onInit={(_evt, editor) => editorRef.current = editor}
         initialValue='<p>This is the initial content of the editor.</p>'
         init={{
@@ -496,7 +496,7 @@ import './tinymce/skins/ui/oxide/content.js';
 export default function BundledEditor(props) {
   return (
     <Editor
-      licenseKey='gpl|T8LK:your-license-key' // gpl for open source, T8LK:your-license-key for commercial
+      licenseKey='gpl' // gpl for open source, T8LK:... for commercial
       {...props}
     />
   );

--- a/modules/ROOT/partials/integrations/react-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/react-tech-ref.adoc
@@ -189,7 +189,7 @@ include::partial$misc/get-an-api-key.adoc[]
 
 {cloudname} License key.
 
-Use this when self-hosting {productname} instead of loading from {cloudname}. License keys must start with the "T8LK:" prefix and use client-side JWT validation. For more information, see: xref:license-key.adoc[License Key].
+Use this when self-hosting {productname} instead of loading from {cloudname}. License keys must start with the "T8LK:" prefix and use client-side JWT validation that runs entirely in the browser, requiring no server communication or "phone home" checks. For more information, see: xref:license-key.adoc[License Key].
 
 *Type:* `+String+`
 

--- a/modules/ROOT/partials/integrations/react-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/react-tech-ref.adoc
@@ -195,16 +195,16 @@ Use this when self-hosting {productname} instead of loading from {cloudname}. Li
 
 *Default value:* `+undefined+`
 
-*Possible values:* 
+*Possible values:*
 * `undefined` - Use this when loading from {cloudname} with an API key
 * `'gpl'` - For open source projects using GPL license
-* `'T8LK:your-license-key'` - For commercial {productname} installations
+* `'T8LK:...'` - For commercial {productname} installations
 
 ==== Example: Commercial license
 [source,jsx]
 ----
 <Editor
-  licenseKey='T8LK:your-license-key'
+  licenseKey='T8LK:...'
 />
 ----
 
@@ -394,7 +394,7 @@ For detailed information on using `+onEditorChange+`, see: xref:using-the-tinymc
 
 IMPORTANT: This option was removed with the release of the {productname} React component 4.0.0.
 
-This option was used to specify the format of the content produced by the 
+This option was used to specify the format of the content produced by the
 xref:oneditorchange[`+onEditorChange+`] event, however as it did not change the
 input format it was almost impossible to use correctly.
 

--- a/modules/ROOT/partials/integrations/react-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/react-tech-ref.adoc
@@ -189,20 +189,30 @@ include::partial$misc/get-an-api-key.adoc[]
 
 {cloudname} License key.
 
-Use this when self-hosting {productname} instead of loading from {cloudname}. For more information, see: xref:license-key.adoc[License Key].
+Use this when self-hosting {productname} instead of loading from {cloudname}. License keys must start with the "T8LK:" prefix and use client-side JWT validation. For more information, see: xref:license-key.adoc[License Key].
 
 *Type:* `+String+`
 
 *Default value:* `+undefined+`
 
-*Possible values:* `undefined`, `'gpl'` or a valid {productname} license key
+*Possible values:* 
+* `undefined` - Use this when loading from {cloudname} with an API key
+* `'gpl'` - For open source projects using GPL license
+* `'T8LK:your-license-key'` - For commercial {productname} installations
 
-==== Example: using `+licenseKey+`
-
+==== Example: Commercial license
 [source,jsx]
 ----
 <Editor
-  licenseKey='your-license-key'
+  licenseKey='T8LK:your-license-key'
+/>
+----
+
+==== Example: using `+licenseKey+` with GPL
+[source,jsx]
+----
+<Editor
+  licenseKey='gpl'
 />
 ----
 

--- a/modules/ROOT/partials/integrations/react-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/react-tech-ref.adoc
@@ -187,18 +187,8 @@ include::partial$misc/get-an-api-key.adoc[]
 [[licenseKey]]
 === `+licenseKey+`
 
-{cloudname} License key.
 
-Use this when self-hosting {productname} instead of loading from {cloudname}. License keys must start with the "T8LK:" prefix and use client-side JWT validation that runs entirely in the browser, requiring no server communication or "phone home" checks. For more information, see: xref:license-key.adoc[License Key].
-
-*Type:* `+String+`
-
-*Default value:* `+undefined+`
-
-*Possible values:*
-* `undefined` - Use this when loading from {cloudname} with an API key
-* `'gpl'` - For open source projects using GPL license
-* `'T8LK:...'` - For commercial {productname} installations
+include::partial$integrations/common/license-key-property.adoc[]
 
 ==== Example: Commercial license
 [source,jsx]

--- a/modules/ROOT/partials/integrations/svelte-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/svelte-quick-start.adoc
@@ -1,4 +1,4 @@
-The https://github.com/tinymce/tinymce-svelte[Official {productname} Svelte component] integrates {productname} into https://svelte.dev/[Svelte applications].  
+The https://github.com/tinymce/tinymce-svelte[Official {productname} Svelte component] integrates {productname} into https://svelte.dev/[Svelte applications].
 Creates a basic Svelte application containing a {productname} editor.
 
 For examples of the {productname} integration, visit the https://tinymce.github.io/tinymce-svelte/[tinymce-svelte storybook].
@@ -118,7 +118,7 @@ export default defineConfig({
 ----
 . Open `+src/App.svelte+` and replace the contents with:
 +
-[source,html]
+[source,javascript]
 ----
 <script>
 import Editor from '@tinymce/tinymce-svelte';
@@ -139,7 +139,7 @@ let conf = {
 <main>
   <h1>Hello Tiny</h1>
   <Editor
-    licenseKey='T8LK:your-license-key'
+    licenseKey='gpl', // gpl for open source, T8LK:... for commercial
     scriptSrc='tinymce/tinymce.min.js'
     value='<p>This is the initial content of the editor.</p>'
     {conf}
@@ -154,7 +154,7 @@ ifeval::["{productSource}" == "zip"]
 
 . Open `+src/App.svelte+` and replace the contents with:
 +
-[source,html]
+[source,javascript]
 ----
 <script>
 import Editor from '@tinymce/tinymce-svelte';
@@ -175,7 +175,7 @@ let conf = {
 <main>
   <h1>Hello Tiny</h1>
   <Editor
-    licenseKey='T8LK:your-license-key'
+    license_key: 'gpl', // gpl for open source, T8LK:... for commercial
     scriptSrc='/path/or/url/to/tinymce.min.js'
     value='<p>This is the initial content of the editor.</p>'
     {conf}

--- a/modules/ROOT/partials/integrations/svelte-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/svelte-quick-start.adoc
@@ -118,7 +118,7 @@ export default defineConfig({
 ----
 . Open `+src/App.svelte+` and replace the contents with:
 +
-[source,javascript]
+[source,svelte]
 ----
 <script>
 import Editor from '@tinymce/tinymce-svelte';

--- a/modules/ROOT/partials/integrations/svelte-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/svelte-quick-start.adoc
@@ -175,7 +175,7 @@ let conf = {
 <main>
   <h1>Hello Tiny</h1>
   <Editor
-    license_key: 'gpl', // gpl for open source, T8LK:... for commercial
+    license_key: 'gpl',
     scriptSrc='/path/or/url/to/tinymce.min.js'
     value='<p>This is the initial content of the editor.</p>'
     {conf}

--- a/modules/ROOT/partials/integrations/svelte-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/svelte-quick-start.adoc
@@ -74,7 +74,6 @@ let conf = {
   <h1>Hello Tiny</h1>
   <Editor
     apiKey='no-api-key'
-    pass:a[channel='{productmajorversion}']
     value='<p>This is the initial content of the editor.</p>'
     {conf}
   />
@@ -140,7 +139,7 @@ let conf = {
 <main>
   <h1>Hello Tiny</h1>
   <Editor
-    licenseKey='your-license-key'
+    licenseKey='T8LK:your-license-key'
     scriptSrc='tinymce/tinymce.min.js'
     value='<p>This is the initial content of the editor.</p>'
     {conf}
@@ -176,7 +175,7 @@ let conf = {
 <main>
   <h1>Hello Tiny</h1>
   <Editor
-    licenseKey='your-license-key'
+    licenseKey='T8LK:your-license-key'
     scriptSrc='/path/or/url/to/tinymce.min.js'
     value='<p>This is the initial content of the editor.</p>'
     {conf}

--- a/modules/ROOT/partials/integrations/svelte-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/svelte-quick-start.adoc
@@ -139,7 +139,7 @@ let conf = {
 <main>
   <h1>Hello Tiny</h1>
   <Editor
-    licenseKey='gpl', // gpl for open source, T8LK:... for commercial
+    licenseKey='gpl'
     scriptSrc='tinymce/tinymce.min.js'
     value='<p>This is the initial content of the editor.</p>'
     {conf}

--- a/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
@@ -58,20 +58,30 @@ include::partial$misc/get-an-api-key.adoc[]
 
 {cloudname} License key.
 
-Use this option when self-hosting {productname} instead of loading from {cloudname}. For more information, see: xref:license-key.adoc[License Key].
+Use this option when self-hosting {productname} instead of loading from {cloudname}. License keys must start with the "T8LK:" prefix and use client-side JWT validation. For more information, see: xref:license-key.adoc[License Key].
 
 *Type:* `+String+`
 
 *Default value:* `+undefined+`
 
-*Possible values:* `undefined`, `'gpl'` or a valid {productname} license key
+*Possible values:* 
+* `undefined` - Use this when loading from {cloudname} with an API key
+* `'gpl'` - For open source projects using GPL license
+* `'T8LK:your-license-key'` - For commercial {productname} installations
 
-==== Example: using `+licenseKey+`
-
+==== Example: Commercial license
 [source,jsx]
 ----
 <Editor
-  licenseKey="your-license-key"
+  licenseKey="T8LK:your-license-key"
+/>
+----
+
+==== Example: using `+licenseKey+` with GPL
+[source,jsx]
+----
+<Editor
+  licenseKey="gpl"
 />
 ----
 

--- a/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
@@ -56,18 +56,8 @@ include::partial$misc/get-an-api-key.adoc[]
 [[licensekey]]
 === `+licenseKey+`
 
-{cloudname} License key.
 
-Use this option when self-hosting {productname} instead of loading from {cloudname}. License keys must start with the "T8LK:" prefix and use client-side JWT validation that runs entirely in the browser, requiring no server communication or "phone home" checks. For more information, see: xref:license-key.adoc[License Key].
-
-*Type:* `+String+`
-
-*Default value:* `+undefined+`
-
-*Possible values:*
-* `undefined` - Use this when loading from {cloudname} with an API key
-* `'gpl'` - For open source projects using GPL license
-* `'T8LK:...'` - For commercial {productname} installations
+include::partial$integrations/common/license-key-property.adoc[]
 
 ==== Example: Commercial license
 [source,jsx]

--- a/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
@@ -58,7 +58,7 @@ include::partial$misc/get-an-api-key.adoc[]
 
 {cloudname} License key.
 
-Use this option when self-hosting {productname} instead of loading from {cloudname}. License keys must start with the "T8LK:" prefix and use client-side JWT validation. For more information, see: xref:license-key.adoc[License Key].
+Use this option when self-hosting {productname} instead of loading from {cloudname}. License keys must start with the "T8LK:" prefix and use client-side JWT validation that runs entirely in the browser, requiring no server communication or "phone home" checks. For more information, see: xref:license-key.adoc[License Key].
 
 *Type:* `+String+`
 

--- a/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
@@ -64,16 +64,16 @@ Use this option when self-hosting {productname} instead of loading from {cloudna
 
 *Default value:* `+undefined+`
 
-*Possible values:* 
+*Possible values:*
 * `undefined` - Use this when loading from {cloudname} with an API key
 * `'gpl'` - For open source projects using GPL license
-* `'T8LK:your-license-key'` - For commercial {productname} installations
+* `'T8LK:...'` - For commercial {productname} installations
 
 ==== Example: Commercial license
 [source,jsx]
 ----
 <Editor
-  licenseKey="T8LK:your-license-key"
+  licenseKey="T8LK:..."
 />
 ----
 

--- a/modules/ROOT/partials/integrations/vue-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/vue-quick-start.adoc
@@ -167,7 +167,7 @@ import Editor from '@tinymce/tinymce-vue'
     <img alt="Vue logo" class="logo" src="./assets/logo.svg" width="125" height="125" />
     <editor
       id="uuid"
-      licenseKey="gpl" /* gpl for open source, T8LK:... for commercial */
+      licenseKey="gpl"
       :init="{
         plugins: 'advlist anchor autolink charmap code fullscreen help image insertdatetime link lists media preview searchreplace table visualblocks wordcount',
         toolbar: 'undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image',
@@ -213,7 +213,7 @@ import Editor from '@tinymce/tinymce-vue'
     <img alt="Vue logo" class="logo" src="./assets/logo.svg" width="125" height="125" />
     <editor
       id="uuid"
-      licenseKey="gpl" /* gpl for open source, T8LK:... for commercial */
+      licenseKey="gpl"
       :init="{
         plugins: 'advlist anchor autolink charmap code fullscreen help image insertdatetime link lists media preview searchreplace table visualblocks wordcount',
         toolbar: 'undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image',

--- a/modules/ROOT/partials/integrations/vue-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/vue-quick-start.adoc
@@ -213,7 +213,7 @@ import Editor from '@tinymce/tinymce-vue'
     <img alt="Vue logo" class="logo" src="./assets/logo.svg" width="125" height="125" />
     <editor
       id="uuid"
-      licenseKey="gpl" // gpl for open source, T8LK:... for commercial
+      licenseKey="gpl" /* gpl for open source, T8LK:... for commercial */
       :init="{
         plugins: 'advlist anchor autolink charmap code fullscreen help image insertdatetime link lists media preview searchreplace table visualblocks wordcount',
         toolbar: 'undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image',

--- a/modules/ROOT/partials/integrations/vue-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/vue-quick-start.adoc
@@ -167,7 +167,7 @@ import Editor from '@tinymce/tinymce-vue'
     <img alt="Vue logo" class="logo" src="./assets/logo.svg" width="125" height="125" />
     <editor
       id="uuid"
-      licenseKey="gpl" // gpl for open source, T8LK:... for commercial
+      licenseKey="gpl" /* gpl for open source, T8LK:... for commercial */
       :init="{
         plugins: 'advlist anchor autolink charmap code fullscreen help image insertdatetime link lists media preview searchreplace table visualblocks wordcount',
         toolbar: 'undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image',

--- a/modules/ROOT/partials/integrations/vue-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/vue-quick-start.adoc
@@ -167,7 +167,7 @@ import Editor from '@tinymce/tinymce-vue'
     <img alt="Vue logo" class="logo" src="./assets/logo.svg" width="125" height="125" />
     <editor
       id="uuid"
-      licenseKey="gpl|T8LK:your-license-key" // gpl for open source, T8LK:your-license-key for commercial
+      licenseKey="gpl" // gpl for open source, T8LK:... for commercial
       :init="{
         plugins: 'advlist anchor autolink charmap code fullscreen help image insertdatetime link lists media preview searchreplace table visualblocks wordcount',
         toolbar: 'undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image',
@@ -213,7 +213,7 @@ import Editor from '@tinymce/tinymce-vue'
     <img alt="Vue logo" class="logo" src="./assets/logo.svg" width="125" height="125" />
     <editor
       id="uuid"
-      licenseKey="gpl|T8LK:your-license-key" // gpl for open source, T8LK:your-license-key for commercial
+      licenseKey="gpl" // gpl for open source, T8LK:... for commercial
       :init="{
         plugins: 'advlist anchor autolink charmap code fullscreen help image insertdatetime link lists media preview searchreplace table visualblocks wordcount',
         toolbar: 'undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image',

--- a/modules/ROOT/partials/integrations/vue-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/vue-quick-start.adoc
@@ -167,7 +167,7 @@ import Editor from '@tinymce/tinymce-vue'
     <img alt="Vue logo" class="logo" src="./assets/logo.svg" width="125" height="125" />
     <editor
       id="uuid"
-      licenseKey="gpl"
+      licenseKey="gpl|T8LK:your-license-key" // gpl for open source, T8LK:your-license-key for commercial
       :init="{
         plugins: 'advlist anchor autolink charmap code fullscreen help image insertdatetime link lists media preview searchreplace table visualblocks wordcount',
         toolbar: 'undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image',
@@ -213,7 +213,7 @@ import Editor from '@tinymce/tinymce-vue'
     <img alt="Vue logo" class="logo" src="./assets/logo.svg" width="125" height="125" />
     <editor
       id="uuid"
-      licenseKey="gpl"
+      licenseKey="gpl|T8LK:your-license-key" // gpl for open source, T8LK:your-license-key for commercial
       :init="{
         plugins: 'advlist anchor autolink charmap code fullscreen help image insertdatetime link lists media preview searchreplace table visualblocks wordcount',
         toolbar: 'undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image',

--- a/modules/ROOT/partials/integrations/vue-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/vue-tech-ref.adoc
@@ -145,16 +145,16 @@ Use this when self-hosting {productname} instead of loading from {cloudname}. Li
 
 *Default value:* `+undefined+`
 
-*Possible values:* 
+*Possible values:*
 * `undefined` - Use this when loading from {cloudname} with an API key
 * `'gpl'` - For open source projects using GPL license
-* `'T8LK:your-license-key'` - For commercial {productname} installations
+* `'T8LK:...'` - For commercial {productname} installations
 
 ==== Example: Commercial license
 [source,html]
 ----
 <editor
-  licenseKey="T8LK:your-license-key"
+  licenseKey="T8LK:..."
 />
 ----
 

--- a/modules/ROOT/partials/integrations/vue-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/vue-tech-ref.adoc
@@ -139,20 +139,30 @@ include::partial$misc/get-an-api-key.adoc[]
 
 {cloudname} License key.
 
-Use this when self-hosting {productname} instead of loading from {cloudname}. For more information, see: xref:license-key.adoc[License Key].
+Use this when self-hosting {productname} instead of loading from {cloudname}. License keys must start with the "T8LK:" prefix and use client-side JWT validation. For more information, see: xref:license-key.adoc[License Key].
 
 *Type:* `+String+`
 
 *Default value:* `+undefined+`
 
-*Possible values:* `undefined`, `'gpl'` or a valid {productname} license key
+*Possible values:* 
+* `undefined` - Use this when loading from {cloudname} with an API key
+* `'gpl'` - For open source projects using GPL license
+* `'T8LK:your-license-key'` - For commercial {productname} installations
 
-==== Example: using `+licenseKey+`
-
+==== Example: Commercial license
 [source,html]
 ----
 <editor
-  licenseKey="your-license-key"
+  licenseKey="T8LK:your-license-key"
+/>
+----
+
+==== Example: using `+licenseKey+` with GPL
+[source,html]
+----
+<editor
+  licenseKey="gpl"
 />
 ----
 

--- a/modules/ROOT/partials/integrations/vue-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/vue-tech-ref.adoc
@@ -137,18 +137,8 @@ include::partial$misc/get-an-api-key.adoc[]
 [[license-key]]
 === `+licenseKey+`
 
-{cloudname} License key.
 
-Use this when self-hosting {productname} instead of loading from {cloudname}. License keys must start with the "T8LK:" prefix and use client-side JWT validation that runs entirely in the browser, requiring no server communication or "phone home" checks. For more information, see: xref:license-key.adoc[License Key].
-
-*Type:* `+String+`
-
-*Default value:* `+undefined+`
-
-*Possible values:*
-* `undefined` - Use this when loading from {cloudname} with an API key
-* `'gpl'` - For open source projects using GPL license
-* `'T8LK:...'` - For commercial {productname} installations
+include::partial$integrations/common/license-key-property.adoc[]
 
 ==== Example: Commercial license
 [source,html]

--- a/modules/ROOT/partials/integrations/vue-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/vue-tech-ref.adoc
@@ -139,7 +139,7 @@ include::partial$misc/get-an-api-key.adoc[]
 
 {cloudname} License key.
 
-Use this when self-hosting {productname} instead of loading from {cloudname}. License keys must start with the "T8LK:" prefix and use client-side JWT validation. For more information, see: xref:license-key.adoc[License Key].
+Use this when self-hosting {productname} instead of loading from {cloudname}. License keys must start with the "T8LK:" prefix and use client-side JWT validation that runs entirely in the browser, requiring no server communication or "phone home" checks. For more information, see: xref:license-key.adoc[License Key].
 
 *Type:* `+String+`
 

--- a/modules/ROOT/partials/integrations/webcomponent-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/webcomponent-quick-start.adoc
@@ -88,7 +88,7 @@ ifeval::["{productSource}" != "cloud"]
 +
 [source,html,subs="attributes+"]
 ----
-<tinymce-editor license-key="your-license-key"></tinymce-editor>
+<tinymce-editor license-key="T8LK:your-license-key-here"></tinymce-editor>
 ----
 The default {productname} editor will load at this location if the page is opened in a web browser.
 

--- a/modules/ROOT/partials/integrations/webcomponent-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/webcomponent-quick-start.adoc
@@ -88,7 +88,12 @@ ifeval::["{productSource}" != "cloud"]
 +
 [source,html,subs="attributes+"]
 ----
-<tinymce-editor license-key="gpl"></tinymce-editor>
+<script>
+  var editorConfig= {
+    license_key: 'gpl'
+  }
+</script>
+<tinymce-editor config="editorConfig"></tinymce-editor>
 ----
 The default {productname} editor will load at this location if the page is opened in a web browser.
 

--- a/modules/ROOT/partials/integrations/webcomponent-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/webcomponent-quick-start.adoc
@@ -88,7 +88,7 @@ ifeval::["{productSource}" != "cloud"]
 +
 [source,html,subs="attributes+"]
 ----
-<tinymce-editor license-key="T8LK:your-license-key-here"></tinymce-editor>
+<tinymce-editor license-key="gpl"></tinymce-editor>
 ----
 The default {productname} editor will load at this location if the page is opened in a web browser.
 

--- a/modules/ROOT/partials/integrations/webcomponent-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/webcomponent-tech-ref.adoc
@@ -79,7 +79,7 @@ To use {productname} from the {cloudname}, add the `+api-key+` attribute to the 
 [[licensekey]]
 == Setting the license key
 
-When self-hosting {productname}, specify a license key using the `+license-key+` attribute on the `+tinymce-editor+` element. License keys must start with the "T8LK:" prefix and use client-side JWT validation. Do not use both an API key and a license key - use API key for cloud deployments, and license key for self-hosted deployments. For more information, see: xref:license-key.adoc[License Key].
+When self-hosting {productname}, specify a license key using the `+license-key+` attribute on the `+tinymce-editor+` element. License keys must start with the "T8LK:" prefix and use client-side JWT validation that runs entirely in the browser, requiring no server communication or "phone home" checks. Do not use both an API key and a license key - use API key for cloud deployments, and license key for self-hosted deployments. For more information, see: xref:license-key.adoc[License Key].
 
 *Type:* `+String+`
 
@@ -105,7 +105,7 @@ When self-hosting {productname}, specify a license key using the `+license-key+`
 [IMPORTANT]
 ====
 * The `+license-key+` attribute is only required when self-hosting {productname}
-* License keys starting with "T8LK:" use client-side JWT validation
+* License keys starting with "T8LK:" use client-side JWT validation that runs entirely in the browser
 * Do not use both an API key and a license key - use API key for cloud deployments, and license key for self-hosted deployments
 ====
 

--- a/modules/ROOT/partials/integrations/webcomponent-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/webcomponent-tech-ref.adoc
@@ -3,6 +3,7 @@
 * xref:use-a-cloud-version-of-the-tinymce-web-component-integration[Use a cloud version of the {productname} Web Component integration]
 * xref:installing-the-tinymce-web-component-integration[Installing the {productname} Web Component integration]
 * xref:loading-tinymce[Loading {productname}]
+* xref:licensekey[Setting the license key]
 * xref:configuring-the-editor[Configuring the editor]
 ** xref:setting-the-initial-content[Setting the initial content]
 ** xref:loading-plugins[Loading plugins]
@@ -74,6 +75,41 @@ If {productname} is not available for {productname} Web Component, the latest ve
 To use {productname} Web Component with a self-hosted copy of {productname}, ensure that the self-hosted copy of {productname} can be loaded in the same location as the {productname} Web Component (such as the same web page).
 
 To use {productname} from the {cloudname}, add the `+api-key+` attribute to the `+tinymce-editor+` element with an API from link:{accountpageurl}/[{accountpage}].
+
+[[licensekey]]
+== Setting the license key
+
+When self-hosting {productname}, specify a license key using the `+license-key+` attribute on the `+tinymce-editor+` element. License keys must start with the "T8LK:" prefix and use client-side JWT validation. Do not use both an API key and a license key - use API key for cloud deployments, and license key for self-hosted deployments. For more information, see: xref:license-key.adoc[License Key].
+
+*Type:* `+String+`
+
+*Default value:* `+undefined+`
+
+*Possible values:* 
+* `undefined` - Use this when loading from {cloudname} with an API key
+* `"gpl"` - For open source projects using GPL license
+* `"T8LK:your-license-key"` - For commercial {productname} installations
+
+=== Example: Commercial license
+[source,html]
+----
+<tinymce-editor license-key="T8LK:your-license-key"></tinymce-editor>
+----
+
+=== Example: Open source GPL license
+[source,html]
+----
+<tinymce-editor license-key="gpl"></tinymce-editor>
+----
+
+[IMPORTANT]
+====
+* The `+license-key+` attribute is only required when self-hosting {productname}
+* License keys starting with "T8LK:" use client-side JWT validation
+* Do not use both an API key and a license key - use API key for cloud deployments, and license key for self-hosted deployments
+====
+
+For more information on licensing, see: xref:license-key.adoc[License Key].
 
 [[configuring-the-editor]]
 == Configuring the editor

--- a/modules/ROOT/partials/integrations/webcomponent-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/webcomponent-tech-ref.adoc
@@ -96,7 +96,7 @@ include::partial$integrations/common/license-key-property.adoc[]
 [IMPORTANT]
 ====
 * The `+license-key+` attribute is only required when self-hosting {productname}
-* License keys starting with "T8LK:" use client-side JWT validation that runs entirely in the browser
+* License keys starting with "T8LK:" use client-side validation.
 * Do not use both an API key and a license key - use API key for cloud deployments, and license key for self-hosted deployments
 ====
 

--- a/modules/ROOT/partials/integrations/webcomponent-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/webcomponent-tech-ref.adoc
@@ -85,15 +85,15 @@ When self-hosting {productname}, specify a license key using the `+license-key+`
 
 *Default value:* `+undefined+`
 
-*Possible values:* 
+*Possible values:*
 * `undefined` - Use this when loading from {cloudname} with an API key
 * `"gpl"` - For open source projects using GPL license
-* `"T8LK:your-license-key"` - For commercial {productname} installations
+* `"T8LK:..."` - For commercial {productname} installations
 
 === Example: Commercial license
 [source,html]
 ----
-<tinymce-editor license-key="T8LK:your-license-key"></tinymce-editor>
+<tinymce-editor license-key="T8LK:..."></tinymce-editor>
 ----
 
 === Example: Open source GPL license

--- a/modules/ROOT/partials/integrations/webcomponent-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/webcomponent-tech-ref.adoc
@@ -95,7 +95,7 @@ include::partial$integrations/common/license-key-property.adoc[]
 
 [IMPORTANT]
 ====
-* The `+license-key+` attribute is only required when self-hosting {productname}
+* The license key is only required when self-hosting {productname}
 * License keys starting with "T8LK:" use client-side validation.
 * Do not use both an API key and a license key - use API key for cloud deployments, and license key for self-hosted deployments
 ====

--- a/modules/ROOT/partials/integrations/webcomponent-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/webcomponent-tech-ref.adoc
@@ -79,16 +79,7 @@ To use {productname} from the {cloudname}, add the `+api-key+` attribute to the 
 [[licensekey]]
 == Setting the license key
 
-When self-hosting {productname}, specify a license key using the `+license-key+` attribute on the `+tinymce-editor+` element. License keys must start with the "T8LK:" prefix and use client-side JWT validation that runs entirely in the browser, requiring no server communication or "phone home" checks. Do not use both an API key and a license key - use API key for cloud deployments, and license key for self-hosted deployments. For more information, see: xref:license-key.adoc[License Key].
-
-*Type:* `+String+`
-
-*Default value:* `+undefined+`
-
-*Possible values:*
-* `undefined` - Use this when loading from {cloudname} with an API key
-* `"gpl"` - For open source projects using GPL license
-* `"T8LK:..."` - For commercial {productname} installations
+include::partial$integrations/common/license-key-property.adoc[]
 
 === Example: Commercial license
 [source,html]

--- a/modules/ROOT/partials/integrations/webcomponent-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/webcomponent-tech-ref.adoc
@@ -84,7 +84,12 @@ include::partial$integrations/common/license-key-property.adoc[]
 === Example: Commercial license
 [source,html]
 ----
-<tinymce-editor license-key="T8LK:..."></tinymce-editor>
+<script>
+  var editorConfig= {
+    license_key: 'T8LK:...'
+  }
+</script>
+<tinymce-editor config="editorConfig"></tinymce-editor>
 ----
 
 === Example: Open source GPL license

--- a/modules/ROOT/partials/integrations/webcomponent-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/webcomponent-tech-ref.adoc
@@ -90,7 +90,12 @@ include::partial$integrations/common/license-key-property.adoc[]
 === Example: Open source GPL license
 [source,html]
 ----
-<tinymce-editor license-key="gpl"></tinymce-editor>
+<script>
+  var editorConfig= {
+    license_key: 'gpl'
+  }
+</script>
+<tinymce-editor config="editorConfig"></tinymce-editor>
 ----
 
 [IMPORTANT]

--- a/modules/ROOT/partials/misc/setting-the-license.adoc
+++ b/modules/ROOT/partials/misc/setting-the-license.adoc
@@ -2,7 +2,7 @@
 
 === Use {productname} with the GPLv2+ license
 
-If the developer intends to self-host {productname} under the GPL license, they can set the `license_key` config option to 'gpl'. Case sensitivity does not matter.
+If the developer intends to self-host {productname} under the GPL license and agree to its terms, they can set the `license_key` config option to 'gpl'. Case sensitivity does not matter.
 
 ==== Example
 
@@ -18,35 +18,30 @@ tinymce.init({
 
 If the developer intends to self-host {productname} under a commercial license, a valid license key must be provided. Customers who have purchased a self-hosted-eligible license for {productname} will find their license key in the link:https://www.tiny.cloud/auth/login/[account portal]. To purchase a commercial license, see available options on the link:{pricingpage}/[pricing page].
 
+The {productname} 8 commercial license key will have a `+T8LK:+` prefix.
+
 ==== Example
 
 [source,js]
 ----
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  license_key: 'T8LK:your-license-key'
+  license_key: 'T8LK:...'
 });
 ----
 
 === Use {productname} under GPL with Premium Features
 
-For open source projects that need to use {productname} under the GPL license while also accessing premium features, use the combined GPL and commercial license format:
+If the developer intends to self-host the {productname} editor under the GPL license and agree to its terms, whilst also self-hosting premium features, a valid license key must be provided. Customers who have purchased a self-hosted-eligible license for {productname} will find their license key in the link:https://www.tiny.cloud/auth/login/[account portal]. To purchase a commercial license, see available options on the link:{pricingpage}/[pricing page].
+
+This type of license key is specifically for open source projects that need premium features while maintaining GPL compliance.
+
+The {productname} 8 commercial license key will have a `+GPL+T8LK:+` prefix.
 
 [source,js]
 ----
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  license_key: 'GPL+T8LK:your-license-key'
+  license_key: 'GPL+T8LK:...'
 });
 ----
-
-[IMPORTANT]
-====
-* The GPL portion acknowledges open source usage requirements 
-* The T8LK portion enables access to premium plugins and features included in your subscription
-* Without the T8LK portion, premium plugins would not be available with just the GPL license
-* You can find your commercial license key in the link:https://www.tiny.cloud/auth/login/[account portal]
-* This format is specifically for open source projects that need premium features while maintaining GPL compliance
-====
-
-To purchase a commercial license, see available options on the link:{pricingpage}/[pricing page].

--- a/modules/ROOT/partials/misc/setting-the-license.adoc
+++ b/modules/ROOT/partials/misc/setting-the-license.adoc
@@ -24,6 +24,29 @@ If the developer intends to self-host {productname} under a commercial license, 
 ----
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  license_key: '<your-license-key>'
+  license_key: 'T8LK:your-license-key'
 });
 ----
+
+=== Use {productname} under GPL with Premium Features
+
+For open source projects that need to use {productname} under the GPL license while also accessing premium features, use the combined GPL and commercial license format:
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  license_key: 'GPL+T8LK:your-license-key'
+});
+----
+
+[IMPORTANT]
+====
+* The GPL portion acknowledges open source usage requirements 
+* The T8LK portion enables access to premium plugins and features included in your subscription
+* Without the T8LK portion, premium plugins would not be available with just the GPL license
+* You can find your commercial license key in the link:https://www.tiny.cloud/auth/login/[account portal]
+* This format is specifically for open source projects that need premium features while maintaining GPL compliance
+====
+
+To purchase a commercial license, see available options on the link:{pricingpage}/[pricing page].

--- a/modules/ROOT/partials/module-loading/bundling-vite-es6-npm_editor.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-vite-es6-npm_editor.adoc
@@ -44,7 +44,7 @@ import contentCss from 'tinymce/skins/content/default/content.js';
 export function render () {
   tinymce.init({
     selector: 'textarea#editor',
-    license_key: 'gpl', // gpl for open source, T8LK:... for commercial
+    license_key: 'gpl',
     plugins: 'advlist code emoticons link lists table',
     toolbar: 'bold italic | bullist numlist | link emoticons',
     skin_url: 'default',

--- a/modules/ROOT/partials/module-loading/bundling-vite-es6-npm_editor.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-vite-es6-npm_editor.adoc
@@ -48,6 +48,8 @@ export function render () {
     toolbar: 'bold italic | bullist numlist | link emoticons',
     skin_url: 'default',
     content_css: 'default',
+    // Add your commercial license key for self-hosted deployments
+    license_key: 'T8LK:your-license-key'  // Your license key from the Tiny Cloud Account
   });
 };
 ----

--- a/modules/ROOT/partials/module-loading/bundling-vite-es6-npm_editor.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-vite-es6-npm_editor.adoc
@@ -44,12 +44,11 @@ import contentCss from 'tinymce/skins/content/default/content.js';
 export function render () {
   tinymce.init({
     selector: 'textarea#editor',
+    license_key: 'gpl', // gpl for open source, T8LK:... for commercial
     plugins: 'advlist code emoticons link lists table',
     toolbar: 'bold italic | bullist numlist | link emoticons',
     skin_url: 'default',
     content_css: 'default',
-    // Add your commercial license key for self-hosted deployments
-    license_key: 'T8LK:your-license-key'  // Your license key from the Tiny Cloud Account
   });
 };
 ----


### PR DESCRIPTION
Ticket: DOC-3226
Parent: DOC-3147
Support: EPIC-225

Site: [Release notes-IMPORTANT](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/8.0-release-notes/#overview:~:text=This%20release%20includes%20breaking%20changes%20to%20the%20license%20key%20system.%20All%20commercial%20self%2Dhosted%20deployments%20must%20update%20their%20license%20keys%20to%20use%20the%20new%20T8LK%3A%20prefix%20format.%20For%20details%20on%20this%20and%20other%20breaking%20changes%20when%20considering%20upgrading%2C%20see%20Migrating%20from%20TinyMCE%207%20to%20TinyMCE%208.0.0.)
Site: [Release notes- Changes](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/8.0-release-notes/#enhanced-license-key-system-with-t8lk-prefix)
Site: [license-key.adoc](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/license-key/)
Site: [vite-es6-npm/](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/vite-es6-npm/)

React:
Site: [Using a package manager with hosting](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/react-pm-host/#:~:text=licenseKey%3D%27gpl%7CT8LK%3Ayour%2Dlicense%2Dkey%27%20//%20gpl%20for%20open%20source%2C%20T8LK%3Ayour%2Dlicense%2Dkey%20for%20commercial)
Site: [Using a package manager with bundling](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/react-pm-bundle/#:~:text=licenseKey%3D%27gpl%7CT8LK%3Ayour%2Dlicense%2Dkey%27%20//%20gpl%20for%20open%20source%2C%20T8LK%3Ayour%2Dlicense%2Dkey%20for%20commercial)
Site: [Using a .zip package with hosting](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/react-zip-host/#:~:text=licenseKey%3D%27gpl%7CT8LK%3Ayour%2Dlicense%2Dkey%27%20//%20gpl%20for%20open%20source%2C%20T8LK%3Ayour%2Dlicense%2Dkey%20for%20commercial)
Site: [Using a .zip package with bundling](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/react-zip-bundle/#:~:text=licenseKey%3D%27gpl%7CT8LK%3Ayour%2Dlicense%2Dkey%27%20//%20gpl%20for%20open%20source%2C%20T8LK%3Ayour%2Dlicense%2Dkey%20for%20commercial)
Site: [react-ref/#licenseKey](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/react-ref/#licenseKey)

Angular:
Does not mention license_key in `Using a package manager` or `Using a .zip package`
Site: [angular-ref/#licensekey](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/angular-ref/#licensekey)

Vue:
Site: [Using a package manager](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/vue-pm/#:~:text=licenseKey%3D%22gpl%7CT8LK%3Ayour%2Dlicense%2Dkey%22%20//%20gpl%20for%20open%20source%2C%20T8LK%3Ayour%2Dlicense%2Dkey%20for%20commercial)
Site: [Using a .zip package](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/vue-zip/#:~:text=licenseKey%3D%22gpl%7CT8LK%3Ayour%2Dlicense%2Dkey%22%20//%20gpl%20for%20open%20source%2C%20T8LK%3Ayour%2Dlicense%2Dkey%20for%20commercial)
Site: [vue-ref/#license-key](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/vue-ref/#license-key)

Blazor:
Site: [Using a package manager](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/blazor-pm/#:~:text=%3CEditor%20LicenseKey%3D%22gpl%7CT8LK%3Ayour%2Dlicense%2Dkey%22%20/%3E)
Site: [Using a .zip package](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/blazor-zip/#:~:text=%3CEditor%20LicenseKey%3D%22gpl%7CT8LK%3Ayour%2Dlicense%2Dkey%22%20/%3E)
Site: [blazor-ref/#licensekey](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/blazor-ref/#licensekey)
Site: [blazor-ref/#configuring-the-tinymce-blazor-integration](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/blazor-ref/#configuring-the-tinymce-blazor-integration:~:text=no%2Dapi%2Dkey%22-,LicenseKey%3D%22T8LK%3Ayour%2Dlicense%2Dkey%22,-ScriptSrc%3D%22/path)

Svelte:
Site: [Using a package manager](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/svelte-pm/#:~:text=licenseKey%3D%27T8LK%3Ayour%2Dlicense%2Dkey%27)
Site: [Using a .zip package](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/svelte-zip/#:~:text=licenseKey%3D%27T8LK%3Ayour%2Dlicense%2Dkey%27)
Site: [svelte-ref/#licensekey](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/svelte-ref/#licensekey)

Webcomponent:
Site: [Using a package manager](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/webcomponent-pm/#:~:text=%3Ctinymce%2Deditor%20license%2Dkey%3D%22T8LK%3Ayour%2Dlicense%2Dkey%2Dhere%22%3E%3C/tinymce%2Deditor%3E)
Site: [Using a .zip package](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/webcomponent-zip/#:~:text=%3Ctinymce%2Deditor%20license%2Dkey%3D%22T8LK%3Ayour%2Dlicense%2Dkey%2Dhere%22%3E%3C/tinymce%2Deditor%3E)
Site: [webcomponent-ref/#licensekey](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/webcomponent-ref/#licensekey)

jQuery:
Site: [jQuery-pm](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/jquery-pm/#:~:text=%3A%20500%2C-,license_key%3A%20%27gpl%7CT8LK%3Ayour%2Dlicense%2Dkey%27%20//gpl%20for%20open%20source%2C%20T8LK%3Ayour%2Dlicense%2Dkey%20for%20commercial,-/*%20other%20settings...%20*/)
Site: [example-integration](http://docs-feature-800-doc-3147doc-3226.staging.tiny.cloud/docs/tinymce/latest/jquery-pm/#:~:text=%3A%20500%2C-,license_key%3A%20%27gpl%7CT8LK%3Ayour%2Dlicense%2Dkey%27%20//gpl%20for%20open%20source%2C%20T8LK%3Ayour%2Dlicense%2Dkey%20for%20commercial,-menubar%3A%20false)


 Changes Summary

Licensing Updates for TinyMCE 8
- Updated licensing examples and documentation for TinyMCE 8.
- Introduced `T8LK:` prefix for license keys (self-hosted and hybrid use).
- Explained JWT validation, offline/cloud fallback, and migration notes.

Modified Files

- **8.0-release-notes.adoc** – Added licensing change summary and migration info.
- **license-key.adoc** – Fully updated:
  - License types (date-based vs version-locked)
  - Deployment types and examples
  - License states (Active, Grace, Expired)
  - Hybrid usage warnings and FAQ
- **vite-es6-npm.adoc** – Mentioned `T8LK:` use in prerequisites; added hybrid licensing note.
- **basic-quickstart-base.adoc** – Updated `license_key` example to use `gpl|T8LK:...`.
- **angular-tech-ref.adoc** – Described `T8LK:` key format and JWT; added GPL/commercial examples.
- **blazor-postinstall.adoc** – Updated example to use `gpl|T8LK:...`.
- **blazor-tech-ref.adoc** – Detailed `LicenseKey` property, usage, and examples.
- **jquery-quick-start.adoc** – Updated license key example.
- **react-bundling.adoc** – Updated example to use `gpl|T8LK:...`.
- **react-quick-start.adoc** – Aligned `App()` and `BundledEditor()` with new license key format.
- **react-tech-ref.adoc** – Expanded `licenseKey` property docs and examples.
- **svelte-quick-start.adoc** – Updated `<Editor>` license key usage.
- **svelte-tech-ref.adoc** – Documented valid values and added examples.
- **vue-quick-start.adoc** – Updated `<editor>` `licenseKey` bindings.
- **vue-tech-ref.adoc** – Added GPL/commercial examples and explanation.
- **webcomponent-quick-start.adoc** – Updated example to `license-key="T8LK:..."`.
- **webcomponent-tech-ref.adoc** – New `[[licensekey]]` section with examples and validation notes.
- **setting-the-license.adoc** – Added hybrid GPL + T8LK format for open-source with premium.
- **bundling-vite-es6-npm_editor.adoc** – Added `T8LK:` license key example.

---

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.

Review:
- [x] Documentation Team Lead has reviewed