### PR TITLE
DOC-3307_v7: Fix order for sortRevisions for RevisionHistory demo.

### DIFF
--- a/modules/ROOT/examples/live-demos/revisionhistory/index.js
+++ b/modules/ROOT/examples/live-demos/revisionhistory/index.js
@@ -139,7 +139,7 @@ const revisions = [
 const revisionhistory_fetch = () => new Promise((resolve) => {
   setTimeout(() => {
     const sortedRevisions = revisions
-      .sort((a, b) => new Date(a.createdAt) < new Date(b.createdAt) ? 1 : -1);
+      .sort((a, b) => new Date(a.createdAt) < new Date(b.createdAt) ? -1 : 1);
     resolve(sortedRevisions);
   }, fakeDelay);
 });


### PR DESCRIPTION
Ticket: DOC-3307

Site: [Staging branch](http://docs-hotfix-7-doc-3307.staging.tiny.cloud/docs/tinymce/7/revisionhistory)

Changes:
* Port changes from `v8` docs for updating `sortedRevisions` func.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed