### PR TITLE
DOC-3311: Resizing the editor's height would add a fixed width value.

### DIFF
--- a/modules/ROOT/pages/8.2.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.1-release-notes.adoc
@@ -22,7 +22,9 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 {productname} {release-version} also includes the following bug fixes:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Resizing the editor's height would add a fixed width value.
+// #TINY-13138
 
-// CCFR here.
+Previously, an issue was identified where the editor’s width styles were overwritten when resizing the editor. This caused the width styles to break, resulting in the editor having a fixed width value instead of adapting to the container’s width.
+
+In {productname} {release-version}, this issue has been resolved. The editor's width is no longer overwritten after resizing when the xref:editor-size-options.adoc#resize[resize option] is set to `true`. Now, resizing only affects the width when the resize option is set to `both`. This ensures that only the necessary styles are applied during editor resizing, preserving other styles and allowing the resize behavior to function as expected.


### PR DESCRIPTION
Ticket: DOC-3311

Site: [Staging branch](http://docs-feature-821-doc-3311tiny-13138.staging.tiny.cloud/docs/tinymce/latest/8.2.1-release-notes/#resizing-the-editors-height-would-add-a-fixed-width-value)

Changes:
* Documented the bug fix for TINY-13138

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed