### PR TITLE
DOC-3267: Deprecate content_css_cors option

### DIFF
--- a/modules/ROOT/pages/8.1.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.1.0-release-notes.adoc
@@ -132,6 +132,10 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // placeholder here.
 
+=== The `content_css_cors` configuration option has been deprecated
+// #TINY-12578
+
+As of {productname} {release-version}, the `content_css_cors` configuration option has been marked as *deprecated*. It will be completely removed in the upcoming {productname} 9.0 release. As an alternative, we recommend using xref:tinymce-and-cors.adoc#crossorigin[crossorigin] instead.
 
 [[known-issues]]
 == Known issues

--- a/modules/ROOT/partials/configuration/content_css_cors.adoc
+++ b/modules/ROOT/partials/configuration/content_css_cors.adoc
@@ -1,6 +1,8 @@
 [[content_css_cors]]
 == `+content_css_cors+`
 
+IMPORTANT: This option has been marked as *deprecated*. It will be completely removed in the upcoming {productname} 9.0 release. As an alternative, we recommend using xref:tinymce-and-cors.adoc#crossorigin[`crossorigin`] instead.
+
 When `+content_css_cors+` is set to `+true+`, the editor will add a `+crossorigin="anonymous"+` attribute to the link tags that the StyleSheetLoader uses when loading the `+content_css+`. This allows you to host the `+content_css+` on a different server than the editor itself.
 
 *Type:* `+Boolean+`


### PR DESCRIPTION
Ticket: DOC-3267

Site: [Staging branch](http://docs-feature-810-doc-3209doc-3267.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* Deprecate `content_css_cors` option

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
~~- [ ] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.~~
~~- [ ] Included a `release note` entry for any `New product features`.~~
~~- [ ] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.~~

Review:
- [x] Documentation Team Lead has reviewed