### PR TITLE
DOC-3250: Elements with no visible height were not displaying in the Review Edits view.

### DIFF
--- a/modules/ROOT/pages/8.0.2-release-notes.adoc
+++ b/modules/ROOT/pages/8.0.2-release-notes.adoc
@@ -48,7 +48,15 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== Elements with no visible height were not displaying in the Review Edits view.
 // TINY-12257
 
-//CCFR here.
+Previously, elements with no visible height (`+<br>+`, `+<!-- pagebreak -->+` comments, and `+<hr>+` tags) were missing from the Review Edits preview. This caused operations related to these elements to appear as floating cards without corresponding visual content, making it difficult for reviewers to understand the context of changes.
+
+{productname} {release-version} now renders visual representations of these elements in the preview:
+
+* `+<br>+` tags display as an **Enter** icon.
+* `+<!-- pagebreak -->+` comments render the same as in the editor.
+* `+<hr>+` tags show with change indicators for insertions or deletions.
+
+This ensures reviewers can clearly identify what and where changes occurred, even for elements that have no visible height.
 
 For information on the **Suggested Edits** plugin, see: xref:suggestededits.adoc[Suggested Edits].
 


### PR DESCRIPTION
Ticket: DOC-3250

Site: [Release notes](http://docs-feature-802-doc-3250tiny-12257.staging.tiny.cloud/docs/tinymce/latest/8.0.2-release-notes/#elements-with-no-visible-height-were-not-displaying-in-the-review-edits-view)

Changes:
* Fix for TINY-12257

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed