### PR TITLE
TINY-12258: New `suggestededits_auto_approve` option

### DIFF
--- a/modules/ROOT/examples/live-demos/suggestededits-auto-approve/index.html
+++ b/modules/ROOT/examples/live-demos/suggestededits-auto-approve/index.html
@@ -1,0 +1,44 @@
+<textarea id="suggestededits-auto-approve" suggestededits-model='{"history":{"2":[{"id":1,"uid":"james-wilson","timestamp":1752576936000,"feedback":"Nice improvement!"}]},"version":1,"contents":[{"type":"p","children":[{"type":"img","attrs":{"style":"display: block; margin-left: auto; margin-right: auto;","title":"Tiny Logo","src":"https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png","alt":"TinyMCE Logo","width":"128","height":"128"}}]},{"type":"h2","attrs":{"style":"text-align: center;"},"children":[{"text":"Welcome to the TinyMCE Suggested Edits "},{"text":"interactive ","opData":{"id":1,"type":"insert","uid":"alex-thompson","timestamp":1752015064000}},{"text":"demo!"}]},{"type":"p","attrs":{"style":"text-align: center;"},"children":[{"text":"Try out the Suggested Edits feature"},{"text":": type in the editor, apply formatting or delete some content. T","opData":{"id":2,"type":"insert","uid":"alex-thompson","timestamp":1752415064000}},{"text":" by typing in the editor and t","opData":{"id":2,"type":"remove","uid":"alex-thompson","timestamp":1752415064000}},{"text":"hen"},{"text":",","opData":{"id":3,"type":"insert","uid":"alex-thompson","timestamp":1752515064000}},{"text":" click"},{"text":"ing","opData":{"id":4,"type":"remove","uid":"alex-thompson","timestamp":1752515064000}},{"text":" the Review Changes button in the toolbar"},{"text":" to see your changes","opData":{"id":5,"type":"insert","uid":"kai-nakamura","timestamp":1752615064000}},{"text":"."}]},{"type":"p","attrs":{"style":"text-align: center;"},"children":[{"text":"And visit the "},{"text":"pricing page","opData":{"id":6,"type":"modify","uid":"kai-nakamura","timestamp":1752615064000},"format":[{"type":"a","attrs":{"href":"https://www.tiny.cloud/pricing"}}],"oldFormat":[{"type":"a","attrs":{"href":"https://www.tiny.cloud/pricing"}},"em"]},{"text":" to learn more about our Premium plugins."}]},{"type":"h2","children":[{"text":"A simple table to play with"}]},{"type":"table","attrs":{"style":"border-collapse: collapse; width: 100%;","border":"1"},"children":[{"type":"thead","children":[{"type":"tr","attrs":{"style":"text-align: left;"},"children":[{"type":"th","children":[{"text":"Product"}]},{"type":"th","children":[{"text":"Cost"}]},{"type":"th","children":[{"text":"Really?"}]}]}]},{"type":"tbody","children":[{"type":"tr","children":[{"type":"td","children":[{"text":"TinyMCE Cloud"}]},{"type":"td","children":[{"text":"Get started for free"}]},{"type":"td","children":[{"text":"Yes!","format":["strong"]}]}]},{"type":"tr","children":[{"type":"td","children":[{"text":"Plupload"}]},{"type":"td","children":[{"text":"Free"}]},{"type":"td","children":[{"text":"Yes!","format":["strong"]}]}]}]}]},{"type":"h2","opData":{"id":7,"type":"insert","uid":"mia-andersson","timestamp":1752576331000},"children":[{"text":"Found a bug?"}]},{"type":"p","children":[{"text":" ","opData":{"id":7,"type":"remove","uid":"mia-andersson","timestamp":1752576331000}},{"text":"If you believe you have found a bug please create an issue on the ","opData":{"id":7,"type":"insert","uid":"mia-andersson","timestamp":1752576331000}},{"text":"GitHub repo","opData":{"id":7,"type":"insert","uid":"mia-andersson","timestamp":1752576331000},"format":[{"type":"a","attrs":{"href":"https://github.com/tinymce/tinymce/issues"}}]},{"text":" to report it to the developers.","opData":{"id":7,"type":"insert","uid":"mia-andersson","timestamp":1752576331000}}]},{"type":"h2","children":[{"text":"Finally…"}]},{"type":"p","children":[{"text":"Don’t forget to check out "},{"text":"Plupload","format":[{"type":"a","attrs":{"href":"http://www.plupload.com","target":"_blank","rel":"noopener"}}]},{"text":", the upload solution featuring HTML5 upload support."}]},{"type":"p","children":[{"text":"Thanks for supporting TinyMCE. We hope it helps you and your users create great content."}]},{"type":"p","children":[{"text":"All the best from the TinyMCE team."}]}]}'>
+  {{logofordemoshtml}}
+
+  <h2 style="text-align: center;">Welcome to the TinyMCE Suggested Edits interactive demo!</h2>
+
+  <p style="text-align: center;">Try out the Suggested Edits feature: type in the editor, apply formatting or delete some content. Then, click the Review Changes button in the toolbar to see your changes.</p>
+
+  <p style="text-align: center;">And visit the <a href="https://www.tiny.cloud/pricing">pricing page</a> to learn more about our Premium plugins.</p>
+  
+  <h2>A simple table to play with</h2>
+
+  <table style="border-collapse: collapse; width: 100%;" border="1">
+    <thead>
+      <tr style="text-align: left;">
+        <th>Product</th>
+        <th>Cost</th>
+        <th>Really?</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>TinyMCE Cloud</td>
+        <td>Get started for free</td>
+        <td><strong>Yes!</strong></td>
+      </tr>
+      <tr>
+        <td>Plupload</td>
+        <td>Free</td>
+        <td><strong>Yes!</strong></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Found a bug?</h2>
+
+  <p>If you believe you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
+
+  <h2>Finally…</h2>
+
+  <p>Don't forget to check out <a href="http://www.plupload.com" target="_blank" rel="noopener">Plupload</a>, the upload solution featuring HTML5 upload support.</p>
+  <p>Thanks for supporting TinyMCE. We hope it helps you and your users create great content.</p>
+  <p>All the best from the TinyMCE team.</p>
+
+</textarea>

--- a/modules/ROOT/examples/live-demos/suggestededits-auto-approve/index.js
+++ b/modules/ROOT/examples/live-demos/suggestededits-auto-approve/index.js
@@ -1,0 +1,24 @@
+const API_URL = 'https://demouserdirectory.tiny.cloud/v1/users';
+
+const tinymceElement = document.querySelector('textarea#suggestededits-auto-approve');
+const model = JSON.parse(tinymceElement.getAttribute('suggestededits-model'));
+
+tinymce.init({
+  selector: 'textarea#suggestededits-auto-approve',
+  height: 500,
+  plugins: 'suggestededits advlist anchor autolink code charmap emoticons fullscreen help image link lists media preview searchreplace table',
+  toolbar: 'undo redo | suggestededits | styles fontsizeinput | bold italic | align bullist numlist | table link image | code',
+  content_style: 'body { font-family:Helvetica,Arial,sans-serif; font-size:16px }',
+  
+  suggestededits_model: model,
+  suggestededits_access: 'full',
+  suggestededits_content: 'html',
+  suggestededits_auto_approve: true,
+
+  user_id: 'kai-nakamura',
+  fetch_users: (userIds) => Promise.all(userIds
+    .map((userId) =>
+      fetch(`${API_URL}/${userId}`)
+        .then((response) => response.json())
+        .catch(() => ({ id: userId })))),
+});

--- a/modules/ROOT/pages/8.2.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.0-release-notes.adoc
@@ -72,6 +72,20 @@ The {productname} 8.2.0 release includes an accompanying release of the **<Premi
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
 
+=== Suggested Edits
+
+The {productname} {release-version} release includes an accompanying release of the **Suggested Edits** premium plugin.
+
+**Suggested Edits** includes the following improvement.
+
+==== Added new `+suggestededits_auto_approve+` option to auto-approve edits by the current user
+// #TINY-12258
+
+A new `suggestededits_auto_approve` option has been added to the **Suggested Edits** plugin. This option allows automatic approval of edits made by the current user, as defined by the xref:suggestededits.adoc#user_id[`+user_id+`] setting, without requiring manual review. When enabled, any new edits and previously suggested changes from the same user are instantly approved and applied, streamlining workflows where review is unnecessary.
+
+For more information on the `+suggestededits_auto_approve+` option, see: xref:suggestededits.adoc#suggestededits_auto_approve[suggestededits_auto_approve].
+
+
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement
 

--- a/modules/ROOT/pages/suggestededits.adoc
+++ b/modules/ROOT/pages/suggestededits.adoc
@@ -123,6 +123,8 @@ include::partial$configuration/suggestededits_content.adoc[leveloffset=+1]
 
 include::partial$configuration/suggestededits_access.adoc[leveloffset=+1]
 
+include::partial$configuration/suggestededits_auto_approve.adoc[leveloffset=+1]
+
 include::partial$configuration/user_id.adoc[leveloffset=+1]
 
 include::partial$configuration/fetch_users.adoc[leveloffset=+1]

--- a/modules/ROOT/partials/configuration/suggestededits_auto_approve.adoc
+++ b/modules/ROOT/partials/configuration/suggestededits_auto_approve.adoc
@@ -1,0 +1,27 @@
+[[suggestededits_auto_approve]]
+== `suggestededits_auto_approve`
+
+The `suggestededits_auto_approve` option controls whether edits made during the session by the current user are automatically approved without requiring manual review. With this option enabled any edits by the current user, as set by the xref:#user_id[`+user_id+` option], as well as any previous suggestions made by the current user, will be instantly applied, bypassing the review process. This is useful for scenarios where reviews aren't necessary, such as when creating an initial draft or when the user is a trusted editor.
+
+When set to:
+
+* `false`: All edits require manual approval before being applied.
+* `true`: All new edits are automatically approved and applied.
+
+
+*Type:* `+Boolean+`
+
+*Default Value*: `false`
+
+.Example: `suggestededits_auto_approve: true`
+[source,javascript]
+----
+tinymce.init({
+  selector: 'textarea#suggestededits',  // Change this value according to your HTML
+  plugins: 'suggestededits',
+  toolbar: 'suggestededits',
+  suggestededits_auto_approve: true, // Change this value to auto-approve suggested edits
+});
+----
+
+liveDemo::suggestededits-auto-approve[]


### PR DESCRIPTION
Ticket: TINY-12258

Site: [Staging branch](http://docs-feature-8-tiny-12258.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* New `suggestededits_auto_approve` option with demo

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.
- [x] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed