### PR TITLE
DOC-2627: Documentation Enhancements for: List Styles plugin and include live-demo

### DIFF
--- a/modules/ROOT/examples/live-demos/advlist/index.html
+++ b/modules/ROOT/examples/live-demos/advlist/index.html
@@ -1,0 +1,70 @@
+<textarea id="advlist-demo">
+    <h2>Advanced List Styles Demo</h2>
+    
+    <h3>Basic Bulleted Lists</h3>
+    <p>Try changing these bullet styles using the toolbar or highlighted text and change the list styles from the context toolbar:</p>
+    <ul>
+        <li>Default bullet style</li>
+        <li>Another item with default style</li>
+        <li>Third item to demonstrate</li>
+    </ul>
+
+    <h3>Numbered Lists with Different Styles</h3>
+    <p>Experiment with different numbering formats:</p>
+    <ol>
+        <li>First step in the process</li>
+        <li>Second step with more details</li>
+        <li>Third step to complete the sequence</li>
+    </ol>
+
+    <h3>Nested Lists (Indentation)</h3>
+    <p>Create nested lists by indenting items:</p>
+    <ul>
+        <li>Main category
+            <ul>
+                <li>Subcategory item 1</li>
+                <li>Subcategory item 2</li>
+            </ul>
+        </li>
+        <li>Another main category
+            <ol>
+                <li>Numbered sub-item 1</li>
+                <li>Numbered sub-item 2</li>
+            </ol>
+        </li>
+    </ul>
+
+    <h3>Mixed Content Lists</h3>
+    <p>Lists can contain various content types:</p>
+    <ul>
+        <li><strong>Bold text</strong> in a list item</li>
+        <li><em>Italic text</em> for emphasis</li>
+        <li>Text with <a href="#">links</a> included</li>
+        <li>Items with <code>inline code</code> snippets</li>
+    </ul>
+
+    <h3>Project Planning Example</h3>
+    <ol>
+        <li>Project Setup
+            <ul>
+                <li>Initialize repository</li>
+                <li>Install dependencies</li>
+                <li>Configure build tools</li>
+            </ul>
+        </li>
+        <li>Development Phase
+            <ol>
+                <li>Create wireframes</li>
+                <li>Implement core features</li>
+                <li>Add user interface elements</li>
+            </ol>
+        </li>
+        <li>Testing & Deployment
+            <ul>
+                <li>Unit testing</li>
+                <li>Integration testing</li>
+                <li>Production deployment</li>
+            </ul>
+        </li>
+    </ol>
+</textarea>

--- a/modules/ROOT/examples/live-demos/advlist/index.js
+++ b/modules/ROOT/examples/live-demos/advlist/index.js
@@ -1,0 +1,20 @@
+tinymce.init({
+    selector: '#advlist-demo',
+    plugins: [
+        'advlist', 'anchor', 'autolink', 'charmap', 'code', 'fullscreen',
+        'help', 'image', 'insertdatetime', 'link', 'lists', 'media',
+        'preview', 'searchreplace', 'table', 'visualblocks', 'wordcount'
+    ],
+    toolbar: 'undo redo | styles | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image | code | fullscreen | help',
+    menubar: 'file edit view insert format tools table help',
+    height: 600,
+
+    setup: (editor) => {
+      editor.ui.registry.addContextToolbar('textselection', {
+        predicate: () => !editor.selection.isCollapsed(),
+        items: 'bullist numlist',
+        position: 'selection', // 'selection' | 'node' | 'line'
+        scope: 'node'
+      });
+    }
+});

--- a/modules/ROOT/pages/advlist.adoc
+++ b/modules/ROOT/pages/advlist.adoc
@@ -22,6 +22,10 @@ tinymce.init({
 });
 ----
 
+== Interactive demo
+
+liveDemo::advlist[]
+
 == Options
 
 These settings affect the execution of the `+advlist+` plugin by providing more granular control of list styles.
@@ -29,6 +33,10 @@ These settings affect the execution of the `+advlist+` plugin by providing more 
 include::partial$configuration/advlist_bullet_styles.adoc[leveloffset=+1]
 
 include::partial$configuration/advlist_number_styles.adoc[leveloffset=+1]
+
+include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
+
+include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 
 == Commands
 

--- a/modules/ROOT/pages/available-menu-items.adoc
+++ b/modules/ROOT/pages/available-menu-items.adoc
@@ -37,6 +37,11 @@ include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
 :!altplugincode:
 
+:plugincategory: opensource
+:pluginname: List Styles
+:plugincode: advlist
+include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]
+
 :plugincategory: premium
 :pluginname: Enhanced Tables
 :plugincode: advtable

--- a/modules/ROOT/pages/available-toolbar-buttons.adoc
+++ b/modules/ROOT/pages/available-toolbar-buttons.adoc
@@ -42,6 +42,11 @@ include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 :!altplugincode:
 
+:plugincategory: opensource
+:pluginname: List Styles
+:plugincode: advlist
+include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
+
 :plugincategory: premium
 :pluginname: Enhanced Tables
 :plugincode: advtable

--- a/modules/ROOT/partials/menu-item-ids/advlist-menu-items.adoc
+++ b/modules/ROOT/partials/menu-item-ids/advlist-menu-items.adoc
@@ -1,0 +1,8 @@
+[cols="1,1,2",options="header"]
+|===
+|Menu item identifier |xref:menus-configuration-options.adoc#example-the-tinymce-default-menu-items[Default Menu Location] |Description
+|`+bullist+` |Format |Formats the current selection as a bullet list with dropdown options for different bullet styles.
+|`+numlist+` |Format |Formats the current selection as a numbered list with dropdown options for different number styles.
+|===
+
+NOTE: The {pluginname} plugin extends the core list menu items in the *Format* menu by adding dropdown functionality that allows users to select from different list styles. These menu items are provided by the core `+lists+` plugin, but the dropdown functionality is added by the {pluginname} plugin.

--- a/modules/ROOT/partials/toolbar-button-ids/advlist-toolbar-buttons.adoc
+++ b/modules/ROOT/partials/toolbar-button-ids/advlist-toolbar-buttons.adoc
@@ -1,0 +1,8 @@
+[cols="1,3",options="header"]
+|===
+|Toolbar button identifier |Description
+|`+bullist+` |Formats the current selection as a bullet list with dropdown options for different bullet styles (disc, circle, square).
+|`+numlist+` |Formats the current selection as a numbered list with dropdown options for different number styles (decimal, alpha, roman, greek).
+|===
+
+NOTE: The {pluginname} plugin extends the core `+bullist+` and `+numlist+` toolbar buttons by adding dropdown arrows that allow users to select from different list styles. These buttons are provided by the core `+lists+` plugin, but the dropdown functionality is added by the {pluginname} plugin.


### PR DESCRIPTION
Ticket: DOC-2627

Site: [Staging branch](http://docs-hotfix-8-doc-2627.staging.tiny.cloud/docs/tinymce/latest/advlist)

Changes:
* Documentation Enhancements for `advlist` plugin
* Added new live-demo
* Added missing menu-items and toolbar-items
* Validated demo is functional.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed