### PR TITLE
DOC-3227: Update Document Converter JWT authentication requirements and plugin descriptions.

### DIFF
--- a/modules/ROOT/pages/exportpdf.adoc
+++ b/modules/ROOT/pages/exportpdf.adoc
@@ -30,8 +30,8 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'exportpdf',
   toolbar: 'exportpdf',
-// Below option is only required when using the cloud-based Export to PDF plugin from Tiny.Cloud.
-// Avoid setting it up during the trial period.
+  // Required for the cloud-based Export to PDF plugin with Tiny Cloud
+  // Create a JWT key in the Customer Portal for trial functionality to enable watermark-free exports during the trial period
   exportpdf_token_provider: () => { 
     return fetch('http://localhost:3000/jwt', { // specify your token endpoint
       method: 'POST',

--- a/modules/ROOT/pages/exportword.adoc
+++ b/modules/ROOT/pages/exportword.adoc
@@ -37,8 +37,8 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'exportword',
   toolbar: 'exportword',
-// Below option is only required when using the cloud-based Export to Word plugin from Tiny.Cloud.
-// Avoid setting it up during the trial period.
+  // Required for the cloud-based Export to Word plugin with Tiny Cloud
+  // Create a JWT key in the Customer Portal for trial functionality to enable watermark-free exports during the trial period
   exportword_token_provider: () => {
     return fetch('http://localhost:3000/jwt', { // specify your token endpoint
       method: 'POST',

--- a/modules/ROOT/pages/importword.adoc
+++ b/modules/ROOT/pages/importword.adoc
@@ -1,4 +1,3 @@
-
 = {pluginname} plugin
 :plugincode: importword
 :pluginname: Import from Word
@@ -32,9 +31,9 @@ tinymce.init({
   selector: 'textarea',
   plugins: 'importword',
   toolbar: 'importword',
-// Below option is only required when using the cloud-based Import from Word plugin from Tiny.Cloud.
-// Avoid setting it up during the trial period.
-  importword_token_provider: () => { // required when using the Import from Word plugin with Tiny Cloud.
+  // Required for the cloud-based Import from Word plugin with Tiny Cloud
+  // Create a JWT key in the Customer Portal for trial functionality to enable watermark-free exports during the trial period
+  importword_token_provider: () => {
     return fetch('http://localhost:3000/jwt', { // specify your token endpoint
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/modules/ROOT/pages/migration-from-4x.adoc
+++ b/modules/ROOT/pages/migration-from-4x.adoc
@@ -1,6 +1,6 @@
 = Migrating from {productname} 4 to {productname} {release-version}
 :navtitle: Migrating from TinyMCE 4
-:description: Guidance for migrating from TinyMCE 4 to TinyMCE {release-version}
+:description: Guidance for migrating from TinyMCE 4 to TinyMCE 7
 :keywords: migration, considerations, premigration, pre-migration
 :release-version: 7.0
 

--- a/modules/ROOT/pages/migration-from-5x.adoc
+++ b/modules/ROOT/pages/migration-from-5x.adoc
@@ -1,6 +1,6 @@
-= Migrating from {productname} 5 to {productname} {release-version}
+= Migrating from {productname} 5 to {productname} 7
 :navtitle: Migrating from TinyMCE 5
-:description: Guidance for migrating from TinyMCE 5 to TinyMCE {release-version}
+:description: Guidance for migrating from TinyMCE 5 to TinyMCE 7
 :keywords: migration, considerations, premigration, pre-migration
 :release-version: 7.0
 

--- a/modules/ROOT/partials/misc/admon-jwt-authentication-requirements.adoc
+++ b/modules/ROOT/partials/misc/admon-jwt-authentication-requirements.adoc
@@ -13,11 +13,11 @@ For more information on how to set up JWT authentication with {pluginname}, see 
 
 * **Trial Period:**
 ** With JWT: Full functionality, unlimited usage, no watermarks.
-** Without JWT: Limited functionality with watermarks and page limits.
+** Without JWT: Full functionality with watermarks.
 
 * **After Trial:**
 ** With {pluginname} "add-on" + JWT: Full functionality (subscription-based).
-** Without add-on: Limited functionality with watermarks and page limits.
+** Without add-on: Plugin entitlements are `disabled` and functionality is no longer available.
 
 Visit the link:https://www.tiny.cloud/auth/login/[account portal] to obtain your JWT key and test full functionality.
 ====

--- a/modules/ROOT/partials/misc/admon-jwt-authentication-requirements.adoc
+++ b/modules/ROOT/partials/misc/admon-jwt-authentication-requirements.adoc
@@ -11,13 +11,25 @@ For more information on how to set up JWT authentication with {pluginname}, see 
 
 **Trial period behavior**
 
+ifeval::["{plugincode}" == "importword"]
+* **Trial Period:**
+** With JWT: Full functionality, unlimited usage, no watermarks.
+** Without JWT: Full functionality with watermarks and page limits.
+
+* **After Trial:**
+** With {pluginname} add-on + JWT: Full functionality (subscription-based)
+** Without add-on: Plugin entitlements are `disabled` and functionality is no longer available.
+endif::[]
+
+ifeval::["{plugincode}" != "importword"]
 * **Trial Period:**
 ** With JWT: Full functionality, unlimited usage, no watermarks.
 ** Without JWT: Full functionality with watermarks.
 
 * **After Trial:**
-** With {pluginname} "add-on" + JWT: Full functionality (subscription-based).
+** With {pluginname} add-on + JWT: Full functionality (subscription-based)
 ** Without add-on: Plugin entitlements are `disabled` and functionality is no longer available.
+endif::[]
 
 Visit the link:https://www.tiny.cloud/auth/login/[account portal] to obtain your JWT key and test full functionality.
 ====

--- a/modules/ROOT/partials/misc/admon-jwt-authentication-requirements.adoc
+++ b/modules/ROOT/partials/misc/admon-jwt-authentication-requirements.adoc
@@ -2,17 +2,22 @@
 ====
 The {pluginname} plugin **requires** JWT authentication when using the {companyname} Cloud service.
 
-* Configure the `{plugincode}_token_provider` option to specify the endpoint for retrieving a valid JWT token.
+**Authentication Setup:**
 
-For more information on how to set up JWT authentication with {pluginname}, see examples:
+. Create a JWT key in the Customer Portal
+. Configure the `{plugincode}_token_provider` option to specify the endpoint for retrieving your JWT token
 
-* xref:{pluginfilename}-with-jwt-authentication-nodejs.adoc[{pluginname} with JWT authentication (Node.js)]
-* xref:{pluginfilename}-with-jwt-authentication-php.adoc[{pluginname} with JWT authentication (PHP)]
+For more information on how to set up JWT authentication with {pluginname}, see examples: xref:{pluginfilename}-with-jwt-authentication-nodejs.adoc[{pluginname} with JWT authentication (Node.js)] or xref:{pluginfilename}-with-jwt-authentication-php.adoc[{pluginname} with JWT authentication (PHP)]
 
-**Trial period behavior:**
+**Trial period behavior**
 
-* The {pluginname} plugin runs in evaluation mode and adds a watermark to exported content.
-* The `{plugincode}_token_provider` option is "not required" during the trial period.
-* If the trial period "expires" or the plugin lacks the necessary entitlement, it becomes _non-functional_.
-* Attempting to use JWT authentication during the trial will result in an _error_.
+* **Trial Period:**
+** With JWT: Full functionality, unlimited usage, no watermarks.
+** Without JWT: Limited functionality with watermarks and page limits.
+
+* **After Trial:**
+** With {pluginname} "add-on" + JWT: Full functionality (subscription-based).
+** Without add-on: Limited functionality with watermarks and page limits.
+
+Visit the link:https://www.tiny.cloud/auth/login/[account portal] to obtain your JWT key and test full functionality.
 ====


### PR DESCRIPTION
Ticket: DOC-3227

Site: [Export Word](http://docs-hotfix-7-doc-3227.staging.tiny.cloud/docs/tinymce/7/exportword/)
Site: [Export PDF](http://docs-hotfix-7-doc-3227.staging.tiny.cloud/docs/tinymce/7/exportpdf/)
Site: [Import Word](http://docs-hotfix-7-doc-3227.staging.tiny.cloud/docs/tinymce/7/importword/)

Changes:
Behavioral Changes:
- Old behavior: JWT authentication caused errors during the trial and was not required.
- Updated to suite new behavior: JWT authentication is allowed and recommended during the trial for full functionality.
- Introduced a distinction between using the plugin with vs without JWT and with vs without a valid add-on entitlement.

New Additions:
- A clear instruction to create a JWT key via the Customer Portal.
- A direct link to the portal to simplify setup for users.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed