### PR TITLE
DOC-3303: Remove fullpagehtml from how-to-guides table.

### DIFF
--- a/modules/ROOT/pages/how-to-guides.adoc
+++ b/modules/ROOT/pages/how-to-guides.adoc
@@ -93,12 +93,6 @@ List of common editor events
 
 a|
 [.lead]
-xref:fullpagehtml.adoc[Full Page HTML Plugin]
-
-Edit document metadata and properties including title, keywords, and description via dialog interface.
-
-a|
-[.lead]
 xref:keyboard-shortcuts.adoc[Keyboard shortcuts]
 
 Complete list of keyboard shortcuts.


### PR DESCRIPTION
Ticket: DOC-3303

Site: [Staging branch](http://docs-hotfix-8-doc-3303.staging.tiny.cloud/docs/tinymce/latest/how-to-guides)

Changes:
* Remove `fullpagehtml` from table.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed