### PR TITLE
DOC-3286: Add additional config option to full feature demo, and relevant doc pages as note.

### DIFF
--- a/modules/ROOT/examples/live-demos/full-featured/index.js
+++ b/modules/ROOT/examples/live-demos/full-featured/index.js
@@ -712,6 +712,7 @@ tinymce.init({
       'size': 'Letter'
     }
   },
+  pagebreak_separator: '<div style="break-after: page"></div>',
   importword_converter_options: {
     'formatting': {
       'styles': 'inline',

--- a/modules/ROOT/examples/live-demos/full-featured/index.js
+++ b/modules/ROOT/examples/live-demos/full-featured/index.js
@@ -713,6 +713,7 @@ tinymce.init({
     }
   },
   pagebreak_separator: '<div style="break-after: page"></div>',
+  pagebreak_split_block: true,
   importword_converter_options: {
     'formatting': {
       'styles': 'inline',

--- a/modules/ROOT/pages/exportpdf.adoc
+++ b/modules/ROOT/pages/exportpdf.adoc
@@ -64,6 +64,10 @@ tinymce.init({
 The `exportpdf_service_url` option automatically appends `/v1/convert` to the URL provided, so only the base URL is required. For example, if the service is hosted at `http://localhost:8080/v1/convert`, the `exportpdf_service_url` option should be set to `http://localhost:8080/`. When using in production, ensure that `exportpdf_service_url` is updated to the production URL such as `https://myserver.com/`.
 ====
 
+== Additional Configuration
+
+include::partial$misc/pagebreak-export-note.adoc[]
+
 == Options
 
 The following configuration options affect the behavior of the {pluginname} plugin.

--- a/modules/ROOT/pages/exportword.adoc
+++ b/modules/ROOT/pages/exportword.adoc
@@ -7,6 +7,7 @@
 :description_short: Generate a .docx file directly from the editor.
 :keywords: plugin, {plugincode}, {pluginname}
 :plugincategory: premium
+:plugincode: exportword
 
 include::partial$misc/admon-export-word-paid-addon-pricing.adoc[]
 
@@ -70,6 +71,10 @@ tinymce.init({
 ====
 The `exportword_service_url` option automatically appends `/v2/convert/html-docx` to the URL provided, so only the base URL is required. For example, if the service is hosted at `http://localhost:8080/v2/convert/html-docx`, the `exportword_service_url` option should be set to `http://localhost:8080/`. When using in production, ensure that `exportword_service_url` is updated to the production URL such as `https://myserver.com/`.
 ====
+
+== Additional Configuration
+
+include::partial$misc/pagebreak-export-note.adoc[]
 
 == Options
 

--- a/modules/ROOT/partials/misc/pagebreak-export-note.adoc
+++ b/modules/ROOT/partials/misc/pagebreak-export-note.adoc
@@ -1,0 +1,36 @@
+[NOTE]
+====
+.Page break support
+To ensure page breaks work correctly in exported documents, configure the `pagebreak_separator` option:
+ifeval::["{plugincode}" == "exportpdf"]
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',
+  plugins: 'exportpdf',
+  toolbar: 'exportpdf',
+  pagebreak_separator: '<div style="break-after: page"></div>',
+  // ... other configuration options
+});
+----
+
+For DOCX exports, the page breaks will be converted to Word-compatible page breaks.
+endif::[]
+
+ifeval::["{plugincode}" != "exportpdf"]
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',
+  plugins: 'exportword',
+  toolbar: 'exportword',
+  pagebreak_separator: '<div style="break-after: page"></div>',
+  // ... other configuration options
+});
+----
+
+For PDF exports, ensure your content includes proper page break elements that will be converted to PDF page breaks.
+endif::[]
+====

--- a/modules/ROOT/partials/misc/pagebreak-export-note.adoc
+++ b/modules/ROOT/partials/misc/pagebreak-export-note.adoc
@@ -1,7 +1,7 @@
 [NOTE]
 ====
 .Page break support
-To ensure page breaks work correctly in exported documents, configure the `pagebreak_separator` option:
+To ensure page breaks work correctly in exported documents, configure the `pagebreak_separator` and `pagebreak_split_block` options:
 ifeval::["{plugincode}" == "exportpdf"]
 
 [source,js]
@@ -11,11 +11,12 @@ tinymce.init({
   plugins: 'exportpdf',
   toolbar: 'exportpdf',
   pagebreak_separator: '<div style="break-after: page"></div>',
+  pagebreak_split_block: true,
   // ... other configuration options
 });
 ----
 
-For DOCX exports, the page breaks will be converted to Word-compatible page breaks.
+For PDF exports, ensure your content includes proper page break elements that will be converted to PDF page breaks.
 endif::[]
 
 ifeval::["{plugincode}" != "exportpdf"]
@@ -27,10 +28,11 @@ tinymce.init({
   plugins: 'exportword',
   toolbar: 'exportword',
   pagebreak_separator: '<div style="break-after: page"></div>',
+  pagebreak_split_block: true,
   // ... other configuration options
 });
 ----
 
-For PDF exports, ensure your content includes proper page break elements that will be converted to PDF page breaks.
+For DOCX exports, the page breaks will be converted to Word-compatible page breaks.
 endif::[]
 ====


### PR DESCRIPTION
Ticket: DOC-3286
Backlog ticket: DOC-3289

Site: [full feature demo update](http://docs-hotfix-8-doc-3286.staging.tiny.cloud/docs/tinymce/latest/full-featured-premium-demo/)
Site: [exportword](http://docs-hotfix-8-doc-3286.staging.tiny.cloud/docs/tinymce/latest/exportword/#additional-configuration)
Site: [exportpdf](http://docs-hotfix-8-doc-3286.staging.tiny.cloud/docs/tinymce/latest/exportpdf/#additional-configuration)

Changes:
* add workaround for `pagebreak_separator: '<div style="break-after: page"></div>',` to docs pages and live demo so users can fix issues if they run into them.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed