### PR TITLE
DOC-3261: Update react-quick-start documentation to use new links for the React component and SWC plugin

### DIFF
--- a/modules/ROOT/partials/integrations/react-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/react-quick-start.adoc
@@ -4,7 +4,7 @@ ifeval::["{productUse}" == "bundle"]
 IMPORTANT: {companyname} does not recommend bundling the `tinymce` package. Bundling {productname} can be complex and error prone.
 
 endif::[]
-The https://github.com/tinymce/tinymce-react[Official {productname} React component] integrates {productname} into React projects. This procedure creates a https://github.com/vitejs/vite-plugin-react-swc[basic React application] containing a {productname} editor.
+The link:https://github.com/tinymce/tinymce-react[Official {productname} React component] integrates {productname} into React projects. This procedure creates a link:https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react-swc[React SWC plugin] containing a {productname} editor.
 
 For examples of the {productname} integration, visit https://tinymce.github.io/tinymce-react/[the tinymce-react storybook].
 
@@ -14,7 +14,7 @@ This procedure requires https://nodejs.org/[Node.js (and npm)].
 
 == Procedure
 
-. Use the https://github.com/vitejs/vite[Vite] package and the https://github.com/vitejs/vite-plugin-react-swc[React SWC plugin] to create a new React project named `+tinymce-react-demo+`.
+. Use the https://github.com/vitejs/vite[Vite] package and the link:https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react-swc[React SWC plugin] to create a new React project named `+tinymce-react-demo+`.
 +
 [source,sh]
 ----


### PR DESCRIPTION
Ticket: DOC-3261

Site: [Staging branch- react-cloud/](http://docs-hotfix-8-doc-3261.staging.tiny.cloud/docs/tinymce/latest/react-cloud/)
Site: [Staging branch- react-pm-host/](http://docs-hotfix-8-doc-3261.staging.tiny.cloud/docs/tinymce/latest/react-pm-host/)
Site: [Staging branch- react-pm-bundle/](http://docs-hotfix-8-doc-3261.staging.tiny.cloud/docs/tinymce/latest/react-pm-bundle/)
Site: [Staging branch- react-zip-host/](http://docs-hotfix-8-doc-3261.staging.tiny.cloud/docs/tinymce/latest/react-zip-host/)
Site: [Staging branch- react-zip-bundle/](http://docs-hotfix-8-doc-3261.staging.tiny.cloud/docs/tinymce/latest/react-zip-bundle/)

Changes:
* update links.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed