### PR TITLE
DOC-3209: Empty editor operations sometimes showed as modified instead of added/removed

### DIFF
--- a/modules/ROOT/pages/8.1.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.1.0-release-notes.adoc
@@ -64,9 +64,9 @@ The {productname} {release-version} release includes an accompanying release of 
 === Empty editor operations sometimes showed as modified instead of added/removed
 // #TINY-12273
 
-Previously empty editor operations were sometimes incorrectly displayed as modifications instead of insertions or removals. This behavior caused confusion, as an editor that appeared empty could still show a “modified” state.
+Previously empty editor operations were sometimes incorrectly displayed as modifications instead of additions or removals. This behavior caused confusion, as an editor that appeared empty could still show a “modified” state.
 
-To resolve this, empty content is no longer sent. When the editor is empty or becomes empty, the entire state is now correctly represented as inserted or removed. This improvement ensures that change tracking is clearer and more accurate, reducing confusion when editors contain no content.
+To resolve this, empty content is no longer sent. When the editor is empty or becomes empty, the entire state is now correctly represented as added or removed. This improvement ensures that change tracking is clearer and more accurate, reducing confusion when editors contain no content.
 
 For information on the **Suggested Edits** plugin, see: xref:suggestededits.adoc[Suggested Edits].
 

--- a/modules/ROOT/pages/8.1.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.1.0-release-notes.adoc
@@ -55,6 +55,21 @@ The following premium plugin updates were released alongside {productname} {rele
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
 
+=== Suggested Edits
+
+The {productname} {release-version} release includes an accompanying release of the **Suggested Edits** premium plugin.
+
+**Suggested Edits** includes the following fix:
+
+=== Empty editor operations sometimes showed as modified instead of added/removed
+// #TINY-12273
+
+Previously empty editor operations were sometimes incorrectly displayed as modifications instead of insertions or removals. This behavior caused confusion, as an editor that appeared empty could still show a “modified” state.
+
+To resolve this, empty content is no longer sent. When the editor is empty or becomes empty, the entire state is now correctly represented as inserted or removed. This improvement ensures that change tracking is clearer and more accurate, reducing confusion when editors contain no content.
+
+For information on the **Suggested Edits** plugin, see: xref:suggestededits.adoc[Suggested Edits].
+
 [[improvements]]
 == Improvements
 


### PR DESCRIPTION
Ticket: DOC-3209

Site: [Staging branch](http://docs-feature-810-doc-3209tiny-12273.staging.tiny.cloud/docs/tinymce/latest/8.1.0-release-notes/#empty-editor-operations-sometimes-showed-as-modified-instead-of-addedremoved)

Changes:
* Fix documentation for TINY-12273

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed