### PR TITLE
DOC-3247: Fix broken `userlookup` link in partial.

### DIFF
--- a/modules/ROOT/pages/license-key.adoc
+++ b/modules/ROOT/pages/license-key.adoc
@@ -234,6 +234,7 @@ For any licensing or technical support questions, see our available options on t
 === Technical Support
 
 For licensing or technical support:
+
 * API key issues: Visit link:https://www.tiny.cloud/my-account[Tiny Cloud Account]
 * License key issues: Visit link:https://www.tiny.cloud/my-account[Tiny Cloud Account] or contact your account manager
 * Technical support: Visit link:https://support.tiny.cloud[Support Portal]

--- a/modules/ROOT/partials/DEPRECATED/generic_8_userlookup.adoc
+++ b/modules/ROOT/partials/DEPRECATED/generic_8_userlookup.adoc
@@ -1,1 +1,1 @@
-IMPORTANT: This option has been deprecated in {productname} {productmajorversion} and may be removed in a future major {productname} release. Use a combination of `user_id` and `fetch_users` instead. | `xref:apis/tinymce.editor.userlookup.adoc[UserLookup]`
+IMPORTANT: This option has been deprecated in {productname} {productmajorversion} and may be removed in a future major {productname} release. Use a combination of `user_id` and `fetch_users` instead. | `xref:userlookup.adoc[User Lookup API]`


### PR DESCRIPTION
Ticket: DOC-3248

Site: [Staging branch](http://docs-hotfix-800-doc-3248.staging.tiny.cloud/docs/tinymce/latest/revisionhistory/#revisionhistory_author:~:text=and%20fetch_users%20instead.%20%7C-,User%20Lookup%20API,-This%20option%20configures)

Changes:
* fix broken `userlookup` link.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed