### PR TITLE
DOC-3147: Default value for `pagebreak_separator` option to better suit modern standards.

### DIFF
--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -121,10 +121,17 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following change<s>:
 
-// === <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Changed the default value for the `pagebreak_separator` option.
+// #TINY-12013
 
-// CCFR here.
+In previous versions of {productname}, inserting a page break in the editor did not translate correctly when exporting using the xref:exportpdf.adoc[Export to PDF] plugin. Similarly, the xref:exportword.adoc[Export to Word] plugin also failed to preserve page breaks in the exported documents. As a result, exported files lacked the intended page breaks, leading to confusing output for users.
+
+With the release of {productname} {release-version}, this issue has been resolved by updating the default HTML value of the `pagebreak_separator` option:
+
+* **Old value** – `'<!-- pagebreak -->'`
+* **New value** – `'<div style=”page-break-after: all”></div>'`
+
+This change aligns better with modern standards and ensures that page breaks are now accurately rendered in exported documents.
 
 
 [[removed]]

--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -129,7 +129,7 @@ In previous versions of {productname}, inserting a page break in the editor did 
 With the release of {productname} {release-version}, this issue has been resolved by updating the default HTML value of the `pagebreak_separator` option:
 
 * **Old value** – `'<!-- pagebreak -->'`
-* **New value** – `'<div style=”page-break-after: all”></div>'`
+* **New value** – `'<div style="break-after: page"></div>'`
 
 This change aligns better with modern standards and ensures that page breaks are now accurately rendered in exported documents.
 

--- a/modules/ROOT/partials/configuration/pagebreak_separator.adoc
+++ b/modules/ROOT/partials/configuration/pagebreak_separator.adoc
@@ -3,7 +3,7 @@
 
 *Type:* `+String+`
 
-*Default value:* `+'<div style=”page-break-after: all”></div>'+`
+*Default value:* `+'<div style="break-after: page"></div>'+`
 
 === Example: using `+pagebreak_separator+`
 

--- a/modules/ROOT/partials/configuration/pagebreak_separator.adoc
+++ b/modules/ROOT/partials/configuration/pagebreak_separator.adoc
@@ -13,6 +13,6 @@ tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
   plugins: 'pagebreak',
   toolbar: 'pagebreak',
-  pagebreak_separator: '<div style=”page-break-after: all”>My page break</div>
+  pagebreak_separator: '<div style=”page-break-after: all”>My page break</div>'
 });
 ----

--- a/modules/ROOT/partials/configuration/pagebreak_separator.adoc
+++ b/modules/ROOT/partials/configuration/pagebreak_separator.adoc
@@ -13,6 +13,6 @@ tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
   plugins: 'pagebreak',
   toolbar: 'pagebreak',
-  pagebreak_separator: '<div style=”page-break-after: all”>My page break</div>'
+  pagebreak_separator: '<div style="break-after: page">My page break</div>'
 });
 ----

--- a/modules/ROOT/partials/configuration/pagebreak_separator.adoc
+++ b/modules/ROOT/partials/configuration/pagebreak_separator.adoc
@@ -3,7 +3,7 @@
 
 *Type:* `+String+`
 
-*Default value:* `+'<!-- pagebreak -->'+`
+*Default value:* `+'<div style=”page-break-after: all”></div>'+`
 
 === Example: using `+pagebreak_separator+`
 
@@ -13,6 +13,6 @@ tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
   plugins: 'pagebreak',
   toolbar: 'pagebreak',
-  pagebreak_separator: '<!-- my page break -->'
+  pagebreak_separator: '<div style=”page-break-after: all”>My page break</div>
 });
 ----


### PR DESCRIPTION
Ticket: DOC-3147

* Release Note: [Release Note](http://docs-feature-800-doc-3147tiny-12013.staging.tiny.cloud/docs/tinymce/latest/8.0-release-notes/#changed-the-default-value-for-the-pagebreak_separator-option)

* Default value change: [Default Value](http://docs-feature-800-doc-3147tiny-12013.staging.tiny.cloud/docs/tinymce/latest/pagebreak/#pagebreak_separator)

Changes:
* Documented the change described in TINY-12013

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed