### PR TITLE
DOC-2503: DOC-2503: Add example to `exportpdf_converter_style` partial for configuring watermarks to exported document.

### DIFF
--- a/modules/ROOT/partials/configuration/exportpdf_converter_style.adoc
+++ b/modules/ROOT/partials/configuration/exportpdf_converter_style.adoc
@@ -27,3 +27,25 @@ tinymce.init({
   exportpdf_converter_style: 'p { color: cyan !important }' // requires both "exportpdf_converter_style" and "exportpdf_service_url" to be set.
 });
 ----
+
+[TIP]
+Watermarks can be added to exported PDF documents using CSS. Add the watermark styles to the `exportpdf_converter_style` option, targeting `body::after` instead of `#tinymce::after` for proper rendering. For more information see: link:https://exportpdf.converter.tiny.cloud/docs#section/General/CSS[General/CSS].
+
+=== Example: Adding watermarks to exported PDF documents
+
+[source,js]
+----
+exportpdf_converter_style: `
+  body::after {
+    content: "CONFIDENTIAL";
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) rotate(-45deg);
+    font-size: 48px;
+    color: rgba(0, 0, 0, 0.1);
+    z-index: 1000;
+    pointer-events: none;
+  }
+`
+----


### PR DESCRIPTION
Ticket: DOC-2503

Site: [Staging branch](http://docs-hotfix-8-doc-2503.staging.tiny.cloud/docs/tinymce/latest/exportpdf/#exportpdf-converter-style)

Changes:
* Add config example to showcase how to add watermarks to exported pdf's.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] Port changes to 7x once merged.

Review:
- [x] Documentation Team Lead has reviewed