### PR TITLE
DOC-3147: Cutting a whole HTML element would add an empty paragraph.

### DIFF
--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -143,10 +143,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-// === <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Cutting a whole HTML element would add an empty paragraph.
+// #TINY-12171
 
-// CCFR here.
+Previously, an issue was identified where cutting an entire block element, such as a `div` or `p` HTML element, resulted in the block being replaced by an empty paragraph. This behavior only occurred for blocks not contained within tables and led to inconsistent outcomes where cutting content inside tables behaved differently from outside. Additionally, the behavior diverged from that of the backspace `delete` operation.
+
+{productname} {release-version} resolves this issue by unifying the behavior for content both inside and outside tables. The updated implementation aligns cutting behavior with that of the backspace `delete` operation, ensuring a more consistent and predictable editing experience.
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-3147

Site: [Staging branch](http://docs-feature-800-doc-3147tiny-12171.staging.tiny.cloud/docs/tinymce/latest/8.0-release-notes/#cutting-a-whole-html-element-would-add-an-empty-paragraph)

Changes:
* Documented the bug fix for TINY-12171

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [ ] Documentation Team Lead has reviewed