### PR TITLE
DOC-3147: Strikethrough format could be added outside font size format, which renders incorrectly in some browsers.

### DIFF
--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -148,6 +148,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Strikethrough format could be added outside font size format, which renders incorrectly in some browsers.
+// #TINY-12004
+
+Previously, there was an issue where combining strikethrough (`s` element) and font size formatting could lead to incorrect rendering in some browsers, particularly Chrome. This occurred when the `s` (strikethrough) element was placed outside a font size span, causing the strikethrough line to render incorrectly.
+
+The fix ensures that the `s` element is now properly nested inside the font size element, improving visual consistency across browsers.
+
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -151,7 +151,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Strikethrough format could be added outside font size format, which renders incorrectly in some browsers.
 // #TINY-12004
 
-Previously, there was an issue where combining strikethrough (`s` element) and font size formatting could lead to incorrect rendering in some browsers, particularly Chrome. This occurred when the `s` (strikethrough) element was placed outside a font size span, causing the strikethrough line to render incorrectly.
+Previously, there was an issue where combining strikethrough (`s` element) and font size formatting could lead to incorrect rendering in some browsers, particularly Chrome. This occurred when the `s` (strikethrough) element was placed outside a font size `span`, causing the strikethrough line to render incorrectly.
 
 The fix ensures that the `s` element is now properly nested inside the font size element, improving visual consistency across browsers.
 


### PR DESCRIPTION
Ticket: DOC-3147

Site: [Staging branch](http://docs-feature-800-doc-3147tiny-12004.staging.tiny.cloud/docs/tinymce/latest/8.0-release-notes/#strikethrough-format-could-be-added-outside-font-size-format-which-renders-incorrectly-in-some-browsers)

Changes:
* Fix documentation for TINY-12004

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed