### PR TITLE
DOC-3269: Fix missing `tinycomments_fetch_author_info` callback causing "ANON" avatar display in new comments

### DIFF
--- a/modules/ROOT/examples/live-demos/comments-callback-with-mentions/index.js
+++ b/modules/ROOT/examples/live-demos/comments-callback-with-mentions/index.js
@@ -235,6 +235,18 @@ const tinycomments_fetch = (conversationUids, done) => {
   setTimeout(() => done({ conversations: fetchedConversations }), fakeDelay);
 };
 
+const tinycomments_fetch_author_info = (done) => {
+  fetch(`${API_URL}/${user_id}`)
+    .then(res => res.json())
+    .then(currentUser => {
+      done({
+        author: currentUser.id,
+        authorName: currentUser.name,
+        authorAvatar: currentUser.avatar
+      });
+    });
+};
+
 tinymce.init({
   selector: 'textarea#comments-callback-with-mentions',
   license_key: 'gpl',
@@ -262,15 +274,12 @@ tinymce.init({
   tinycomments_delete_comment,
   tinycomments_edit_comment,
   tinycomments_fetch,
-
+  tinycomments_fetch_author_info,
   mentions_item_type: 'profile',
   mentions_min_chars: 0,
   mentions_selector: '.mymention',
   mentions_fetch,
   mentions_menu_hover,
   mentions_menu_complete,
-  mentions_select,
-  tinycomments_author: user_id,
-  tinycomments_author_name: 'James Wilson',
-  tinycomments_author_avatar: 'https://sneak-preview.tiny.cloud/demouserdirectory/images/employee_james-wilson_128_52f19412.jpg'
+  mentions_select
 });

--- a/modules/ROOT/examples/live-demos/comments-callback/index.js
+++ b/modules/ROOT/examples/live-demos/comments-callback/index.js
@@ -181,6 +181,18 @@ const tinycomments_fetch = (conversationUids, done) => {
   setTimeout(() => done({ conversations: fetchedConversations }), fakeDelay);
 };
 
+const tinycomments_fetch_author_info = (done) => {
+  fetch(`${API_URL}/${user_id}`)
+    .then(res => res.json())
+    .then(currentUser => {
+      done({
+        author: currentUser.id,
+        authorName: currentUser.name,
+        authorAvatar: currentUser.avatar
+      });
+    });
+};
+
 tinymce.init({
   selector: 'textarea#comments-callback',
   license_key: 'gpl',
@@ -208,7 +220,5 @@ tinymce.init({
   tinycomments_delete_comment,
   tinycomments_edit_comment,
   tinycomments_fetch,
-  tinycomments_author: user_id,
-  tinycomments_author_name: 'James Wilson',
-  tinycomments_author_avatar: 'https://sneak-preview.tiny.cloud/demouserdirectory/images/employee_james-wilson_128_52f19412.jpg'
+  tinycomments_fetch_author_info
 });

--- a/modules/ROOT/examples/live-demos/full-featured/index.js
+++ b/modules/ROOT/examples/live-demos/full-featured/index.js
@@ -238,6 +238,18 @@ const tinycomments_fetch = (conversationUids, done) => {
   setTimeout(() => done({ conversations: fetchedConversations }), fakeDelay);
 };
 
+const tinycomments_fetch_author_info = (done) => {
+  fetch(`${API_URL}/${user_id}`)
+    .then(res => res.json())
+    .then(currentUser => {
+      done({
+        author: currentUser.id,
+        authorName: currentUser.name,
+        authorAvatar: currentUser.avatar
+      });
+    });
+};
+
 const ai_request = (request, respondWith) => {
   respondWith.stream((signal, streamMessage) => {
     // Adds each previous query and response as individual messages
@@ -525,7 +537,7 @@ const revisionhistory_fetch_revision = (_editor, revision) => new Promise((resol
 tinymce.init({
   selector: 'textarea#full-featured',
   plugins: [
-    'ai', 'suggestededits', 'preview', 'powerpaste', 'casechange', 'importcss', 'tinydrive', 'searchreplace',
+    'ai', 'preview', 'powerpaste', 'casechange', 'importcss', 'tinydrive', 'searchreplace',
     'autolink', 'autosave', 'save', 'directionality', 'advcode', 'visualblocks', 'visualchars', 'fullscreen',
     'image', 'link', 'math', 'media', 'mediaembed', 'codesample', 'table', 'charmap', 'pagebreak', 'nonbreaking',
     'anchor', 'tableofcontents', 'insertdatetime', 'advlist', 'lists', 'checklist', 'wordcount', 'tinymcespellchecker',
@@ -541,9 +553,9 @@ tinymce.init({
   },
   menubar: 'file edit view insert format tools table tc help',
   // Note: if a toolbar item requires a plugin, the item will not present in the toolbar if the plugin is not also loaded.
-  toolbar: "undo redo | importword exportword exportpdf | suggestededits | revisionhistory | aidialog aishortcuts | blocks fontsizeinput | bold italic | align numlist bullist | link image | table math media pageembed | lineheight  outdent indent | strikethrough forecolor backcolor formatpainter removeformat | charmap emoticons checklist | code fullscreen preview | save print | pagebreak anchor codesample footnotes mergetags | addtemplate inserttemplate | addcomment showcomments | ltr rtl casechange | spellcheckdialog a11ycheck", 
+  toolbar: "undo redo | importword exportword exportpdf | revisionhistory | aidialog aishortcuts | blocks fontsizeinput | bold italic | align numlist bullist | link image | table math media pageembed | lineheight  outdent indent | strikethrough forecolor backcolor formatpainter removeformat | charmap emoticons checklist | code fullscreen preview | save print | pagebreak anchor codesample footnotes mergetags | addtemplate inserttemplate | addcomment showcomments | ltr rtl casechange | spellcheckdialog a11ycheck", 
   mobile: {
-    plugins: 'ai suggestededits preview powerpaste casechange importcss tinydrive searchreplace autolink autosave save directionality advcode visualblocks visualchars fullscreen image link math media mediaembed codesample table charmap pagebreak nonbreaking anchor tableofcontents insertdatetime advlist lists checklist wordcount tinymcespellchecker a11ychecker help formatpainter pageembed charmap mentions quickbars emoticons advtable footnotes mergetags autocorrect typography advtemplate',
+    plugins: 'ai preview powerpaste casechange importcss tinydrive searchreplace autolink autosave save directionality advcode visualblocks visualchars fullscreen image link math media mediaembed codesample table charmap pagebreak nonbreaking anchor tableofcontents insertdatetime advlist lists checklist wordcount tinymcespellchecker a11ychecker help formatpainter pageembed charmap mentions quickbars emoticons advtable footnotes mergetags autocorrect typography advtemplate',
   },
 
   editimage_cors_hosts: ['picsum.photos'],
@@ -658,6 +670,7 @@ tinymce.init({
   tinycomments_delete_comment,
   tinycomments_edit_comment,
   tinycomments_fetch,
+  tinycomments_fetch_author_info,
 
   mentions_item_type: 'profile',
   mentions_min_chars: 0,
@@ -721,10 +734,5 @@ tinymce.init({
   },
   revisionhistory_fetch,
   revisionhistory_fetch_revision,
-  revisionhistory_display_author: true,
-  suggestededits_content: 'html',
-  suggestededits_access: 'full',
-  tinycomments_author: user_id,
-  tinycomments_author_name: 'James Wilson',
-  tinycomments_author_avatar: 'https://sneak-preview.tiny.cloud/demouserdirectory/images/employee_james-wilson_128_52f19412.jpg'
+  revisionhistory_display_author: true
 });


### PR DESCRIPTION
Ticket: DOC-3269

Site: [fullfeature-demo](http://docs-hotfix-7-doc-3269.staging.tiny.cloud/docs/tinymce/7/full-featured-premium-demo/)

Site: [comments-callback-demo](http://docs-hotfix-7-doc-3269.staging.tiny.cloud/docs/tinymce/7/comments-callback-mode/#comments-callback-live-demo)

Site: [comments-with-mentions-demo](http://docs-hotfix-7-doc-3269.staging.tiny.cloud/docs/tinymce/7/comments-with-mentions/#comments-callback-with-mentions-live-demo)

Changes:
- [x] Hardcoded `user_name` and `user_avatar` variables removed
- [x] Re-introduced the `tinycomments_fetch_author_info` callback so it uses the API data
- [x] Tested that all demos are functional
- [x] Verified that the Avatar displays from API response instead of hardcoded URL via network tracking.
- [x] Remove `suggestededits` from plugin and toolbar list as its not supported in 7x - added by accident and was causing console errors.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed