### PR TITLE
DOC-3316: Update incorrect import for bundling-vite-es6-npm v7 guide.

### DIFF
--- a/modules/ROOT/partials/module-loading/bundling-vite-es6-npm_editor.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-vite-es6-npm_editor.adoc
@@ -35,10 +35,10 @@ import 'tinymce/plugins/table';
 /* import './plugins/<plugincode>'; */
 
 /* content UI CSS is required */
-import contentUiSkinCss from 'tinymce/skins/ui/oxide/content.js';
+import 'tinymce/skins/ui/oxide/content.js';
 
 /* The default content CSS can be changed or replaced with appropriate CSS for the editor content. */
-import contentCss from 'tinymce/skins/content/default/content.js';
+import 'tinymce/skins/content/default/content.js';
 
 /* Initialize TinyMCE */
 export function render () {


### PR DESCRIPTION
Ticket: DOC-3316

Site: [Staging branch](http://docs-hotfix-7-doc-3316.staging.tiny.cloud/docs/tinymce/7/vite-es6-npm/)

Changes:
* Fix incorrect `imports` for `Bundling an npm version of TinyMCE with ES6 and Vite` in `7x`.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed