### PR TITLE
DOC-3270: Add partial to mention conflict between `Uploadcare` and `Image/EditImage` plugins which prevents `Uploadcare` from loading in TinyMCE. (#3843)

### DIFF
--- a/modules/ROOT/pages/editimage.adoc
+++ b/modules/ROOT/pages/editimage.adoc
@@ -12,7 +12,7 @@ The {pluginname} (`{plugincode}`) plugin adds a contextual editing toolbar to im
 
 If the toolbar does not appear after clicking on an image, you may need to enable `+editimage_cors_hosts+` or `+editimage_proxy_service_url+` (see below).
 
-NOTE: In previous versions of {productname}, the {pluginname} plugin was provided as an open source plugin known as the Image Tools plugin.
+
 
 == Interactive example
 
@@ -20,7 +20,10 @@ liveDemo::edit-image[]
 
 include::partial$misc/admon-svg-not-supported.adoc[]
 
-// include::partial$misc/purchase-premium-plugins.adoc[]
+:includedSection: editimagePlugin
+include::partial$misc/plugin-compatibility-uploadcare-image.adoc[]
+:!includedSection:
+
 
 == Cloud Installation
 

--- a/modules/ROOT/pages/image.adoc
+++ b/modules/ROOT/pages/image.adoc
@@ -24,6 +24,10 @@ tinymce.init({
 
 NOTE: This is not drag-drop functionality and the user is required to enter the path to the image. Optionally the user can also enter the image description, dimensions, and whether image proportions should be constrained (selected via a checkbox). Some of these settings can be preset using the plugin's configuration options.
 
+:includedSection: imagePlugin
+include::partial$misc/plugin-compatibility-uploadcare-image.adoc[]
+:!includedSection:
+
 include::partial$misc/admon-svg-not-supported.adoc[]
 
 == Options

--- a/modules/ROOT/pages/uploadcare.adoc
+++ b/modules/ROOT/pages/uploadcare.adoc
@@ -26,6 +26,10 @@ The **Image Optimizer** plugin offers a range of powerful features for image hos
 
 liveDemo::{plugincode}[]
 
+:includedSection: uploadcarePlugin
+include::partial$misc/plugin-compatibility-uploadcare-image.adoc[]
+:!includedSection:
+
 == Basic setup
 
 To add the {pluginname} plugin to the editor, include `{plugincode}` in the `plugins` option in the editor configuration.
@@ -49,6 +53,7 @@ tinymce.init({
 ====
 The {pluginname} plugin overrides the xref:quickbars.adoc[Quickbar] quickimage toolbar item. To ensure a better user experience and to avoid having two image buttons configure `quickbars_insert_toolbar` to omit the `quickimage` toolbar item.
 ====
+
 
 == Image Operations
 

--- a/modules/ROOT/partials/misc/plugin-compatibility-uploadcare-image.adoc
+++ b/modules/ROOT/partials/misc/plugin-compatibility-uploadcare-image.adoc
@@ -9,5 +9,5 @@ The xref:uploadcare.adoc[Image Optimizer Powered by Uploadcare] premium plugin c
 * Configure either the xref:image.adoc[Image] and xref:editimage.adoc[Image Editing] plugins together, or
 * Configure the xref:uploadcare.adoc[Image Optimizer Powered by Uploadcare] plugin as the sole image handler for all images.
 
-If all three plugins are enabled, editor notification: "Unable to initialize uploadcare due to the presence of incompatible plugins. Details are in the browser console." will be shown along with console error: "Unable to initialize uploadcare due to the presence of incompatible plugins: image, editimage".
+If all three plugins are enabled, editor notification: "Unable to initialize uploadcare due to the presence of incompatible plugins. Details are in the browser console." will be shown along with a console error: "Unable to initialize uploadcare due to the presence of incompatible plugins: image, editimage".
 ====

--- a/modules/ROOT/partials/misc/plugin-compatibility-uploadcare-image.adoc
+++ b/modules/ROOT/partials/misc/plugin-compatibility-uploadcare-image.adoc
@@ -2,7 +2,7 @@
 ====
 **Plugin Compatibility Issues**
 
-The xref:uploadcare.adoc[Image Optimizer Powered by Uploadcare] premium plugin cannot be configured together with the xref:image.adoc[Image] and xref:editimage.adoc[Image Editing] plugins. These plugins have conflicting functionality that prevent proper image editing operations.
+The xref:uploadcare.adoc[Image Optimizer Powered by Uploadcare] premium plugin cannot be configured together with the xref:image.adoc[Image] and xref:editimage.adoc[Image Editing] plugins. These plugins have conflicting functionalities that prevent proper image editing operations.
 
 **Recommended Solutions:**
 

--- a/modules/ROOT/partials/misc/plugin-compatibility-uploadcare-image.adoc
+++ b/modules/ROOT/partials/misc/plugin-compatibility-uploadcare-image.adoc
@@ -1,0 +1,13 @@
+[WARNING]
+====
+**Plugin Compatibility Issues**
+
+The xref:uploadcare.adoc[Image Optimizer Powered by Uploadcare] premium plugin cannot be configured together with the xref:image.adoc[Image] and xref:editimage.adoc[Image Editing] plugins. These plugins have conflicting functionality's that prevent proper image editing operations.
+
+**Recommended Solutions:**
+
+* Configure either the xref:image.adoc[Image] and xref:editimage.adoc[Image Editing] plugins together, or
+* Configure the xref:uploadcare.adoc[Image Optimizer Powered by Uploadcare] plugin as the sole image handler for all images.
+
+If all three plugins are enabled, editor notification: "Unable to initialize uploadcare due to the presence of incompatible plugins. Details are in the browser console." will be shown along with console error: "Unable to initialize uploadcare due to the presence of incompatible plugins: image, editimage".
+====

--- a/modules/ROOT/partials/misc/plugin-compatibility-uploadcare-image.adoc
+++ b/modules/ROOT/partials/misc/plugin-compatibility-uploadcare-image.adoc
@@ -2,7 +2,7 @@
 ====
 **Plugin Compatibility Issues**
 
-The xref:uploadcare.adoc[Image Optimizer Powered by Uploadcare] premium plugin cannot be configured together with the xref:image.adoc[Image] and xref:editimage.adoc[Image Editing] plugins. These plugins have conflicting functionality's that prevent proper image editing operations.
+The xref:uploadcare.adoc[Image Optimizer Powered by Uploadcare] premium plugin cannot be configured together with the xref:image.adoc[Image] and xref:editimage.adoc[Image Editing] plugins. These plugins have conflicting functionality that prevent proper image editing operations.
 
 **Recommended Solutions:**
 


### PR DESCRIPTION
Ticket: DOC-3270

Changes: Porting changes from `v8` to `v7`

Site: [core:image](http://docs-hotfix-7-doc-3270.staging.tiny.cloud/docs/tinymce/7/image/)
Site: [premium:uploadcare](http://docs-hotfix-7-doc-3270.staging.tiny.cloud/docs/tinymce/7/uploadcare/)
Site: [premium:editimage](http://docs-hotfix-7-doc-3270.staging.tiny.cloud/docs/tinymce/7/editimage/)

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed