### PR TITLE
DOC-3311: Dragging an element over the editor would cause it to jump unexpectedly on some versions of Chrome with the PowerPaste plugin.

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -423,6 +423,7 @@
 ** xref:release-notes.adoc[Release notes for {productname}]
 *** {productname} 8.2.1
 **** xref:8.2.1-release-notes.adoc#overview[Overview]
+**** xref:8.2.1-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]
 **** xref:8.2.1-release-notes.adoc#bug-fixes[Bug fixes]
 *** {productname} 8.2.0
 **** xref:8.2.0-release-notes.adoc#overview[Overview]

--- a/modules/ROOT/pages/8.2.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.0-release-notes.adoc
@@ -140,7 +140,7 @@ Previously, certain elements received an additional newline when indented due to
 
 Previously, UI elements such as focus outlines and placeholder text were rendered in printed versions of the editor content, resulting in unwanted visual artifacts in printed documents. This behavior caused confusion and reduced the professional appearance of printed materials. To address this issue, printing-specific styles were introduced to automatically hide all UI-related elements within the editor content during printing. As a result, printed output now includes only the intended content, ensuring clean and consistent presentation across all printouts.
 
-=== The `open` attribute on `<details>` elements is now normalized to `open="open"` when the accordion plugin is enabled. 
+=== The `open` attribute on `<details>` elements is now normalized to `open="open"` when the accordion plugin is enabled.
 // #TINY-12862
 
 Previously, the `open` attribute on `<details>` elements was inconsistently defined when used with the accordion plugin. In some cases, the attribute appeared as `+open="true"+`, while toggling through the plugin converted it to `+open="open"+`. This inconsistency caused issues when loading externally created content that contained multiple open accordions with different attribute values, leading to mismatched accordion states.

--- a/modules/ROOT/pages/8.2.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.1-release-notes.adoc
@@ -22,7 +22,11 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 {productname} {release-version} also includes the following bug fixes:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Dragging an element over the editor would cause it to jump unexpectedly on some versions of Chrome with the PowerPaste plugin.
+// #TINY-13196
 
-// CCFR here.
+In {productname} xref:8.2.0-release-notes.adoc#the-editor-would-upon-gaining-focus-scroll-to-the-center-of-the-editor-on-some-browsers-if-the-top-of-the-editor-was-out-of-frame[8.2.0], an issue was resolved where the editor would unexpectedly scroll in certain situations. This behavior originated from a workaround for a Chromium bug, which caused the editor to scroll when the top of the editor was out of frame.
+
+While this issue was addressed for the core editor behavior in that release, the same problem persisted in the xref:introduction-to-powerpaste.adoc[PowerPaste] plugin, resulting in similar unexpected scrolling.
+
+In {productname} {release-version}, this issue has now been fully resolved for PowerPaste as well. The editor no longer scrolls unexpectedly when using the PowerPaste plugin.

--- a/modules/ROOT/pages/8.2.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.1-release-notes.adoc
@@ -21,7 +21,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
-=== PowerPaste plugin
+=== PowerPaste
 
 The {productname} {release-version} release includes an accompanying release of the **PowerPaste** premium plugin.
 

--- a/modules/ROOT/pages/8.2.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.1-release-notes.adoc
@@ -14,15 +14,20 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 {productname} {release-version} was released for {enterpriseversion} and {cloudname} on <weekday>, <month> <DD>^<st|nd|rd|th>^, <YYYY>. These release notes provide an overview of the changes for {productname} {release-version}, including:
 
 // Remove sections and section boilerplates as necessary.
+* xref:accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
 * xref:bug-fixes[Bug fixes]
 
+== Accompanying Premium plugin changes
 
-[[bug-fixes]]
-== Bug fixes
+The following premium plugin updates were released alongside {productname} {release-version}.
 
-{productname} {release-version} also includes the following bug fixes:
+=== PowerPaste plugin
 
-=== Dragging an element over the editor would cause it to jump unexpectedly on some versions of Chrome with the PowerPaste plugin.
+The {productname} {release-version} release includes an accompanying release of the **PowerPaste** premium plugin.
+
+**The PowerPaste plugin** includes the following fix.
+
+==== Dragging an element over the editor would cause it to jump unexpectedly on some versions of Chrome with the PowerPaste plugin.
 // #TINY-13196
 
 In {productname} xref:8.2.0-release-notes.adoc#the-editor-would-upon-gaining-focus-scroll-to-the-center-of-the-editor-on-some-browsers-if-the-top-of-the-editor-was-out-of-frame[8.2.0], an issue was resolved where the editor would unexpectedly scroll in certain situations. This behavior originated from a workaround for a Chromium bug, which caused the editor to scroll when the top of the editor was out of frame.
@@ -30,3 +35,5 @@ In {productname} xref:8.2.0-release-notes.adoc#the-editor-would-upon-gaining-foc
 While this issue was addressed for the core editor behavior in that release, the same problem persisted in the xref:introduction-to-powerpaste.adoc[PowerPaste] plugin, resulting in similar unexpected scrolling.
 
 In {productname} {release-version}, this issue has now been fully resolved for PowerPaste as well. The editor no longer scrolls unexpectedly when using the PowerPaste plugin.
+
+For information on the **PowerPaste** plugin, see: xref:introduction-to-powerpaste.adoc[PowerPaste plugin].


### PR DESCRIPTION
Ticket: DOC-3311

Site: [Staging branch](http://docs-feature-821-doc-3311tiny-13196.staging.tiny.cloud/docs/tinymce/latest/8.2.1-release-notes/#dragging-an-element-over-the-editor-would-cause-it-to-jump-unexpectedly-on-some-versions-of-chrome-with-the-powerpaste-plugin)

Changes:
* Documented the bug fix for TINY-13196

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed