### PR TITLE
DOC-3147: HTML schema did not treat `colgroup` or `col` elements as block elements

### DIFF
--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -143,10 +143,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-// === <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== The HTML schema did not treat `colgroup` or `col` elements as block elements.
+// #TINY-12092
 
-// CCFR here.
+In previous versions of {productname}, whitespace between `<colgroup>` and `<col>` tags was not removed by {productname}'s HTML schema. This behavior caused the editor to preserve unnecessary whitespace characters in the table markup.
+
+This issue has been resolved in `{release-version}`. Both `colgroup` and `col` elements are now treated as block-level elements, ensuring that extraneous whitespace is stripped from these areas. As a result, the editor now produces cleaner and more concise table markup.
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-3147

Site: [Staging branch](http://docs-feature-800-doc-3147tiny-.staging.tiny.cloud/docs/tinymce/latest/8.0-release-notes/#the-html-schema-did-not-treat-colgroup-or-col-elements-as-block-elements)

Changes:
* Documented the bug fix for TINY-12092

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [ ] Documentation Team Lead has reviewed