### PR TITLE
DOC-3228: Cherry pick `tinymce/7` latest changes into `tinymce/8 >> release/8.0.0` branch.

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -15,7 +15,7 @@ asciidoc:
     webcomponent_url: https://cdn.jsdelivr.net/npm/@tinymce/tinymce-webcomponent/dist/tinymce-webcomponent.min.js
     jquery_url: https://cdn.jsdelivr.net/npm/@tinymce/tinymce-jquery@2/dist/tinymce-jquery.min.js
     openai_proxy_url: https://openai.ai-demo-proxy.tiny.cloud/v1/chat/completions
-    openai_proxy_token: eyJhbGciOiJFUzM4NCJ9.eyJhdWQiOlsiaHR0cHM6Ly9vcGVuYWkuYWktZGVtby1wcm94eS50aW55LmNsb3VkLyJdLCJleHAiOjE3NTEzMjgwMDAsImh0dHBzOi8vb3BlbmFpLmFpLWRlbW8tcHJveHkudGlueS5jbG91ZC9yb2xlIjoicHVibGljLWRlbW8iLCJpc3MiOiJodHRwczovL2FpLWRlbW8tcHJveHkudGlueS5jbG91ZC8iLCJqdGkiOiJmOGFmY2EyNC1mN2FhLTQxMjktYTc2Yy02YThlZDU3YjAyZjYiLCJzdWIiOiJhaS1hc3Npc3RhbnQtZGVtbyJ9.Xu0apHCbxgmRQTeTqrTIDFFhh2CgKeARRXa3mCxSGoCwZqkoQaFRZBCzDo8Xz7DuUa5mW2XHl-HYcYiXJM9ly16d0oY7lJefHBeLlmJEBE1CSttHBkCRWZS8eFLCasL6
+    openai_proxy_token: eyJhbGciOiJFUzM4NCJ9.eyJhdWQiOlsiaHR0cHM6Ly9vcGVuYWkuYWktZGVtby1wcm94eS50aW55LmNsb3VkLyJdLCJleHAiOjE3ODI4NjQwMDAsImh0dHBzOi8vb3BlbmFpLmFpLWRlbW8tcHJveHkudGlueS5jbG91ZC9yb2xlIjoicHVibGljLWRlbW8iLCJpc3MiOiJodHRwczovL2FpLWRlbW8tcHJveHkudGlueS5jbG91ZC8iLCJqdGkiOiIxZWY3NjJiNi1mZDYyLTQ3ZWQtOGRkNS0yOGRmMzBkZDU4YmMiLCJzdWIiOiJhaS1hc3Npc3RhbnQtZGVtbyJ9.WC8GIY19MgZneDVZoA-Ttt9E7gNkD0Yl-pcM_5c2RT3RdV_zE0i4bPOGBJpg_g6wu_4ki2ery6_JZtk2Q9gXEBHH7fIu7hXDFS8uIV9qe8MyxEqqRncGFVDjSTldVXGS
     default_meta_keywords: tinymce, documentation, docs, plugins, customizable skins, configuration, examples, html, php, java, javascript, image editor, inline editor, distraction-free editor, classic editor, wysiwyg
     # product docker variables
     dockerimageimportfromwordexporttoword: registry.containers.tiny.cloud/docx-converter-tiny

--- a/modules/ROOT/pages/exportpdf.adoc
+++ b/modules/ROOT/pages/exportpdf.adoc
@@ -28,8 +28,8 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'exportpdf',
   toolbar: 'exportpdf',
