### PR TITLE
DOC-3147: Tab to create a new row in tables with a non-editable final row would freeze the editor.

### DIFF
--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -148,6 +148,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Tab to create a new row in tables with a non-editable final row would freeze the editor.
+// #TINY-12018
+
+Previously, when attempting to create a new row by pressing Tab in a table with a non-editable final row, the editor would freeze causing a infinite loop of insert attempts. This was due to the logic not correctly detecting whether the last row was editable, leading to repeated, unsuccessful insert attempts.
+
+{productname} {release-version} fixes this issue by correctly detecting whether the last row is editable, allowing the user to create a new row without freezing the editor.
+
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -151,9 +151,9 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Tab to create a new row in tables with a non-editable final row would freeze the editor.
 // #TINY-12018
 
-Previously, when attempting to create a new row by pressing Tab in a table with a non-editable final row, the editor would freeze causing a infinite loop of insert attempts. This was due to the logic not correctly detecting whether the last row was editable, leading to repeated, unsuccessful insert attempts.
+Previously, when tabbing into a non-editable final row of a table, the editor failed to recognize that the row was read-only and instead duplicated it. This resulted in an attempt to place the cursor in the duplicated row, which again could not be edited. The process would repeat indefinitely, creating a loop that ultimately froze the editor.
 
-{productname} {release-version} fixes this issue by correctly detecting whether the last row is editable, allowing the user to create a new row without freezing the editor.
+{productname} {release-version} resolves this issue by detecting when the final row of a table is read-only and preventing the insertion of a new row in such cases. This ensures stable behavior when navigating through tables using the Tab key.
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-3147

Site: [Staging branch](http://docs-feature-800-doc-3147tiny-12018.staging.tiny.cloud/docs/tinymce/latest/8.0-release-notes/#tab-to-create-a-new-row-in-tables-with-a-non-editable-final-row-would-freeze-the-editor)

Changes:
* Fix documentation for TINY-12018

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed