### PR TITLE
DOC-3223: Accordions were expandable in disabled editors.

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -415,6 +415,22 @@
 ** xref:tinymce-and-cors.adoc[Cross-Origin Resource Sharing (CORS)]
 * Release information
 ** xref:release-notes.adoc[Release notes for {productname}]
+*** {productname} 8.2.0
+**** xref:8.2.0-release-notes.adoc#overview[Overview]
+**** xref:8.2.0-release-notes.adoc#new-premium-plugin<s>[New Premium Plugin<s>]
+**** xref:8.2.0-release-notes.adoc#new-open-source-plugin<s>[New Open Source Plugin<s>]
+**** xref:8.2.0-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]
+**** xref:8.2.0-release-notes.adoc#accompanying-premium-plugin-end-of-life-announcement[Accompanying Premium Plugin end-of-life announcement]
+**** xref:8.2.0-release-notes.adoc#accompanying-open-source-plugin-end-of-life-announcement[Accompanying Open Source Plugin end-of-life announcement]
+**** xref:8.2.0-release-notes.adoc#accompanying-enhanced-skins-and-icon-packs-changes[Accompanying Enhanced Skins & Icon Packs changes]
+**** xref:8.2.0-release-notes.adoc#improvements[Improvements]
+**** xref:8.2.0-release-notes.adoc#additions[Additions]
+**** xref:8.2.0-release-notes.adoc#changes[Changes]
+**** xref:8.2.0-release-notes.adoc#removed[Removed]
+**** xref:8.2.0-release-notes.adoc#bug-fixes[Bug fixes]
+**** xref:8.2.0-release-notes.adoc#security-fixes[Security fixes]
+**** xref:8.2.0-release-notes.adoc#deprecated[Deprecated]
+**** xref:8.2.0-release-notes.adoc#known-issues[Known issues]
 *** {productname} 8.1.2
 **** xref:8.1.2-release-notes.adoc#overview[Overview]
 **** xref:8.1.2-release-notes.adoc#bug-fix[Bug fix]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -417,11 +417,7 @@
 ** xref:release-notes.adoc[Release notes for {productname}]
 *** {productname} 8.2.0
 **** xref:8.2.0-release-notes.adoc#overview[Overview]
-**** xref:8.2.0-release-notes.adoc#new-premium-plugin<s>[New Premium Plugin<s>]
-**** xref:8.2.0-release-notes.adoc#new-open-source-plugin<s>[New Open Source Plugin<s>]
 **** xref:8.2.0-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]
-**** xref:8.2.0-release-notes.adoc#accompanying-premium-plugin-end-of-life-announcement[Accompanying Premium Plugin end-of-life announcement]
-**** xref:8.2.0-release-notes.adoc#accompanying-open-source-plugin-end-of-life-announcement[Accompanying Open Source Plugin end-of-life announcement]
 **** xref:8.2.0-release-notes.adoc#accompanying-enhanced-skins-and-icon-packs-changes[Accompanying Enhanced Skins & Icon Packs changes]
 **** xref:8.2.0-release-notes.adoc#improvements[Improvements]
 **** xref:8.2.0-release-notes.adoc#additions[Additions]

--- a/modules/ROOT/pages/8.2.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.0-release-notes.adoc
@@ -111,6 +111,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+== Accordions were expandable in disabled editors
+// #TINY-12315
+
+Previously, an issues was identified where accordions remained interactive in disabled editors when the `+disabled+` option was set to `+true+`, allowing users to expand and collapse them revealing the content nested within the accordion.
+
+This unintended behavior caused inconsistencies, particularly affecting the `autoresize` plugin, which relied on stable editor states. In {release-version}, accordions are no longer expandable when the editor is in disabled mode, ensuring that content cannot be interacted with. This fix restores the intended behavior of {productname}, preventing unexpected resizing issues and reinforcing that disabled editors should not allow user interaction.
+
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/pages/8.2.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.0-release-notes.adoc
@@ -1,0 +1,195 @@
+= {productname} 8.2.0
+:release-version: 8.2.0
+:navtitle: {productname} 8.2.0
+:description: Release notes for {productname} 8.2.0
+:keywords: releasenotes, new, changes, bugfixes
+:page-toclevels: 1
+
+include::partial$misc/admon-releasenotes-for-stable.adoc[]
+
+
+[[overview]]
+== Overview
+
+{productname} 8.2.0 was released for {enterpriseversion} and {cloudname} on Wednesday, October 22^nd^, 2025. These release notes provide an overview of the changes for {productname} 8.2.0, including:
+
+// Remove sections and section boilerplates as necessary.
+// Pluralise as necessary or remove the placeholder plural marker.
+* xref:new-premium-plugin<s>[New Premium plugin<s>]
+* xref:new-open-source-plugin<s>[New Open Source plugin<s>]
+* xref:accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
+* xref:accompanying-premium-plugin-end-of-life-announcement[Accompanying Premium plugin end-of-life announcement]
+* xref:accompanying-open-source-plugin-end-of-life-announcement[Accompanying open source plugin end-of-life-announcement]
+* xref:accompanying-enhanced-skins-and-icon-packs-changes[Accompanying Enhanced Skins & Icon Packs changes]
+* xref:improvements[Improvements]
+* xref:additions[Additions]
+* xref:changes[Changes]
+* xref:bug-fixes[Bug fixes]
+* xref:security-fixes[Security fixes]
+* xref:deprecated[Deprecated]
+* xref:known-issues[Known issues]
+
+
+[[new-premium-plugin<s>]]
+== New Premium plugin<s>
+
+The following new Premium plugin was released alongside {productname} 8.2.0.
+
+=== <Premium plugin name>
+
+The new Premium plugin, **<Premium plugin name>** // description here.
+
+For information on the **<Premium plugin name>** plugin, see xref:<plugincode>.adoc[<Premium plugin name>].
+
+
+[[new-open-source-plugin]]
+== New Open Source plugin
+
+The following new Open Source plugin was released alongside {productname} 8.2.0.
+
+=== <Open source plugin name>
+
+The new open source plugin, **<Open source plugin name>** // description here.
+
+For information on the **<Open source plugin name>** plugin, see xref:<plugincode>.adoc[<Open source plugin name>].
+
+
+[[accompanying-premium-plugin-changes]]
+== Accompanying Premium plugin changes
+
+The following premium plugin updates were released alongside {productname} 8.2.0.
+
+=== <Premium plugin name 1> <Premium plugin name 1 version>
+
+The {productname} 8.2.0 release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+
+**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+
+==== <Premium plugin name 1 change 1>
+
+// CCFR here.
+
+For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+
+
+[[accompanying-premium-plugin-end-of-life-announcement]]
+== Accompanying Premium plugin end-of-life announcement
+
+The following Premium plugin has been announced as reaching its end-of-life:
+
+=== <Premium plugin name eol>
+
+{productname}'s xref:<plugincode>.adoc[<Premium plugin name eol>] plugin will be deactivated on <month> <DD>, <YYYY>, and is no longer available for purchase.
+
+
+[[accompanying-open-source-plugin-end-of-life-announcement]]
+== Accompanying open source plugin end-of-life announcement
+
+The following open source plugin has been announced as reaching its end-of-life:
+
+=== <Open source plugin name eol>
+
+{productname}'s xref:<plugincode>.adoc[<Open source plugin name eol>] plugin will be deactivated on <month> <DD>, <YYYY>, and is no longer available for purchase.
+
+
+[[accompanying-enhanced-skins-and-icon-packs-changes]]
+== Accompanying Enhanced Skins & Icon Packs changes
+
+The {productname} 8.2.0 release includes an accompanying release of the **Enhanced Skins & Icon Packs**.
+
+=== Enhanced Skins & Icon Packs
+
+The **Enhanced Skins & Icon Packs** release includes the following updates:
+
+The **Enhanced Skins & Icon Packs** were rebuilt to pull in the changes also incorporated into the default {productname} 8.2.0 skin, Oxide.
+
+For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-and-icon-packs.adoc[Enhanced Skins & Icon Packs].
+
+
+[[improvements]]
+== Improvements
+
+{productname} 8.2.0 also includes the following improvement<s>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[additions]]
+== Additions
+
+{productname} 8.2.0 also includes the following addition<s>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[changes]]
+== Changes
+
+{productname} 8.2.0 also includes the following change<s>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[removed]]
+== Removed
+
+{productname} 8.2.0 also includes the following removal<s>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[bug-fixes]]
+== Bug fixes
+
+{productname} 8.2.0 also includes the following bug fix<es>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[security-fixes]]
+== Security fixes
+
+{productname} 8.2.0 includes <a fix | fixes for the following security issue<s>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[deprecated]]
+== Deprecated
+
+{productname} 8.2.0 includes the following deprecation<s>:
+
+=== The `<plugin>` configuration property, `<name>`, has been deprecated
+
+// placeholder here.
+
+
+[[known-issues]]
+== Known issues
+
+This section describes issues that users of {productname} 8.2.0 may encounter and possible workarounds for these issues.
+
+There <is one | are <number> known issue<s> in {productname} 8.2.0.
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.

--- a/modules/ROOT/pages/8.2.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.0-release-notes.adoc
@@ -13,13 +13,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 {productname} 8.2.0 was released for {enterpriseversion} and {cloudname} on Wednesday, October 22^nd^, 2025. These release notes provide an overview of the changes for {productname} 8.2.0, including:
 
-// Remove sections and section boilerplates as necessary.
-// Pluralise as necessary or remove the placeholder plural marker.
-* xref:new-premium-plugin<s>[New Premium plugin<s>]
-* xref:new-open-source-plugin<s>[New Open Source plugin<s>]
 * xref:accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
-* xref:accompanying-premium-plugin-end-of-life-announcement[Accompanying Premium plugin end-of-life announcement]
-* xref:accompanying-open-source-plugin-end-of-life-announcement[Accompanying open source plugin end-of-life-announcement]
 * xref:accompanying-enhanced-skins-and-icon-packs-changes[Accompanying Enhanced Skins & Icon Packs changes]
 * xref:improvements[Improvements]
 * xref:additions[Additions]
@@ -30,66 +24,23 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 * xref:known-issues[Known issues]
 
 
-[[new-premium-plugin<s>]]
-== New Premium plugin<s>
-
-The following new Premium plugin was released alongside {productname} 8.2.0.
-
-=== <Premium plugin name>
-
-The new Premium plugin, **<Premium plugin name>** // description here.
-
-For information on the **<Premium plugin name>** plugin, see xref:<plugincode>.adoc[<Premium plugin name>].
-
-
-[[new-open-source-plugin]]
-== New Open Source plugin
-
-The following new Open Source plugin was released alongside {productname} 8.2.0.
-
-=== <Open source plugin name>
-
-The new open source plugin, **<Open source plugin name>** // description here.
-
-For information on the **<Open source plugin name>** plugin, see xref:<plugincode>.adoc[<Open source plugin name>].
-
-
 [[accompanying-premium-plugin-changes]]
 == Accompanying Premium plugin changes
 
 The following premium plugin updates were released alongside {productname} 8.2.0.
 
-=== <Premium plugin name 1> <Premium plugin name 1 version>
+// === <Premium plugin name 1> <Premium plugin name 1 version>
 
-The {productname} 8.2.0 release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+// The {productname} 8.2.0 release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
 
-**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+// **<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
 
-==== <Premium plugin name 1 change 1>
+// ==== <Premium plugin name 1 change 1>
+// #TINY-vwxyz1
 
 // CCFR here.
 
-For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
-
-
-[[accompanying-premium-plugin-end-of-life-announcement]]
-== Accompanying Premium plugin end-of-life announcement
-
-The following Premium plugin has been announced as reaching its end-of-life:
-
-=== <Premium plugin name eol>
-
-{productname}'s xref:<plugincode>.adoc[<Premium plugin name eol>] plugin will be deactivated on <month> <DD>, <YYYY>, and is no longer available for purchase.
-
-
-[[accompanying-open-source-plugin-end-of-life-announcement]]
-== Accompanying open source plugin end-of-life announcement
-
-The following open source plugin has been announced as reaching its end-of-life:
-
-=== <Open source plugin name eol>
-
-{productname}'s xref:<plugincode>.adoc[<Open source plugin name eol>] plugin will be deactivated on <month> <DD>, <YYYY>, and is no longer available for purchase.
+// For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
 
 [[accompanying-enhanced-skins-and-icon-packs-changes]]
@@ -111,7 +62,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} 8.2.0 also includes the following improvement<s>:
 
-=== <TINY-vwxyz 1 changelog entry>
+// === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1
 
 // CCFR here.
@@ -122,7 +73,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} 8.2.0 also includes the following addition<s>:
 
-=== <TINY-vwxyz 1 changelog entry>
+// === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1
 
 // CCFR here.
@@ -133,7 +84,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} 8.2.0 also includes the following change<s>:
 
-=== <TINY-vwxyz 1 changelog entry>
+// === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1
 
 // CCFR here.
@@ -144,7 +95,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} 8.2.0 also includes the following removal<s>:
 
-=== <TINY-vwxyz 1 changelog entry>
+// === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1
 
 // CCFR here.
@@ -155,7 +106,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} 8.2.0 also includes the following bug fix<es>:
 
-=== <TINY-vwxyz 1 changelog entry>
+// === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1
 
 // CCFR here.
@@ -166,7 +117,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} 8.2.0 includes <a fix | fixes for the following security issue<s>:
 
-=== <TINY-vwxyz 1 changelog entry>
+// === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1
 
 // CCFR here.
@@ -177,9 +128,10 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} 8.2.0 includes the following deprecation<s>:
 
-=== The `<plugin>` configuration property, `<name>`, has been deprecated
+// === The `<plugin>` configuration property, `<name>`, has been deprecated
+// #TINY-vwxyz1
 
-// placeholder here.
+// CCFR here.
 
 
 [[known-issues]]
@@ -189,7 +141,7 @@ This section describes issues that users of {productname} 8.2.0 may encounter an
 
 There <is one | are <number> known issue<s> in {productname} 8.2.0.
 
-=== <TINY-vwxyz 1 changelog entry>
+// === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1
 
 // CCFR here.

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -4,6 +4,10 @@
 
 NOTE: This is the {productname} Community version changelog. For information about the latest {cloudname} or {enterpriseversion} Release, see: xref:release-notes.adoc[{productname} Release Notes].
 
+== xref:8.2.0-release-notes.adoc[8.2.0 - 2025-10-22]
+
+//TODO
+
 == xref:8.1.2-release-notes.adoc[8.1.2 - 2025-09-18]
 
 ### Fixed

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -11,6 +11,12 @@ This section lists the releases for {productname} {productmajorversion} and the 
 
 a|
 [.lead]
+xref:8.2.0-release-notes.adoc#overview[{productname} 8.2.0]
+
+Release notes for {productname} 8.2.0
+
+a|
+[.lead]
 xref:8.1.2-release-notes.adoc#overview[{productname} 8.1.2]
 
 Release notes for {productname} 8.1.2

--- a/modules/ROOT/partials/misc/supported-versions.adoc
+++ b/modules/ROOT/partials/misc/supported-versions.adoc
@@ -6,6 +6,7 @@ Supported versions of {productname}:
 [cols="^,^,^",options="header"]
 |===
 |Version |Release Date |End of Premium Support
+|8.2 |2025-10-22 |2027-10-22
 |8.0 |2025-07-23 |2027-01-23
 |7.9 |2025-05-14 |2026-11-14
 |7.8 |2025-04-09 |2026-10-09


### PR DESCRIPTION
Ticket: DOC-3223

Site: [Staging branch](http://docs-feature-820-doc-3223tiny-12315.staging.tiny.cloud/docs/tinymce/latest/8.2.0-release-notes/#accordions-were-expandable-in-disabled-editors)

Changes:
* Fix documentation for TINY-12315

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed