### PR TITLE
DOC-3250: Enforce  string check on all image rules.

### DIFF
--- a/modules/ROOT/pages/8.0.2-release-notes.adoc
+++ b/modules/ROOT/pages/8.0.2-release-notes.adoc
@@ -61,7 +61,16 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== Enforce `+alt+` string check on all image rules
 // TINY-12546
 
-//CCFR here.
+Previously, users attempting to repair accessibility issues in the `a11ychecker` may not have consistently seen error messages when their input failed validation. This led to confusion, as users were not informed why their repair attempt was rejected. For example, submitting an image filename as `+alt+` text or entering excessively long or empty text—when not permitted—should have triggered specific validation messages, but these were not always shown.
+
+{productname} {release-version} ensures all defined validation messages are now displayed reliably for all relevant rule violations across the `a11ychecker` repair workflow. Scenarios include:
+
+* Filename used as `+alt+` text when decorative images are not allowed.
+** Result: Now a filename error is shown in the repair dialog.
+* `+alt+` text exceeding maximum length.
+** Result: Now a length validation error is shown in the repair dialog.
+* Empty `+alt+` text when a description is required.
+** Result: Now a empty text error is shown in the repair dialog.
 
 For information on the **Accessibility Checker** plugin, see: xref:a11ychecker.adoc[Accessibility Checker].
 


### PR DESCRIPTION
Ticket: DOC-3250

Site: [Staging branch](http://docs-feature-802-doc-3250tiny-12546.staging.tiny.cloud/docs/tinymce/latest/8.0.2-release-notes/#enforce-alt-string-check-on-all-image-rules)

Changes:
* <placeholder-text>

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed