### PR TITLE
DOC-3275: Update Angular guide for self hosting, failing on `licenseKey` prop.

### DIFF
--- a/modules/ROOT/partials/integrations/angular-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/angular-quick-start.adoc
@@ -61,10 +61,11 @@ import { EditorComponent } from '@tinymce/tinymce-angular';
   <h1>{productname} {productmajorversion} Angular Demo</h1>
   <editor
     [init]="init"
+    licenseKey="gpl"
   />
   `
 })
-export class AppComponent {
+export class App {
   init: EditorComponent['init'] = {
     plugins: 'lists link image table code help wordcount'
   };

--- a/modules/ROOT/partials/integrations/angular-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/angular-tech-ref.adoc
@@ -148,7 +148,7 @@ include::partial$integrations/common/license-key-property.adoc[]
 ----
 
 [TIP]
-The `+licenseKey="gpl"+` property must be set on the `<editor>` component.
+The `+licenseKey="gpl"+` property must be set on the `<editor>` component when using TinyMCE 8 and above.
 
 [[cloudchannel]]
 === `+cloudChannel+`

--- a/modules/ROOT/partials/integrations/angular-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/angular-tech-ref.adoc
@@ -97,6 +97,7 @@ The editor accepts the following properties:
 <editor
   apiKey="no-api-key"
   cloudChannel="{productmajorversion}"
+  licenseKey="gpl"
   [disabled]="false"
   [readonly]="false"
   id=""
@@ -145,6 +146,9 @@ include::partial$integrations/common/license-key-property.adoc[]
 ----
 <editor licenseKey="gpl" />
 ----
+
+[TIP]
+The `+licenseKey="gpl"+` property must be set on the `<editor>` component.
 
 [[cloudchannel]]
 === `+cloudChannel+`


### PR DESCRIPTION
Ticket: DOC-3275

Site: [angular-pm](http://docs-hotfix-8-doc-3275.staging.tiny.cloud/docs/tinymce/latest/angular-pm/)
Site: [angular-ref](http://docs-hotfix-8-doc-3275.staging.tiny.cloud/docs/tinymce/latest/angular-ref/#:~:text=%3D%228%22-,licenseKey%3D%22gpl%22,-%5Bdisabled%5D%3D)
Site: [TIP](http://docs-hotfix-8-doc-3275.staging.tiny.cloud/docs/tinymce/latest/angular-ref/#:~:text=The%20licenseKey%3D%22gpl%22%20property%20must%20be%20set%20on%20the%20%3Ceditor%3E%20component.)

Changes:
- [x] Update export class name from `AppComponent` to `App` due to build errors.
- [x] Explicitly set licenseKey="gpl" on the <editor> component so integrators can setup self-hosted versions without their editors being blocked.
- [x] Check that the technical ref [TinyMCE Angular integration technical reference | TinyMCE Documentation](https://www.tiny.cloud/docs/tinymce/latest/angular-ref/)  is up to date with the licenseKey prop in examples.
- [x] Validate building demo using the guide.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed