### PR TITLE
DOC-3209: Clicking on a "non selectable" element when the selection is off screen no longer scrolls to the selection.

### DIFF
--- a/modules/ROOT/pages/8.1.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.1.0-release-notes.adoc
@@ -65,6 +65,16 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // CCFR here.
 
+=== Clicking on a non selectable element when the selection is off screen no longer scrolls to the selection
+// #TINY-12245
+
+Previously, and issue was identified where clicking the editor's horizontal scrollbar a "non-selectable" UI element implicitly focused the editor, placed the caret at the beginning of the content, and then scrolled the document vertically to that caret position, causing the page to scroll away from the user's current view.
+
+{productname} {release-version} addresses this issue. Now, the editor avoids taking focus when users click elements that are not selectable (such as scrollbars), preventing unintended vertical scrolling.
+
+[NOTE]
+Due to browser limitations, the caret may still initialize at the start of the editor content when the selection is not determinable from such interactions, but the page no longer scrolls away from the user's current view.
+
 
 [[additions]]
 == Additions

--- a/modules/ROOT/pages/8.1.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.1.0-release-notes.adoc
@@ -72,8 +72,6 @@ Previously, and issue was identified where clicking the editor's horizontal scro
 
 {productname} {release-version} addresses this issue. Now, the editor avoids taking focus when users click elements that are not selectable (such as scrollbars), preventing unintended vertical scrolling.
 
-[NOTE]
-Due to browser limitations, the caret may still initialize at the start of the editor content when the selection is not determinable from such interactions, but the page no longer scrolls away from the user's current view.
 
 
 [[additions]]


### PR DESCRIPTION
Ticket: DOC-3209

Site: [Staging branch](http://docs-feature-810-doc-3209tiny-12245.staging.tiny.cloud/docs/tinymce/latest/8.1.0-release-notes/#clicking-on-a-non-selectable-element-when-the-selection-is-off-screen-no-longer-scrolls-to-the-selection/)

Changes:
* Improvement documentation for TINY-12245

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed