### PR TITLE
DOC-3209: Auto-suggest `alt` text from existing `alt`, `aria-label`, and `title` attributes with priority fallback in image repair dialogs.

### DIFF
--- a/modules/ROOT/pages/8.1.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.1.0-release-notes.adoc
@@ -54,6 +54,21 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Accessibility Checker
+
+The {productname} {release-version} release includes an accompanying release of the **Accessibility Checker** premium plugin.
+
+**Accessibility Checker** includes the following improvement.
+
+==== Auto-suggest `+alt+` text from existing `+alt+`, `+aria-label+`, and `+title+` attributes with priority fallback in image repair dialogs.
+// #TINY-12547
+
+In previous version of **Accessibility Checker**, the image repair dialog only proposed values from `+alt+`, ignoring `+aria-label+` and `+title+`, which forced manual entry and slowed accessibility repairs while increasing the risk of inconsistent descriptions.
+
+{productname} {release-version} now auto-suggests `+alt+` text using a priority-based fallback that checks existing attributes in order `+alt+`, then `+aria-label+`, then `+title+` and leaves the field empty if none are present. This ensures that users can label images faster and with greater accuracy by leveraging existing accessibility attributes, improving repair efficiency and consistency.
+
+For information on the **Accessibility Checker** plugin, see: xref:a11ychecker.adoc[Accessibility Checker].
+
 
 [[improvements]]
 == Improvements

--- a/modules/ROOT/pages/8.1.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.1.0-release-notes.adoc
@@ -65,7 +65,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 In previous version of **Accessibility Checker**, the image repair dialog only proposed values from `+alt+`, ignoring `+aria-label+` and `+title+`, which forced manual entry and slowed accessibility repairs while increasing the risk of inconsistent descriptions.
 
-{productname} {release-version} now auto-suggests `+alt+` text using a priority-based fallback that checks existing attributes in order `+alt+`, then `+aria-label+`, then `+title+` and leaves the field empty if none are present. This ensures that users can label images faster and with greater accuracy by leveraging existing accessibility attributes, improving repair efficiency and consistency.
+{productname} {release-version} now auto-suggests `+alt+` text using a priority-based fallback that checks existing attributes in order `+aria-labelledby+`, `+aria-label+`, `+alt+` then `+title+` and leaves the field empty if none are present. This ensures that users can label images faster and with greater accuracy by leveraging existing accessibility attributes, improving repair efficiency and consistency.
 
 For information on the **Accessibility Checker** plugin, see: xref:a11ychecker.adoc[Accessibility Checker].
 


### PR DESCRIPTION
Ticket: DOC-3209

Site: [Staging branch](http://docs-feature-810-doc-3209tiny-12547.staging.tiny.cloud/docs/tinymce/latest/8.1.0-release-notes/#auto-suggest-alt-text-from-existing-alt-aria-label-and-title-attributes-with-priority-fallback-in-image-repair-dialogs)

Changes:
* Improvement documentation for TINY-12547

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed