### PR TITLE
DOC-3244: Fix typo in JWT token claims description for On-Premises documentation

### DIFF
--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-autorization-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-autorization-on-premises.adoc
@@ -17,7 +17,7 @@ If the `SECRET_KEY` is not setup during the installation, then {pluginname} On-P
 * it is not issued in the future (e.i. the `iat` timestamp cannot be newer than the current time),
 * it has not expired yet.
 
-Tokens for the {pluginname} On-Premises do not require any additional claims such as the environment ID (which is specific for Collaboration Server On-Premises), the token can be created with an empty payload.
+Tokens for the {pluginname} On-Premises do not require any additional claims such as the aud (which is specific to cloud-based document converters), so the token can be created with an empty payload.
 
 If the specific use case involves sending requests from a backend server, then JWT tokens can be generated locally, as shown in the below request example.
 


### PR DESCRIPTION
Ticket: DOC-3244

Site: [Staging branch](http://docs-feature-800-doc-3244.staging.tiny.cloud/docs/tinymce/7/)

Changes:
* Fix potentially misleading claims explanation in Import/Export to Word On-Premises token documentation

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [ ] Documentation Team Lead has reviewed