### PR TITLE
DOC-3147: Word import of lists with a lighter level failed parsing.

### DIFF
--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -1,4 +1,3 @@
-
 = {productname} {release-version}
 :release-version: 8.0.0
 :navtitle: {productname} {release-version}
@@ -58,6 +57,16 @@ The following premium plugin updates were released alongside {productname} {rele
 // // CCFR here.
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+
+=== PowerPaste
+
+The {productname} {release-version} release includes an accompanying release of the **PowerPaste** premium plugin.
+
+==== Word import of lists with a "lighter" level failed parsing.
+
+When users pasted content from Microsoft Word documents containing lists styled with Word’s "No List" setting into the editor with PowerPaste enabled, the operation failed due to a parsing error. As a result, the content was not inserted into the editor, causing disruption to content workflows. {productname} {release-version} addresses this issue by updating the **PowerPaste** parser to correctly handle lists with the "No List" style. As a result, users can now successfully paste such content into the editor without encountering errors.
+
+For information on the **PowerPaste** plugin, see: xref:introduction-to-powerpaste.adoc[PowerPaste].
 
 
 [[accompanying-premium-plugin-end-of-life-announcement]]


### PR DESCRIPTION
Ticket: DOC-3147

Site: [Staging branch](http://docs-feature-800-doc-3147tiny-11893.staging.tiny.cloud/docs/tinymce/latest/8.0-release-notes/#word-import-of-lists-with-a-lighter-level-failed-parsing)

Changes:
* Added fix documentation for TINY-11893

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed