### PR TITLE
DOC-3315: TinyMCE 8.2.1 Release Documentation.

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -421,6 +421,9 @@
 ** xref:tinymce-and-cors.adoc[Cross-Origin Resource Sharing (CORS)]
 * Release information
 ** xref:release-notes.adoc[Release notes for {productname}]
+*** {productname} 8.2.1
+**** xref:8.2.0-release-notes.adoc#overview[Overview]
+**** xref:8.2.0-release-notes.adoc#bug-fixes[Bug fixes]
 *** {productname} 8.2.0
 **** xref:8.2.0-release-notes.adoc#overview[Overview]
 **** xref:8.2.0-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]

--- a/modules/ROOT/pages/8.2.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.1-release-notes.adoc
@@ -1,0 +1,28 @@
+= {productname} {release-version}
+:release-version: 8.2.1
+:navtitle: {productname} {release-version}
+:description: Release notes for {productname} {release-version}
+:keywords: releasenotes, bugfixes
+:page-toclevels: 1
+
+include::partial$misc/admon-releasenotes-for-stable.adoc[]
+
+
+[[overview]]
+== Overview
+
+{productname} {release-version} was released for {enterpriseversion} and {cloudname} on <weekday>, <month> <DD>^<st|nd|rd|th>^, <YYYY>. These release notes provide an overview of the changes for {productname} {release-version}, including:
+
+// Remove sections and section boilerplates as necessary.
+* xref:bug-fixes[Bug fixes]
+
+
+[[bug-fixes]]
+== Bug fixes
+
+{productname} {release-version} also includes the following bug fix<es>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.


### PR DESCRIPTION
Ticket: DOC-3315

Site: [Staging branch](http://docs-release-821.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* EPIC: TinyMCE 8.2.1 Release Documentation.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.
- [x] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [ ] Documentation Team Lead has reviewed