### PR TITLE
DOC-3304: Add missing Java Swing integration deprecation message.

### DIFF
--- a/modules/ROOT/pages/8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.0-release-notes.adoc
@@ -622,6 +622,13 @@ In {productname} {release-version}, the parser has been updated to improve the r
 
 {productname} {release-version} includes the following deprecations:
 
+=== Java Swing integration has been deprecated
+// #DOC-3304
+
+{productname}'s Java Swing integration has been deprecated in {productname} 8.0 and will reach end-of-life as of December 31, 2025.
+
+For information about the Java Swing integration, see: xref:swing.adoc[TinyMCE for Java Swing integration]
+
 === Java application server-based server components have been deprecated
 // #DOC-3231
 

--- a/modules/ROOT/pages/migration-from-7x.adoc
+++ b/modules/ROOT/pages/migration-from-7x.adoc
@@ -534,6 +534,20 @@ Several empty files have been removed from the codebase to reduce clutter and im
 
 === Service and Configuration Changes
 
+==== Java Swing Integration Deprecation
+// #DOC-3304
+
+{productname}'s Java Swing integration has been deprecated in {productname} 8.0 and will reach end-of-life as of December 31, 2025.
+
+**Impact**: Customers using the Java Swing integration need to plan for migration to alternative solutions before the end-of-life date.
+
+**Migration checklist:**
+
+* [ ] Evaluate alternative integration options
+* [ ] Plan migration timeline to complete before December 31, 2025
+
+For information about the Java Swing integration, see: xref:swing.adoc[TinyMCE for Java Swing integration]
+
 ==== Discontinuation of Medical English (UK)
 // #EPIC-255
 

--- a/modules/ROOT/pages/swing.adoc
+++ b/modules/ROOT/pages/swing.adoc
@@ -3,4 +3,9 @@
 :description: Seamlessly integrates TinyMCE into Java Swing applications.
 :keywords: integration, integrate, java, swing
 
+[IMPORTANT]
+====
+{productname}'s Java Swing integration has been deprecated in {productname} 8.0 and will reach end-of-life as of December 31, 2025.
+====
+
 include::partial$integrations/swing-quick-start.adoc[]


### PR DESCRIPTION
Ticket: DOC-3304

Site: [Release note depreciation message for 8.0](http://docs-hotfix-8-doc-3304.staging.tiny.cloud/docs/tinymce/latest/8.0-release-notes/#java-swing-integration-has-been-deprecated)
Site: [Swing.adoc IMPORTANT message](http://docs-hotfix-8-doc-3304.staging.tiny.cloud/docs/tinymce/latest/swing/#:~:text=TinyMCE%E2%80%99s%20Java%20Swing%20integration%20has%20been%20deprecated%20in%20TinyMCE%208.0%20and%20will%20reach%20end%2Dof%2Dlife%20as%20of%20December%2031%2C%202025.)
Site: [Migration from 7 depreciation message](http://docs-hotfix-8-doc-3304.staging.tiny.cloud/docs/tinymce/latest/migration-from-7x/#java-swing-integration-deprecation)

Changes:
* Add missing Java Swing integration deprecation message.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed