### PR TITLE
DOC-3209: Spellcheck could create an invalid selection if the first element in the document was `noneditable`.

### DIFF
--- a/modules/ROOT/pages/8.1.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.1.0-release-notes.adoc
@@ -54,6 +54,21 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Spell Checker
+
+The {productname} {release-version} release includes an accompanying release of the **Spell Checker** premium plugin.
+
+**Spell Checker** Premium plugin includes the following fix.
+
+==== Spellcheck could create an invalid selection if the first element in the document was `+noneditable+`.
+// #TINY-12514
+
+Previously when the first element of a document was set as a `contenteditable="false"` (CEF) element, selecting all content with {productname} spellchecker could result in an invalid selection state. This issue prevented the deletion of the entire content selection, creating an edge case that disrupted normal editing workflows.
+
+To resolve this, {productname} now inserts a temporary hidden element before the initial CEF element in such scenarios. This adjustment ensures that full selections are valid and can be deleted as expected.
+
+For information on the **Spell Checker** plugin, see: xref:introduction-to-tiny-spellchecker.adoc[Spell Checker].
+
 
 [[improvements]]
 == Improvements


### PR DESCRIPTION
Ticket: DOC-3209

Site: [Staging branch](http://docs-feature-810-doc-3209tiny-12514.staging.tiny.cloud/docs/tinymce/latest/8.1.0-release-notes/#spellcheck-could-create-an-invalid-selection-if-the-first-element-in-the-document-was-noneditable)

Changes:
* Fix documentation for TINY-12514

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed