### PR TITLE
DOC-2628: Documentation Enhancement: Enhanced Table

### DIFF
--- a/modules/ROOT/pages/advtable.adoc
+++ b/modules/ROOT/pages/advtable.adoc
@@ -9,15 +9,12 @@
 
 include::partial$misc/admon-premium-plugin.adoc[]
 
-[TIP]
-As of {productname} 7.0, the Advanced Tables plugin is now named {pluginname}. When using the {pluginname} plugin in your editor, continue to use {plugincode} in the `+plugins+` list.
-
 The `+advtable+` plugin is a premium plugin that extends the core xref:table.adoc[`+table+` plugin] by adding the following advanced functionality:
 
 * Sort options for rows and columns.
 * Row numbering column for tables.
 
-== Try our Enhanced Tables Demo
+== Interactive demo
 
 liveDemo::advtable[]
 
@@ -35,12 +32,15 @@ tinymce.init({
 });
 ----
 
+[NOTE]
+As of {productname} 7.0, the Advanced Tables plugin is now named {pluginname}. When using the {pluginname} plugin in your editor, continue to use {plugincode} in the `+plugins+` list.
+
 == Sorting table rows and columns
 
 Tables can be sorted by row or column values using:
 
 * The *Sort* options in the *Table* menu.
-* The *Sort* options in the table contextual menu.
+* The *Sort* options in the *Table* contextual menu.
 * The *Sort* options in the *Table* toolbar menu button.
 
 *For example:*
@@ -66,7 +66,7 @@ A numeric and alpha value series are available by default. The available value s
 
 image::advtable-row-numbering.png[Table with numeric row numbering column and row numbering menu open (Numeric item checked)]
 
-A commonly desired customisation of the row-numbering column is that a table’s header and footer rows not be included in the numbering.
+A commonly desired customization of the row-numbering column is that a table’s header and footer rows not be included in the numbering.
 
 This can be done using the xref:advtable_value_series[`+advtable_value_series+` option] to specify a custom generator.
 

--- a/modules/ROOT/pages/advtable.adoc
+++ b/modules/ROOT/pages/advtable.adoc
@@ -32,8 +32,6 @@ tinymce.init({
 });
 ----
 
-[NOTE]
-As of {productname} 7.0, the Advanced Tables plugin is now named {pluginname}. When using the {pluginname} plugin in your editor, continue to use {plugincode} in the `+plugins+` list.
 
 == Sorting table rows and columns
 

--- a/modules/ROOT/partials/configuration/advtable_value_series.adoc
+++ b/modules/ROOT/partials/configuration/advtable_value_series.adoc
@@ -125,9 +125,9 @@ tinymce.init({
       update: true,
       resizable: false,
       generator: function(info, rowIndex, colIndex) {
-        var prevCount = info.prev ? info.prev.count : 0;
+        let prevCount = info.prev ? info.prev.count : 0;
         if (info.sectionType === 'tbody' && info.cellType === 'td') {
-          var newCount = prevCount + 1;
+          let newCount = prevCount + 1;
           return {
             value: newCount,
             count: newCount
@@ -147,5 +147,4 @@ With this custom generator, when a table with a header and footer row already se
 
 image::advtable-row-numbered-table-with-un-numbered-header-and-footer-rows.png[Row-numbered table with un-numbered header and footer rows]
 
-NOTE: This simple custom generator is a demonstration. It has limitations. Perhaps most significant, it requires the header and footer rows be set _before_ row numbers are added to a table. If row numbers are added and then a header row, or a footer row, or both, are set, this generator will _not_ remove existing row numbers from the now-set header and footer rows.
-
+NOTE: This simple custom generator is a demonstration. It has limitations. Perhaps most significant, it requires the header and footer rows be set *before* row numbers are added to a table. If row numbers are added and then a header row, or a footer row, or both, are set, this generator will *not* remove existing row numbers from the now-set header and footer rows.


### PR DESCRIPTION
Ticket: DOC-2628

Site: [Staging branch](http://docs-hotfix-8-doc-2628.staging.tiny.cloud/docs/tinymce/latest/advtable/)

Changes:
* Verified language and writing style to see if it fits en-US standard. Fixed some minor instances.
* Moved the **NOTE** at the beginning about the plugin rename below the section where we explain how to enable the plugin for better flow.
* Modified the `advtable_value_series` option partial to use `let` instead of `var` in order to adhere to modern JavaScript practices.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed