### PR TITLE
DOC-3229: Add missing `iframe_attrs` option.

### DIFF
--- a/modules/ROOT/pages/editor-important-options.adoc
+++ b/modules/ROOT/pages/editor-important-options.adoc
@@ -13,6 +13,10 @@ include::partial$configuration/target.adoc[leveloffset=+1]
 
 include::partial$configuration/placeholder.adoc[leveloffset=+1]
 
+== Configuring the editor iframe
+
+include::partial$configuration/iframe_attrs.adoc[leveloffset=+1]
+
 == Focusing on the editor
 
 include::partial$configuration/taborder.adoc[leveloffset=+1]
@@ -56,8 +60,3 @@ include::partial$configuration/content_security_policy.adoc[leveloffset=+1]
 include::partial$configuration/referrer_policy.adoc[leveloffset=+1]
 
 include::partial$configuration/suffix.adoc[leveloffset=+1]
-
-////
-Not documented, but probably belongs in a new section here somewhere.
-include::partial$configuration/iframe_attrs.adoc[]
-////

--- a/modules/ROOT/partials/configuration/iframe_attrs.adoc
+++ b/modules/ROOT/partials/configuration/iframe_attrs.adoc
@@ -1,7 +1,7 @@
 [[iframe_attrs]]
 == `+iframe_attrs+`
 
-This option allows setting custom attributes on the editor's content iframe element when {productname} is running in iframe mode. The attributes are applied during iframe creation and can be used for accessibility compliance, form validation, custom styling, and other customization needs.
+This option allows adding custom attributes to the editor's content iframe element when running in classic mode. The attributes are applied during the iframe creation.
 
 NOTE: This option only affects the main editor content iframe, not other iframes such as preview frames or dialog iframes.
 

--- a/modules/ROOT/partials/configuration/iframe_attrs.adoc
+++ b/modules/ROOT/partials/configuration/iframe_attrs.adoc
@@ -37,5 +37,5 @@ tinymce.init({
 ----
 // After the editor is initialized, you can verify the configuration:
 console.log(tinymce.activeEditor.options.get('iframe_attrs'));
-// Output: {style: 'background-color: #f5f5f5; border: 2px solid #ddd;', class: 'custom-editor-frame'}
+// Output:  {style: 'background-color:rgb(64, 167, 99); border: 2px solid #ddd;', class: 'custom-editor-frame'}
 ----

--- a/modules/ROOT/partials/configuration/iframe_attrs.adoc
+++ b/modules/ROOT/partials/configuration/iframe_attrs.adoc
@@ -1,0 +1,40 @@
+[[iframe_attrs]]
+== `+iframe_attrs+`
+
+This option allows setting custom attributes on the editor's content iframe element when {productname} is running in iframe mode. The attributes are applied during iframe creation and can be used for accessibility compliance, form validation, custom styling, and other customization needs.
+
+NOTE: This option only affects the main editor content iframe, not other iframes such as preview frames or dialog iframes.
+
+*Type:* `+Object+`
+
+.Example: using `+iframe_attrs+` for accessibility
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  iframe_attrs: {
+    'aria-required': 'true',
+    'aria-describedby': 'editor-description'
+  }
+});
+----
+
+.Example: using `+iframe_attrs+` for custom styling
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  iframe_attrs: {
+    'style': 'background-color:rgb(64, 167, 99); border: 2px solid #ddd;',
+    'class': 'custom-editor-frame'
+  }
+});
+----
+
+.Example: verifying `+iframe_attrs+` configuration
+[source,js]
+----
+// After the editor is initialized, you can verify the configuration:
+console.log(tinymce.activeEditor.options.get('iframe_attrs'));
+// Output: {style: 'background-color: #f5f5f5; border: 2px solid #ddd;', class: 'custom-editor-frame'}
+----

--- a/modules/ROOT/partials/configuration/iframe_attrs.adoc
+++ b/modules/ROOT/partials/configuration/iframe_attrs.adoc
@@ -3,6 +3,8 @@
 
 This option allows adding custom attributes to the editor's content iframe element when running in classic mode. The attributes are applied during the iframe creation.
 
+NOTE: This option only affects the main editor content iframe, not other iframes such as preview frames, dialog iframes, or iframe elements created within the editor content.
+
 
 *Type:* `+Object+`
 

--- a/modules/ROOT/partials/configuration/iframe_attrs.adoc
+++ b/modules/ROOT/partials/configuration/iframe_attrs.adoc
@@ -3,7 +3,6 @@
 
 This option allows adding custom attributes to the editor's content iframe element when running in classic mode. The attributes are applied during the iframe creation.
 
-NOTE: This option only affects the main editor content iframe, not other iframes such as preview frames or dialog iframes.
 
 *Type:* `+Object+`
 


### PR DESCRIPTION
Ticket: DOC-3229

Site: [Staging branch](http://docs-hotfix-8-doc-3229.staging.tiny.cloud/docs/tinymce/latest/editor-important-options/#iframe_attrs)

Changes:
* Add missing `iframe_attrs` option to docs.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] Migrate to `6` | `7` post merging.

Review:
- [x] Documentation Team Lead has reviewed