-// Below option is only required when using the cloud-based Export to PDF plugin from Tiny.Cloud.
-// Avoid setting it up during the trial period.
+  // Required for the cloud-based Export to PDF plugin with Tiny Cloud
+  // Create a JWT key in the Customer Portal for trial functionality to enable watermark-free exports during the trial period
   exportpdf_token_provider: () => { 
     return fetch('http://localhost:3000/jwt', { // specify your token endpoint
       method: 'POST',

--- a/modules/ROOT/pages/exportword.adoc
+++ b/modules/ROOT/pages/exportword.adoc
@@ -35,8 +35,8 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'exportword',
   toolbar: 'exportword',
-// Below option is only required when using the cloud-based Export to Word plugin from Tiny.Cloud.
-// Avoid setting it up during the trial period.
+  // Required for the cloud-based Export to Word plugin with Tiny Cloud
+  // Create a JWT key in the Customer Portal for trial functionality to enable watermark-free exports during the trial period
   exportword_token_provider: () => {
     return fetch('http://localhost:3000/jwt', { // specify your token endpoint
       method: 'POST',

--- a/modules/ROOT/pages/importword.adoc
+++ b/modules/ROOT/pages/importword.adoc
@@ -1,4 +1,3 @@
-
 = {pluginname} plugin
 :plugincode: importword
 :pluginname: Import from Word
@@ -30,9 +29,9 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'importword',
   toolbar: 'importword',
-// Below option is only required when using the cloud-based Import from Word plugin from Tiny.Cloud.
-// Avoid setting it up during the trial period.
-  importword_token_provider: () => { // required when using the Import from Word plugin with Tiny Cloud.
+  // Required for the cloud-based Import from Word plugin with Tiny Cloud
+  // Create a JWT key in the Customer Portal for trial functionality to enable watermark-free exports during the trial period
+  importword_token_provider: () => {
     return fetch('http://localhost:3000/jwt', { // specify your token endpoint
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/modules/ROOT/pages/understanding-editor-loads.adoc
+++ b/modules/ROOT/pages/understanding-editor-loads.adoc
@@ -6,7 +6,7 @@
 == Understanding editor loads for {productname}
 
 [IMPORTANT]
-This information is only relevant to Tiny Cloud users. Users who self-host the open source version of {productname} are not subject to editor load restrictions, but must comply with the https://github.com/tinymce/tinymce/blob/master/LICENSE.TXT[open source license]. 
+This information is only relevant to Tiny Cloud users. Users who self-host the open source version of {productname} are not subject to editor load restrictions, but must comply with the link:https://github.com/tinymce/tinymce/blob/release/{productmajorversion}/LICENSE.md[open source license]. 
 
 An editor load is the event that occurs each time {productname} is initialized in your application. The editor dispatches the 'init' event to indicate a successful load. For example, if 100 users load {productname} 10 times each, the result would be 1,000 editor loads. 
 

--- a/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-installation.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-installation.adoc
@@ -32,7 +32,7 @@ Pull the Docker image:
 
 [source, sh, subs="attributes+"]
 ----
-docker pull registry.containers.tiny.cloud/{dockerimageexporttopdf}:[version]
+docker pull {dockerimageexporttopdf}:[version]
 ----
 
 [TIP]

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-autorization-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-autorization-on-premises.adoc
@@ -17,7 +17,7 @@ If the `SECRET_KEY` is not setup during the installation, then {pluginname} On-P
 * it is not issued in the future (e.i. the `iat` timestamp cannot be newer than the current time),
 * it has not expired yet.
 
-Tokens for the {pluginname} On-Premises do not require any additional claims such as the environment ID (which is specific for Collaboration Server On-Premises), the token can be created with an empty payload.
+Tokens for the {pluginname} On-Premises do not require any additional claims such as the `aud` (which is specific to cloud-based document converters), so the token can be created with an empty payload.
 
 If the specific use case involves sending requests from a backend server, then JWT tokens can be generated locally, as shown in the below request example.
 

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
@@ -32,7 +32,7 @@ Pull the Docker image:
 
 [source, sh, subs="attributes+"]
 ----
-docker pull registry.containers.tiny.cloud/{dockerimageimportfromwordexporttoword}:[version]
+docker pull {dockerimageimportfromwordexporttoword}:[version]
 ----
 
 [TIP]

--- a/modules/ROOT/partials/integrations/angular-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/angular-tech-ref.adoc
@@ -8,6 +8,7 @@
 ** xref:licensekey[`+licenseKey+`]
 ** xref:cloudchannel[`+cloudChannel+`]
 ** xref:disabled[`+disabled+`]
+** xref:readonly[`+readonly+`]
 ** xref:id[`+id+`]
 ** xref:init[`+init+`]
 ** xref:initialvalue[`+initialValue+`]
@@ -97,6 +98,7 @@ The editor accepts the following properties:
   apiKey="no-api-key"
   cloudChannel="{productmajorversion}"
   [disabled]="false"
+  [readonly]="false"
   id=""
   [init]="{ }"
   initialValue=""
@@ -191,6 +193,24 @@ The `+disabled+` property can dynamically switch the editor between a "disabled"
 [source,html]
 ----
 <editor [disabled]="true" />
+----
+
+[[readonly]]
+=== `+readonly+`
+
+The `+readonly+` property can dynamically switch the editor between a "read-only" mode (`+true+`) and the standard editable mode (`+false+`).
+
+*Type:* `+Boolean+`
+
+*Default value:* `+false+`
+
+*Possible values:* `+true+`, `+false+`
+
+==== Example: using `+readonly+`
+
+[source,html]
+----
+<editor [readonly]="true" />
 ----
 
 [[id]]

--- a/modules/ROOT/partials/integrations/react-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/react-tech-ref.adoc
@@ -8,6 +8,7 @@
 ** xref:licenseKey[`+licenseKey+`]
 ** xref:cloudchannel[`+cloudChannel+`]
 ** xref:disabled[`+disabled+`]
+** xref:readonly[`+readonly+`]
 ** xref:id[`+id+`]
 ** xref:init[`+init+`]
 ** xref:initialvalue[`+initialValue+`]
@@ -143,7 +144,8 @@ xref:toolbar[`+toolbar+`]:: Specify the editor toolbar. This will *override* the
 
 These props can be updated after the editor is initialized. Note that there are xref:event-binding[other events] not mentioned here.
 
-xref:disabled[`+disabled+`]:: Should the editor be in read-only mode.
+xref:disabled[`+disabled+`]:: Should the editor be disabled.
+xref:readonly[`+readonly+`]:: Should the editor be in read-only mode.
 
 xref:initialvalue[`+initialValue+`]:: The starting value of the editor. Changing this value after the editor has loaded will reset the editor (including the editor content).
 
@@ -240,7 +242,7 @@ For information {productname} development channels, see: xref:editor-plugin-vers
 [[disabled]]
 === `+disabled+`
 
-The `+disabled+` prop can dynamically switch the editor between a "disabled" (read-only) mode (`+true+`) and the standard editable mode (`+false+`).
+The `+disabled+` prop can dynamically toggle the editor's disabled state.
 
 *Type:* `Boolean`
 
@@ -254,6 +256,26 @@ The `+disabled+` prop can dynamically switch the editor between a "disabled" (re
 ----
 <Editor
   disabled={true}
+/>
+----
+
+[[readonly]]
+=== `+readonly+`
+
+The `+readonly+` prop can dynamically switch the editor between a read-only mode (`+true+`) and the standard editable mode (`+false+`).
+
+*Type:* `Boolean`
+
+*Default value:* `+false+`
+
+*Possible values:* `+true+`, `+false+`
+
+==== Example: using `+readonly+`
+
+[source,jsx]
+----
+<Editor
+  readonly={true}
 />
 ----
 

--- a/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
@@ -7,6 +7,7 @@ Covered in this section:
 ** xref:id[id]
 ** xref:inline[inline]
 ** xref:disabled[disabled]
+** xref:readonly[readonly]
 ** xref:scriptsrc[scriptsrc]
 ** xref:conf[conf]
 * xref:component-binding[Component binding]
@@ -25,6 +26,7 @@ The `+tinymce-svelte+` `+Editor+` component accepts the following properties:
   id="uuid"
   inline=false
   disabled=false
+  readonly=false
   scriptSrc=undefined
   conf={}
   modelEvents="input change undo redo"
@@ -134,7 +136,7 @@ Sets the editor to use inline mode.
 [[disabled]]
 === `+disabled+`
 
-Set the editor to readonly mode.
+Set the editor to disabled.
 
 *Type:* `+Boolean+`
 
@@ -146,6 +148,24 @@ Set the editor to readonly mode.
 ----
 <Editor
   disabled=true
+/>
+----
+
+[[readonly]]
+=== `+readonly+`
+
+Set the editor to readonly mode.
+
+*Type:* `+Boolean+`
+
+*Default value:* `+false+`
+
+==== Example using `+readonly+`
+
+[source,jsx]
+----
+<Editor
+  readonly=true
 />
 ----
 

--- a/modules/ROOT/partials/integrations/vue-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/vue-tech-ref.adoc
@@ -7,6 +7,7 @@
 ** xref:license-key[`+licenseKey+`]
 ** xref:cloud-channel[`+cloud-channel+`]
 ** xref:disabled[`+disabled+`]
+** xref:readonly[`+readonly+`]
 ** xref:id[`+id+`]
 ** xref:init[`+init+`]
 ** xref:initial-value[`+initial-value+`]
@@ -99,6 +100,7 @@ The editor accepts the following properties:
   api-key="no-api-key"
   cloud-channel="{productmajorversion}"
   :disabled=false
+  :readonly=false
   id="uuid"
   :init= "{ }"
   initial-value=""
@@ -202,6 +204,26 @@ The `+disabled+` property can dynamically switch the editor between a "disabled"
 ----
 <editor
   :disabled=true
+/>
+----
+
+[[readonly]]
+=== `+readonly+`
+
+The `+readonly+` property can dynamically switch the editor between a "read-only" mode (`+true+`) and the standard editable mode (`+false+`).
+
+*Type:* `+Boolean+`
+
+*Default value:* `+false+`
+
+*Possible values:* `+true+`, `+false+`
+
+==== Example: using `+readonly+`
+
+[source,html]
+----
+<editor
+  :readonly=true
 />
 ----
 

--- a/modules/ROOT/partials/integrations/webcomponent-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/webcomponent-tech-ref.adoc
@@ -8,6 +8,8 @@
 ** xref:loading-plugins[Loading plugins]
 ** xref:setting-the-editor-width[Setting the editor width]
 ** xref:setting-the-editor-height[Setting the editor height]
+** xref:setting-readonly[Setting the editor to readonly]
+** xref:setting-disabled[Setting the editor to disabled]
 ** xref:setting-the-toolbar[Setting the toolbar]
 ** xref:setting-the-toolbar-mode[Setting the toolbar mode]
 ** xref:setting-the-menu-bar[Setting the menu bar]
@@ -144,6 +146,26 @@ To set the height of the editor (content area and user interface), use the `+hei
 [source,html]
 ----
 <tinymce-editor height="15em"></tinymce-editor>
+----
+
+
+[[setting-readonly]]
+=== Setting readonly mode
+
+To set the editor's mode to `readonly`.
+
+[source,html]
+----
+<tinymce-editor readonly></tinymce-editor>
+----
+
+[[setting-disaled-state]]
+=== Setting disabled state
+To set the editor to a disabled state.
+
+[source,html]
+----
+<tinymce-editor disabled></tinymce-editor>
 ----
 
 [[setting-the-toolbar]]

--- a/modules/ROOT/partials/misc/admon-jwt-authentication-requirements.adoc
+++ b/modules/ROOT/partials/misc/admon-jwt-authentication-requirements.adoc
@@ -2,17 +2,34 @@
 ====
 The {pluginname} plugin **requires** JWT authentication when using the {companyname} Cloud service.
 
-* Configure the `{plugincode}_token_provider` option to specify the endpoint for retrieving a valid JWT token.
+**Authentication Setup:**
 
-For more information on how to set up JWT authentication with {pluginname}, see examples:
+. Create a JWT key in the Customer Portal
+. Configure the `{plugincode}_token_provider` option to specify the endpoint for retrieving your JWT token
 
-* xref:{pluginfilename}-with-jwt-authentication-nodejs.adoc[{pluginname} with JWT authentication (Node.js)]
-* xref:{pluginfilename}-with-jwt-authentication-php.adoc[{pluginname} with JWT authentication (PHP)]
+For more information on how to set up JWT authentication with {pluginname}, see examples: xref:{pluginfilename}-with-jwt-authentication-nodejs.adoc[{pluginname} with JWT authentication (Node.js)] or xref:{pluginfilename}-with-jwt-authentication-php.adoc[{pluginname} with JWT authentication (PHP)]
 
-**Trial period behavior:**
+**Trial period behavior**
 
-* The {pluginname} plugin runs in evaluation mode and adds a watermark to exported content.
-* The `{plugincode}_token_provider` option is "not required" during the trial period.
-* If the trial period "expires" or the plugin lacks the necessary entitlement, it becomes _non-functional_.
-* Attempting to use JWT authentication during the trial will result in an _error_.
+ifeval::["{plugincode}" == "importword"]
+* **Trial Period:**
+** With JWT: Full functionality, unlimited usage, no watermarks.
+** Without JWT: Full functionality with watermarks and page limits.
+
+* **After Trial:**
+** With {pluginname} add-on + JWT: Full functionality (subscription-based)
+** Without add-on: Plugin entitlements are `disabled` and functionality is no longer available.
+endif::[]
+
+ifeval::["{plugincode}" != "importword"]
+* **Trial Period:**
+** With JWT: Full functionality, unlimited usage, no watermarks.
+** Without JWT: Full functionality with watermarks.
+
+* **After Trial:**
+** With {pluginname} add-on + JWT: Full functionality (subscription-based)
+** Without add-on: Plugin entitlements are `disabled` and functionality is no longer available.
+endif::[]
+
+Visit the link:https://www.tiny.cloud/auth/login/[account portal] to obtain your JWT key and test full functionality.
 ====


### PR DESCRIPTION
Ticket: DOC-3228

Changes:
* using `git log tinymce/7 ^tinymce/8 --oneline` to compare branches for missing commits- less the ones we want to be omitted from the `v8` docs.

- [dc450da](https://github.com/tinymce/tinymce-docs/pull/3754/commits/dc450dabc701ad5473f64ca487cbc309031f931b)
- [af9b478](https://github.com/tinymce/tinymce-docs/pull/3754/commits/af9b4789c60a2df3ee188aea146c9312f0b6384b)
- [bfbf03f](https://github.com/tinymce/tinymce-docs/pull/3754/commits/bfbf03f9f71e6c72eed99827c46f5a0f69064a4e)
- [a76c253](https://github.com/tinymce/tinymce-docs/pull/3754/commits/a76c2533864dfe70ef3eacca656ef6900d3568c5)
- [bfc3a11](https://github.com/tinymce/tinymce-docs/pull/3754/commits/bfc3a1102e4d4a834bb83c4d30653afe6912996c)
- [ae55c31](https://github.com/tinymce/tinymce-docs/pull/3754/commits/ae55c313f74ff6bf739c755fbd14d2a41876aa81)
- [2a683d7](https://github.com/tinymce/tinymce-docs/pull/3754/commits/2a683d723fcd8f877d5fc9694b1e448985f8f42d)
- [f208488](https://github.com/tinymce/tinymce-docs/pull/3754/commits/f20848808098781ed5987c33beddbaebbd50606c)
- [550119a](https://github.com/tinymce/tinymce-docs/pull/3754/commits/550119a6dd961617460580a4221e1682d53a6312)
- [7bbe8d9](https://github.com/tinymce/tinymce-docs/pull/3754/commits/7bbe8d9baf0e4c7323f31fd7944819c403a99120)

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed