### PR TITLE
DOC-3311: The Help Plugin did not contain an entry for the Full Page HTML plugin.

### DIFF
--- a/modules/ROOT/pages/8.2.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.1-release-notes.adoc
@@ -22,7 +22,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 {productname} {release-version} also includes the following bug fixes:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== The Help Plugin did not contain an entry for the Full Page HTML plugin.
+// #TINY-13183
 
-// CCFR here.
+Prior to the {release-version} release, the xref:fullpagehtml.adoc[Full Page HTML] plugin was not included in the plugin list displayed in the xref:help.adoc[Help plugin] dialog. This has now been corrected, and the Help plugin dialog properly lists the plugin.


### PR DESCRIPTION
Ticket: DOC-3311

Site: [Staging branch](http://docs-feature-821-doc-3311tiny-13183.staging.tiny.cloud/docs/tinymce/latest/8.2.1-release-notes/#bug-fixes)

Changes:
* Documented the bug fix for TINY-13183

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed