### PR TITLE
DOC-3147: It wasn't possible to navigate out of a `figcaption` using the left and right arrow keys in Firefox.

### DIFF
--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -143,10 +143,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-// === <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== It was not possible to navigate out of a `figcaption` using the left and right arrow keys in Firefox.
+// #TINY-11982
 
-// CCFR here.
+Prior to {productname} {release-version}, Firefox exhibited an issue where pressing the left or right arrow keys would not allow users to exit the image `figcaption` element. This behavior was inconsistent with other major browsers such as Google Chrome and Safari, where the arrow keys functioned as expected and allowed seamless navigation out of the `figcaption`.
+
+With {productname} {release-version}, this issue has been resolved. Users can now exit the `figcaption` using the left/right arrow keys in Firefox, aligning its behavior with that of other browsers. This update ensures a more consistent user experience.
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-3147

Site: [Staging branch](http://docs-feature-800-doc-3147tiny-11982.staging.tiny.cloud/docs/tinymce/latest/8.0-release-notes/#it-was-not-possible-to-navigate-out-of-a-figcaption-using-the-left-and-right-arrow-keys-in-firefox)

Changes:
* Documented the bug fix for TINY-11982

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed