### PR TITLE
DOC-3209: Users without avatars now display avatar placeholders in th…

### DIFF
--- a/modules/ROOT/pages/8.1.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.1.0-release-notes.adoc
@@ -54,6 +54,21 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Mentions
+
+The {productname} {release-version} release includes an accompanying release of the **Mentions** premium plugin.
+
+**Mentions** Premium plugin includes the following improvement.
+
+==== Users without avatars now display avatar placeholders in the mentions dropdown
+// #TINY-12473
+
+Previously, the mentions dropdown did not properly handle cases where users lacked profile avatars, resulting in a visually inconsistent and unclear user interface. This impacted usability by making it harder to distinguish between users without avatars and those with incomplete or broken profile information.
+
+In {release-version}, {productname} now provides a default avatar placeholder for users without avatars, ensuring a consistent and polished experience when using the mentions dropdown.
+
+For information on the **Mentions** plugin, see: xref:mentions.adoc[Mentions].
+
 
 [[improvements]]
 == Improvements

--- a/modules/ROOT/pages/8.1.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.1.0-release-notes.adoc
@@ -65,7 +65,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 Previously, the mentions dropdown did not properly handle cases where users lacked profile avatars, resulting in a visually inconsistent and unclear user interface. This impacted usability by making it harder to distinguish between users without avatars and those with incomplete or broken profile information.
 
-In {release-version}, {productname} now provides a default avatar placeholder for users without avatars, ensuring a consistent and polished experience when using the mentions dropdown.
+In {productname} {release-version}, this issue has been addressed. Now, {productname} provides a default avatar placeholder for users without avatars, ensuring a consistent and polished experience when using the mentions dropdown.
 
 For information on the **Mentions** plugin, see: xref:mentions.adoc[Mentions].
 


### PR DESCRIPTION
…e mentions dropdown.

Ticket: DOC-3209

Site: [Staging branch](http://docs-feature-810-doc-3209tiny-12473.staging.tiny.cloud/docs/tinymce/latest/8.1.0-release-notes/#users-without-avatars-now-display-avatar-placeholders-in-the-mentions-dropdown)

Changes:
* Improvement documentation for TINY-12473

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed