### PR TITLE
DOC-3209: NVDA would announce `iframe_aria_text` multiple times.

### DIFF
--- a/modules/ROOT/pages/8.1.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.1.0-release-notes.adoc
@@ -111,7 +111,7 @@ The following premium plugin updates were released alongside {productname} {rele
 === NVDA would announce iframe_aria_text multiple times
 // #TINY-11296
 
-Previously, in certain browsers, when using screen readers such as NVDA or JAWS, the `iframe_aria_text` was either not announced at all or announced twice, causing inconsistent and potentially confusing behavior for users relying on assistive technology. To resolve this, behavior has been standardized by adjusting how the label is applied:
+Previously, in certain browsers, when using screen readers such as NVDA or JAWS, the `iframe_aria_text` was either not announced at all or announced twice, causing inconsistent and potentially confusing behavior for users relying on assistive technology. To resolve this, the behavior has been standardized by adjusting how the label is applied:
 
 * in Firefox, the `title` attribute is now set directly on the iframe element and the `aria-label` on the body is not used.
 * while in other browsers the `aria-label` is applied to the body inside the iframe without setting a `title` attribute on the iframe.

--- a/modules/ROOT/pages/8.1.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.1.0-release-notes.adoc
@@ -108,6 +108,17 @@ The following premium plugin updates were released alongside {productname} {rele
 // #TINY-vwxyz1
 
 // CCFR here.
+=== NVDA would announce iframe_aria_text multiple times
+// #TINY-11296
+
+Previously, in certain browsers, when using screen readers such as NVDA or JAWS, the `iframe_aria_text` was either not announced at all or announced twice, causing inconsistent and potentially confusing behavior for users relying on assistive technology. To resolve this, behavior has been standardized by adjusting how the label is applied:
+
+* in Firefox, the `title` attribute is now set directly on the iframe element and the `aria-label` on the body is not used.
+* while in other browsers the `aria-label` is applied to the body inside the iframe without setting a `title` attribute on the iframe.
+
+As a result, `iframe_aria_text` is now consistently announced once across all supported browsers.
+
+For more information, see: xref:accessibility.adoc#iframe_aria_text[iframe_aria_text].
 
 
 [[security-fixes]]

--- a/modules/ROOT/partials/configuration/iframe_aria_text.adoc
+++ b/modules/ROOT/partials/configuration/iframe_aria_text.adoc
@@ -23,3 +23,11 @@ tinymce.init({
   iframe_aria_text: 'Text Editor'
 });
 ----
+
+[NOTE]
+====
+The `+iframe_aria_text+` option is applied differently depending on the browser to ensure consistent screen reader announcements:
+
+* **Firefox**: The `+title+` attribute is set on the iframe element. The `+aria-label+` on the body is not set.
+* **Other browsers**: The `+aria-label+` is set on the body inside the iframe. The `+title+` is not set on the iframe.
+====


### PR DESCRIPTION
Ticket: DOC-3209

Site: [Staging branch](http://docs-feature-810-doc-3209tiny-11296.staging.tiny.cloud/docs/tinymce/latest/8.1.0-release-notes/#nvda-would-announce-iframe_aria_text-multiple-times)
Site: [iframe_aria_text option admonition](http://docs-feature-810-doc-3209tiny-11296.staging.tiny.cloud/docs/tinymce/latest/accessibility/#iframe_aria_text)

Changes:
* add fix documentation for TINY-11296

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed