### PR TITLE
DOC-3209: Cursor movement did not operate correctly after a `figure` was selected.

### DIFF
--- a/modules/ROOT/pages/8.1.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.1.0-release-notes.adoc
@@ -109,6 +109,13 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // CCFR here.
 
+=== Cursor movement did not operate correctly after a `figure` was selected
+// #TINY-12458
+
+In previous versions of {productname}, using the TAB key to move focus into a `figcaption` element after selecting a `figure` caused the editor to enter a broken state where the caret was displayed inside the figcaption but typing did not produce any visible content. This issue prevented users from editing figcaptions using only the keyboard, forcing them to rely on a mouse or other pointing device to make changes.
+
+In {productname} {release-version}, this bug has been fixed, ensuring that figcaptions can now be edited seamlessly with keyboard navigation alone, improving accessibility and overall editing efficiency.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-3209

Site: [Staging branch](http://docs-feature-810-doc-3209tiny-12458.staging.tiny.cloud/docs/tinymce/latest/8.1.0-release-notes/#cursor-movement-did-not-operate-correctly-after-a-figure-was-selected)

Changes:
* Fix documentation for TINY-12458

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed