### PR TITLE
DOC-3252: Fix Port Reference in SSL Documentation for Word/PDF Document Converters.

### DIFF
--- a/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-ssl-communication.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-ssl-communication.adoc
@@ -32,7 +32,7 @@ frontend http-in
   default_backend servers
 
 backend servers
-  server server1 127.0.0.1:8000 maxconn 32
+  server server1 127.0.0.1:8080 maxconn 32
 ----
 
 === NGINX example
@@ -55,7 +55,7 @@ http {
     ssl_certificate_key /etc/ssl/your_cert_key.key;
 
     location / {
-      proxy_pass http://127.0.0.1:8000;
+      proxy_pass http://127.0.0.1:8080;
 
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "Upgrade";
@@ -66,3 +66,9 @@ http {
   }
 }
 ----
+
+
+[NOTE]
+====
+The Docker images do not include built-in SSL configuration. SSL must be handled by a reverse proxy that forwards requests to the container's HTTP service on port 8080.
+====

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-ssl-communication-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-ssl-communication-on-premises.adoc
@@ -1,4 +1,4 @@
-[[sll-communication]]
+[[ssl-communication]]
 == SSL Communication
 
 Its possible to communicate with {pluginname} On-Premises using secure connections. To achieve this, the load balancer like `NGINX` or `HAProxy` needs to be setup with your SSL certificate.

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-ssl-communication-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-ssl-communication-on-premises.adoc
@@ -32,7 +32,7 @@ frontend http-in
   default_backend servers
 
 backend servers
-  server server1 127.0.0.1:8000 maxconn 32
+  server server1 127.0.0.1:8080 maxconn 32
 ----
 
 === NGINX example
@@ -55,7 +55,7 @@ http {
     ssl_certificate_key /etc/ssl/your_cert_key.key;
 
     location / {
-      proxy_pass http://127.0.0.1:8000;
+      proxy_pass http://127.0.0.1:8080;
 
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "Upgrade";
@@ -66,3 +66,9 @@ http {
   }
 }
 ----
+
+
+[NOTE]
+====
+The Docker images do not include built-in SSL configuration. SSL must be handled by a reverse proxy that forwards requests to the container's HTTP service on port 8080.
+====


### PR DESCRIPTION
Ticket: DOC-3252

Site: [individual-import-from-word-and-export-to-word-on-premises/#sll-communication](http://docs-hotfix-8-doc-3252.staging.tiny.cloud/docs/tinymce/latest/individual-import-from-word-and-export-to-word-on-premises/#sll-communication)
Site: [individual-export-to-pdf-on-premises/#ssl-communication](http://docs-hotfix-8-doc-3252.staging.tiny.cloud/docs/tinymce/latest/individual-export-to-pdf-on-premises/#ssl-communication)

Changes:
* Fix outdated PORT References.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed