### PR TITLE
DOC-3257: Document spellchecker_language local storage override behavior

### DIFF
--- a/modules/ROOT/partials/configuration/spellchecker_language.adoc
+++ b/modules/ROOT/partials/configuration/spellchecker_language.adoc
@@ -17,3 +17,20 @@ tinymce.init({
   spellchecker_language: 'de'  // Use ISO language code, hyphenated for regional variants (e.g., 'de-DE')
 });
 ----
+
+[NOTE]
+====
+If a user selects a language from the Spell Checker language toolbar dropdown, that selection is saved to the browser's local storage and takes precedence over the `+spellchecker_language+` configuration option. The local storage value persists across browser sessions and will continue to override the developer-specified setting.
+
+*Debugging language issues:*
+
+* To check the current active language for the specific device, use the browser console: `+tinymce.activeEditor.plugins.tinymcespellchecker.getLanguage()+`
+* If integrators or users are having issues with the `+spellchecker_language+` option not being respected, they can:
+
+. Open browser developer tools (F12)
+. Go to the Console tab
+. Run `+localStorage.clear()+` to clear all local storage
+. Refresh the page to reinitialize the editor
+
+For more information about localStorage, see link:https://developer.mozilla.org/en-US/docs/Web/API/Storage/clear[MDN Web Docs].
+====

--- a/modules/ROOT/partials/configuration/spellchecker_language.adoc
+++ b/modules/ROOT/partials/configuration/spellchecker_language.adoc
@@ -20,7 +20,7 @@ tinymce.init({
 
 [NOTE]
 ====
-If a user selects a language from the Spell Checker language toolbar dropdown, that selection is saved to the browser's local storage and takes precedence over the `+spellchecker_language+` configuration option. The local storage value persists across browser sessions and will continue to override the developer-specified setting.
+If a user selects a language from the Spell Checker language toolbar dropdown, that selection is saved to the browser's local storage and takes precedence over the `+spellchecker_language+` configuration option. The local storage value persists across browser sessions and will continue to override the configured setting.
 
 *Debugging language issues:*
 


### PR DESCRIPTION
Ticket: DOC-3257

Site: [Staging branch](http://docs-hotfix-8-doc-3257.staging.tiny.cloud/docs/tinymce/latest/introduction-to-tiny-spellchecker/#spellchecker_language)

Changes:
* CS support ticket to improve knowledge about the `spellchecker_language` option not respecting in UI due to `localStorage` caching.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed