### PR TITLE
DOC-3147: The translate API now automatically replaces three dots in a row with an ellipsis character.

### DIFF
--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -104,6 +104,10 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== The translate API now automatically replaces three dots in a row with an ellipsis character.
+// #TINY-12155
+
+Previously, menu items and tooltips containing three consecutive periods (`...`) were read aloud by the JAWS screen reader as "dot dot dot," which could confuse users relying on assistive technologies. To enhance accessibility, the `translate` API in {productname} {release-version} now automatically replaces three dots with the typographic ellipsis character (`…`) across all translations. This update ensures a consistent visual appearance while improving screen reader behavior, as the ellipsis character is not read aloud. The change is implemented directly in the translation function, ensuring comprehensive coverage across all languages.
 
 [[additions]]
 == Additions


### PR DESCRIPTION
Ticket: DOC-3147

Site: [Staging branch](http://docs-feature-800-doc-3147tiny-12155.staging.tiny.cloud/docs/tinymce/latest/8.0-release-notes/#the-translate-api-now-automatically-replaces-three-dots-in-a-row-with-an-ellipsis-character)

Changes:
* Improvement documentation for TINY-12155

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed