### PR TITLE
DOC-3235: remove usage of deprecated setContent method from docs

### DIFF
--- a/modules/ROOT/pages/apis/tinymce.dom.domutils.adoc
+++ b/modules/ROOT/pages/apis/tinymce.dom.domutils.adoc
@@ -269,7 +269,7 @@ Creates HTML string for element. The element will be closed unless an empty inne
 [source, javascript]
 ----
 // Creates a html chunk and inserts it at the current selection/caret location
-tinymce.activeEditor.selection.setContent(tinymce.activeEditor.dom.createHTML('a', { href: 'test.html' }, 'some line'));
+tinymce.activeEditor.insertContent(tinymce.activeEditor.dom.createHTML('a', { href: 'test.html' }, 'some line'));
 ----
 
 ==== Parameters


### PR DESCRIPTION
Ticket: DOC-3235

Site: [Staging branch](http://docs-feature-8-doc-3235.staging.tiny.cloud/docs/tinymce/8/)

Changes:
* replace deprecated `editor.selection.setContent` with `editor.insertContent`

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- ~~[ ] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.~~
- ~~[ ] Included a `release note` entry for any `New product features`.~~
- ~~[ ] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.~~

Review:
- [ ] Documentation Team Lead has reviewed