### PR TITLE
DOC-3250: Add missing `licensekeymanager` for some bundles.

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -421,6 +421,7 @@
 *** {productname} 8.0.1
 **** xref:8.0.1-release-notes.adoc#overview[Overview]
 **** xref:8.0.1-release-notes.adoc#bug-fixes[Bug fixes]
+**** xref:8.0.1-release-notes.adoc#known-issue[Known issue]
 *** {productname} 8.0
 **** xref:8.0-release-notes.adoc#overview[Overview]
 **** xref:8.0-release-notes.adoc#new-premium-plugins[New Premium plugins]

--- a/modules/ROOT/pages/8.0.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.0.1-release-notes.adoc
@@ -20,6 +20,7 @@ This patch release introduces no new features or enhancements. It solely include
 These release notes summarize the updates introduced in {productname} {release-version}, including:
 
 * xref:bug-fixes[Bug fixes]
+* xref:known-issue[Known issue]
 
 [[bug-fixes]]
 == Bug Fixes
@@ -30,3 +31,13 @@ This section outlines the bug fixes and corrections included in {productname} {r
 // #TINY-12581
 
 In {productname} {productmajorversion}, the changelog information for the link:https://download.tiny.cloud/tinymce/community/tinymce_8.0.0.zip[community/tinymce_8.0.0.zip] file was inadvertently omitted. This release corrects that by providing the previously missing changelog entries for the community bundle.
+
+[[known-issues]]
+== Known Issues
+
+[[missing-licensekeymanager-plugin]]
+=== Missing `licensekeymanager` plugin in some bundles
+
+In {productname} 8.0.1, the `licensekeymanager` plugin was missing from some available bundles.
+
+**Status:** This has been corrected in {productname} 8.0.2, which now includes the `licensekeymanager` plugin in all available bundles.

--- a/modules/ROOT/pages/8.0.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.0.1-release-notes.adoc
@@ -32,12 +32,13 @@ This section outlines the bug fixes and corrections included in {productname} {r
 
 In {productname} {productmajorversion}, the changelog information for the link:https://download.tiny.cloud/tinymce/community/tinymce_8.0.0.zip[community/tinymce_8.0.0.zip] file was inadvertently omitted. This release corrects that by providing the previously missing changelog entries for the community bundle.
 
-[[known-issues]]
-== Known Issues
+[[known-issue]]
+== Known Issue
 
 [[missing-licensekeymanager-plugin]]
 === Missing `licensekeymanager` plugin in some bundles
+// #TINY-12160
 
 In {productname} 8.0.1, the `licensekeymanager` plugin was missing from some available bundles.
 
-**Status:** This has been corrected in {productname} 8.0.2, which now includes the `licensekeymanager` plugin in all available bundles.
+**Status:** This has been corrected in xref:8.0.2-release-notes.adoc[{productname} 8.0.2], which now includes the `licensekeymanager` plugin in all available bundles.

--- a/modules/ROOT/pages/8.0.2-release-notes.adoc
+++ b/modules/ROOT/pages/8.0.2-release-notes.adoc
@@ -16,6 +16,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 * xref:accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
 * xref:accompanying-enhanced-skins-and-icon-packs-changes[Accompanying Enhanced Skins & Icon Packs changes]
 
+// #TINY-12160
 [NOTE]
 ====
 In {productname} 8.0.1, the `licensekeymanager` plugin was missing from some available bundles. {productname} 8.0.2 corrects this by including the `licensekeymanager` plugin in all available bundles which resolves the xref:8.0.1-release-notes.adoc#missing-licensekeymanager-plugin[Known issue] from the previous release.

--- a/modules/ROOT/pages/8.0.2-release-notes.adoc
+++ b/modules/ROOT/pages/8.0.2-release-notes.adoc
@@ -16,6 +16,10 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 * xref:accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
 * xref:accompanying-enhanced-skins-and-icon-packs-changes[Accompanying Enhanced Skins & Icon Packs changes]
 
+[NOTE]
+====
+In {productname} 8.0.1, the `licensekeymanager` plugin was missing from some available bundles. {productname} 8.0.2 corrects this by including the `licensekeymanager` plugin in all available bundles which resolves the xref:8.0.1-release-notes.adoc#missing-licensekeymanager-plugin[Known issue] from the previous release.
+====
 
 [[accompanying-premium-plugin-changes]]
 == Accompanying Premium plugin changes

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -7,6 +7,13 @@ NOTE: This is the {productname} Community version changelog. For information abo
 
 == xref:8.0.2-release-notes.adoc[8.0.2 - 2025-08-14]
 
+[NOTE]
+====
+In {productname} 8.0.1, the `licensekeymanager` plugin was missing from some available bundles. {productname} 8.0.2 corrects this by including the `licensekeymanager` plugin in all available bundles.
+
+**Workaround for 8.0.1 users:** If you are using a bundle that is missing the `licensekeymanager` plugin, you can download the plugin separately and manually add it to your plugins folder. Contact your account manager or support for assistance in obtaining the separate `licensekeymanager` plugin download.
+====
+
 //TODO
 
 == xref:8.0.1-release-notes.adoc[8.0.1 - 2025-07-28]


### PR DESCRIPTION
Ticket: DOC-3250

Site: [Staging branch](http://docs-feature-802-doc-3250tiny-12160.staging.tiny.cloud/docs/tinymce/latest/8.0.2-release-notes/#overview)

Changes:
* Add note to TinyMCE 8.0.2 Release notes and added known issue to [TinyMCE 8.0.1](https://www.tiny.cloud/docs/tinymce/latest/8.0.1-release-notes/) for missing `licensekeymanager` in some bundles.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed