### PR TITLE
DOC-3229: Add missing `iframe_attrs` option. (#3804) `6x` cherry pick from `8x`

### DIFF
--- a/modules/ROOT/pages/editor-important-options.adoc
+++ b/modules/ROOT/pages/editor-important-options.adoc
@@ -13,6 +13,10 @@ include::partial$configuration/target.adoc[leveloffset=+1]
 
 include::partial$configuration/placeholder.adoc[leveloffset=+1]
 
+== Configuring the editor iframe
+
+include::partial$configuration/iframe_attrs.adoc[leveloffset=+1]
+
 == Focusing on the editor
 
 include::partial$configuration/taborder.adoc[leveloffset=+1]
@@ -52,8 +56,3 @@ include::partial$configuration/content_security_policy.adoc[leveloffset=+1]
 include::partial$configuration/referrer_policy.adoc[leveloffset=+1]
 
 include::partial$configuration/suffix.adoc[leveloffset=+1]
-
-////
-Not documented, but probably belongs in a new section here somewhere.
-include::partial$configuration/iframe_attrs.adoc[]
-////

--- a/modules/ROOT/partials/configuration/iframe_attrs.adoc
+++ b/modules/ROOT/partials/configuration/iframe_attrs.adoc
@@ -1,0 +1,41 @@
+[[iframe_attrs]]
+== `+iframe_attrs+`
+
+This option allows adding custom attributes to the editor's content iframe element when running in classic mode. The attributes are applied during the iframe creation.
+
+NOTE: This option only affects the main editor content iframe, not other iframes such as preview frames, dialog iframes, or iframe elements created within the editor content.
+
+
+*Type:* `+Object+`
+
+.Example: using `+iframe_attrs+` for accessibility
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  iframe_attrs: {
+    'aria-required': 'true',
+    'aria-describedby': 'editor-description'
+  }
+});
+----
+
+.Example: using `+iframe_attrs+` for custom styling
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  iframe_attrs: {
+    'style': 'background-color:rgb(64, 167, 99); border: 2px solid #ddd;',
+    'class': 'custom-editor-frame'
+  }
+});
+----
+
+.Example: verifying `+iframe_attrs+` configuration
+[source,js]
+----
+// After the editor is initialized, you can verify the configuration:
+console.log(tinymce.activeEditor.options.get('iframe_attrs'));
+// Output:  {style: 'background-color:rgb(64, 167, 99); border: 2px solid #ddd;', class: 'custom-editor-frame'}
+----


### PR DESCRIPTION
* DOC-3229: Add missing iframe_attrs option.

* Update modules/ROOT/partials/configuration/iframe_attrs.adoc

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed