### PR TITLE
DOC-3147: Instructions on how to navigate the color swatch, image select and insert table widget are now announced by the screen readers.

### DIFF
--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -99,10 +99,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following improvement<s>:
 
-// === <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Instructions on how to navigate the color swatch, image select and insert table widget are now announced by screen readers.
+// #TINY-12189
 
-// CCFR here.
+Previously, interactive elements such as the color swatch, create table grid, and image select were missing an `aria-label`. This resulted in a lack of instructions for keyboard users and hindered overall accessibility.
+
+{productname} {release-version} now includes `aria-labels` for these elements, providing clear keyboard navigation instructions. This improvement ensures a more accessible experience for all users.
 
 
 [[additions]]


### PR DESCRIPTION
Ticket: DOC-3147

Site: [Staging branch](http://docs-feature-800-doc-3147tiny-12189.staging.tiny.cloud/docs/tinymce/latest/8.0-release-notes/#instructions-on-how-to-navigate-the-color-swatch-image-select-and-insert-table-widget-are-now-announced-by-screen-readers)

Changes:
* Documented the improvement for TINY-12189

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [ ] Documentation Team Lead has reviewed