### PR TITLE
DOC-3266: Standardised section order for options.

### DIFF
--- a/modules/ROOT/partials/configuration/advanced-typography.adoc
+++ b/modules/ROOT/partials/configuration/advanced-typography.adoc
@@ -29,7 +29,7 @@ If an HTML tag or an HTML tag with a specified attribute is added to the `typogr
 
 *Default value:* none
 
-*Possible values:* `+['<html-selector>', 'span["<html-selector>"]' ]+`
+*Possible values:* `+[ '<html-selector>', 'span["<html-selector>"]' ]+`
 
 === Example: Using `typography_ignore`
 

--- a/modules/ROOT/partials/configuration/advanced-typography.adoc
+++ b/modules/ROOT/partials/configuration/advanced-typography.adoc
@@ -27,9 +27,9 @@ If an HTML tag or an HTML tag with a specified attribute is added to the `typogr
 
 *Type:* `+Array+`
 
-*Possible values:* `[ '<html-selector>', 'span["<html-selector>"]' ]`
-
 *Default value:* none
+
+*Possible values:* `+['<html-selector>', 'span["<html-selector>"]' ]+`
 
 === Example: Using `typography_ignore`
 
@@ -39,7 +39,7 @@ tinymce.init({
   selector: 'textarea',  // change this value according to your html
   plugins: '{plugincode}',
   toolbar: 'typography',
-  typography_default_lang: 'en-US', 
+  typography_default_lang: 'en-US',
   typography_ignore: [ 'code', 'span["lang"]' ]
 });
 ----
@@ -96,7 +96,7 @@ tinymce.init({
 
 [cols="1,1"]
 |===
-|Supported language |Language code 
+|Supported language |Language code
 
 |Belarusian
 |be
@@ -212,5 +212,3 @@ tinymce.init({
   ]
 });
 ----
-
-

--- a/modules/ROOT/partials/configuration/details_initial_state.adoc
+++ b/modules/ROOT/partials/configuration/details_initial_state.adoc
@@ -16,9 +16,9 @@ The default value for this option is `+inherited+`.
 
 *Type:* `+String+`
 
-*Default value:* `+inherited+`
+*Default value:* `'+inherited+'`
 
-*Possible values:* `+inherited+`, `+collapsed+`, `+expanded+`
+*Possible values:* `'+inherited+'`, `'+collapsed+'`, `'+expanded+'`
 
 === Example: using `details_initial_state` to set all created Accordion sections to present as closed by default
 

--- a/modules/ROOT/partials/configuration/details_initial_state.adoc
+++ b/modules/ROOT/partials/configuration/details_initial_state.adoc
@@ -16,9 +16,9 @@ The default value for this option is `+inherited+`.
 
 *Type:* `+String+`
 
-*Possible values:* `+inherited+`, `+collapsed+`, `+expanded+`
-
 *Default value:* `+inherited+`
+
+*Possible values:* `+inherited+`, `+collapsed+`, `+expanded+`
 
 === Example: using `details_initial_state` to set all created Accordion sections to present as closed by default
 

--- a/modules/ROOT/partials/configuration/details_serialized_state.adoc
+++ b/modules/ROOT/partials/configuration/details_serialized_state.adoc
@@ -13,7 +13,7 @@ The default value for this option is `+inherited+`.
 
 *Type:* `+String+`
 
-*Default value:* `+inherited+`
+*Default value:* `'+inherited+'`
 
 *Possible values:* `'+inherited+'`, `'+collapsed+'`, `'+expanded+'`
 

--- a/modules/ROOT/partials/configuration/details_serialized_state.adoc
+++ b/modules/ROOT/partials/configuration/details_serialized_state.adoc
@@ -13,9 +13,9 @@ The default value for this option is `+inherited+`.
 
 *Type:* `+String+`
 
-*Possible values:* `+inherited+`, `+collapsed+`, `+expanded+`
-
 *Default value:* `+inherited+`
+
+*Possible values:* `+inherited+`, `+collapsed+`, `+expanded+`
 
 === Example: using `details_serialized_state` to close all Accordions on content save
 

--- a/modules/ROOT/partials/configuration/details_serialized_state.adoc
+++ b/modules/ROOT/partials/configuration/details_serialized_state.adoc
@@ -15,7 +15,7 @@ The default value for this option is `+inherited+`.
 
 *Default value:* `+inherited+`
 
-*Possible values:* `+inherited+`, `+collapsed+`, `+expanded+`
+*Possible values:* `'+inherited+'`, `'+collapsed+'`, `'+expanded+'`
 
 === Example: using `details_serialized_state` to close all Accordions on content save
 

--- a/modules/ROOT/partials/configuration/dialog_align.adoc
+++ b/modules/ROOT/partials/configuration/dialog_align.adoc
@@ -9,9 +9,9 @@ This is also the value applied if the property is not explicitly set.
 
 *Type:* `+String+`
 
-*Possible values:* `'+start+'`, `'+center+'`, `+end+`
-
 *Default value:* `+start+`
+
+*Possible values:* `'+start+'`, `'+center+'`, `+end+`
 
 The values, `+start+` and `+end+`, refer to the beginning or end of a text line and are relative to the display language.
 
@@ -28,7 +28,7 @@ tinymce.activeEditor.windowManager.open({
   title: 'Dialog Title', // The dialog's title - displayed in the dialog header
   body: {
     type: 'panel', // The root body type - a Panel or TabPanel
-    items: [ 
+    items: [
         {
           type: 'label', // component type
           label: 'Caption', // text for the group label
@@ -38,7 +38,7 @@ tinymce.activeEditor.windowManager.open({
               type: 'htmlpanel', // an HTML panel component
               html: 'Panel content goes here.'
             }
-          ] 
+          ]
         }
     ]
   },

--- a/modules/ROOT/partials/configuration/dialog_align.adoc
+++ b/modules/ROOT/partials/configuration/dialog_align.adoc
@@ -29,17 +29,17 @@ tinymce.activeEditor.windowManager.open({
   body: {
     type: 'panel', // The root body type - a Panel or TabPanel
     items: [
-        {
-          type: 'label', // component type
-          label: 'Caption', // text for the group label
-          align: 'end',
-          items: [
-            {
-              type: 'htmlpanel', // an HTML panel component
-              html: 'Panel content goes here.'
-            }
-          ]
-        }
+      {
+        type: 'label', // component type
+        label: 'Caption', // text for the group label
+        align: 'end',
+        items: [
+          {
+            type: 'htmlpanel', // an HTML panel component
+            html: 'Panel content goes here.'
+          }
+        ]
+      }
     ]
   },
   buttons: [ // A list of footer buttons

--- a/modules/ROOT/partials/configuration/dialog_align.adoc
+++ b/modules/ROOT/partials/configuration/dialog_align.adoc
@@ -11,7 +11,7 @@ This is also the value applied if the property is not explicitly set.
 
 *Default value:* `+start+`
 
-*Possible values:* `'+start+'`, `'+center+'`, `+end+`
+*Possible values:* `'+start+'`, `'+center+'`, `'+end+'`
 
 The values, `+start+` and `+end+`, refer to the beginning or end of a text line and are relative to the display language.
 

--- a/modules/ROOT/partials/configuration/dialog_border.adoc
+++ b/modules/ROOT/partials/configuration/dialog_border.adoc
@@ -11,9 +11,9 @@ The border is also highlighted when the `iframe` component takes focus (by, for 
 
 *Type:* `+Boolean+`
 
-*Possible values:* `+true+`, `+false+`
-
 *Default value:* `+false+`
+
+*Possible values:* `+true+`, `+false+`
 
 === Example: using `border` to display a border around an `iframe` component
 

--- a/modules/ROOT/partials/configuration/dialog_persistent.adoc
+++ b/modules/ROOT/partials/configuration/dialog_persistent.adoc
@@ -13,9 +13,9 @@ NOTE: If an inline dialog is open and focus is switched away from the {productna
 
 *Type:* `+Boolean+`
 
-*Possible values:* `+true+`, `+false+`
+*Default value:* `+false+`
 
-*Default value:* `false`
+*Possible values:* `+true+`, `+false+`
 
 === Example: using `persistent`
 

--- a/modules/ROOT/partials/configuration/dialog_streamContent.adoc
+++ b/modules/ROOT/partials/configuration/dialog_streamContent.adoc
@@ -19,9 +19,9 @@ A user can, however, scroll through the `+iframe+` component as updates are bein
 
 *Type:* `+Boolean+`
 
-*Possible values:* `+true+` `+false+`
+*Default value:* `+false+`
 
-*Default value:* `false`
+*Possible values:* `+true+` `+false+`
 
 === Example: setting an `iframe` component to display updating content using the `streamContent` property
 
@@ -72,4 +72,3 @@ The recommended method for updating content in an `+iframe+` component is:
 . `onAction` is a callback defined in the dialog spec. It is called when a button within the dialog `body` is triggered.
 
 . `myiframe` is the name of the `+iframe+` component in this spec.
-

--- a/modules/ROOT/partials/configuration/editimage_toolbar.adoc
+++ b/modules/ROOT/partials/configuration/editimage_toolbar.adoc
@@ -3,6 +3,10 @@
 
 The exact selection of buttons that will appear on the contextual toolbar can be controlled via `+editimage_toolbar+` option.
 
+*Type:* `+String+`
+
+*Default value:* `+'rotateleft rotateright | flipv fliph | editimage imageoptions'+`
+
 *Possible values:*
 
 * `+rotateleft+`
@@ -11,10 +15,6 @@ The exact selection of buttons that will appear on the contextual toolbar can be
 * `+fliph+`
 * `+editimage+`
 * `+imageoptions+`
-
-*Type:* `+String+`
-
-*Default value:* `+'rotateleft rotateright | flipv fliph | editimage imageoptions'+`
 
 === Example: using `+editimage_toolbar+`
 

--- a/modules/ROOT/partials/configuration/tableofcontents_orderedlist_type.adoc
+++ b/modules/ROOT/partials/configuration/tableofcontents_orderedlist_type.adoc
@@ -11,9 +11,9 @@ And setting the `+tableofcontents_orderedlist_type+` to one of its available val
 
 *Type:* `+String+`
 
-*Possible values:* `+'1'+`, `+'A'+`, `+'a'+`, `+'I'+`, `+'i'+`
-
 *Default value:* `+'1'+`
+
+*Possible values:* `+'1'+`, `+'A'+`, `+'a'+`, `+'I'+`, `+'i'+`
 
 The possible values set the type attribute of the ordered list, `<ol>` as follows:
 


### PR DESCRIPTION
Ticket: DOC-3266

Site: [Staging branch](http://docs-hotfix-8-doc-3266.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* Standardised section order for options for the following files:

  - advanced-typography.adoc
  - details_initial_state.adoc
  - details_serialized_state.adoc
  - dialog_align.adoc
  - dialog_border.adoc
  - dialog_persistent.adoc
  - dialog_streamContent.adoc
  - editimage_toolbar.adoc
  - tableofcontents_orderedlist_type.adoc

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed