### PR TITLE
DOC-3223: The schema will now allow the  RDFa attribute on  elements.

### DIFF
--- a/modules/ROOT/pages/8.2.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.0-release-notes.adoc
@@ -114,7 +114,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === The schema will now allow the `property` RDFa attribute on `meta` elements
 // #TINY-12858
 
-Previously, the schema did not include the `property` RDFa attribute as a valid attribute for `meta` elements. This caused the attribute to be filtered out when using features such as the {productname} `fullpagehtml` premium plugin, potentially removing important metadata required by social media or structured data integrations.
+Previously, the schema did not recognize the `property` RDFa attribute as valid for `meta` elements, causing it to be removed during content validation in features such as the {productname} `fullpagehtml` premium plugin. This behavior could strip essential metadata used for social media previews or structured data integrations, and required integrators to manually whitelist the attribute to retain it.
 
 In {release-version}, the schema has been updated to include `property` as a valid attribute for `meta` elements. This change ensures compatibility with common metadata standards.
 

--- a/modules/ROOT/pages/8.2.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.0-release-notes.adoc
@@ -111,6 +111,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== The schema will now allow the `property` RDFa attribute on `meta` elements
+// #TINY-12858
+
+Previously, the schema did not include the `property` RDFa attribute as a valid attribute for `meta` elements. This caused the attribute to be filtered out when using features such as the {productname} `fullpagehtml` premium plugin, potentially removing important metadata required by social media or structured data integrations.
+
+In {release-version}, the schema has been updated to include `property` as a valid attribute for `meta` elements. This change ensures compatibility with common metadata standards.
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
Ticket: DOC-3223

Site: [Staging branch](http://docs-feature-820-doc-3223tiny-12858.staging.tiny.cloud/docs/tinymce/latest/8.2.0-release-notes/#the-schema-will-now-allow-the-property-rdfa-attribute-on-meta-elements)

Changes:
* Fix documentation for TINY-12858

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed