### PR TITLE
DOC-3307: Fix order for `sortedRevisions` from v8 Revision History demo.

### DIFF
--- a/modules/ROOT/examples/live-demos/revisionhistory/index.html
+++ b/modules/ROOT/examples/live-demos/revisionhistory/index.html
@@ -33,7 +33,7 @@
   <h2>Got questions or need help?</h2>
 
   <ul>
-    <li>Our <a class="mceNonEditable" href="https://www.tiny.cloud/docs/tinymce/8/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a class="mceNonEditable" href="https://www.tiny.cloud/docs/tinymce/latest/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="https://stackoverflow.com/questions/tagged/tinymce" target="_blank" rel="noopener"><code>tinymce</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="https://www.tiny.cloud/pricing">TinyMCE premium subscriptions</a>.</li>
   </ul>

--- a/modules/ROOT/examples/live-demos/revisionhistory/index.js
+++ b/modules/ROOT/examples/live-demos/revisionhistory/index.js
@@ -139,7 +139,9 @@ const revisions = [
 
 const revisionhistory_fetch = () => new Promise((resolve) => {
   setTimeout(() => {
-    resolve(revisions);
+    const sortedRevisions = revisions
+      .sort((a, b) => new Date(a.createdAt) < new Date(b.createdAt) ? -1 : 1);
+    resolve(sortedRevisions);
   }, fakeDelay);
 });
 

--- a/modules/ROOT/examples/live-demos/revisionhistory/index.js
+++ b/modules/ROOT/examples/live-demos/revisionhistory/index.js
@@ -8,7 +8,7 @@ const revisions = [
     createdAt: '2023-11-24T22:26:21.578Z',
     author: {
       id: 'james-wilson',
-      name: 'A Tiny Husky',
+      name: 'James Wilson',
       avatar: 'https://sneak-preview.tiny.cloud/demouserdirectory/images/employee_james-wilson_128_52f19412.jpg',
     },
     content: `
@@ -139,9 +139,7 @@ const revisions = [
 
 const revisionhistory_fetch = () => new Promise((resolve) => {
   setTimeout(() => {
-    const sortedRevisions = revisions
-      .sort((a, b) => new Date(a.createdAt) < new Date(b.createdAt) ? 1 : -1);
-    resolve(sortedRevisions);
+    resolve(revisions);
   }, fakeDelay);
 });
 


### PR DESCRIPTION
Ticket: DOC-3307

Site: [Staging branch](http://docs-hotfix-8-doc-3307.staging.tiny.cloud/docs/tinymce/latest/revisionhistory/#interactive-example)

Changes:
* Fix order for `sortedRevsions` func from demo.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed