### PR TITLE
DOC-3268: Added missing `Possible values` section to boolean properties.

### DIFF
--- a/modules/ROOT/partials/configuration/allow_html_in_comments.adoc
+++ b/modules/ROOT/partials/configuration/allow_html_in_comments.adoc
@@ -7,6 +7,8 @@ The `allow_html_in_comments` option allows HTML-like content to be retained in c
 
 *Default value:* `+false+`
 
+*Possible values:* `+true+`, `+false+`
+
 [WARNING]
 Setting this option to `true` may expose your application to XSS vulnerabilities. The DOMPurify maintainers have identified potential security risks when HTML-like content is allowed in comments. Only enable this option if you trust your content sources and understand the security implications.
 

--- a/modules/ROOT/partials/configuration/contextmenu_never_use_native.adoc
+++ b/modules/ROOT/partials/configuration/contextmenu_never_use_native.adoc
@@ -9,6 +9,8 @@ CAUTION: Using this option may result in unexpected behavior when right-clicking
 
 *Default value:* `+false+`
 
+*Possible values:* `+true+`, `+false+`
+
 === Example: using `+contextmenu_never_use_native+`
 
 [source,js]

--- a/modules/ROOT/partials/configuration/editable_root.adoc
+++ b/modules/ROOT/partials/configuration/editable_root.adoc
@@ -11,13 +11,14 @@ NOTE: a {productname} root set as not-editable can contain child elements with t
 
 *Default value:* `+true+`
 
+*Possible values:* `+true+`, `+false+`
+
 === Example: using `+editable_root+`
 
 [source,js]
 ----
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
-  editable_root: false 
+  editable_root: false
 });
 ----
-

--- a/modules/ROOT/partials/configuration/format_empty_lines.adoc
+++ b/modules/ROOT/partials/configuration/format_empty_lines.adoc
@@ -7,6 +7,8 @@ This option allows "inline" formats to be applied to empty lines for multi-line 
 
 *Default value:* `+false+`
 
+*Possible values:* `+true+`, `+false+`
+
 === Example: using `+format_empty_lines+`
 
 [source,js]

--- a/modules/ROOT/partials/configuration/formats.adoc
+++ b/modules/ROOT/partials/configuration/formats.adoc
@@ -235,6 +235,8 @@ Makes sure that the format is not merged with other wrappers having the same for
 
 *Default value:* `+false+`
 
+*Possible values:* `+true+`, `+false+`
+
 ===== Example: using `+exact+` parameter
 
 [source,js]
@@ -257,6 +259,8 @@ States that the format is a container format for block elements. For example, a 
 *Type:* `+Boolean+`
 
 *Default value:* `+false+`
+
+*Possible values:* `+true+`, `+false+`
 
 ===== Example: using `+wrapper+`
 
@@ -317,6 +321,10 @@ So if the selection is from _a_ to _b_ in this html contents `+<h1><b>[a</b></h1
 
 *Type:* `+Boolean+`
 
++Default value:* `+false+`
+
+*Possible values:* `+true+`, `+false+`
+
 ===== Example: using `+block_expand+`
 
 [source,js]
@@ -356,6 +364,8 @@ Enables control for removing the child elements of the matching format. This is 
 
 *Default value:* `+false+` for `+selector+` formats
 
+*Possible values:* `+true+`, `+false+`
+
 ===== Example: using `+deep+`
 
 [source,js]
@@ -393,6 +403,8 @@ After merge:
 *Type:* `+Boolean+`
 
 *Default value:* `+true+`
+
+*Possible values:* `+true+`, `+false+`
 
 ===== Example: using `+merge_siblings+`
 

--- a/modules/ROOT/partials/configuration/importcss_append.adoc
+++ b/modules/ROOT/partials/configuration/importcss_append.adoc
@@ -7,6 +7,8 @@ If set to `+true+` this option will append the imported styles to the end of the
 
 *Default value:* `+false+`
 
+*Possible values:* `+true+`, `+false+`
+
 === Example: using `+importcss_append+`
 
 [source,js]

--- a/modules/ROOT/partials/configuration/importcss_exclusive.adoc
+++ b/modules/ROOT/partials/configuration/importcss_exclusive.adoc
@@ -7,6 +7,8 @@ If set to `+false+` then selectors will not be globally exclusive meaning they c
 
 *Default value:* `+true+`
 
+*Possible values:* `+true+`, `+false+`
+
 === Example: using `+importcss_exclusive+`
 
 [source,js]

--- a/modules/ROOT/partials/configuration/importcss_merge_classes.adoc
+++ b/modules/ROOT/partials/configuration/importcss_merge_classes.adoc
@@ -7,6 +7,8 @@ This option is used in cases where the class attribute should be replaced or mer
 
 *Default value:* `+true+`
 
+*Possible values:* `+true+`, `+false+`
+
 === Example: using `+importcss_merge_classes+`
 
 [source,js]

--- a/modules/ROOT/partials/configuration/indent_use_margin.adoc
+++ b/modules/ROOT/partials/configuration/indent_use_margin.adoc
@@ -7,6 +7,8 @@ This option is set if the editor should use margin instead of padding when inden
 
 *Default value:* `+false+`
 
+*Possible values:* `+true+`, `+false+`
+
 === Example: using `+indent_use_margin+`
 
 [source,js]

--- a/modules/ROOT/partials/configuration/init_content_sync.adoc
+++ b/modules/ROOT/partials/configuration/init_content_sync.adoc
@@ -15,6 +15,8 @@ NOTE: using the https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.
 
 *Default value:* `+false+`
 
+*Possible values:* `+true+`, `+false+`
+
 === Example: using `+init_content_sync+`
 
 [source,js]

--- a/modules/ROOT/partials/configuration/link_target_list.adoc
+++ b/modules/ROOT/partials/configuration/link_target_list.adoc
@@ -7,6 +7,8 @@ If xref:link.adoc#link_default_target[`+link_default_target+`] is also configure
 
 *Type:* `+Boolean+` or `+Array+`
 
+*Possible values:* `+true+, +false+, +_blank+`, `+_self+`, `+_parent+`, `+_blank+`
+
 *Default value:*
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/revisionhistory_allow_restore.adoc
+++ b/modules/ROOT/partials/configuration/revisionhistory_allow_restore.adoc
@@ -7,6 +7,8 @@ The `revisionhistory_allow_restore` option enables or disables the ability to re
 
 *Default vale:* `+true+`
 
+*Possible values:* `+true+`, `+false+`
+
 === Example: Using `revisionhistory_allow_restore`
 
 [source,js]

--- a/modules/ROOT/partials/configuration/revisionhistory_display_author.adoc
+++ b/modules/ROOT/partials/configuration/revisionhistory_display_author.adoc
@@ -7,6 +7,8 @@ This option configures the display of the revision's author. When set to `+true+
 
 *Default value:* `+false+`
 
+*Possible values:* `+true+`, `+false+`
+
 === Example: using `revisionhistory_display_author`
 
 [source,js]

--- a/modules/ROOT/partials/configuration/style_formats_autohide.adoc
+++ b/modules/ROOT/partials/configuration/style_formats_autohide.adoc
@@ -7,6 +7,8 @@ This option enables auto hiding of styles that can't be applied to the current c
 
 *Default value:* `+false+`
 
+*Possible values:* `+true+`, `+false+`
+
 === Example: using `+style_formats_autohide+`
 
 [source,js]

--- a/modules/ROOT/partials/configuration/style_formats_merge.adoc
+++ b/modules/ROOT/partials/configuration/style_formats_merge.adoc
@@ -7,6 +7,8 @@ This option allows you to set whether {productname} should append custom styles 
 
 *Default value:* `+false+`
 
+*Possible values:* `+true+`, `+false+`
+
 === Example: using `+style_formats_merge+`
 
 [source,js]

--- a/modules/ROOT/partials/configuration/text_color.adoc
+++ b/modules/ROOT/partials/configuration/text_color.adoc
@@ -342,6 +342,8 @@ This option allows disabling the custom color picker in all color swatches of th
 
 *Default value:* `+true+`
 
+*Possible values:* `+true+`, `+false+`
+
 ==== Example: using `+custom_colors+`
 
 [source,js]


### PR DESCRIPTION
Ticket: DOC-3268

Site: [Staging branch](http://docs-hotfix-8-doc-3268.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* Added missing `Possible values` sections for the following files:

  - allow_html_in_comments.adoc
  - contextmenu_never_use_native.adoc
  - editable_root.adoc\
  - format_empty_lines.adoc
  - formats.adoc 
  - importcss_append.adoc
  - importcss_exclusive.adoc
  - importcss_merge_classes.adoc
  - indent_use_margin.adoc
  - init_content_sync.adoc
  - link_target_list.adoc
  - revisionhistory_allow_restore.adoc
  - revisionhistory_display_author.adoc
  - style_formats_autohide.adoc
  - style_formats_merge.adoc
  - text_color.adoc 

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed