### PR TITLE
DOC-3209: Using `Command (CMD)` + `Backspace` would not preserve inline formatting.

### DIFF
--- a/modules/ROOT/pages/8.1.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.1.0-release-notes.adoc
@@ -109,6 +109,13 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // CCFR here.
 
+=== Using `+Command (CMD)+` + `+Backspace+` would not preserve inline formatting.
+// #TINY-12071
+
+Previously, using `+Command (CMD)+` + `+Backspace+` at the end of a line removed the entire line without preserving inline formatting, unlike selecting the line with a triple-click and pressing `+Backspace+`. This inconsistency caused confusion, as different deletion methods produced different results.
+
+In {release-version}, the behavior of `+Command (CMD)+` + `+Backspace+` has been updated to match other deletion methods, ensuring that inline formatting is preserved.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-3209

Site: [Staging branch](http://docs-feature-810-doc-3209tiny-12071.staging.tiny.cloud/docs/tinymce/latest/8.1.0-release-notes/#using-command-cmd-backspace-would-not-preserve-inline-formatting)

Changes:
* Add fix documentation for TINY-12071

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed