### PR TITLE
DOC-3147: Long tooltips could overflow narrow browser windows.

### DIFF
--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -148,6 +148,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Long tooltips could overflow narrow browser windows
+// #TINY-11884
+
+Previously, long tooltips could overflow narrow browser windows, causing the tooltip text to be partially cut off and unreadable. This issue was most noticeable with the `...` ellipsis toolbar for the "reveal or hide additional toolbar options" button, where the tooltip text would not fit within the narrow viewport.
+
+In {productname} {release-version}, the tooltip behavior has been improved to ensure that long tooltips are properly positioned and wrapped within narrow browser windows. This prevents overflow and ensures that the full tooltip text is visible, even in smaller viewports.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-3147

Site: [Staging branch](http://docs-feature-800-doc-3147tiny-11884.staging.tiny.cloud/docs/tinymce/latest/8.0-release-notes/#long-tooltips-could-overflow-narrow-browser-windows)

Changes:
* Add fix documentation for TINY-11884

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed