### PR TITLE
DOC-3147: Tabbing when a  was selected didn't move the selection on the `figcaption` correctly.

### DIFF
--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -143,10 +143,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-// === <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+// === Tabbing when a `figure` was selected didn't move the selection to the `figcaption` correctly.
+// #TINY-11753
 
-// CCFR here.
+Previously, the `tab` key did not correctly handle nested components. Specifically, when a `CET` (Child Editable Text) element was placed inside a `CEF` (Container Editable Field) element such as a `figcaption`, focus behavior was unintuitive. This led to inconsistent and confusing keyboard navigation when interacting with editable nested elements like a `figcaption`.
+
+{productname} {release-version} addresses this issue by ensuring that pressing the `tab` key correctly moves focus to the `CET` element when it is nested within a `CEF` element. This ensures smooth and predictable keyboard navigation for nested editable elements such as a `figcaption`.
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-3147

Site: [Staging branch](http://docs-feature-800-doc-3147tiny-11753.staging.tiny.cloud/docs/tinymce/latest/8.0-release-notes/#tabbing-when-a-figure-was-selected-didnt-move-the-selection-to-the-figcaption-correctly)

Changes:
* Documented the bug fix for TINY-11753

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [ ] Documentation Team Lead has reviewed