### PR TITLE
DOC-3223: The editor would upon gaining focus scroll to the center of the editor on some browsers if the top of the editor was out of frame

### DIFF
--- a/modules/ROOT/pages/8.2.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.0-release-notes.adoc
@@ -114,7 +114,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === The editor would upon gaining focus scroll to the center of the editor on some browsers if the top of the editor was out of frame
 // #TINY-12626
 
-In {productname} {release-version}, a legacy workaround for a Chromium bug caused the page to scroll to the center of the editor when the editor gained focus while its top edge was outside the viewport; although unrelated, features like autoresize could frequently trigger this behavior. This resulted in unexpected scrolling in some situations.
+A legacy workaround for a Chromium bug caused the page to scroll to the center of the editor when the editor gained focus while its top edge was outside the viewport; although unrelated, features like autoresize could frequently trigger this behavior and resulted in unexpected scrolling in some situations.
 
 As of {productname} {release-version}, the workaround has been removed now that the underlying Chromium issue has been fixed, allowing the browser to manage scrolling natively.
 

--- a/modules/ROOT/pages/8.2.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.0-release-notes.adoc
@@ -111,6 +111,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== The editor would upon gaining focus scroll to the center of the editor on some browsers if the top of the editor was out of frame
+// #TINY-12626
+
+In {productname} {release-version}, a legacy workaround for a Chromium bug caused the page to scroll to the center of the editor when the editor gained focus while its top edge was outside the viewport; although unrelated, features like autoresize could frequently trigger this behavior. This resulted in unexpected scrolling in some situations.
+
+As of {productname} {release-version}, the workaround has been removed now that the underlying Chromium issue has been fixed, allowing the browser to manage scrolling natively.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-3223

Site: [Staging branch][(http://docs-feature-820-doc-3223tiny-12626.staging.tiny.cloud/docs/tinymce/latest/](http://docs-feature-820-doc-3223tiny-12626.staging.tiny.cloud/docs/tinymce/latest/8.2.0-release-notes/#the-editor-would-upon-gaining-focus-scroll-to-the-center-of-the-editor-on-some-browsers-if-the-top-of-the-editor-was-out-of-frame))

Changes:
* Fix documentation for TINY-12626

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed