### PR TITLE
DOC-3274: Fixed the docker guides for Hyperlinking, Image Proxy, and Spelling services for the TinyMCE 7 Docs.

### DIFF
--- a/modules/ROOT/partials/docker/hyperlinking-service/hyperlinking-service-installation.adoc
+++ b/modules/ROOT/partials/docker/hyperlinking-service/hyperlinking-service-installation.adoc
@@ -5,7 +5,7 @@ include::partial$misc/admon-docker-access.adoc[]
 
 === Retrieve Docker Image
 
-. Login into the {companyname} Cloud Docker Registry: 
+. Login into the {companyname} Cloud Docker Registry:
 +
 [source, sh, subs="attributes+"]
 ----
@@ -23,9 +23,9 @@ Replace `<VERSION>` with `latest` or the specific version number.
 
 include::partial$misc/admon-available-docker-images.adoc[]
 
-=== Specify Configurations 
+=== Specify Configurations
 
-After completing the previous steps, run the Docker container from the pulled image: 
+After completing the previous steps, run the Docker container from the pulled image:
 
 [source, sh, subs="attributes+"]
 ----
@@ -34,7 +34,7 @@ docker run -p 19100:19100 registry.containers.tiny.cloud/hyperlinking-tiny:<VERS
 
 This triggers `-p 19100:19100`, exposing the service on `localhost:19100`. The service runs on port `19100` inside the Docker container, and this maps it to the same port on your localhost.
 
-If set up correctly, the logs should display output similar to the following: 
+If set up correctly, the logs should display output similar to the following:
 
 [source, log]
 ----
@@ -45,7 +45,7 @@ If set up correctly, the logs should display output similar to the following:
 2025-01-02 11:06:46 [io-compute-blocker-8] WARN  c.e.d.config.AllowedOriginsConfig$ - No allowed-origins specified in config!
 2025-01-02 11:06:46 [io-compute-blocker-8] INFO  navi - navi config loaded successfully: NaviConfig(LinkCheckerConfig(true,ReturnUnknown),true,CacheConfig(10000,86400 seconds,3600 seconds),SdkServiceWithClientConfig(HttpConfig(100,10,10,3,HttpConfigTimeouts(10,10,10),JvmTrustModel()),None,OriginWhitelist(List(),OriginPrecision(true))),SelfHostedMediaSourcesConfig(CustomEmbedPlugins(UrlTrie(Branch(None,TreeMap()),Branch(None,TreeMap()))),None),OriginWhitelist(List(),OriginPrecision(true)),Logger[navi])
 2025-01-02 11:06:46 [io-compute-9] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /0:0:0:0:0:0:0:0:19100
-2025-01-02 11:06:46 [io-compute-9] INFO  o.h.blaze.server.BlazeServerBuilder - 
+2025-01-02 11:06:46 [io-compute-9] INFO  o.h.blaze.server.BlazeServerBuilder -
   _   _   _        _ _
  | |_| |_| |_ _ __| | | ___
  | ' \\  _|  _| '_ \\_  _(_-<
@@ -56,7 +56,7 @@ If set up correctly, the logs should display output similar to the following:
 
 Running this command will generate a log warning about `allowed-origins` not being configured. This is expected, as it will be set up in the next step.
 
-The {productname} server-side components require a configuration file to function correctly. By convention, this file is named `application.conf`. For more information, refer to link:https://www.tiny.cloud/docs/tinymce/latest/configure-required-services/[Required configuration for the server-side components^]. 
+The {productname} server-side components require a configuration file to function correctly. By convention, this file is named `application.conf`. For more information, refer to link:https://www.tiny.cloud/docs/tinymce/latest/configure-required-services/[Required configuration for the server-side components^].
 
 This configuration file requires at least the following information:
 
@@ -96,7 +96,7 @@ The Docker container can also be run with `docker compose`. In this example, the
 ----
 hyperlinking-service/
 ├── application.conf
-└── docker-compose.yaml 
+└── docker-compose.yaml
 ----
 
 Here is an example of the application.conf file with the basic configurations:
@@ -133,10 +133,16 @@ services:
     init: true
     volumes:
       - type: bind
-        source: ./application.conf #change this to the path on your local machine 
-        target: /ephox-hyperlinking/ephox-hyperlinking-docker-env.conf 
+        source: ./application.conf #change this to the path on your local machine
+        # Use the below target path if using any version below 2.109.6.
+        # target: /ephox-hyperlinking/ephox-hyperlinking-docker-env.conf
+        target: /app/application.conf
         read_only: true
 ----
+
++
+[NOTE]
+From version 2.109.6 onwards, the `target` path in the volums option must point to `/app/application.conf` .
 
 . Run the service (within the same directory where `docker-compose.yaml` was placed):
 +
@@ -151,7 +157,7 @@ If the setup is correct, the initiation logs should appear as follows:
 +
 [source, log]
 ----
- ✔ Container hyperlinking-tiny-hyperlinking-tiny-1  Recreated                                                                                                                                                                     0.1s 
+ ✔ Container hyperlinking-tiny-hyperlinking-tiny-1  Recreated                                                                                                                                                                     0.1s
 Attaching to hyperlinking-tiny-1
 hyperlinking-tiny-1  | 2025-01-02 16:17:28 [io-compute-1] INFO  navi - navi
 
@@ -177,7 +183,7 @@ hyperlinking-tiny-1  |  - localhost:8000
 hyperlinking-tiny-1  |  - ephox.com
 hyperlinking-tiny-1  | 2025-01-02 16:17:28 [io-compute-blocker-1] INFO  navi - navi config loaded successfully: NaviConfig(LinkCheckerConfig(true,ReturnUnknown),true,CacheConfig(10000,86400 seconds,3600 seconds),SdkServiceWithClientConfig(HttpConfig(100,10,10,3,HttpConfigTimeouts(15,15,15),JvmTrustModel()),None,OriginWhitelist(List(localhost, localhost:8000, ephox.com),OriginPrecision(true))),SelfHostedMediaSourcesConfig(CustomEmbedPlugins(UrlTrie(Branch(None,TreeMap()),Branch(None,TreeMap(org -> Branch(None,TreeMap(wikipedia -> Branch(None,TreeMap(en -> Branch(Some(PathMatcher(List((wiki/.*,WikipediaEmbedPlugin(https://en.wikipedia.org/w/api.php,10))))),TreeMap()))))))))),None),OriginWhitelist(List(localhost, localhost:8000, ephox.com),OriginPrecision(true)),Logger[navi])
 hyperlinking-tiny-1  | 2025-01-02 16:17:29 [io-compute-6] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /0:0:0:0:0:0:0:0:19100
-hyperlinking-tiny-1  | 2025-01-02 16:17:29 [io-compute-6] INFO  o.h.blaze.server.BlazeServerBuilder - 
+hyperlinking-tiny-1  | 2025-01-02 16:17:29 [io-compute-6] INFO  o.h.blaze.server.BlazeServerBuilder -
 hyperlinking-tiny-1  |   _   _   _        _ _
 hyperlinking-tiny-1  |  | |_| |_| |_ _ __| | | ___
 hyperlinking-tiny-1  |  | ' \\  _|  _| '_ \\_  _(_-<
@@ -211,9 +217,9 @@ To confirm that a request is being sent to the {linkcheckerplugin} service, use:
 +
 [source, sh]
 ----
-curl --location 'http://localhost:19100/1/check' \\
---header 'Origin: http://good.com' \\
---header 'Content-Type: application/json' \\
+curl --location 'http://localhost:19100/1/check' \
+--header 'Origin: http://good.com' \
+--header 'Content-Type: application/json' \
 --data '{ "urls": [{"url":"http://google.com"}, {"url": "http://youtube.com"}, {"url":"http://google.com/404"}, {"url":"https://ephox.."}]}'
 ----
 
@@ -223,9 +229,9 @@ Finally, to verify if a request is unauthorized and originates from an incorrect
 +
 [source, sh]
 ----
-curl --location 'http://localhost:19100/1/check' \\
---header 'Origin: http://bad.com' \\
---header 'Content-Type: application/json' \\
+curl --location 'http://localhost:19100/1/check' \
+--header 'Origin: http://bad.com' \
+--header 'Content-Type: application/json' \
 --data '{ "urls": [{"url":"http://google.com"}, {"url": "http://youtube.com"}, {"url":"http://google.com/404"}, {"url":"https://ephox.."}]}'
 ----
 

--- a/modules/ROOT/partials/docker/hyperlinking-service/hyperlinking-service-installation.adoc
+++ b/modules/ROOT/partials/docker/hyperlinking-service/hyperlinking-service-installation.adoc
@@ -142,7 +142,7 @@ services:
 
 +
 [NOTE]
-From version 2.109.6 onwards, the `target` path in the volums option must point to `/app/application.conf` .
+From version 2.109.6 onwards, the `target` path in the `volumes` option must point to `/app/application.conf`.
 
 . Run the service (within the same directory where `docker-compose.yaml` was placed):
 +

--- a/modules/ROOT/partials/docker/hyperlinking-service/hyperlinking-service-installation.adoc
+++ b/modules/ROOT/partials/docker/hyperlinking-service/hyperlinking-service-installation.adoc
@@ -126,7 +126,7 @@ Once the application configuration file is ready, proceed with the Docker Compos
 ----
 services:
   hyperlinking-tiny:
-	  image: registry.containers.tiny.cloud/hyperlinking-tiny:<VERSION>
+    image: registry.containers.tiny.cloud/hyperlinking-tiny:<VERSION>
     ports:
       - "19100:19100"
     restart: always

--- a/modules/ROOT/partials/docker/hyperlinking-service/hyperlinking-service-installation.adoc
+++ b/modules/ROOT/partials/docker/hyperlinking-service/hyperlinking-service-installation.adoc
@@ -107,8 +107,8 @@ ephox {
 
   allowed-origins {
     origins = [
-      "<http://example.com>",
-      "<http://good.com> ",
+      "http://example.com",
+      "http://good.com",
       "*.my.company.org"
     ]
   }

--- a/modules/ROOT/partials/docker/hyperlinking-service/hyperlinking-service-installation.adoc
+++ b/modules/ROOT/partials/docker/hyperlinking-service/hyperlinking-service-installation.adoc
@@ -38,20 +38,20 @@ If set up correctly, the logs should display output similar to the following:
 
 [source, log]
 ----
-2025-01-02 11:06:45 [io-compute-8] INFO  navi - navi
+2025-09-15 04:46:17 [io-compute-3] INFO  navi - navi
 ...
-2025-01-02 11:06:45 [io-compute-blocker-8] INFO  navi - -> Raw Config assembled from various sources: ConfigOrigin(merge of /ephox-hyperlinking/ephox-hyperlinking-docker-env.conf: 1,system properties,reference.conf @ jar:file:/ephox-hyperlinking/ephox-hyperlinking.jar!/reference.conf: 1)
-2025-01-02 11:06:46 [io-compute-blocker-8] WARN  c.e.d.config.AllowedOriginsConfig$ - No allowed-origins specified in config!
-2025-01-02 11:06:46 [io-compute-blocker-8] WARN  c.e.d.config.AllowedOriginsConfig$ - No allowed-origins specified in config!
-2025-01-02 11:06:46 [io-compute-blocker-8] INFO  navi - navi config loaded successfully: NaviConfig(LinkCheckerConfig(true,ReturnUnknown),true,CacheConfig(10000,86400 seconds,3600 seconds),SdkServiceWithClientConfig(HttpConfig(100,10,10,3,HttpConfigTimeouts(10,10,10),JvmTrustModel()),None,OriginWhitelist(List(),OriginPrecision(true))),SelfHostedMediaSourcesConfig(CustomEmbedPlugins(UrlTrie(Branch(None,TreeMap()),Branch(None,TreeMap()))),None),OriginWhitelist(List(),OriginPrecision(true)),Logger[navi])
-2025-01-02 11:06:46 [io-compute-9] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /0:0:0:0:0:0:0:0:19100
-2025-01-02 11:06:46 [io-compute-9] INFO  o.h.blaze.server.BlazeServerBuilder -
+2025-09-15 04:46:17 [io-compute-blocker-3] INFO  navi - -> Raw Config assembled from various sources: ConfigOrigin(merge of /app/application.conf: 1,system properties,reference.conf @ jar:file:/app/navi.jar!/reference.conf: 1)
+2025-09-15 04:46:17 [io-compute-blocker-3] WARN  c.e.d.config.AllowedOriginsConfig$ - No allowed-origins specified in config!
+2025-09-15 04:46:17 [io-compute-blocker-3] WARN  c.e.d.config.AllowedOriginsConfig$ - No allowed-origins specified in config!
+2025-09-15 04:46:17 [io-compute-blocker-3] INFO  navi - navi config loaded successfully: NaviConfig(LinkCheckerConfig(true,ReturnUnknown),true,CacheConfig(10000,86400 seconds,3600 seconds),SdkServiceWithClientConfig(HttpConfig(100,10,10,3,HttpConfigTimeouts(10,10,10),JvmTrustModel()),None,OriginWhitelist(List(),OriginPrecision(true))),SelfHostedMediaSourcesConfig(CustomEmbedPlugins(UrlTrie(Branch(None,TreeMap()),Branch(None,TreeMap()))),None),OriginWhitelist(List(),OriginPrecision(true)),Logger[navi])
+2025-09-15 04:46:18 [io-compute-blocker-3] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /[0:0:0:0:0:0:0:0]:19100
+2025-09-15 04:46:18 [io-compute-blocker-3] INFO  o.h.blaze.server.BlazeServerBuilder -
   _   _   _        _ _
  | |_| |_| |_ _ __| | | ___
- | ' \\  _|  _| '_ \\_  _(_-<
- |_||_\\__|\\__| .__/ |_|/__/
+ | ' \  _|  _| '_ \_  _(_-<
+ |_||_\__|\__| .__/ |_|/__/
              |_|
-2025-01-02 11:06:46 [io-compute-9] INFO  o.h.blaze.server.BlazeServerBuilder - http4s v0.23.27 on blaze v0.23.16 started at http://[::]:19100/
+2025-09-15 04:46:18 [io-compute-blocker-3] INFO  o.h.blaze.server.BlazeServerBuilder - http4s v0.23.27 on blaze v0.23.16 started at http://[::]:19100/
 ----
 
 Running this command will generate a log warning about `allowed-origins` not being configured. This is expected, as it will be set up in the next step.
@@ -157,39 +157,39 @@ If the setup is correct, the initiation logs should appear as follows:
 +
 [source, log]
 ----
- ✔ Container hyperlinking-tiny-hyperlinking-tiny-1  Recreated                                                                                                                                                                     0.1s
+ ✔ Container hyperlinking-tiny-hyperlinking-tiny-1                                                                                                                         Created        0.1s
 Attaching to hyperlinking-tiny-1
-hyperlinking-tiny-1  | 2025-01-02 16:17:28 [io-compute-1] INFO  navi - navi
-
+hyperlinking-tiny-1  | 2025-09-15 04:57:29 [io-compute-7] INFO  navi - navi
 ...
-
--> Found value for property: /ephox-hyperlinking/ephox-hyperlinking-docker-env.conf
-hyperlinking-tiny-1  | 2025-01-02 16:17:28 [io-compute-blocker-1] INFO  navi -       * Parsing config defined by /ephox-hyperlinking/ephox-hyperlinking-docker-env.conf from property: ephox.config.file
-hyperlinking-tiny-1  | 2025-01-02 16:17:28 [io-compute-blocker-1] INFO  navi -         -> Processing file: /ephox-hyperlinking/ephox-hyperlinking-docker-env.conf
-hyperlinking-tiny-1  | 2025-01-02 16:17:28 [io-compute-blocker-1] INFO  navi -   * External application.conf => /opt/ephox/application.conf
-hyperlinking-tiny-1  | 2025-01-02 16:17:28 [io-compute-blocker-1] INFO  navi -     * Optional File (/opt/ephox/application.conf). Defaults to empty if file not found
-hyperlinking-tiny-1  | 2025-01-02 16:17:28 [io-compute-blocker-1] INFO  navi - * Internal Configuration
-hyperlinking-tiny-1  | 2025-01-02 16:17:28 [io-compute-blocker-1] INFO  navi -   -> No extra internal configuration specified - skipping
-hyperlinking-tiny-1  | 2025-01-02 16:17:28 [io-compute-blocker-1] INFO  navi - * Default (Reference) Configuration
-hyperlinking-tiny-1  | 2025-01-02 16:17:28 [io-compute-blocker-1] INFO  navi -   * Loading configuration files from classpath (reference.conf and integration.conf). Neither is required.
-hyperlinking-tiny-1  | 2025-01-02 16:17:28 [io-compute-blocker-1] INFO  navi - -> Raw Config assembled from various sources: ConfigOrigin(merge of /ephox-hyperlinking/ephox-hyperlinking-docker-env.conf: 1,system properties,reference.conf @ jar:file:/ephox-hyperlinking/ephox-hyperlinking.jar!/reference.conf: 1)
-hyperlinking-tiny-1  | 2025-01-02 16:17:28 [io-compute-blocker-1] INFO  c.e.d.config.AllowedOriginsConfig$ - Read allowed-origins config (ignoring ports = true) as:
-hyperlinking-tiny-1  |  - localhost
+-> Found value for property: /app/application.conf
+hyperlinking-tiny-1  | 2025-09-15 04:57:29 [io-compute-blocker-7] INFO  navi -       * Parsing config defined by /app/application.conf from property: ephox.config.file
+hyperlinking-tiny-1  | 2025-09-15 04:57:29 [io-compute-blocker-7] INFO  navi -         -> Processing file: /app/application.conf
+hyperlinking-tiny-1  | 2025-09-15 04:57:29 [io-compute-blocker-7] INFO  navi -   * External application.conf => /opt/ephox/application.conf
+hyperlinking-tiny-1  | 2025-09-15 04:57:29 [io-compute-blocker-7] INFO  navi -     * Optional File (/opt/ephox/application.conf). Defaults to empty if file not found
+hyperlinking-tiny-1  | 2025-09-15 04:57:29 [io-compute-blocker-7] INFO  navi - * Internal Configuration
+hyperlinking-tiny-1  | 2025-09-15 04:57:29 [io-compute-blocker-7] INFO  navi -   -> No extra internal configuration specified - skipping
+hyperlinking-tiny-1  | 2025-09-15 04:57:29 [io-compute-blocker-7] INFO  navi - * Default (Reference) Configuration
+hyperlinking-tiny-1  | 2025-09-15 04:57:29 [io-compute-blocker-7] INFO  navi -   * Loading configuration files from classpath (reference.conf and integration.conf). Neither is required.
+hyperlinking-tiny-1  | 2025-09-15 04:57:29 [io-compute-blocker-7] INFO  navi - -> Raw Config assembled from various sources: ConfigOrigin(merge of /app/application.conf: 1,system properties,reference.conf @ jar:file:/app/navi.jar!/reference.conf: 1)
+hyperlinking-tiny-1  | 2025-09-15 04:57:29 [io-compute-blocker-7] INFO  c.e.d.config.AllowedOriginsConfig$ - Read allowed-origins config (ignoring ports = true) as:
 hyperlinking-tiny-1  |  - localhost:8000
-hyperlinking-tiny-1  |  - ephox.com
-hyperlinking-tiny-1  | 2025-01-02 16:17:28 [io-compute-blocker-1] INFO  c.e.d.config.AllowedOriginsConfig$ - Read allowed-origins config (ignoring ports = true) as:
-hyperlinking-tiny-1  |  - localhost
+hyperlinking-tiny-1  |  - example.com
+hyperlinking-tiny-1  |  - good.com
+hyperlinking-tiny-1  |  - my.company.org
+hyperlinking-tiny-1  | 2025-09-15 04:57:29 [io-compute-blocker-7] INFO  c.e.d.config.AllowedOriginsConfig$ - Read allowed-origins config (ignoring ports = true) as:
 hyperlinking-tiny-1  |  - localhost:8000
-hyperlinking-tiny-1  |  - ephox.com
-hyperlinking-tiny-1  | 2025-01-02 16:17:28 [io-compute-blocker-1] INFO  navi - navi config loaded successfully: NaviConfig(LinkCheckerConfig(true,ReturnUnknown),true,CacheConfig(10000,86400 seconds,3600 seconds),SdkServiceWithClientConfig(HttpConfig(100,10,10,3,HttpConfigTimeouts(15,15,15),JvmTrustModel()),None,OriginWhitelist(List(localhost, localhost:8000, ephox.com),OriginPrecision(true))),SelfHostedMediaSourcesConfig(CustomEmbedPlugins(UrlTrie(Branch(None,TreeMap()),Branch(None,TreeMap(org -> Branch(None,TreeMap(wikipedia -> Branch(None,TreeMap(en -> Branch(Some(PathMatcher(List((wiki/.*,WikipediaEmbedPlugin(https://en.wikipedia.org/w/api.php,10))))),TreeMap()))))))))),None),OriginWhitelist(List(localhost, localhost:8000, ephox.com),OriginPrecision(true)),Logger[navi])
-hyperlinking-tiny-1  | 2025-01-02 16:17:29 [io-compute-6] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /0:0:0:0:0:0:0:0:19100
-hyperlinking-tiny-1  | 2025-01-02 16:17:29 [io-compute-6] INFO  o.h.blaze.server.BlazeServerBuilder -
+hyperlinking-tiny-1  |  - example.com
+hyperlinking-tiny-1  |  - good.com
+hyperlinking-tiny-1  |  - my.company.org
+hyperlinking-tiny-1  | 2025-09-15 04:57:29 [io-compute-blocker-7] INFO  navi - navi config loaded successfully: NaviConfig(LinkCheckerConfig(true,ReturnUnknown),true,CacheConfig(10000,86400 seconds,3600 seconds),SdkServiceWithClientConfig(HttpConfig(100,10,10,3,HttpConfigTimeouts(15,15,15),JvmTrustModel()),None,OriginWhitelist(List(localhost:8000, example.com, good.com, my.company.org),OriginPrecision(true))),SelfHostedMediaSourcesConfig(CustomEmbedPlugins(UrlTrie(Branch(None,TreeMap()),Branch(None,TreeMap(org -> Branch(None,TreeMap(wikipedia -> Branch(None,TreeMap(en -> Branch(Some(PathMatcher(List((wiki/.*,WikipediaEmbedPlugin(https://en.wikipedia.org/w/api.php,10))))),TreeMap()))))))))),None),OriginWhitelist(List(localhost:8000, example.com, good.com, my.company.org),OriginPrecision(true)),Logger[navi])
+hyperlinking-tiny-1  | 2025-09-15 04:57:30 [io-compute-blocker-7] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /[0:0:0:0:0:0:0:0]:19100
+hyperlinking-tiny-1  | 2025-09-15 04:57:30 [io-compute-blocker-7] INFO  o.h.blaze.server.BlazeServerBuilder -
 hyperlinking-tiny-1  |   _   _   _        _ _
 hyperlinking-tiny-1  |  | |_| |_| |_ _ __| | | ___
-hyperlinking-tiny-1  |  | ' \\  _|  _| '_ \\_  _(_-<
-hyperlinking-tiny-1  |  |_||_\\__|\\__| .__/ |_|/__/
+hyperlinking-tiny-1  |  | ' \  _|  _| '_ \_  _(_-<
+hyperlinking-tiny-1  |  |_||_\__|\__| .__/ |_|/__/
 hyperlinking-tiny-1  |              |_|
-hyperlinking-tiny-1  | 2025-01-02 16:17:29 [io-compute-6] INFO  o.h.blaze.server.BlazeServerBuilder - http4s v0.23.27 on blaze v0.23.16 started at http://[::]:19100/
+hyperlinking-tiny-1  | 2025-09-15 04:57:30 [io-compute-blocker-7] INFO  o.h.blaze.server.BlazeServerBuilder - http4s v0.23.27 on blaze v0.23.16 started at http://[::]:19100/
 ----
 
 === Next Steps

--- a/modules/ROOT/partials/docker/image-proxy-service/image-proxy-service-installation.adoc
+++ b/modules/ROOT/partials/docker/image-proxy-service/image-proxy-service-installation.adoc
@@ -123,7 +123,7 @@ services:
 
 +
 [NOTE]
-From version 2.111.7 onwards, the `target` path in the volumes option must point to `/app/application.conf` .
+From version 2.111.7 onwards, the `target` path in the `volumes` option must point to `/app/application.conf`.
 
 . Run the service (within the same directory where `docker-compose.yaml` was placed):
 

--- a/modules/ROOT/partials/docker/image-proxy-service/image-proxy-service-installation.adoc
+++ b/modules/ROOT/partials/docker/image-proxy-service/image-proxy-service-installation.adoc
@@ -90,8 +90,8 @@ Here is an example of the `application.conf` file with the basic configurations:
 ephox {
   allowed-origins {
     origins = [
-      "<http://example.com>",
-      "<http://good.com> ",
+      "http://example.com",
+      "http://good.com",
       "*.my.company.org"
     ]
   }

--- a/modules/ROOT/partials/docker/image-proxy-service/image-proxy-service-installation.adoc
+++ b/modules/ROOT/partials/docker/image-proxy-service/image-proxy-service-installation.adoc
@@ -7,7 +7,7 @@ link:https://www.tiny.cloud/contact/[Contact {companyname} Support^] to request 
 
 === Retrieve Docker Image
 
-. Login into the {companyname} Cloud Docker Registry: 
+. Login into the {companyname} Cloud Docker Registry:
 +
 [source, sh, subs="attributes+"]
 ----
@@ -25,9 +25,9 @@ Replace `<VERSION>` with `latest` or the specific version number.
 
 [NOTE]
 Currently, the Docker images are only supported on x86-64 (also known as AMD64) architecture processors.
-=== Specify Configurations 
+=== Specify Configurations
 
-After completing the previous steps, run the Docker container from the pulled image: 
+After completing the previous steps, run the Docker container from the pulled image:
 
 [source, sh, subs="attributes+"]
 ----
@@ -36,7 +36,7 @@ docker run -p 19040:19040 registry.containers.tiny.cloud/image-proxy-tiny:<VERSI
 
 This triggers `-p 19040:19040`, exposing the service on `localhost:19040`. The service runs on port `19040` inside the Docker container, and this maps it to the same port on your localhost.
 
-If set up correctly, the logs should display output similar to the following: 
+If set up correctly, the logs should display output similar to the following:
 
 [source, log]
 ----
@@ -46,7 +46,7 @@ If set up correctly, the logs should display output similar to the following:
 2025-01-08 12:03:16 [io-compute-blocker-3] WARN  c.e.d.config.AllowedOriginsConfig$ - No allowed-origins specified in config!
 2025-01-08 12:03:16 [io-compute-blocker-3] INFO  emissary - emissary config loaded successfully: EmissaryConfig(SdkHttpConfig(HttpConfig(100,10,10,3,HttpConfigTimeouts(10,10,10),JvmTrustModel()),None),OriginWhitelist(List(),OriginPrecision(true)),Some(10000000))
 2025-01-08 12:03:17 [io-compute-1] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /0:0:0:0:0:0:0:0:19040
-2025-01-08 12:03:17 [io-compute-1] INFO  o.h.blaze.server.BlazeServerBuilder - 
+2025-01-08 12:03:17 [io-compute-1] INFO  o.h.blaze.server.BlazeServerBuilder -
   _   _   _        _ _
  | |_| |_| |_ _ __| | | ___
  | ' \\  _|  _| '_ \\_  _(_-<
@@ -57,7 +57,7 @@ If set up correctly, the logs should display output similar to the following:
 
 Running this command will generate a log warning about `allowed-origins` not being configured. This is expected, as it will be set up in the next step.
 
-The {productname} server-side components require a configuration file to function correctly. By convention, this file is named `application.conf`. For more information, refer to link:https://www.tiny.cloud/docs/tinymce/latest/configure-required-services/[Required configuration for the server-side components]. 
+The {productname} server-side components require a configuration file to function correctly. By convention, this file is named `application.conf`. For more information, refer to link:https://www.tiny.cloud/docs/tinymce/latest/configure-required-services/[Required configuration for the server-side components].
 
 This configuration file requires at least the following information:
 
@@ -72,9 +72,9 @@ The following settings for the Image Proxy service premium server-side component
 
 * link:https://www.tiny.cloud/docs/tinymce/latest/configure-imageproxy-service/#image-proxy[image-proxy configuration]
 
-=== Run the Docker Container 
+=== Run the Docker Container
 
-The Docker container can also be run with `docker compose`. In this example, the following directory structure is assumed: 
+The Docker container can also be run with `docker compose`. In this example, the following directory structure is assumed:
 
 [source,sh]
 ----
@@ -83,7 +83,7 @@ tiny-image-proxy/
 └── application.conf        # Configuration file for allowed origins and other settings
 ----
 
-Here is an example of the `application.conf` file with the basic configurations: 
+Here is an example of the `application.conf` file with the basic configurations:
 
 [source, conf]
 ----
@@ -115,9 +115,15 @@ services:
     volumes:
       - type: bind
         source: ./application.conf #change this to the path on your local machine
-        target: /ephox-image-proxy/ephox-image-proxy-docker-env.conf 
+        # Use the below target path if using any version below 2.111.7.
+        # target: /ephox-image-proxy/ephox-image-proxy-docker-env.conf
+        target: /app/application.conf
         read_only: true
 ----
+
++
+[NOTE]
+From version 2.111.7 onwards, the `target` path in the volumes option must point to `/app/application.conf` .
 
 . Run the service (within the same directory where `docker-compose.yaml` was placed):
 
@@ -133,7 +139,7 @@ If the setup is correct, the initiation logs should appear as follows:
 +
 [source, log]
 ----
- ✔ Container image-proxy-tiny-image-proxy-tiny-1  Created                                                                                                                                                                                                                                                         0.0s 
+ ✔ Container image-proxy-tiny-image-proxy-tiny-1  Created                                                                                                                                                                                                                                                         0.0s
 Attaching to image-proxy-tiny-1
 image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-8] INFO  emissary - emissary
 image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-8] INFO  emissary - * External Configuration
@@ -160,7 +166,7 @@ image-proxy-tiny-1  |  - good.com
 image-proxy-tiny-1  |  - example.com
 image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-blocker-8] INFO  emissary - emissary config loaded successfully: EmissaryConfig(SdkHttpConfig(HttpConfig(100,10,10,3,HttpConfigTimeouts(10,10,10),JvmTrustModel()),None),OriginWhitelist(List(good.com, example.com),OriginPrecision(true)),Some(10000000))
 image-proxy-tiny-1  | 2025-01-08 15:02:37 [io-compute-1] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /0:0:0:0:0:0:0:0:19040
-image-proxy-tiny-1  | 2025-01-08 15:02:37 [io-compute-1] INFO  o.h.blaze.server.BlazeServerBuilder - 
+image-proxy-tiny-1  | 2025-01-08 15:02:37 [io-compute-1] INFO  o.h.blaze.server.BlazeServerBuilder -
 image-proxy-tiny-1  |   _   _   _        _ _
 image-proxy-tiny-1  |  | |_| |_| |_ _ __| | | ___
 image-proxy-tiny-1  |  | ' \\  _|  _| '_ \\_  _(_-<
@@ -169,7 +175,7 @@ image-proxy-tiny-1  |              |_|
 image-proxy-tiny-1  | 2025-01-08 15:02:37 [io-compute-1] INFO  o.h.blaze.server.BlazeServerBuilder - http4s v0.23.27 on blaze v0.23.16 started at http://[::]:19040/
 ----
 
-=== Next Steps 
+=== Next Steps
 
 . Test the service via cURL command
 
@@ -194,7 +200,7 @@ To confirm that a request is being sent to the Image Proxy service, use:
 +
 [source, sh]
 ----
-curl --location 'http://localhost:19040/2/image?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsrikomm%2FBMP-EDITING%2Frefs%2Fheads%2Fmaster%2Fsrc%2FInputs%2Ffish.bmp' \\
+curl --location 'http://localhost:19040/2/image?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsrikomm%2FBMP-EDITING%2Frefs%2Fheads%2Fmaster%2Fsrc%2FInputs%2Ffish.bmp' \
 --header 'Origin: http://good.com'
 ----
 
@@ -204,7 +210,7 @@ Finally, to verify if a request is unauthorized and originates from an incorrect
 +
 [source, sh]
 ----
-curl --location 'http://localhost:19040/2/image?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsrikomm%2FBMP-EDITING%2Frefs%2Fheads%2Fmaster%2Fsrc%2FInputs%2Ffish.bmp' \\
+curl --location 'http://localhost:19040/2/image?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsrikomm%2FBMP-EDITING%2Frefs%2Fheads%2Fmaster%2Fsrc%2FInputs%2Ffish.bmp' \
 --header 'Origin: http://bad.com'
 ----
 

--- a/modules/ROOT/partials/docker/image-proxy-service/image-proxy-service-installation.adoc
+++ b/modules/ROOT/partials/docker/image-proxy-service/image-proxy-service-installation.adoc
@@ -40,19 +40,19 @@ If set up correctly, the logs should display output similar to the following:
 
 [source, log]
 ----
-2025-09-15 05:11:23 [io-compute-4] INFO  emissary - emissary
+2025-09-22 00:04:26 [io-compute-8] INFO  emissary - emissary
 ...
-2025-09-15 05:11:24 [io-compute-blocker-4] INFO  emissary - -> Raw Config assembled from various sources: ConfigOrigin(merge of /ephox-image-proxy/ephox-image-proxy-docker-env.conf: 1,system properties,reference.conf @ jar:file:/ephox-image-proxy/ephox-image-proxy.jar!/reference.conf: 1)
-2025-09-15 05:11:24 [io-compute-blocker-4] WARN  c.e.d.config.AllowedOriginsConfig$ - No allowed-origins specified in config!
-2025-09-15 05:11:24 [io-compute-blocker-4] INFO  emissary - emissary config loaded successfully: EmissaryConfig(SdkHttpConfig(HttpConfig(100,10,10,3,HttpConfigTimeouts(10,10,10),JvmTrustModel()),None),OriginWhitelist(List(),OriginPrecision(true)),Some(10000000))
-2025-09-15 05:11:24 [io-compute-7] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /0:0:0:0:0:0:0:0:19040
-2025-09-15 05:11:24 [io-compute-7] INFO  o.h.blaze.server.BlazeServerBuilder -
+2025-09-22 00:04:26 [io-compute-blocker-8] INFO  emissary - -> Raw Config assembled from various sources: ConfigOrigin(merge of /app/application.conf: 1,system properties,reference.conf @ jar:file:/app/emissary.jar!/reference.conf: 1)
+2025-09-22 00:04:26 [io-compute-blocker-8] WARN  c.e.d.config.AllowedOriginsConfig$ - No allowed-origins specified in config!
+2025-09-22 00:04:26 [io-compute-blocker-8] INFO  emissary - emissary config loaded successfully: EmissaryConfig(SdkHttpConfig(HttpConfig(100,10,10,3,HttpConfigTimeouts(10,10,10),JvmTrustModel()),None),OriginWhitelist(List(),OriginPrecision(true)),Some(10000000))
+2025-09-22 00:04:27 [io-compute-7] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /[0:0:0:0:0:0:0:0]:19040
+2025-09-22 00:04:27 [io-compute-7] INFO  o.h.blaze.server.BlazeServerBuilder -
   _   _   _        _ _
  | |_| |_| |_ _ __| | | ___
  | ' \  _|  _| '_ \_  _(_-<
  |_||_\__|\__| .__/ |_|/__/
              |_|
-2025-09-15 05:11:24 [io-compute-7] INFO  o.h.blaze.server.BlazeServerBuilder - http4s v0.23.27 on blaze v0.23.16 started at http://[::]:19040/
+2025-09-22 00:04:27 [io-compute-7] INFO  o.h.blaze.server.BlazeServerBuilder - http4s v0.23.27 on blaze v0.23.16 started at http://[::]:19040/
 ----
 
 Running this command will generate a log warning about `allowed-origins` not being configured. This is expected, as it will be set up in the next step.
@@ -107,7 +107,7 @@ Once the application configuration file is ready, proceed with the Docker Compos
 ----
 services:
   image-proxy-tiny:
-	  image: registry.containers.tiny.cloud/image-proxy-tiny:[version]
+    image: registry.containers.tiny.cloud/image-proxy-tiny:[version]
     ports:
       - "19040:19040"
     restart: always
@@ -115,9 +115,15 @@ services:
     volumes:
       - type: bind
         source: ./application.conf #change this to the path on your local machine
-        target: /ephox-image-proxy/ephox-image-proxy-docker-env.conf
+        # Use the below target path if using any version below 2.111.12.
+        # target: /ephox-image-proxy/ephox-image-proxy-docker-env.conf
+        target: /app/application.conf
         read_only: true
 ----
+
++
+[NOTE]
+From version 2.111.12 onwards, the `target` path in the volumes option must point to `/app/application.conf` .
 
 
 . Run the service (within the same directory where `docker-compose.yaml` was placed):
@@ -134,42 +140,42 @@ If the setup is correct, the initiation logs should appear as follows:
 +
 [source, log]
 ----
-✔ Container image-proxy-tiny-image-proxy-tiny-1                                                                                                                         Recreated       0.0s
+ ✔ Container image-proxy-tiny-image-proxy-tiny-1                                                                                                                         Created0.2s
 Attaching to image-proxy-tiny-1
-image-proxy-tiny-1  | 2025-09-15 05:18:27 [io-compute-4] INFO  emissary - emissary
-image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-4] INFO  emissary - * External Configuration
-image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-4] INFO  emissary -   * External configuration via System Properties
-image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -     * parseConfigSources
-image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -       * looking up property: ephox.config.url
-image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -         -> Property not set
-image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -       * looking up property: config.url
-image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -         -> Property not set
-image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -     * parseConfigSources
-image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -       * looking up property: ephox.config.file
-image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -         -> Found value for property: /ephox-image-proxy/ephox-image-proxy-docker-env.conf
-image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -       * Parsing config defined by /ephox-image-proxy/ephox-image-proxy-docker-env.conf from property: ephox.config.file
-image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -         -> Processing file: /ephox-image-proxy/ephox-image-proxy-docker-env.conf
-image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -   * External application.conf => /opt/ephox/application.conf
-image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -     * Optional File (/opt/ephox/application.conf). Defaults to empty if file not found
-image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary - * Internal Configuration
-image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -   -> No extra internal configuration specified - skipping
-image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary - * Default (Reference) Configuration
-image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -   * Loading configuration files from classpath (reference.conf and integration.conf). Neither is required.
-image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary - -> Raw Config assembled from various sources: ConfigOrigin(merge of /ephox-image-proxy/ephox-image-proxy-docker-env.conf: 1,system properties,reference.conf @ jar:file:/ephox-image-proxy/ephox-image-proxy.jar!/reference.conf: 1)
-image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  c.e.d.config.AllowedOriginsConfig$ - Read allowed-origins config (ignoring ports = true) as:
+image-proxy-tiny-1  | 2025-09-22 00:14:39 [io-compute-9] INFO  emissary - emissary
+image-proxy-tiny-1  | 2025-09-22 00:14:39 [io-compute-9] INFO  emissary - * External Configuration
+image-proxy-tiny-1  | 2025-09-22 00:14:39 [io-compute-9] INFO  emissary -   * External configuration via System Properties
+image-proxy-tiny-1  | 2025-09-22 00:14:39 [io-compute-blocker-9] INFO  emissary -     * parseConfigSources
+image-proxy-tiny-1  | 2025-09-22 00:14:39 [io-compute-blocker-9] INFO  emissary -       * looking up property: ephox.config.url
+image-proxy-tiny-1  | 2025-09-22 00:14:39 [io-compute-blocker-9] INFO  emissary -         -> Property not set
+image-proxy-tiny-1  | 2025-09-22 00:14:39 [io-compute-blocker-9] INFO  emissary -       * looking up property: config.url
+image-proxy-tiny-1  | 2025-09-22 00:14:39 [io-compute-blocker-9] INFO  emissary -         -> Property not set
+image-proxy-tiny-1  | 2025-09-22 00:14:39 [io-compute-blocker-9] INFO  emissary -     * parseConfigSources
+image-proxy-tiny-1  | 2025-09-22 00:14:39 [io-compute-blocker-9] INFO  emissary -       * looking up property: ephox.config.file
+image-proxy-tiny-1  | 2025-09-22 00:14:39 [io-compute-blocker-9] INFO  emissary -         -> Found value for property: /app/application.conf
+image-proxy-tiny-1  | 2025-09-22 00:14:39 [io-compute-blocker-9] INFO  emissary -       * Parsing config defined by /app/application.conf from property: ephox.config.file
+image-proxy-tiny-1  | 2025-09-22 00:14:39 [io-compute-blocker-9] INFO  emissary -         -> Processing file: /app/application.conf
+image-proxy-tiny-1  | 2025-09-22 00:14:39 [io-compute-blocker-9] INFO  emissary -   * External application.conf => /opt/ephox/application.conf
+image-proxy-tiny-1  | 2025-09-22 00:14:39 [io-compute-blocker-9] INFO  emissary -     * Optional File (/opt/ephox/application.conf). Defaults to empty if file not found
+image-proxy-tiny-1  | 2025-09-22 00:14:39 [io-compute-blocker-9] INFO  emissary - * Internal Configuration
+image-proxy-tiny-1  | 2025-09-22 00:14:39 [io-compute-blocker-9] INFO  emissary -   -> No extra internal configuration specified - skipping
+image-proxy-tiny-1  | 2025-09-22 00:14:39 [io-compute-blocker-9] INFO  emissary - * Default (Reference) Configuration
+image-proxy-tiny-1  | 2025-09-22 00:14:39 [io-compute-blocker-9] INFO  emissary -   * Loading configuration files from classpath (reference.conf and integration.conf). Neither is required.
+image-proxy-tiny-1  | 2025-09-22 00:14:39 [io-compute-blocker-9] INFO  emissary - -> Raw Config assembled from various sources: ConfigOrigin(merge of /app/application.conf: 1,system properties,reference.conf @ jar:file:/app/emissary.jar!/reference.conf: 1)
+image-proxy-tiny-1  | 2025-09-22 00:14:39 [io-compute-blocker-9] INFO  c.e.d.config.AllowedOriginsConfig$ - Read allowed-origins config (ignoring ports = true) as:
 image-proxy-tiny-1  |  - localhost:8000
 image-proxy-tiny-1  |  - example.com
 image-proxy-tiny-1  |  - good.com
 image-proxy-tiny-1  |  - my.company.org
-image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary - emissary config loaded successfully: EmissaryConfig(SdkHttpConfig(HttpConfig(100,10,10,3,HttpConfigTimeouts(10,10,10),JvmTrustModel()),None),OriginWhitelist(List(localhost:8000, example.com, good.com, my.company.org),OriginPrecision(true)),Some(10000000))
-image-proxy-tiny-1  | 2025-09-15 05:18:29 [io-compute-0] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /0:0:0:0:0:0:0:0:19040
-image-proxy-tiny-1  | 2025-09-15 05:18:29 [io-compute-0] INFO  o.h.blaze.server.BlazeServerBuilder -
+image-proxy-tiny-1  | 2025-09-22 00:14:39 [io-compute-blocker-9] INFO  emissary - emissary config loaded successfully: EmissaryConfig(SdkHttpConfig(HttpConfig(100,10,10,3,HttpConfigTimeouts(10,10,10),JvmTrustModel()),None),OriginWhitelist(List(localhost:8000, example.com, good.com, my.company.org),OriginPrecision(true)),Some(10000000))
+image-proxy-tiny-1  | 2025-09-22 00:14:40 [io-compute-2] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /[0:0:0:0:0:0:0:0]:19040
+image-proxy-tiny-1  | 2025-09-22 00:14:40 [io-compute-2] INFO  o.h.blaze.server.BlazeServerBuilder -
 image-proxy-tiny-1  |   _   _   _        _ _
 image-proxy-tiny-1  |  | |_| |_| |_ _ __| | | ___
 image-proxy-tiny-1  |  | ' \  _|  _| '_ \_  _(_-<
 image-proxy-tiny-1  |  |_||_\__|\__| .__/ |_|/__/
 image-proxy-tiny-1  |              |_|
-image-proxy-tiny-1  | 2025-09-15 05:18:29 [io-compute-0] INFO  o.h.blaze.server.BlazeServerBuilder - http4s v0.23.27 on blaze v0.23.16 started at http://[::]:19040/
+image-proxy-tiny-1  | 2025-09-22 00:14:40 [io-compute-2] INFO  o.h.blaze.server.BlazeServerBuilder - http4s v0.23.27 on blaze v0.23.16 started at http://[::]:19040/
 ----
 
 === Next Steps

--- a/modules/ROOT/partials/docker/image-proxy-service/image-proxy-service-installation.adoc
+++ b/modules/ROOT/partials/docker/image-proxy-service/image-proxy-service-installation.adoc
@@ -40,19 +40,19 @@ If set up correctly, the logs should display output similar to the following:
 
 [source, log]
 ----
-2025-01-08 12:03:15 [io-compute-3] INFO  emissary - emissary
+2025-09-15 05:11:23 [io-compute-4] INFO  emissary - emissary
 ...
-2025-01-08 12:03:16 [io-compute-blocker-3] INFO  emissary - -> Raw Config assembled from various sources: ConfigOrigin(merge of /ephox-image-proxy/ephox-image-proxy-docker-env.conf: 1,system properties,reference.conf @ jar:file:/ephox-image-proxy/ephox-image-proxy.jar!/reference.conf: 1)
-2025-01-08 12:03:16 [io-compute-blocker-3] WARN  c.e.d.config.AllowedOriginsConfig$ - No allowed-origins specified in config!
-2025-01-08 12:03:16 [io-compute-blocker-3] INFO  emissary - emissary config loaded successfully: EmissaryConfig(SdkHttpConfig(HttpConfig(100,10,10,3,HttpConfigTimeouts(10,10,10),JvmTrustModel()),None),OriginWhitelist(List(),OriginPrecision(true)),Some(10000000))
-2025-01-08 12:03:17 [io-compute-1] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /0:0:0:0:0:0:0:0:19040
-2025-01-08 12:03:17 [io-compute-1] INFO  o.h.blaze.server.BlazeServerBuilder -
+2025-09-15 05:11:24 [io-compute-blocker-4] INFO  emissary - -> Raw Config assembled from various sources: ConfigOrigin(merge of /ephox-image-proxy/ephox-image-proxy-docker-env.conf: 1,system properties,reference.conf @ jar:file:/ephox-image-proxy/ephox-image-proxy.jar!/reference.conf: 1)
+2025-09-15 05:11:24 [io-compute-blocker-4] WARN  c.e.d.config.AllowedOriginsConfig$ - No allowed-origins specified in config!
+2025-09-15 05:11:24 [io-compute-blocker-4] INFO  emissary - emissary config loaded successfully: EmissaryConfig(SdkHttpConfig(HttpConfig(100,10,10,3,HttpConfigTimeouts(10,10,10),JvmTrustModel()),None),OriginWhitelist(List(),OriginPrecision(true)),Some(10000000))
+2025-09-15 05:11:24 [io-compute-7] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /0:0:0:0:0:0:0:0:19040
+2025-09-15 05:11:24 [io-compute-7] INFO  o.h.blaze.server.BlazeServerBuilder -
   _   _   _        _ _
  | |_| |_| |_ _ __| | | ___
- | ' \\  _|  _| '_ \\_  _(_-<
- |_||_\\__|\\__| .__/ |_|/__/
+ | ' \  _|  _| '_ \_  _(_-<
+ |_||_\__|\__| .__/ |_|/__/
              |_|
-2025-01-08 12:03:17 [io-compute-1] INFO  o.h.blaze.server.BlazeServerBuilder - http4s v0.23.27 on blaze v0.23.16 started at http://[::]:19040/
+2025-09-15 05:11:24 [io-compute-7] INFO  o.h.blaze.server.BlazeServerBuilder - http4s v0.23.27 on blaze v0.23.16 started at http://[::]:19040/
 ----
 
 Running this command will generate a log warning about `allowed-origins` not being configured. This is expected, as it will be set up in the next step.
@@ -115,15 +115,10 @@ services:
     volumes:
       - type: bind
         source: ./application.conf #change this to the path on your local machine
-        # Use the below target path if using any version below 2.111.7.
-        # target: /ephox-image-proxy/ephox-image-proxy-docker-env.conf
-        target: /app/application.conf
+        target: /ephox-image-proxy/ephox-image-proxy-docker-env.conf
         read_only: true
 ----
 
-+
-[NOTE]
-From version 2.111.7 onwards, the `target` path in the `volumes` option must point to `/app/application.conf`.
 
 . Run the service (within the same directory where `docker-compose.yaml` was placed):
 
@@ -139,40 +134,42 @@ If the setup is correct, the initiation logs should appear as follows:
 +
 [source, log]
 ----
- ✔ Container image-proxy-tiny-image-proxy-tiny-1  Created                                                                                                                                                                                                                                                         0.0s
+✔ Container image-proxy-tiny-image-proxy-tiny-1                                                                                                                         Recreated       0.0s
 Attaching to image-proxy-tiny-1
-image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-8] INFO  emissary - emissary
-image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-8] INFO  emissary - * External Configuration
-image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-8] INFO  emissary -   * External configuration via System Properties
-image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-blocker-8] INFO  emissary -     * parseConfigSources
-image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-blocker-8] INFO  emissary -       * looking up property: ephox.config.url
-image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-blocker-8] INFO  emissary -         -> Property not set
-image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-blocker-8] INFO  emissary -       * looking up property: config.url
-image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-blocker-8] INFO  emissary -         -> Property not set
-image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-blocker-8] INFO  emissary -     * parseConfigSources
-image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-blocker-8] INFO  emissary -       * looking up property: ephox.config.file
-image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-blocker-8] INFO  emissary -         -> Found value for property: /ephox-image-proxy/ephox-image-proxy-docker-env.conf
-image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-blocker-8] INFO  emissary -       * Parsing config defined by /ephox-image-proxy/ephox-image-proxy-docker-env.conf from property: ephox.config.file
-image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-blocker-8] INFO  emissary -         -> Processing file: /ephox-image-proxy/ephox-image-proxy-docker-env.conf
-image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-blocker-8] INFO  emissary -   * External application.conf => /opt/ephox/application.conf
-image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-blocker-8] INFO  emissary -     * Optional File (/opt/ephox/application.conf). Defaults to empty if file not found
-image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-blocker-8] INFO  emissary - * Internal Configuration
-image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-blocker-8] INFO  emissary -   -> No extra internal configuration specified - skipping
-image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-blocker-8] INFO  emissary - * Default (Reference) Configuration
-image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-blocker-8] INFO  emissary -   * Loading configuration files from classpath (reference.conf and integration.conf). Neither is required.
-image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-blocker-8] INFO  emissary - -> Raw Config assembled from various sources: ConfigOrigin(merge of /ephox-image-proxy/ephox-image-proxy-docker-env.conf: 1,system properties,reference.conf @ jar:file:/ephox-image-proxy/ephox-image-proxy.jar!/reference.conf: 1)
-image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-blocker-8] INFO  c.e.d.config.AllowedOriginsConfig$ - Read allowed-origins config (ignoring ports = true) as:
-image-proxy-tiny-1  |  - good.com
+image-proxy-tiny-1  | 2025-09-15 05:18:27 [io-compute-4] INFO  emissary - emissary
+image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-4] INFO  emissary - * External Configuration
+image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-4] INFO  emissary -   * External configuration via System Properties
+image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -     * parseConfigSources
+image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -       * looking up property: ephox.config.url
+image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -         -> Property not set
+image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -       * looking up property: config.url
+image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -         -> Property not set
+image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -     * parseConfigSources
+image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -       * looking up property: ephox.config.file
+image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -         -> Found value for property: /ephox-image-proxy/ephox-image-proxy-docker-env.conf
+image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -       * Parsing config defined by /ephox-image-proxy/ephox-image-proxy-docker-env.conf from property: ephox.config.file
+image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -         -> Processing file: /ephox-image-proxy/ephox-image-proxy-docker-env.conf
+image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -   * External application.conf => /opt/ephox/application.conf
+image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -     * Optional File (/opt/ephox/application.conf). Defaults to empty if file not found
+image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary - * Internal Configuration
+image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -   -> No extra internal configuration specified - skipping
+image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary - * Default (Reference) Configuration
+image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary -   * Loading configuration files from classpath (reference.conf and integration.conf). Neither is required.
+image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary - -> Raw Config assembled from various sources: ConfigOrigin(merge of /ephox-image-proxy/ephox-image-proxy-docker-env.conf: 1,system properties,reference.conf @ jar:file:/ephox-image-proxy/ephox-image-proxy.jar!/reference.conf: 1)
+image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  c.e.d.config.AllowedOriginsConfig$ - Read allowed-origins config (ignoring ports = true) as:
+image-proxy-tiny-1  |  - localhost:8000
 image-proxy-tiny-1  |  - example.com
-image-proxy-tiny-1  | 2025-01-08 15:02:36 [io-compute-blocker-8] INFO  emissary - emissary config loaded successfully: EmissaryConfig(SdkHttpConfig(HttpConfig(100,10,10,3,HttpConfigTimeouts(10,10,10),JvmTrustModel()),None),OriginWhitelist(List(good.com, example.com),OriginPrecision(true)),Some(10000000))
-image-proxy-tiny-1  | 2025-01-08 15:02:37 [io-compute-1] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /0:0:0:0:0:0:0:0:19040
-image-proxy-tiny-1  | 2025-01-08 15:02:37 [io-compute-1] INFO  o.h.blaze.server.BlazeServerBuilder -
+image-proxy-tiny-1  |  - good.com
+image-proxy-tiny-1  |  - my.company.org
+image-proxy-tiny-1  | 2025-09-15 05:18:28 [io-compute-blocker-4] INFO  emissary - emissary config loaded successfully: EmissaryConfig(SdkHttpConfig(HttpConfig(100,10,10,3,HttpConfigTimeouts(10,10,10),JvmTrustModel()),None),OriginWhitelist(List(localhost:8000, example.com, good.com, my.company.org),OriginPrecision(true)),Some(10000000))
+image-proxy-tiny-1  | 2025-09-15 05:18:29 [io-compute-0] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /0:0:0:0:0:0:0:0:19040
+image-proxy-tiny-1  | 2025-09-15 05:18:29 [io-compute-0] INFO  o.h.blaze.server.BlazeServerBuilder -
 image-proxy-tiny-1  |   _   _   _        _ _
 image-proxy-tiny-1  |  | |_| |_| |_ _ __| | | ___
-image-proxy-tiny-1  |  | ' \\  _|  _| '_ \\_  _(_-<
-image-proxy-tiny-1  |  |_||_\\__|\\__| .__/ |_|/__/
+image-proxy-tiny-1  |  | ' \  _|  _| '_ \_  _(_-<
+image-proxy-tiny-1  |  |_||_\__|\__| .__/ |_|/__/
 image-proxy-tiny-1  |              |_|
-image-proxy-tiny-1  | 2025-01-08 15:02:37 [io-compute-1] INFO  o.h.blaze.server.BlazeServerBuilder - http4s v0.23.27 on blaze v0.23.16 started at http://[::]:19040/
+image-proxy-tiny-1  | 2025-09-15 05:18:29 [io-compute-0] INFO  o.h.blaze.server.BlazeServerBuilder - http4s v0.23.27 on blaze v0.23.16 started at http://[::]:19040/
 ----
 
 === Next Steps

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
@@ -97,8 +97,8 @@ ephox {
 
   allowed-origins {
     origins = [
-      "<http://example.com>",
-      "<http://good.com> ",
+      "http://example.com",
+      "http://good.com",
       "*.my.company.org"
     ]
   }

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
@@ -7,7 +7,7 @@ link:https://www.tiny.cloud/contact/[Contact {companyname} Support^] to request 
 
 === Retrieve Docker Image
 
-. Log into the {companyname} Cloud Docker Registry: 
+. Log into the {companyname} Cloud Docker Registry:
 +
 [source, sh, subs="attributes+"]
 ----
@@ -27,9 +27,9 @@ Replace `<VERSION>` with `latest` or the specific version number.
 [NOTE]
 Currently, the Docker images are only supported on x86-64 (also known as AMD64) architecture processors.
 
-=== Specify Configurations 
+=== Specify Configurations
 
-After completing the previous steps, run the Docker container from the pulled image: 
+After completing the previous steps, run the Docker container from the pulled image:
 
 [source, sh, subs="attributes+"]
 ----
@@ -38,7 +38,7 @@ docker run -p 18080:18080 registry.containers.tiny.cloud/spelling-tiny:<VERSION>
 
 This triggers `-p 18080:18080`, exposing the service on `localhost:18080`. The service runs on port `18080` inside the Docker container, and this maps it to the same port on your localhost.
 
-If set up correctly, the logs should display output similar to the following: 
+If set up correctly, the logs should display output similar to the following:
 
 [source, log]
 ----
@@ -50,7 +50,7 @@ If set up correctly, the logs should display output similar to the following:
 2024-12-05 11:30:51.275Z [io-compute-blocker-9] INFO  com.ephox.nectar.data.Bees$ - Loading all dictionaries from WinterTree
 2024-12-05 11:30:51.677Z [io-compute-blocker-6] INFO  com.ephox.nectar.data.Bees$ - Loading all dictionaries from WinterTree
 2024-12-05 11:30:52.127Z [io-compute-7] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /0:0:0:0:0:0:0:0:18080
-2024-12-05 11:30:52.131Z [io-compute-7] INFO  o.h.blaze.server.BlazeServerBuilder - 
+2024-12-05 11:30:52.131Z [io-compute-7] INFO  o.h.blaze.server.BlazeServerBuilder -
   _   _   _        _ _
  | |_| |_| |_ _ __| | | ___
  | ' \\  _|  _| '_ \\_  _(_-<
@@ -61,7 +61,7 @@ If set up correctly, the logs should display output similar to the following:
 
 Running this command will generate a log warning about `allowed-origins` not being configured. This is expected, as it will be set up in the next step.
 
-The {productname} server-side components require a configuration file to function correctly. By convention, this file is named `application.conf`. For more information, refer to link:https://www.tiny.cloud/docs/tinymce/latest/configure-required-services/[Required configuration for the server-side components]. 
+The {productname} server-side components require a configuration file to function correctly. By convention, this file is named `application.conf`. For more information, refer to link:https://www.tiny.cloud/docs/tinymce/latest/configure-required-services/[Required configuration for the server-side components].
 
 This configuration file requires at least the following information:
 
@@ -69,15 +69,15 @@ This configuration file requires at least the following information:
 
 By default, the {pluginname} plugin comes with Hunspell dictionaries for link:https://www.tiny.cloud/docs/tinymce/latest/introduction-to-tiny-spellchecker/#supported-languages[supported languages]. For additional configurations, the service supports the following options in the `application.conf` file:
 
-* `custom-dictionaries-path`: Sets the path to where the file or directory is mounted in the container. For more information on how to set up custom dictionaries, refer to link:https://www.tiny.cloud/docs/tinymce/latest/custom-dictionaries-for-tiny-spellchecker/[Adding custom dictionaries].  
+* `custom-dictionaries-path`: Sets the path to where the file or directory is mounted in the container. For more information on how to set up custom dictionaries, refer to link:https://www.tiny.cloud/docs/tinymce/latest/custom-dictionaries-for-tiny-spellchecker/[Adding custom dictionaries].
 * `dynamic-custom-dictionaries`: When set to true, the {pluginname} service periodically checks the dictionary files in `custom-dictionaries-path` for changes and updates the custom dictionaries at runtime without requiring a service restart. The default value is `false`.
 
 [NOTE]
 Enabling the `dynamic-custom-dictionaries` option introduces some performance overhead, which may result in a wait time for the custom dictionaries to load.
 
-=== Run the Docker Container 
+=== Run the Docker Container
 
-The Docker container can also be run with `docker compose`. In this example, the following directory structure is assumed: 
+The Docker container can also be run with `docker compose`. In this example, the following directory structure is assumed:
 
 [source,sh]
 ----
@@ -89,7 +89,7 @@ spelling-service/
 └── docker-compose.yaml
 ----
 
-Here is an example of the `application.conf` file with the basic configurations: 
+Here is an example of the `application.conf` file with the basic configurations:
 
 [source, conf]
 ----
@@ -102,7 +102,7 @@ ephox {
       "*.my.company.org"
     ]
   }
-  
+
   spelling {
     custom-dictionaries-path = "/app/resources/custom-dictionaries"
     hunspell-dictionaries-path = "/app/resources/hunspell-dictionaries"
@@ -113,7 +113,7 @@ ephox {
 . Create the `docker-compose.yaml` file:
 
 +
-Here is an example of how to set up the file given the above directory structure and `application.conf` file: 
+Here is an example of how to set up the file given the above directory structure and `application.conf` file:
 
 +
 [source, yaml]
@@ -128,7 +128,9 @@ services:
     volumes:
       - type: bind
         source: ./application.conf
-        target: /ephox-spelling/ephox-spelling-docker-env.conf 
+        # Use the below target path if using any version below 2.130.0.
+        # target: /ephox-spelling/ephox-spelling-docker-env.conf
+        target: /app/application.conf
         read_only: true
       - type: bind
         source: ./resources/custom-dictionaries
@@ -142,7 +144,11 @@ services:
 
 +
 [NOTE]
-Ensure the `target` path in the `volumes` option matches the `custom-dictionaries-path` and `hunspell-dictionaries-path` in the `application.conf` file. 
+From version 2.130.0 onwards, the `target` path in the volums option must point to `/app/application.conf` .
+
++
+[NOTE]
+Ensure the `target` path in the `volumes` option matches the `custom-dictionaries-path` and `hunspell-dictionaries-path` in the `application.conf` file.
 
 . Run the service (within the same directory where `docker-compose.yaml` was placed):
 
@@ -159,8 +165,8 @@ If the allowed origins, Hunspell, and custom dictionaries folders are configured
 [source, log]
 ----
 [+] Running 2/2
- ✔ Network spelling-tiny_default            Created                                                                                                                                                                                               0.0s 
- ✔ Container spelling-tiny-spelling-tiny-1  Created                                                                                                                                                                                               0.1s 
+ ✔ Network spelling-tiny_default            Created                                                                                                                                                                                               0.0s
+ ✔ Container spelling-tiny-spelling-tiny-1  Created                                                                                                                                                                                               0.1s
 Attaching to spelling-tiny-1
 spelling-tiny-1  | 2025-02-11 09:51:10.332Z [io-compute-5] INFO  ironbark - ironbark
 ...
@@ -181,7 +187,7 @@ spelling-tiny-1  | 2025-02-11 09:51:11.881Z [io-compute-blocker-5] INFO  c.e.nec
 spelling-tiny-1  | 2025-02-11 09:51:13.593Z [io-compute-blocker-5] INFO  c.e.nectar.hunspell.HunspellLoader$ - Loading hunspell dictionary from path: /app/resources/hunspell-dictionaries and locale de_DE
 spelling-tiny-1  | 2025-02-11 09:51:13.651Z [io-compute-blocker-5] INFO  c.e.nectar.hunspell.HunspellLoader$ - Finished loading hunspell for de_DE
 spelling-tiny-1  | 2025-02-11 09:51:14.142Z [io-compute-9] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /0:0:0:0:0:0:0:0:18080
-spelling-tiny-1  | 2025-02-11 09:51:14.146Z [io-compute-9] INFO  o.h.blaze.server.BlazeServerBuilder - 
+spelling-tiny-1  | 2025-02-11 09:51:14.146Z [io-compute-9] INFO  o.h.blaze.server.BlazeServerBuilder -
 spelling-tiny-1  |   _   _   _        _ _
 spelling-tiny-1  |  | |_| |_| |_ _ __| | | ___
 spelling-tiny-1  |  | ' \\  _|  _| '_ \\_  _(_-<
@@ -190,7 +196,7 @@ spelling-tiny-1  |              |_|
 spelling-tiny-1  | 2025-02-11 09:51:14.162Z [io-compute-9] INFO  o.h.blaze.server.BlazeServerBuilder - http4s v0.23.27 on blaze v0.23.16 started at http://[::]:18080/
 ----
 
-=== Next Steps 
+=== Next Steps
 
 . Test the service via `cURL` command
 
@@ -249,8 +255,3 @@ tinymce.init({
   spellchecker_rpc_url: "http://localhost:18080"
 });
 ----
-
-
-
-
-

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
@@ -144,7 +144,7 @@ services:
 
 +
 [NOTE]
-From version 2.130.0 onwards, the `target` path in the volums option must point to `/app/application.conf` .
+From version 2.130.0 onwards, the `target` path in the `volumes` option must point to `/app/application.conf` .
 
 +
 [NOTE]

--- a/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
+++ b/modules/ROOT/partials/docker/spelling-service/spelling-service-installation.adoc
@@ -42,21 +42,21 @@ If set up correctly, the logs should display output similar to the following:
 
 [source, log]
 ----
-2024-12-05 11:30:50.813Z [io-compute-9] INFO  ironbark - ironbark
+2025-09-15 05:31:43.758Z [io-compute-8] INFO  ironbark - ironbark
 ...
-2024-12-05 11:30:51.166Z [io-compute-blocker-9] INFO  ironbark - -> Raw Config assembled from various sources: ConfigOrigin(merge of /ephox-spelling/ephox-spelling-docker-env.conf: 1,system properties,reference.conf @ jar:file:/ephox-spelling/ephox-spelling.jar!/reference.conf: 1)
-2024-12-05 11:30:51.206Z [io-compute-blocker-9] WARN  c.e.d.config.AllowedOriginsConfig$ - No allowed-origins specified in config!
-2024-12-05 11:30:51.219Z [io-compute-blocker-9] INFO  ironbark - ironbark config loaded successfully: IronbarkConfig(Logger[ironbark],SpellingConfig(None,Some(200),None,false),OriginWhitelist(List(),OriginPrecision(true)),None,None,StaticCustomDictionaryScanConfig)
-2024-12-05 11:30:51.275Z [io-compute-blocker-9] INFO  com.ephox.nectar.data.Bees$ - Loading all dictionaries from WinterTree
-2024-12-05 11:30:51.677Z [io-compute-blocker-6] INFO  com.ephox.nectar.data.Bees$ - Loading all dictionaries from WinterTree
-2024-12-05 11:30:52.127Z [io-compute-7] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /0:0:0:0:0:0:0:0:18080
-2024-12-05 11:30:52.131Z [io-compute-7] INFO  o.h.blaze.server.BlazeServerBuilder -
+2025-09-15 05:31:44.093Z [io-compute-blocker-8] INFO  ironbark - -> Raw Config assembled from various sources: ConfigOrigin(merge of /app/application.conf: 1,system properties,reference.conf @ jar:file:/app/ironbark.jar!/reference.conf: 1)
+2025-09-15 05:31:44.120Z [io-compute-blocker-8] WARN  c.e.d.config.AllowedOriginsConfig$ - No allowed-origins specified in config!
+2025-09-15 05:31:44.128Z [io-compute-blocker-8] INFO  ironbark - ironbark config loaded successfully: IronbarkConfig(Logger[ironbark],SpellingConfig(None,200,None,5,0.8,500),OriginWhitelist(List(),OriginPrecision(true)),None,None,StaticCustomDictionaryScanConfig)
+2025-09-15 05:31:44.178Z [io-compute-blocker-8] INFO  com.ephox.nectar.data.Bees$ - Loading all dictionaries from WinterTree
+2025-09-15 05:31:44.680Z [io-compute-blocker-4] INFO  com.ephox.nectar.data.Bees$ - Loading all dictionaries from WinterTree
+2025-09-15 05:31:45.415Z [io-compute-blocker-8] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /[0:0:0:0:0:0:0:0]:18080
+2025-09-15 05:31:45.425Z [io-compute-blocker-8] INFO  o.h.blaze.server.BlazeServerBuilder -
   _   _   _        _ _
  | |_| |_| |_ _ __| | | ___
- | ' \\  _|  _| '_ \\_  _(_-<
- |_||_\\__|\\__| .__/ |_|/__/
+ | ' \  _|  _| '_ \_  _(_-<
+ |_||_\__|\__| .__/ |_|/__/
              |_|
-2024-12-05 11:30:52.145Z [io-compute-7] INFO  o.h.blaze.server.BlazeServerBuilder - http4s v0.23.27 on blaze v0.23.16 started at http://[::]:18080/
+2025-09-15 05:31:45.434Z [io-compute-blocker-8] INFO  o.h.blaze.server.BlazeServerBuilder - http4s v0.23.27 on blaze v0.23.16 started at http://[::]:18080/
 ----
 
 Running this command will generate a log warning about `allowed-origins` not being configured. This is expected, as it will be set up in the next step.
@@ -138,7 +138,7 @@ services:
         read_only: true
       - type: bind
         source: ./resources/hunspell-dictionaries
-        target: /app/resources/custom-dictionaries
+        target: /app/resources/hunspell-dictionaries
         read_only: true
 ----
 
@@ -164,36 +164,26 @@ If the allowed origins, Hunspell, and custom dictionaries folders are configured
 +
 [source, log]
 ----
-[+] Running 2/2
- ✔ Network spelling-tiny_default            Created                                                                                                                                                                                               0.0s
- ✔ Container spelling-tiny-spelling-tiny-1  Created                                                                                                                                                                                               0.1s
+ ✔ Container spelling-tiny-spelling-tiny-1                                                                                                                         Created            0.1s
 Attaching to spelling-tiny-1
-spelling-tiny-1  | 2025-02-11 09:51:10.332Z [io-compute-5] INFO  ironbark - ironbark
+spelling-tiny-1  | 2025-09-15 05:37:52.505Z [io-compute-0] INFO  ironbark - ironbark
 ...
-spelling-tiny-1  | 2025-02-11 09:51:10.736Z [io-compute-blocker-5] INFO  ironbark - -> Raw Config assembled from various sources: ConfigOrigin(merge of /ephox-spelling/ephox-spelling-docker-env.conf: 1,system properties,reference.conf @ jar:file:/ephox-spelling/ephox-spelling.jar!/reference.conf: 1)
-spelling-tiny-1  | 2025-02-11 09:51:10.814Z [io-compute-blocker-5] INFO  c.e.d.config.AllowedOriginsConfig$ - Read allowed-origins config (ignoring ports = true) as:
+spelling-tiny-1  | 2025-09-15 05:37:52.816Z [io-compute-blocker-0] INFO  ironbark - -> Raw Config assembled from various sources: ConfigOrigin(merge of /app/application.conf: 1,system properties,reference.conf @ jar:file:/app/ironbark.jar!/reference.conf: 1)
+spelling-tiny-1  | 2025-09-15 05:37:52.874Z [io-compute-blocker-0] INFO  c.e.d.config.AllowedOriginsConfig$ - Read allowed-origins config (ignoring ports = true) as:
+spelling-tiny-1  |  - localhost:8000
 spelling-tiny-1  |  - example.com
 spelling-tiny-1  |  - good.com
 spelling-tiny-1  |  - my.company.org
-spelling-tiny-1  | 2025-02-11 09:51:10.822Z [io-compute-blocker-5] INFO  ironbark - ironbark config loaded successfully: IronbarkConfig(Logger[ironbark],SpellingConfig(None,Some(200),None,5,0.8),OriginWhitelist(List(example.com, good.com, my.company.org),OriginPrecision(true)),Some(CustomDictionaryPath(/app/resources/custom-dictionaries)),Some(HunspellDictionaryPath(/app/resources/hunspell-dictionaries)),StaticCustomDictionaryScanConfig)
-spelling-tiny-1  | 2025-02-11 09:51:11.101Z [io-compute-blocker-6] INFO  c.e.i.d.StaticCustomDictionaries$ - Using custom dictionary: [global] = 2 words in engine Hunspell
-spelling-tiny-1  | 2025-02-11 09:51:11.104Z [io-compute-blocker-6] INFO  c.e.i.d.StaticCustomDictionaries$ - Using custom dictionary: [global] = 2 words in engine WinterTree
-spelling-tiny-1  | 2025-02-11 09:51:11.161Z [io-compute-blocker-6] INFO  com.ephox.nectar.data.Bees$ - Loading all dictionaries from WinterTree
-spelling-tiny-1  | 2025-02-11 09:51:11.482Z [io-compute-blocker-5] INFO  c.e.nectar.hunspell.HunspellLoader$ - Loading hunspell dictionary from path: /app/resources/hunspell-dictionaries and locale es
-spelling-tiny-1  | 2025-02-11 09:51:11.536Z [io-compute-blocker-5] INFO  c.e.nectar.hunspell.HunspellLoader$ - Finished loading hunspell for es
-spelling-tiny-1  | 2025-02-11 09:51:11.537Z [io-compute-blocker-5] INFO  c.e.nectar.hunspell.HunspellLoader$ - Loading hunspell dictionary from path: /app/resources/hunspell-dictionaries and locale pt_BR
-spelling-tiny-1  | 2025-02-11 09:51:11.881Z [io-compute-blocker-5] INFO  c.e.nectar.hunspell.HunspellLoader$ - Finished loading hunspell for pt_BR
-...
-spelling-tiny-1  | 2025-02-11 09:51:13.593Z [io-compute-blocker-5] INFO  c.e.nectar.hunspell.HunspellLoader$ - Loading hunspell dictionary from path: /app/resources/hunspell-dictionaries and locale de_DE
-spelling-tiny-1  | 2025-02-11 09:51:13.651Z [io-compute-blocker-5] INFO  c.e.nectar.hunspell.HunspellLoader$ - Finished loading hunspell for de_DE
-spelling-tiny-1  | 2025-02-11 09:51:14.142Z [io-compute-9] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /0:0:0:0:0:0:0:0:18080
-spelling-tiny-1  | 2025-02-11 09:51:14.146Z [io-compute-9] INFO  o.h.blaze.server.BlazeServerBuilder -
+spelling-tiny-1  | 2025-09-15 05:37:52.877Z [io-compute-blocker-0] INFO  ironbark - ironbark config loaded successfully: IronbarkConfig(Logger[ironbark],SpellingConfig(None,200,None,5,0.8,500),OriginWhitelist(List(localhost:8000, example.com, good.com, my.company.org),OriginPrecision(true)),Some(CustomDictionaryPath(/app/resources/custom-dictionaries)),Some(HunspellDictionaryPath(/app/resources/hunspell-dictionaries)),StaticCustomDictionaryScanConfig)
+spelling-tiny-1  | 2025-09-15 05:37:52.959Z [io-compute-6] INFO  com.ephox.nectar.data.Bees$ - Loading all dictionaries from WinterTree
+spelling-tiny-1  | 2025-09-15 05:37:54.143Z [io-compute-blocker-0] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /[0:0:0:0:0:0:0:0]:18080
+spelling-tiny-1  | 2025-09-15 05:37:54.149Z [io-compute-blocker-0] INFO  o.h.blaze.server.BlazeServerBuilder -
 spelling-tiny-1  |   _   _   _        _ _
 spelling-tiny-1  |  | |_| |_| |_ _ __| | | ___
-spelling-tiny-1  |  | ' \\  _|  _| '_ \\_  _(_-<
-spelling-tiny-1  |  |_||_\\__|\\__| .__/ |_|/__/
+spelling-tiny-1  |  | ' \  _|  _| '_ \_  _(_-<
+spelling-tiny-1  |  |_||_\__|\__| .__/ |_|/__/
 spelling-tiny-1  |              |_|
-spelling-tiny-1  | 2025-02-11 09:51:14.162Z [io-compute-9] INFO  o.h.blaze.server.BlazeServerBuilder - http4s v0.23.27 on blaze v0.23.16 started at http://[::]:18080/
+spelling-tiny-1  | 2025-09-15 05:37:54.157Z [io-compute-blocker-0] INFO  o.h.blaze.server.BlazeServerBuilder - http4s v0.23.27 on blaze v0.23.16 started at http://[::]:18080/
 ----
 
 === Next Steps


### PR DESCRIPTION
Ticket: DOC-3274

- Hyperlinking Service: [Staging branch](http://docs-hotfix-7-doc-3274.staging.tiny.cloud/docs/tinymce/7/individual-hyperlinking-container/)

- Image Proxy Service: [Staging branch](http://docs-hotfix-7-doc-3274.staging.tiny.cloud/docs/tinymce/7/individual-image-proxy-container/)

- Spelling Service: [Staging branch](http://docs-hotfix-7-doc-3274.staging.tiny.cloud/docs/tinymce/7/individual-spelling-container/)

Changes:
*  Fixed curl commands to use a single slash instead of double slash and modified docker compose yaml files to use latest target path in the Hyperlinking, Image Proxy, and Spelling docker guides. Also added a note underneath the docker compose yaml code.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed