### PR TITLE
DOC-3265: Make boolean formatting and section ordering for these files more consistent.

### DIFF
--- a/modules/ROOT/partials/configuration/convert_unsafe_embeds.adoc
+++ b/modules/ROOT/partials/configuration/convert_unsafe_embeds.adoc
@@ -1,15 +1,15 @@
 [[convert-unsafe-embeds]]
 == `convert_unsafe_embeds` option
 
-This option controls whether an `<object>` and `<embed>` elements will be converted to more restrictive alternatives, namely `<img>` for image MIME types, `<video>` for video MIME types, `<audio>` for audio MIME types, or `<iframe>` for other or unspecified MIME types. 
+This option controls whether an `<object>` and `<embed>` elements will be converted to more restrictive alternatives, namely `<img>` for image MIME types, `<video>` for video MIME types, `<audio>` for audio MIME types, or `<iframe>` for other or unspecified MIME types.
 
 When converted to `<img>`, `<video>`, or `<audio>`, this prevents the embedded resource from performing potentially malicious actions including scripting, file downloads, browser popups, passing the same-origin policy, among others. Enable the `sandbox_iframes` option in addition to ensure <iframe> conversions are also neutralised.
 
 *Type:* `+Boolean+`
 
-*Possible values:* `true`, `false`
+*Default value:* `+true+`
 
-*Default value:* `true`
+*Possible values:* `+true+`, `+false+`
 
 === Example: using `convert_unsafe_embeds` option
 

--- a/modules/ROOT/partials/configuration/help_accessibility.adoc
+++ b/modules/ROOT/partials/configuration/help_accessibility.adoc
@@ -7,9 +7,9 @@ The `help_accessibility` option allows for this display to be turned off.
 
 *Type:* `+Boolean+`
 
-*Possible values:* `true`, `false`
+*Default value:* `+true+`
 
-*Default value:* `true`
+*Possible values:* `+true+`, `+false+`
 
 === Example: turning `help_accessibility` off
 

--- a/modules/ROOT/partials/configuration/indent.adoc
+++ b/modules/ROOT/partials/configuration/indent.adoc
@@ -7,9 +7,9 @@ Set `+indent+` to `false` to get HTML output from {productname} without having a
 
 *Type:* `+Boolean+`
 
-*Possible values:* `true`, `false`
+*Default value:* `+false+`
 
-*Default value:* `true`
+*Possible values:* `+true+`, `+false+`
 
 === Example: setting `+indent+` to false
 

--- a/modules/ROOT/partials/configuration/pad_empty_with_br.adoc
+++ b/modules/ROOT/partials/configuration/pad_empty_with_br.adoc
@@ -11,9 +11,9 @@ For example, when this option is set to `true`, an empty paragraph, `+<p></p>+`,
 
 *Type:* `+Boolean+`
 
-*Possible values:* `true`, `false`
+*Default value:* `+false+`
 
-*Default value:* `false`
+*Possible values:* `+true+`, `+false+`
 
 === Example: using `pad_empty_with_br`
 

--- a/modules/ROOT/partials/configuration/readonly.adoc
+++ b/modules/ROOT/partials/configuration/readonly.adoc
@@ -3,11 +3,11 @@
 
 Setting the `readonly` option to `true` initializes the editor in **readonly** mode instead of editing (**design**) mode. Once initialized, the editor can be switched to **design** mode using the xref:apis/tinymce.editormode.adoc#set[`tinymce.editor.mode.set` API].
 
-*Type:* `Boolean`
+*Type:* `+Boolean+`
 
-*Default value:* `false`
+*Default value:* `+false+`
 
-*Possible values:* `true`, `false`
+*Possible values:* `+true+`, `+false+`
 
 === Example: Using `readonly`
 
@@ -27,7 +27,7 @@ liveDemo::readonly-demo[]
 |===
 | **Behavior** | **Details** | **Allowed (True/False)**
 
-| Navigation and Interaction 
+| Navigation and Interaction
 a|
 * Users can place the cursor within the editor
 * Navigation behaves the same as in design mode, including:
@@ -63,7 +63,7 @@ a|
 | False
 
 | Enabled Features
-a| 
+a|
 * The following toolbar/menu items remain enabled in **readonly** mode:
 ** xref:fullscreen.adoc[Full Screen]
 ** xref:help.adoc[Help]

--- a/modules/ROOT/partials/configuration/sandbox_iframes.adoc
+++ b/modules/ROOT/partials/configuration/sandbox_iframes.adoc
@@ -5,9 +5,9 @@ This option allows control of whether `<iframe>` elements are link:https://devel
 
 *Type:* `+Boolean+`
 
-*Possible values:* `true`, `false`
+*Default value:* `+true+`
 
-*Default value:* `true`
+*Possible values:* `+true+`, `+false+`
 
 === Example: using `sandbox_iframes` option
 

--- a/modules/ROOT/partials/configuration/tinycomments_mentions_enabled.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_mentions_enabled.adoc
@@ -5,18 +5,18 @@ The {pluginname} plugin offers the `+tinycomments_mentions_enabled+` option to c
 
 *Type:* `+Boolean+`
 
-*Possible values:* `true`, `false`
+*Default value:* `+true+`
 
-*Default value:* `true`
+*Possible values:* `+true+`, `+false+`
 
 === Example: using `tinycomments_mentions_enabled` option
 
 [source,js]
 ----
 const userDb = {
-  'johnsmith': { 
-    id: 'johnsmith', 
-    name: 'John Smith' 
+  'johnsmith': {
+    id: 'johnsmith',
+    name: 'John Smith'
   },
 };
 


### PR DESCRIPTION
Ticket: DOC-3265

Site: [Staging branch](http://docs-hotfix-8-doc-3265.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* The first batch of changes for DOC-1928. This PR focuses on making the boolean formatting and section ordering for the following  particular files more consistent:

  - convert_unsafe_embeds.adoc
  - help_accessibility.adoc
  - indent.adoc
  - pad_empty_with_br.adoc
  - readonly.adoc
  - sandbox_iframes.adoc
  - tinycomments_mentions_enabled.adoc

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed