### PR TITLE
DOC-3245: Update license link for Tiny Cloud users in understanding editor loads documentation

### DIFF
--- a/modules/ROOT/pages/understanding-editor-loads.adoc
+++ b/modules/ROOT/pages/understanding-editor-loads.adoc
@@ -6,7 +6,7 @@
 == Understanding editor loads for {productname}
 
 [IMPORTANT]
-This information is only relevant to Tiny Cloud users. Users who self-host the open source version of {productname} are not subject to editor load restrictions, but must comply with the https://github.com/tinymce/tinymce/blob/master/LICENSE.TXT[open source license]. 
+This information is only relevant to Tiny Cloud users. Users who self-host the open source version of {productname} are not subject to editor load restrictions, but must comply with the link:https://github.com/tinymce/tinymce/blob/release/{productmajorversion}/LICENSE.md[open source license]. 
 
 An editor load is the event that occurs each time {productname} is initialized in your application. The editor dispatches the 'init' event to indicate a successful load. For example, if 100 users load {productname} 10 times each, the result would be 1,000 editor loads. 
 


### PR DESCRIPTION
Ticket: DOC-<num>

Site: [Staging branch](http://docs-<hotfix|feature>-<version>-doc-<num>.staging.tiny.cloud/docs/tinymce/<version>/)

Changes:

* Update the open source license link to use:
- The `.md` file extension instead of `.TXT`
- Use `{productmajorversion}` variable for better version management when we clone for new editor major versions.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [ ] Documentation Team Lead has reviewed