### PR TITLE
DOC-3267: Deprecate content_css_cors option

### DIFF
--- a/modules/ROOT/partials/configuration/content_css_cors.adoc
+++ b/modules/ROOT/partials/configuration/content_css_cors.adoc
@@ -1,6 +1,8 @@
 [[content_css_cors]]
 == `+content_css_cors+`
 
+IMPORTANT: This option has been marked as *deprecated*. It will be completely removed in the upcoming {productname} 9.0 release. As an alternative, we recommend using xref:tinymce-and-cors.adoc#crossorigin[`crossorigin`] instead.
+
 When `+content_css_cors+` is set to `+true+`, the editor will add a `+crossorigin="anonymous"+` attribute to the link tags that the StyleSheetLoader uses when loading the `+content_css+`. This allows you to host the `+content_css+` on a different server than the editor itself.
 
 *Type:* `+Boolean+`

--- a/modules/ROOT/partials/integrations/react-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/react-quick-start.adoc
@@ -4,7 +4,7 @@ ifeval::["{productUse}" == "bundle"]
 IMPORTANT: {companyname} does not recommend bundling the `tinymce` package. Bundling {productname} can be complex and error prone.
 
 endif::[]
-The https://github.com/tinymce/tinymce-react[Official {productname} React component] integrates {productname} into React projects. This procedure creates a https://github.com/vitejs/vite-plugin-react-swc[basic React application] containing a {productname} editor.
+The link:https://github.com/tinymce/tinymce-react[Official {productname} React component] integrates {productname} into React projects. This procedure creates a link:https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react-swc[React SWC plugin] containing a {productname} editor.
 
 For examples of the {productname} integration, visit https://tinymce.github.io/tinymce-react/[the tinymce-react storybook].
 
@@ -14,7 +14,7 @@ This procedure requires https://nodejs.org/[Node.js (and npm)].
 
 == Procedure
 
-. Use the https://github.com/vitejs/vite[Vite] package and the https://github.com/vitejs/vite-plugin-react-swc[React SWC plugin] to create a new React project named `+tinymce-react-demo+`.
+. Use the https://github.com/vitejs/vite[Vite] package and the link:https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react-swc[React SWC plugin] to create a new React project named `+tinymce-react-demo+`.
 +
 [source,sh]
 ----


### PR DESCRIPTION
Ticket: DOC-3267

Site: [Staging branch](http://docs-feature-810-doc-3267.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* Deprecate `content_css_cors` option

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
~~- [ ] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.~~
~~- [ ] Included a `release note` entry for any `New product features`.~~

- [ ] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.
☝️ Should I do this? @kemister85 

Review:
- [ ] Documentation Team Lead has reviewed