### PR TITLE
DOC-3147: Deprecated `editor.selection.setContent` API

### DIFF
--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -170,6 +170,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Deprecated `editor.selection.setContent` API
+// TINY-11692
+
+The `editor.selection.setContent` method has been deprecated in {productname} {release-version}. This low-level API was never intended for external use and does not guarantee consistent behavior when inserting complex content structures, such as lists. Integrators are advised to use the supported `editor.insertContent` method or the `mceInsertClipboardContent` command for reliable content insertion.
+
+This deprecation helps reduce confusion and aligns content insertion with {productname}'s supported APIs.
+
 
 [[known-issues]]
 == Known issues

--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -173,7 +173,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Deprecated `editor.selection.setContent` API
 // TINY-11692
 
-The `editor.selection.setContent` method has been deprecated in {productname} {release-version}. This low-level API was never intended for external use and does not guarantee consistent behavior when inserting complex content structures, such as lists. Integrators are advised to use the supported `editor.insertContent` method or the `mceInsertClipboardContent` command for reliable content insertion.
+The `editor.selection.setContent` method has been deprecated in {productname} {release-version}. This low-level API was never intended for external use and does not guarantee consistent behavior when inserting complex content structures, such as lists. Integrators are advised to use the supported `editor.insertContent` method for reliable content insertion.
 
 This deprecation helps reduce confusion and aligns content insertion with {productname}'s supported APIs.
 


### PR DESCRIPTION
Ticket: DOC-3147

Site: [Staging branch](http://docs-feature-800-doc-3147tiny-11692.staging.tiny.cloud/docs/tinymce/latest/8.0-release-notes/#deprecated-editor-selection-setcontent-api)

Changes:
* Fix for TINY-11692

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
Review:
- [x] Documentation Team Lead has reviewed