### PR TITLE
DOC-3223: New `js/commerciallicensekeymanager.js` file to lazyload majority of plugin after editor init.

### DIFF
--- a/modules/ROOT/pages/8.2.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.0-release-notes.adoc
@@ -42,6 +42,16 @@ The following premium plugin updates were released alongside {productname} 8.2.0
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== License Key Manager
+
+The {productname} 8.2.0 release includes an accompanying release of the **License Key Manager**.
+
+==== New `+js/commerciallicensekeymanager.js+` file to lazyload majority of plugin after editor init.
+// #TINY-12820
+
+The **License Key Manager** has been reworked to include a new `+js/commerciallicensekeymanager.js+` file that is lazy-loaded when required. This change reduces the initialization time of the editor and time to first render.
+
+For information on the **License Key Manager** plugin, see: xref:license-key.adoc[License Key Manager].
 
 [[accompanying-enhanced-skins-and-icon-packs-changes]]
 == Accompanying Enhanced Skins & Icon Packs changes

--- a/modules/ROOT/pages/license-key.adoc
+++ b/modules/ROOT/pages/license-key.adoc
@@ -316,6 +316,12 @@ a| * Check your internet connection
 a| * Verify that your API key is valid
 * Check if your subscription is active
 * Visit the link:https://support.tiny.cloud[Support Portal] if the issue persists
+
+| xref:resource-load-error[Resource Load Error]
+| The editor is disabled because the {productname} license key could not be validated.
+| The editor is disabled because the {productname} license key could not be validated. The {productname} Commercial License Key Manager plugin was unable to load additional required resources.
+a| * If bundling, verify that you are using the `licensekeymanager/index.js` file that imports other required resources.
+* If hosting, verify that a `js/commerciallicensekeymanager.js` file is also present in the `plugins/licensekeymanager` folder.
 |===
 
 === Detailed Error Descriptions
@@ -359,5 +365,9 @@ A server-side error occurred while validating the API key. The editor will attem
 [[online-api-key-error-disable]]
 ==== Online API Key Error (4xx - Disable)
 The API key validation failed due to an invalid key or inactive subscription. The editor will be disabled until a valid API key is provided. For API key issues, visit link:https://www.tiny.cloud/my-account[Tiny Cloud Account] or see the "<<What is the difference between a license key and the API key?>>" section for clarification.
+
+[[resource-load-error]]
+==== Resource Load Error
+The TinyMCE Commercial License Key Manager plugin was unable to load additional required resources. This typically occurs when the `js/commerciallicensekeymanager.js` file is missing or not properly configured. For bundled applications, ensure you are using the `licensekeymanager/index.js` file that imports other required resources. For self-hosted installations, verify that a `js/commerciallicensekeymanager.js` file is present in the `plugins/licensekeymanager` folder. See the <<Setting up the Commercial License Key Manager>> section for implementation details.
 
 For additional assistance, visit our link:https://support.tiny.cloud[Support Portal] or contact your link:https://www.tiny.cloud/my-account[Tiny Cloud Account] manager.


### PR DESCRIPTION
Ticket: DOC-3223

Site: [Release note entry](http://docs-feature-820-doc-3223tiny-12820.staging.tiny.cloud/docs/tinymce/latest/8.2.0-release-notes/#license-key-manager)
Site: [resource-load-error(table) insert](http://docs-feature-820-doc-3223tiny-12820.staging.tiny.cloud/docs/tinymce/latest/license-key/#resource-load-error:~:text=Resource%20Load%20Error,also%20present%20in%20the%20plugins/licensekeymanager%20folder.)
Site: [resource-load-error](http://docs-feature-820-doc-3223tiny-12820.staging.tiny.cloud/docs/tinymce/latest/license-key/#resource-load-error)

Changes:
* Change documentation for TINY-12820

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed