### PR TITLE
DOC-3223: The cursor could get stuck around an absolute CEF element when navigating using arrow keys

### DIFF
--- a/modules/ROOT/pages/8.2.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.0-release-notes.adoc
@@ -111,7 +111,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
-=== The cursor could get stuck around an absolute CEF element when navigating using arrow keys
+=== The cursor could get stuck around an absolutely positioned CEF element when navigating using arrow keys
 // #TINY-10306
 
 Previously, when using arrow keys to navigate content containing absolutely positioned non-editable elements, the cursor could become trapped near these elements. This issue disrupted caret movement and made it difficult for users to continue navigating text around complex layouts or embedded content, especially in inline editing scenarios and within table cells.

--- a/modules/ROOT/pages/8.2.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.0-release-notes.adoc
@@ -111,6 +111,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== The cursor could get stuck around an absolute CEF element when navigating using arrow keys
+// #TINY-10306
+
+Previously, when using arrow keys to navigate content containing absolutely positioned non-editable elements, the cursor could become trapped near these elements. This issue disrupted caret movement and made it difficult for users to continue navigating text around complex layouts or embedded content, especially in inline editing scenarios and within table cells.
+
+In {productname} {release-version}, the horizontal caret navigation logic has been updated to recognize absolutely positioned elements and return a range selection instead of attempting to place the caret directly on the floating node. This improvement ensures consistent and predictable arrow-key navigation behavior across various content structures.
+
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/pages/8.2.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.0-release-notes.adoc
@@ -114,7 +114,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === The cursor could get stuck around an absolutely positioned CEF element when navigating using arrow keys
 // #TINY-10306
 
-Previously, when using arrow keys to navigate content containing absolutely positioned non-editable elements, the cursor could become trapped near these elements. This issue disrupted caret movement and made it difficult for users to continue navigating text around complex layouts or embedded content, especially in inline editing scenarios and within table cells.
+Previously, when using arrow keys to navigate content containing absolutely positioned non-editable elements, the cursor could become trapped near these elements. This issue disrupted caret movement and made it difficult for users to continue navigating around the editor's content.
 
 In {productname} {release-version}, the horizontal caret navigation logic has been updated to recognize absolutely positioned elements and return a range selection instead of attempting to place the caret directly on the floating node. This improvement ensures consistent and predictable arrow-key navigation behavior across various content structures.
 

--- a/modules/ROOT/pages/8.2.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.0-release-notes.adoc
@@ -116,7 +116,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 Previously, when using arrow keys to navigate content containing absolutely positioned non-editable elements, the cursor could become trapped near these elements. This issue disrupted caret movement and made it difficult for users to continue navigating around the editor's content.
 
-In {productname} {release-version}, the horizontal caret navigation logic has been updated to recognize absolutely positioned elements and return a range selection instead of attempting to place the caret directly on the floating node. This improvement ensures consistent and predictable arrow-key navigation behavior across various content structures.
+In {productname} {release-version}, the horizontal caret navigation logic has been updated to ensure that the caret movement is no longer disrupted when navigating around absolutely positioned elements.
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-3223

Site: [Staging branch](http://docs-feature-820-doc-3223tiny-10306.staging.tiny.cloud/docs/tinymce/latest/8.2.0-release-notes/#the-cursor-could-get-stuck-around-an-absolute-cef-element-when-navigating-using-arrow-keys)

Changes:
* Fix documentation for TINY-10306

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed