### PR TITLE
DOC-3209: `editor.getContent()` now includes `indent` and `entity_encoding` properties to control HTML formatting.

### DIFF
--- a/modules/ROOT/pages/8.1.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.1.0-release-notes.adoc
@@ -70,7 +70,7 @@ The following premium plugin updates were released alongside {productname} {rele
 
 Previously, when using the {productname} `+getContent+` API, options such as `+indent+` and `+entity_encoding+` could not be overridden during the call. The editor always applied its initial configuration, which limited flexibility when retrieving content. This meant integrators were restricted to the defaults set at initialization, with no way to adjust formatting behavior per call.
 
-In {release-version}, the `+getContent+` API has been enhanced to support per-call overrides for `+indent+` and `+entity_encoding+`. These options can now be specified directly when invoking `+getContent+`, regardless of the editor’s default configuration. This improvement gives developers greater control over output formatting, allowing tailored content retrieval for different use cases.
+In {productname} {release-version}, the `+getContent+` API has been enhanced to support per-call overrides for `+indent+` and `+entity_encoding+`. These options can now be specified directly when invoking `+getContent+`, regardless of the editor’s default configuration. This improvement gives developers greater control over output formatting, allowing tailored content retrieval for different use cases.
 
 .Example: how to use the `+getContent+` API to retrieve content with different formatting options.
 [source,js]

--- a/modules/ROOT/pages/8.1.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.1.0-release-notes.adoc
@@ -65,6 +65,47 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // CCFR here.
 
+=== `editor.getContent()` now includes `indent` and `entity_encoding` properties to control HTML formatting
+// #TINY-12786
+
+Previously, when using the {productname} `+getContent+` API, options such as `+indent+` and `+entity_encoding+` could not be overridden during the call. The editor always applied its initial configuration, which limited flexibility when retrieving content. This meant integrators were restricted to the defaults set at initialization, with no way to adjust formatting behavior per call.
+
+In {release-version}, the `+getContent+` API has been enhanced to support per-call overrides for `+indent+` and `+entity_encoding+`. These options can now be specified directly when invoking `+getContent+`, regardless of the editor’s default configuration. This improvement gives developers greater control over output formatting, allowing tailored content retrieval for different use cases.
+
+.Example: how to use the `+getContent+` API to retrieve content with different formatting options.
+[source,js]
+----
+// Disable indentation
+tinymce.get(0).getContent({ indent: false });
+
+// Serialize using named entities
+tinymce.get(0).getContent({ indent: false, entity_encoding: 'named' });
+
+// Serialize using numeric entities
+tinymce.get(0).getContent({ indent: false, entity_encoding: 'numeric' });
+
+// Serialize core entities as named, others as numeric
+tinymce.get(0).getContent({ indent: false, entity_encoding: 'named+numeric' });
+
+// Output raw characters
+tinymce.get(0).getContent({ indent: false, entity_encoding: 'raw' });
+----
+
+or
+
+.Example of configuring the editor to use named entities and disable indentation.
+[source,js]
+----
+tinymce.init({
+  selector: "textarea",
+  entity_encoding: 'named', // or 'numeric' or 'raw'
+  indent: false, // or true
+});
+----
+
+For more information on the `+getContent+` API, see `xref:apis/tinymce.editor.adoc#getContent[getContent()]`.
+
+
 
 [[additions]]
 == Additions

--- a/modules/ROOT/pages/8.1.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.1.0-release-notes.adoc
@@ -93,7 +93,7 @@ tinymce.get(0).getContent({ indent: false, entity_encoding: 'raw' });
 
 or
 
-.Example of configuring the editor to use named entities and disable indentation.
+.Example of configuring the editor to use named entity encoding and disable indentation.
 [source,js]
 ----
 tinymce.init({


### PR DESCRIPTION
Ticket: DOC-3209

Site: [Staging branch](http://docs-feature-810-doc-3209tiny-12786.staging.tiny.cloud/docs/tinymce/latest/8.1.0-release-notes/#editor-getcontent-now-includes-indent-and-entity_encoding-properties-to-control-html-formatting)

Changes:
* Improvement documentation for TINY-12786

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed