### PR TITLE
DOC-3209: Improved keyboard navigation in Comments dropdown when inserting `@Mention`

### DIFF
--- a/modules/ROOT/pages/8.1.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.1.0-release-notes.adoc
@@ -65,7 +65,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 Previously, typing `@` to open the mentions dropdown list inside the Comments card did not support the **Shift+Enter** keyboard combination. For example, when typing a `@` + navigating to a user in the selected Comment card, pressing **Shift+Enter** did not insert the `@mention` to the `<textarea>` for the comment body.
 
-In {productname} {release-version}, this issue has been resolved by implementing an `onShiftEnter` handler that mirrors the behavior of the regular **Enter** key, ensuring consistent and predictable keyboard interaction when selecting items in the `@mentions` dropdown within comment cards.
+In {productname} {release-version}, this issue has been resolved by  handling **Shift+Enter** in the same way as the regular **Enter** key, ensuring consistent and predictable keyboard interaction when selecting items in the `@mentions` dropdown within comment cards.
 
 For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to Tiny Comments].
 

--- a/modules/ROOT/pages/8.1.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.1.0-release-notes.adoc
@@ -54,6 +54,21 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Comments
+
+The {productname} {release-version} release includes an accompanying release of the **Comments** premium plugin.
+
+**Comments** Premium plugin includes the following removal.
+
+==== Improved keyboard navigation in Comments dropdown when inserting `@Mention`
+// #TINY-12785
+
+Previously, typing `@` to open the mentions dropdown list inside the Comments card did not support the **Shift+Enter** keyboard combination. For example, when typing a `@` + navigating to a user in the selected Comment card, pressing **Shift+Enter** did not insert the `@mention` to the `<textarea>` for the comment body.
+
+In {productname} {release-version}, this issue has been resolved by implementing an `onShiftEnter` handler that mirrors the behavior of the regular **Enter** key, ensuring consistent and predictable keyboard interaction when selecting items in the `@mentions` dropdown within comment cards.
+
+For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Introduction to Tiny Comments].
+
 
 [[improvements]]
 == Improvements


### PR DESCRIPTION
Ticket: DOC-3209

Site: [Staging branch](http://docs-feature-810-doc-3209tiny-12785.staging.tiny.cloud/docs/tinymce/latest/8.1.0-release-notes/#improved-keyboard-navigation-in-comments-dropdown-when-inserting-mention)

Changes:
* add fix documentation for TINY-12785

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed