### PR TITLE
The `contextform` subtoolbar is no longer dismissed when using the back button in inline editors.

### DIFF
--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -143,7 +143,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-=== The `contextform` subtoolbar is no longer dismissed when using the back button in inline mode editors.
+=== In inline mode, pressing the back button dismissed the context toolbar and moved focus from the selected image to the editor.
 // #TINY-12118
 
 In inline mode, the context form toolbar incorrectly shifted focus from the selected image to the editor container. As a result, the plugin which relies on the current selection to apply changes was unable to apply attributes like `alt` text to the correct image.

--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -143,10 +143,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-// === <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== The `contextform` subtoolbar is no longer dismissed when using the back button in inline mode editors.
+// #TINY-12118
 
-// CCFR here.
+In inline mode, the context form toolbar incorrectly shifted focus from the selected image to the editor container. As a result, the plugin which relies on the current selection to apply changes was unable to apply attributes like `alt` text to the correct image.
+
+{productname} {release-version} resolves this by ensuring that the focus is preserved properly, ensuring that the plugin now applies changes such as `alt` text to the correct image in inline mode.
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-3147

Site: [Staging branch](http://docs-feature-800-doc-3147tiny-12118.staging.tiny.cloud/docs/tinymce/latest/8.0-release-notes/#in-inline-mode-pressing-the-back-button-dismissed-the-context-toolbar-and-moved-focus-from-the-selected-image-to-the-editor)

Changes:
* Documented the bug fix for TINY-12118

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed