### PR TITLE
DOC-3319: Fixed known issue entry in 8.2.0 release notes.

### DIFF
--- a/modules/ROOT/pages/8.2.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.2.0-release-notes.adoc
@@ -217,7 +217,7 @@ In {productname} {release-version}, an issue was resolved where split buttons re
 
 {productname} {release-version} also includes the following known issues:
 
-=== Uploadcare video audio continues playing after copying paused and muted video
+=== Uploadcare video audio continues playing after copying a paused and muted video
 // #TINY-13198
 
 In certain edge cases, when a video is inserted, played, paused, and muted, then copied using **Ctrl+C** (or **Cmd+C** on Mac), the paused and muted video may begin playing audio. Once this occurs, the audio continues to play even after deleting the video from the editor.


### PR DESCRIPTION
Ticket: DOC-3319

Site: [Staging branch](http://docs-hotfix-8-doc-3319.staging.tiny.cloud/docs/tinymce/latest/8.2.0-release-notes/#uploadcare-video-audio-continues-playing-after-copying-a-paused-and-muted-video)

Changes:
* Fixed the know issue title from "Uploadcare video audio continues playing after copying a paused and muted video" to 
"Uploadcare video audio continues playing after copying **a** paused and muted video".

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed