### PR TITLE
DOC-3147: Removed undocumented `documentBaseUrl` property from Editor instances. `documentBaseURI` is the supported property now.

### DIFF
--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -137,6 +137,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Removed undocumented `documentBaseUrl` property from Editor instances. `documentBaseURI` is the supported property now.
+// #TINY-12182
+
+An undocumented `documentBaseUrl` property was previously accessible on `Editor` instances. This property was not part of the supported public API and could lead to confusion or inconsistent usage across implementations.
+
+To improve API clarity and maintain a well-defined interface, the `documentBaseUrl` property has been removed. Integrators should use the officially supported `documentBaseURI` property to access the base URI of the document.
 
 [[bug-fixes]]
 == Bug fixes


### PR DESCRIPTION
Ticket: DOC-3147

Site: [Staging branch](http://docs-feature-800-doc-3147tiny-12182.staging.tiny.cloud/docs/tinymce/latest/8.0-release-notes/#removed-undocumented-documentbaseurl-property-from-editor-instances-documentbaseuri-is-the-supported-property-now)

Changes:
* Removed undocumented `documentBaseUrl` property from Editor instances for TINY-12182

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed