### PR TITLE
DOC-3209: Image previews sometimes showed the wrong image from a srcset.

### DIFF
--- a/modules/ROOT/pages/8.1.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.1.0-release-notes.adoc
@@ -54,6 +54,19 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Image Optimizer (Powered by Uploadcare)
+
+The {productname} {release-version} release includes an accompanying release of the **Image Optimizer (Powered by Uploadcare)** premium plugin.
+
+**Image Optimizer (Powered by Uploadcare)** includes the following fix.
+
+==== Image previews sometimes showed the wrong image from a `srcset`.
+
+In previous version of the Image Optimizer premium plugin, an issue where image effects were applied based on the main `src` instead of the active `srcset` URL, causing discrepancies when the displayed image was selected from `srcset`. This led to a mismatch in the adjustment preview (rendered from the main `src`) versus the image shown in the editor (rendered from the `srcset` URL), resulting in different visual outcomes for effects such as blur or resize.
+
+{productname} {release-version} resolves this issue by using the `currentSrc` property to generate previews, ensuring the preview and the editor image reference the same resource. As a result, the preview image and the image in the editor are now consistent.
+
+For information on the **Image Optimizer Powered by Uploadcare** plugin, see: xref:uploadcare.adoc[Image Optimizer (Powered by Uploadcare)].
 
 [[improvements]]
 == Improvements


### PR DESCRIPTION
Ticket: DOC-3209
Site: [Staging branch](http://docs-feature-810-doc-3209tiny-12538.staging.tiny.cloud/docs/tinymce/latest/8.1.0-release-notes/#image-optimizer-powered-by-uploadcare)

Changes:
* add fix documentation for TINY-12538

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed