### PR TITLE
DOC-3147: Nested font sizes no longer cause excessive line spacing.

### DIFF
--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -153,7 +153,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 Previously, applying different font sizes to nested elements could result in inconsistent and overly large line heights. This affected users by introducing visual clutter and making text blocks appear misaligned or difficult to read. 
 
-{productname} {release-version} introduces a fix that ensures line heights are calculated based on the font size of the parent element, rather than the nested child elements. This means that when different font sizes are applied within the same content, the line heights will be consistent and proportional to the parent element's font size.
+{productname} {release-version} introduces a fix that ensures line heights are calculated based on the font size visible in the new line, rather than inheriting line-height from parent element. This means that when different font sizes are applied within the same content, the line heights will be consistent and proportional to the visible font size.
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-3147

Site: [Staging branch](http://docs-feature-800-doc-3147tiny-12073.staging.tiny.cloud/docs/tinymce/latest/8.0-release-notes/#nested-font-sizes-no-longer-cause-excessive-line-spacing)

Changes:
* Fix for TINY-12073

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed