### PR TITLE
DOC-3223: Suggestions now display the type of content that was changed

### DIFF
--- a/modules/ROOT/pages/8.2.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.0-release-notes.adoc
@@ -48,7 +48,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 **Suggested Edits** includes the following improvement.
 
-=== Operation descriptions now shows the type of content that was changed.
+=== Operation descriptions now show the type of content that was changed.
 // #TINY-12598
 
 Previously, the **Suggested Edits** plugin displayed operation cards without indicating the type of content being modified. As a result, reviewers had to open each suggestion individually to determine whether it affected a paragraph, image, table, or another content type.

--- a/modules/ROOT/pages/8.2.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.0-release-notes.adoc
@@ -52,6 +52,7 @@ The {productname} {release-version} release includes an accompanying release of 
 // #TINY-12598
 
 Previously, the **Suggested Edits** plugin only displayed the word "content" in the suggestion card description, as a generalised context for each suggestion.
+
 In {release-version}, the **Suggested Edits** plugin displays the type of content as well as the type of edit in the card description, to provide more context for each suggestion.
 
 For information on the **Suggested Edits** plugin, see: xref:suggestededits.adoc[Suggested Edits].

--- a/modules/ROOT/pages/8.2.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.0-release-notes.adoc
@@ -42,6 +42,23 @@ The following premium plugin updates were released alongside {productname} 8.2.0
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Suggested Edits
+
+The {productname} {release-version} release includes an accompanying release of the **Suggested Edits** premium plugin.
+
+**Suggested Edits** includes the following improvement.
+
+=== Operation descriptions now shows the type of content that was changed.
+// #TINY-12598
+
+Previously, the **Suggested Edits** plugin displayed operation cards without indicating the type of content being modified. As a result, reviewers had to open each suggestion individually to determine whether it affected a paragraph, image, table, or another content type.
+
+This lack of context slowed the review process, particularly in documents with numerous suggestions, as users could not quickly identify or prioritize edits by content type.
+
+In {release-version}, the **Suggested Edits** plugin now displays contextual descriptions on each operation card. The plugin automatically detects the content type involved and shows descriptive labels such as “added paragraph,” “deleted image,” or “modified table.” Supported content types include paragraphs, headings, images, tables, block quotes, code blocks, horizontal rules, inline text, and more.
+
+For information on the **Suggested Edits** plugin, see: xref:suggestededits.adoc[Suggested Edits].
+
 
 [[accompanying-enhanced-skins-and-icon-packs-changes]]
 == Accompanying Enhanced Skins & Icon Packs changes

--- a/modules/ROOT/pages/8.2.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.0-release-notes.adoc
@@ -51,7 +51,7 @@ The {productname} {release-version} release includes an accompanying release of 
 === Operation descriptions now show the type of content that was changed.
 // #TINY-12598
 
-Previously, the **Suggested Edits** plugin displayed operation cards without indicating the type of content being modified. As a result, reviewers had to open each suggestion individually to determine whether it affected a paragraph, image, table, or another content type.
+Previously, the **Suggested Edits** plugin displayed operation cards without indicating the type of content being interacted with. As a result, reviewers had to open each suggestion individually to determine whether it affected a paragraph, image, table, or another content type.
 
 This lack of context slowed the review process, particularly in documents with numerous suggestions, as users could not quickly identify or prioritize edits by content type.
 

--- a/modules/ROOT/pages/8.2.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.0-release-notes.adoc
@@ -48,14 +48,11 @@ The {productname} {release-version} release includes an accompanying release of 
 
 **Suggested Edits** includes the following improvement.
 
-=== Operation descriptions now show the type of content that was changed.
+=== Suggestions now display the type of content that was changed
 // #TINY-12598
 
-Previously, the **Suggested Edits** plugin displayed operation cards without indicating the type of content being interacted with. As a result, reviewers had to open each suggestion individually to determine whether it affected a paragraph, image, table, or another content type.
-
-This lack of context slowed the review process, particularly in documents with numerous suggestions, as users could not quickly identify or prioritize edits by content type.
-
-In {release-version}, the **Suggested Edits** plugin now displays contextual descriptions on each operation card. The plugin automatically detects the content type involved and shows descriptive labels such as “added paragraph” “deleted image” or “modified table” Supported content types include paragraphs, headings, images, tables, block quotes, code blocks, horizontal rules, inline text, and more.
+Previously, the **Suggested Edits** plugin only displayed the word "content" in the suggestion card description, as a generalised context for each suggestion.
+In {release-version}, the **Suggested Edits** plugin displays the type of content as well as the type of edit in the card description, to provide more context for each suggestion.
 
 For information on the **Suggested Edits** plugin, see: xref:suggestededits.adoc[Suggested Edits].
 

--- a/modules/ROOT/pages/8.2.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.0-release-notes.adoc
@@ -55,7 +55,7 @@ Previously, the **Suggested Edits** plugin displayed operation cards without ind
 
 This lack of context slowed the review process, particularly in documents with numerous suggestions, as users could not quickly identify or prioritize edits by content type.
 
-In {release-version}, the **Suggested Edits** plugin now displays contextual descriptions on each operation card. The plugin automatically detects the content type involved and shows descriptive labels such as “added paragraph,” “deleted image,” or “modified table.” Supported content types include paragraphs, headings, images, tables, block quotes, code blocks, horizontal rules, inline text, and more.
+In {release-version}, the **Suggested Edits** plugin now displays contextual descriptions on each operation card. The plugin automatically detects the content type involved and shows descriptive labels such as “added paragraph” “deleted image” or “modified table” Supported content types include paragraphs, headings, images, tables, block quotes, code blocks, horizontal rules, inline text, and more.
 
 For information on the **Suggested Edits** plugin, see: xref:suggestededits.adoc[Suggested Edits].
 

--- a/modules/ROOT/pages/suggestededits.adoc
+++ b/modules/ROOT/pages/suggestededits.adoc
@@ -57,7 +57,7 @@ Replaced content is represented as both added and removed content, and indicates
 
 Each suggested edit is listed as a card in the sidebar and color coded by the type of change. Each operation card displays contextual descriptions that automatically detect and show the type of content being modified, such as "added paragraph" "deleted image" or "modified table" This helps reviewers quickly identify and prioritize edits by content type without having to open each suggestion individually.
 
-The cards also show the user who made the suggestion, when the edit was made, and any feedback provided on that suggestion. Supported content types include paragraphs, headings, images, tables, block quotes, code blocks, horizontal rules, inline text, and more.
+The cards also show the user who made the suggestion, when the edit was made, and any feedback provided for that suggestion. Supported content types include paragraphs, headings, images, tables, block quotes, code blocks, horizontal rules, inline text, and more.
 
 When selected, each suggestion can be handled in the following ways:
 

--- a/modules/ROOT/pages/suggestededits.adoc
+++ b/modules/ROOT/pages/suggestededits.adoc
@@ -55,7 +55,7 @@ Replaced content is represented as both added and removed content, and indicates
 
 === Sidebar
 
-Each suggested edit is listed as a card in the sidebar and color coded by the type of change. Each operation card displays contextual descriptions that automatically detect and show the type of content being modified, such as "added paragraph," "deleted image," or "modified table." This helps reviewers quickly identify and prioritize edits by content type without having to open each suggestion individually.
+Each suggested edit is listed as a card in the sidebar and color coded by the type of change. Each operation card displays contextual descriptions that automatically detect and show the type of content being modified, such as "added paragraph" "deleted image" or "modified table" This helps reviewers quickly identify and prioritize edits by content type without having to open each suggestion individually.
 
 The cards also show the user who made the suggestion, when the edit was made, and any feedback provided on that suggestion. Supported content types include paragraphs, headings, images, tables, block quotes, code blocks, horizontal rules, inline text, and more.
 

--- a/modules/ROOT/pages/suggestededits.adoc
+++ b/modules/ROOT/pages/suggestededits.adoc
@@ -55,9 +55,7 @@ Replaced content is represented as both added and removed content, and indicates
 
 === Sidebar
 
-Each suggested edit is listed as a card in the sidebar and color coded by the type of change. Each operation card displays contextual descriptions that automatically detect and show the type of content being modified, such as "added paragraph" "deleted image" or "modified table" This helps reviewers quickly identify and prioritize edits by content type without having to open each suggestion individually.
-
-The cards also show the user who made the suggestion, when the edit was made, and any feedback provided for that suggestion. Supported content types include paragraphs, headings, images, tables, block quotes, code blocks, horizontal rules, inline text, and more.
+Each suggested edit is listed as a card in the sidebar and color coded by the type of change. Each card shows a contextual description of the content, along with the user who made the suggestion, when the edit was made, and any feedback provided on that suggestion.
 
 When selected, a suggestion can be handled in the following ways:
 

--- a/modules/ROOT/pages/suggestededits.adoc
+++ b/modules/ROOT/pages/suggestededits.adoc
@@ -59,7 +59,7 @@ Each suggested edit is listed as a card in the sidebar and color coded by the ty
 
 The cards also show the user who made the suggestion, when the edit was made, and any feedback provided for that suggestion. Supported content types include paragraphs, headings, images, tables, block quotes, code blocks, horizontal rules, inline text, and more.
 
-When selected, each suggestion can be handled in the following ways:
+When selected, a suggestion can be handled in the following ways:
 
 * Accept: Resolves the suggestion, applying the edit to the document when the review is completed.
 * Reject: Resolves the suggestion, turning back the edit to the original state.

--- a/modules/ROOT/pages/suggestededits.adoc
+++ b/modules/ROOT/pages/suggestededits.adoc
@@ -55,7 +55,11 @@ Replaced content is represented as both added and removed content, and indicates
 
 === Sidebar
 
-Each suggested edit is listed as a card in the sidebar and color coded by the type of change, along with the user who made the suggestion, when the edit was made, and any feedback provided on that suggestion. When selected, each suggestion can be handled in the following ways:
+Each suggested edit is listed as a card in the sidebar and color coded by the type of change. Each operation card displays contextual descriptions that automatically detect and show the type of content being modified, such as "added paragraph," "deleted image," or "modified table." This helps reviewers quickly identify and prioritize edits by content type without having to open each suggestion individually.
+
+The cards also show the user who made the suggestion, when the edit was made, and any feedback provided on that suggestion. Supported content types include paragraphs, headings, images, tables, block quotes, code blocks, horizontal rules, inline text, and more.
+
+When selected, each suggestion can be handled in the following ways:
 
 * Accept: Resolves the suggestion, applying the edit to the document when the review is completed.
 * Reject: Resolves the suggestion, turning back the edit to the original state.


### PR DESCRIPTION
Ticket: DOC-3223

Site: [Release notes](http://docs-feature-820-doc-3223tiny-12598.staging.tiny.cloud/docs/tinymce/latest/8.2.0-release-notes/#operation-descriptions-now-shows-the-type-of-content-that-was-changed)
Site: [Updated feature page](http://docs-feature-820-doc-3223tiny-12598.staging.tiny.cloud/docs/tinymce/latest/suggestededits/#:~:text=Each%20suggested%20edit%20is,in%20the%20following%20ways%3A)

Changes:
* Improvement for TINY-12598
Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed