### PR TITLE
DOC-3240: Remove registry URL from Docker pull commands in installation guides for export-to-pdf and import-from-word components.

### DIFF
--- a/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-installation.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-installation.adoc
@@ -32,7 +32,7 @@ Pull the Docker image:
 
 [source, sh, subs="attributes+"]
 ----
-docker pull registry.containers.tiny.cloud/{dockerimageexporttopdf}:[version]
+docker pull {dockerimageexporttopdf}:[version]
 ----
 
 [TIP]

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
@@ -32,7 +32,7 @@ Pull the Docker image:
 
 [source, sh, subs="attributes+"]
 ----
-docker pull registry.containers.tiny.cloud/{dockerimageimportfromwordexporttoword}:[version]
+docker pull {dockerimageimportfromwordexporttoword}:[version]
 ----
 
 [TIP]


### PR DESCRIPTION
Ticket: DOC-3240

Site: [Export to PDF](http://docs-hotfix-7-doc-3240.staging.tiny.cloud/docs/tinymce/7/individual-export-to-pdf-on-premises/#:~:text=docker%20pull%20registry.containers.tiny.cloud/pdf%2Dconverter%2Dtiny%3A%5Bversion%5D)
Site: [Import from word and Export to word](http://docs-hotfix-7-doc-3240.staging.tiny.cloud/docs/tinymce/7/individual-import-from-word-and-export-to-word-on-premises/#:~:text=docker%20pull%20registry.containers.tiny.cloud/docx%2Dconverter%2Dtiny%3A%5Bversion%5D)

Changes:
* Fix based on Slack Thread

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed