### PR TITLE
DOC-3321_v7: Remove “Plupload” mentions from demo HTML and replace with modern upload reference for v7-docs.

### DIFF
--- a/-new-material-templates/integration-example-(ie)-templates/ROOT/examples/live-demos/ie-{hyphen-delimited-descriptor}/index.html
+++ b/-new-material-templates/integration-example-(ie)-templates/ROOT/examples/live-demos/ie-{hyphen-delimited-descriptor}/index.html
@@ -9,7 +9,7 @@
 
   <h2>Finally…</h2>
 
-  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE. We hope it helps you and your users create great content.</p>
   <p>All the best from the TinyMCE team.</p>
 </textarea>

--- a/-new-material-templates/integration-example-(ie)-templates/ROOT/examples/live-demos/ie-{hyphen-delimited-descriptor}/index.html
+++ b/-new-material-templates/integration-example-(ie)-templates/ROOT/examples/live-demos/ie-{hyphen-delimited-descriptor}/index.html
@@ -9,7 +9,7 @@
 
   <h2>Finally…</h2>
 
-  <p>Don’t forget to check out <a href="http://www.plupload.com" target="_blank">Plupload</a>, the upload solution featuring HTML5 upload support.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE. We hope it helps you and your users create great content.</p>
   <p>All the best from the TinyMCE team.</p>
 </textarea>

--- a/-new-material-templates/plugin-documentation-templates/ROOT/examples/live-demos/{plugincode}/index.html
+++ b/-new-material-templates/plugin-documentation-templates/ROOT/examples/live-demos/{plugincode}/index.html
@@ -9,7 +9,7 @@
 
   <h2>Finally…</h2>
 
-  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE. We hope it helps you and your users create great content.</p>
   <p>All the best from the TinyMCE team.</p>
 </textarea>

--- a/-new-material-templates/plugin-documentation-templates/ROOT/examples/live-demos/{plugincode}/index.html
+++ b/-new-material-templates/plugin-documentation-templates/ROOT/examples/live-demos/{plugincode}/index.html
@@ -9,7 +9,7 @@
 
   <h2>Finally…</h2>
 
-  <p>Don’t forget to check out <a href="http://www.plupload.com" target="_blank">Plupload</a>, the upload solution featuring HTML5 upload support.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE. We hope it helps you and your users create great content.</p>
   <p>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/a11ychecker/index.html
+++ b/modules/ROOT/examples/live-demos/a11ychecker/index.html
@@ -3,7 +3,7 @@
   <p>Note: This demo has been crafted to intentionally trigger most of our accessibility rules for demonstration purposes.</p>
   <hr>
   <h2><a id="example"></a>The Tiny Logo</h2>
-  <p><a href="{{site-url}}/tinymce/6/a11ychecker/#liveexample" target="_blank" rel="noopener"><img src="{{logofordemos}}" alt="" width="128" height="128"></a><a href="{{site-url}}/tinymce/6/a11ychecker/#liveexample" target="_blank" rel="noopener">This is a link to this demo. The same link has been added to logo to the left.</a></p>
+  <p><a href="{{site-url}}/tinymce/7/a11ychecker/#liveexample" target="_blank" rel="noopener"><img src="{{logofordemos}}" alt="" width="128" height="128"></a><a href="{{site-url}}/tinymce/7/a11ychecker/#liveexample" target="_blank" rel="noopener">This is a link to this demo. The same link has been added to logo to the left.</a></p>
   <p>* This is a list.</p>
   <p>* That has been poorly formatted.</p>
   <p>* By using asterisks, instead of using &lt;ul&gt;&lt;li&gt; elements.</p>

--- a/modules/ROOT/examples/live-demos/accordion/index.html
+++ b/modules/ROOT/examples/live-demos/accordion/index.html
@@ -41,7 +41,7 @@
 
   <h2>Finally…</h2>
 
-  <p>Check out <a href="http://plupload.com" target="_blank">Plupload</a>, an upload solution that features HTML5 upload support.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
 
   <p>Thanks for supporting TinyMCE. We hope it helps you in creating great content.</p>
 

--- a/modules/ROOT/examples/live-demos/accordion/index.html
+++ b/modules/ROOT/examples/live-demos/accordion/index.html
@@ -30,7 +30,7 @@
   <h2>Got questions or need help?</h2>
 
   <ul>
-    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>
@@ -41,7 +41,7 @@
 
   <h2>Finally…</h2>
 
-  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
 
   <p>Thanks for supporting TinyMCE. We hope it helps you in creating great content.</p>
 

--- a/modules/ROOT/examples/live-demos/advcode/index.html
+++ b/modules/ROOT/examples/live-demos/advcode/index.html
@@ -31,7 +31,7 @@
             <li>Increase and decrease display font size.</li>
             <li>Full-screen mode.</li>
           </ul>
-          <p>For the Enhanced Code Editor to offer a full-screen mode requires the <a href="https://tiny.cloud/docs/tinymce/6/fullscreen">Full screen</a> plugin and requires the Enhanced Code Editor to be running in <a href="https://tiny.cloud/docs/tinymce/6/advcode/#advcode_inline">inline mode</a>.</p>
+          <p>For the Enhanced Code Editor to offer a full-screen mode requires the <a href="https://tiny.cloud/docs/tinymce/7/fullscreen">Full screen</a> plugin and requires the Enhanced Code Editor to be running in <a href="https://tiny.cloud/docs/tinymce/7/advcode/#advcode_inline">inline mode</a>.</p>
           <p>To open the Enhanced Code Editor dialog:</p>
           <ul>
             <li>On the menu bar, open <strong>View</strong> &gt; <strong>Source code</strong>.</li>

--- a/modules/ROOT/examples/live-demos/advtemplate-insertionpoint/index.html
+++ b/modules/ROOT/examples/live-demos/advtemplate-insertionpoint/index.html
@@ -33,7 +33,7 @@
 
 <h4>Working with Merge Tags</h4>
 
-<p>The second pre-defined template in this demonstration — the <em>Letter outline</em> template — shows the <code>{{prefix}}mce-cursor{{suffix}}</code> string working in conjunction with the <a href="https://tiny.cloud/docs/tinymce/6/mergetags/">Merge Tags</a> Premium plugin.</p>
+<p>The second pre-defined template in this demonstration — the <em>Letter outline</em> template — shows the <code>{{prefix}}mce-cursor{{suffix}}</code> string working in conjunction with the <a href="https://tiny.cloud/docs/tinymce/7/mergetags/">Merge Tags</a> Premium plugin.</p>
 
 <p>The fixed string that is the Insertion Point Marker uses the same delimiting characters as are used by default by the Merge Tags plugin.</p>
 

--- a/modules/ROOT/examples/live-demos/annotations/index.html
+++ b/modules/ROOT/examples/live-demos/annotations/index.html
@@ -7,7 +7,7 @@
 
   <h2>Got questions or need help?</h2>
   <ul>
-    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium subscriptions</a>.</li>
   </ul>
@@ -23,14 +23,9 @@
     </thead>
     <tbody>
       <tr>
-        <td>TinyMCE Cloud</td>
-        <td>Get started for free</td>
-        <td>YES!</td>
-      </tr>
-      <tr>
-        <td>Uploadcare</td>
-        <td>Free tier available</td>
-        <td>YES!</td>
+        <td style="text-align: center;">TinyMCE Cloud</td>
+        <td style="text-align: center;">Get started for free</td>
+        <td style="text-align: center;">YES!</td>
       </tr>
     </tbody>
   </table>
@@ -39,6 +34,6 @@
   <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
 
   <h2>Finally ...</h2>
-  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/annotations/index.html
+++ b/modules/ROOT/examples/live-demos/annotations/index.html
@@ -28,8 +28,8 @@
         <td>YES!</td>
       </tr>
       <tr>
-        <td>Plupload</td>
-        <td>Free</td>
+        <td>Uploadcare</td>
+        <td>Free tier available</td>
         <td>YES!</td>
       </tr>
     </tbody>
@@ -39,6 +39,6 @@
   <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
 
   <h2>Finally ...</h2>
-  <p>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/basic-example/index.html
+++ b/modules/ROOT/examples/live-demos/basic-example/index.html
@@ -5,7 +5,7 @@
   <h2>Got questions or need help?</h2>
 
   <ul>
-    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>
@@ -22,14 +22,9 @@
     </thead>
     <tbody>
       <tr>
-        <td>TinyMCE</td>
-        <td>Free</td>
-        <td>YES!</td>
-      </tr>
-      <tr>
-        <td>Uploadcare</td>
-        <td>Free tier available</td>
-        <td>YES!</td>
+        <td style="text-align: center;">TinyMCE</td>
+        <td style="text-align: center;">Free</td>
+        <td style="text-align: center;">YES!</td>
       </tr>
     </tbody>
   </table>
@@ -43,7 +38,7 @@
   <h2>Finally ...</h2>
 
   <p>
-    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
+    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
   </p>
   <p>
     Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.

--- a/modules/ROOT/examples/live-demos/basic-example/index.html
+++ b/modules/ROOT/examples/live-demos/basic-example/index.html
@@ -27,8 +27,8 @@
         <td>YES!</td>
       </tr>
       <tr>
-        <td>Plupload</td>
-        <td>Free</td>
+        <td>Uploadcare</td>
+        <td>Free tier available</td>
         <td>YES!</td>
       </tr>
     </tbody>
@@ -43,7 +43,7 @@
   <h2>Finally ...</h2>
 
   <p>
-    Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.
+    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
   </p>
   <p>
     Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.

--- a/modules/ROOT/examples/live-demos/casechange/index.html
+++ b/modules/ROOT/examples/live-demos/casechange/index.html
@@ -10,7 +10,7 @@
   <h2>Got questions or need help?</h2>
 
   <ul>
-    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>
@@ -27,14 +27,9 @@
     </thead>
     <tbody>
       <tr>
-        <td>TinyMCE</td>
-        <td>Free</td>
-        <td>YES!</td>
-      </tr>
-      <tr>
-        <td>Uploadcare</td>
-        <td>Free tier available</td>
-        <td>YES!</td>
+        <td style="text-align: center;">TinyMCE</td>
+        <td style="text-align: center;">Free</td>
+        <td style="text-align: center;">YES!</td>
       </tr>
     </tbody>
   </table>
@@ -48,7 +43,7 @@
   <h2>Finally ...</h2>
 
   <p>
-    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
+    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
   </p>
   <p>
     Thanks for supporting TinyMCE! We hope it helps you in creating great content.<br>All the best from the TinyMCE team.

--- a/modules/ROOT/examples/live-demos/casechange/index.html
+++ b/modules/ROOT/examples/live-demos/casechange/index.html
@@ -32,8 +32,8 @@
         <td>YES!</td>
       </tr>
       <tr>
-        <td>Plupload</td>
-        <td>Free</td>
+        <td>Uploadcare</td>
+        <td>Free tier available</td>
         <td>YES!</td>
       </tr>
     </tbody>
@@ -48,7 +48,7 @@
   <h2>Finally ...</h2>
 
   <p>
-    Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.
+    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
   </p>
   <p>
     Thanks for supporting TinyMCE! We hope it helps you in creating great content.<br>All the best from the TinyMCE team.

--- a/modules/ROOT/examples/live-demos/context-form/index.html
+++ b/modules/ROOT/examples/live-demos/context-form/index.html
@@ -1,7 +1,7 @@
 <textarea id="context-form">
   <p>Clicking on the example link below will show the newly configured context form.</p>
 
-  <a href="{{site-url}}/tinymce/6/">TinyMCE Documentation</a>
+  <a href="{{site-url}}/tinymce/7/">TinyMCE Documentation</a>
 
   <p>Clicking on text should not invoke the context form.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/context-menu/index.html
+++ b/modules/ROOT/examples/live-demos/context-menu/index.html
@@ -11,7 +11,7 @@
   <h2>Got questions or need help?</h2>
 
   <ul>
-    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>
@@ -28,14 +28,9 @@
     </thead>
     <tbody>
       <tr>
-        <td>TinyMCE</td>
-        <td>Free</td>
-        <td>YES!</td>
-      </tr>
-      <tr>
-        <td>Uploadcare</td>
-        <td>Free tier available</td>
-        <td>YES!</td>
+        <td style="text-align: center;">TinyMCE</td>
+        <td style="text-align: center;">Free</td>
+        <td style="text-align: center;">YES!</td>
       </tr>
     </tbody>
   </table>
@@ -49,7 +44,7 @@
   <h2>Finally ...</h2>
 
   <p>
-    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
+    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
   </p>
   <p>
     Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.

--- a/modules/ROOT/examples/live-demos/context-menu/index.html
+++ b/modules/ROOT/examples/live-demos/context-menu/index.html
@@ -33,8 +33,8 @@
         <td>YES!</td>
       </tr>
       <tr>
-        <td>Plupload</td>
-        <td>Free</td>
+        <td>Uploadcare</td>
+        <td>Free tier available</td>
         <td>YES!</td>
       </tr>
     </tbody>
@@ -49,7 +49,7 @@
   <h2>Finally ...</h2>
 
   <p>
-    Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.
+    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
   </p>
   <p>
     Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.

--- a/modules/ROOT/examples/live-demos/custom-menu-item/index.html
+++ b/modules/ROOT/examples/live-demos/custom-menu-item/index.html
@@ -5,7 +5,7 @@
 
   <h2>Got questions or need help?</h2>
   <ul>
-    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>

--- a/modules/ROOT/examples/live-demos/custom-toolbar-button/index.html
+++ b/modules/ROOT/examples/live-demos/custom-toolbar-button/index.html
@@ -14,7 +14,7 @@
   <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
 
   <h2>Finally ...</h2>
-  <p>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.
     <br>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/custom-toolbar-button/index.html
+++ b/modules/ROOT/examples/live-demos/custom-toolbar-button/index.html
@@ -5,7 +5,7 @@
 
   <h2>Got questions or need help?</h2>
   <ul>
-    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>
@@ -14,7 +14,7 @@
   <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
 
   <h2>Finally ...</h2>
-  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.
     <br>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/custom-toolbar-group-button/index.html
+++ b/modules/ROOT/examples/live-demos/custom-toolbar-group-button/index.html
@@ -14,7 +14,7 @@
   <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
 
   <h2>Finally ...</h2>
-  <p>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.
     <br>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/custom-toolbar-group-button/index.html
+++ b/modules/ROOT/examples/live-demos/custom-toolbar-group-button/index.html
@@ -5,7 +5,7 @@
 
   <h2>Got questions or need help?</h2>
   <ul>
-    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>
@@ -14,7 +14,7 @@
   <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
 
   <h2>Finally ...</h2>
-  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.
     <br>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/custom-toolbar-menu-button-search/index.html
+++ b/modules/ROOT/examples/live-demos/custom-toolbar-menu-button-search/index.html
@@ -14,7 +14,7 @@
   <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
 
   <h2>Finally ...</h2>
-  <p>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.
     <br>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/custom-toolbar-menu-button-search/index.html
+++ b/modules/ROOT/examples/live-demos/custom-toolbar-menu-button-search/index.html
@@ -5,7 +5,7 @@
 
   <h2>Got questions or need help?</h2>
   <ul>
-    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>
@@ -14,7 +14,7 @@
   <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
 
   <h2>Finally ...</h2>
-  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.
     <br>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/custom-toolbar-menu-button/index.html
+++ b/modules/ROOT/examples/live-demos/custom-toolbar-menu-button/index.html
@@ -14,7 +14,7 @@
   <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
 
   <h2>Finally ...</h2>
-  <p>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.
     <br>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/custom-toolbar-menu-button/index.html
+++ b/modules/ROOT/examples/live-demos/custom-toolbar-menu-button/index.html
@@ -5,7 +5,7 @@
 
   <h2>Got questions or need help?</h2>
   <ul>
-    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>
@@ -14,7 +14,7 @@
   <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
 
   <h2>Finally ...</h2>
-  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.
     <br>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/custom-toolbar-split-button/index.html
+++ b/modules/ROOT/examples/live-demos/custom-toolbar-split-button/index.html
@@ -14,7 +14,7 @@
   <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
 
   <h2>Finally ...</h2>
-  <p>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.
     <br>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/custom-toolbar-split-button/index.html
+++ b/modules/ROOT/examples/live-demos/custom-toolbar-split-button/index.html
@@ -5,7 +5,7 @@
 
   <h2>Got questions or need help?</h2>
   <ul>
-    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>
@@ -14,7 +14,7 @@
   <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
 
   <h2>Finally ...</h2>
-  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.
     <br>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/custom-toolbar-toggle-button/index.html
+++ b/modules/ROOT/examples/live-demos/custom-toolbar-toggle-button/index.html
@@ -14,7 +14,7 @@
   <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
 
   <h2>Finally ...</h2>
-  <p>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.
     <br>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/custom-toolbar-toggle-button/index.html
+++ b/modules/ROOT/examples/live-demos/custom-toolbar-toggle-button/index.html
@@ -5,7 +5,7 @@
 
   <h2>Got questions or need help?</h2>
   <ul>
-    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>
@@ -14,7 +14,7 @@
   <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
 
   <h2>Finally ...</h2>
-  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.
     <br>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/custom-view/index.html
+++ b/modules/ROOT/examples/live-demos/custom-view/index.html
@@ -5,7 +5,7 @@
 
   <h2>Got questions or need help?</h2>
   <ul>
-    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>

--- a/modules/ROOT/examples/live-demos/dark-mode/index.html
+++ b/modules/ROOT/examples/live-demos/dark-mode/index.html
@@ -6,7 +6,7 @@
   <h2>Got questions or need help?</h2>
 
   <ul>
-    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>
@@ -23,14 +23,9 @@
     </thead>
     <tbody>
       <tr>
-        <td>TinyMCE</td>
-        <td>Free</td>
-        <td>YES!</td>
-      </tr>
-      <tr>
-        <td>Uploadcare</td>
-        <td>Free tier available</td>
-        <td>YES!</td>
+        <td style="text-align: center;">TinyMCE</td>
+        <td style="text-align: center;">Free</td>
+        <td style="text-align: center;">YES!</td>
       </tr>
     </tbody>
   </table>
@@ -44,7 +39,7 @@
   <h2>Finally ...</h2>
 
   <p>
-    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
+    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
   </p>
   <p>
     Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.

--- a/modules/ROOT/examples/live-demos/dark-mode/index.html
+++ b/modules/ROOT/examples/live-demos/dark-mode/index.html
@@ -28,8 +28,8 @@
         <td>YES!</td>
       </tr>
       <tr>
-        <td>Plupload</td>
-        <td>Free</td>
+        <td>Uploadcare</td>
+        <td>Free tier available</td>
         <td>YES!</td>
       </tr>
     </tbody>
@@ -44,7 +44,7 @@
   <h2>Finally ...</h2>
 
   <p>
-    Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.
+    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
   </p>
   <p>
     Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.

--- a/modules/ROOT/examples/live-demos/drive-demo-dropbox/index.html
+++ b/modules/ROOT/examples/live-demos/drive-demo-dropbox/index.html
@@ -6,7 +6,7 @@
   </p>
 
   <p>
-    One of these enhancements is <strong>Tiny Drive</strong>: imagine file management for TinyMCE, in the cloud, made super easy. Learn more at <a href="{{site-url}}/tinymce/6/tinydrive-introduction/#interactive-example">our working demo</a>, where you'll find an opportunity to provide feedback to the product team.
+    One of these enhancements is <strong>Tiny Drive</strong>: imagine file management for TinyMCE, in the cloud, made super easy. Learn more at <a href="{{site-url}}/tinymce/7/tinydrive-introduction/#interactive-example">our working demo</a>, where you'll find an opportunity to provide feedback to the product team.
   </p>
 
   <h3>An editor for every project</h3>

--- a/modules/ROOT/examples/live-demos/drive-demo-googledrive/index.html
+++ b/modules/ROOT/examples/live-demos/drive-demo-googledrive/index.html
@@ -6,7 +6,7 @@
   </p>
 
   <p>
-    One of these enhancements is <strong>Tiny Drive</strong>: imagine file management for TinyMCE, in the cloud, made super easy. Learn more at <a href="{{site-url}}/tinymce/6/tinydrive-introduction/#interactive-example">our working demo</a>, where you'll find an opportunity to provide feedback to the product team.
+    One of these enhancements is <strong>Tiny Drive</strong>: imagine file management for TinyMCE, in the cloud, made super easy. Learn more at <a href="{{site-url}}/tinymce/7/tinydrive-introduction/#interactive-example">our working demo</a>, where you'll find an opportunity to provide feedback to the product team.
   </p>
 
   <h3>An editor for every project</h3>

--- a/modules/ROOT/examples/live-demos/edit-image/index.html
+++ b/modules/ROOT/examples/live-demos/edit-image/index.html
@@ -27,8 +27,8 @@
         <td>YES!</td>
       </tr>
       <tr>
-        <td>Plupload</td>
-        <td>Free</td>
+        <td>Uploadcare</td>
+        <td>Free tier available</td>
         <td>YES!</td>
       </tr>
     </tbody>
@@ -38,7 +38,7 @@
   <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
 
   <h2>Finally ...</h2>
-  <p>Don&#39;t forget to check out our other product <a href="http://www.plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
 </textarea>
 

--- a/modules/ROOT/examples/live-demos/edit-image/index.html
+++ b/modules/ROOT/examples/live-demos/edit-image/index.html
@@ -7,7 +7,7 @@
   <h2>Got questions or need help?</h2>
 
   <ul>
-    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>
@@ -22,14 +22,9 @@
     </thead>
     <tbody>
       <tr>
-        <td>TinyMCE</td>
-        <td>Free</td>
-        <td>YES!</td>
-      </tr>
-      <tr>
-        <td>Uploadcare</td>
-        <td>Free tier available</td>
-        <td>YES!</td>
+        <td style="text-align: center;">TinyMCE</td>
+        <td style="text-align: center;">Free</td>
+        <td style="text-align: center;">YES!</td>
       </tr>
     </tbody>
   </table>
@@ -38,7 +33,7 @@
   <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
 
   <h2>Finally ...</h2>
-  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
 </textarea>
 

--- a/modules/ROOT/examples/live-demos/editable-class-and-editable-root/index.html
+++ b/modules/ROOT/examples/live-demos/editable-class-and-editable-root/index.html
@@ -20,7 +20,7 @@
 
   <h2>Finally…</h2>
 
-  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE. We hope it helps you and your users create great content.</p>
   <p>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/editable-class-and-editable-root/index.html
+++ b/modules/ROOT/examples/live-demos/editable-class-and-editable-root/index.html
@@ -20,7 +20,7 @@
 
   <h2>Finally…</h2>
 
-  <p>Don’t forget to check out <a href="http://www.plupload.com" target="_blank">Plupload</a>, the upload solution featuring HTML5 upload support.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE. We hope it helps you and your users create great content.</p>
   <p>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/footnotes/index.html
+++ b/modules/ROOT/examples/live-demos/footnotes/index.html
@@ -16,7 +16,7 @@
         <li id="footnotes_entry_46102500311662090427490"><a class="mce-footnotes-backlink" href="#footnote_46102500311662090427490">^&nbsp;</a><span class="mce-footnotes-note">If there is a highlighted selection when a footnote is added, the new footnote is added to the end of the highlighted selection.&nbsp;</span></li>
         <li id="footnotes_entry_795387001171662097474091"><a class="mce-footnotes-backlink" href="#footnote_795387001171662097474091">^&nbsp;</a><span class="mce-footnotes-note">Scrolling the document to the end, if necessary.</span></li>
         <li id="footnotes_entry_83105724181662097486697"><a class="mce-footnotes-backlink" href="#footnote_83105724181662097486697">^&nbsp;</a><span class="mce-footnotes-note">The footnotes section contains every footnote entry.</span></li>
-        <li id="footnotes_entry_6878577521662090521962"><a class="mce-footnotes-backlink" href="#footnote_6878577521662090521962">^&nbsp;</a><span class="mce-footnotes-note">See <a href="https://tiny.cloud/docs/tinymce/6/plugins/">Premium plugins</a> for details.</span></li>
+        <li id="footnotes_entry_6878577521662090521962"><a class="mce-footnotes-backlink" href="#footnote_6878577521662090521962">^&nbsp;</a><span class="mce-footnotes-note">See <a href="https://tiny.cloud/docs/tinymce/7/plugins/">Premium plugins</a> for details.</span></li>
       </ol>
     </div>
   </textarea>

--- a/modules/ROOT/examples/live-demos/format-custom/index.html
+++ b/modules/ROOT/examples/live-demos/format-custom/index.html
@@ -8,7 +8,7 @@
 
   <h2>Got questions or need help?</h2>
   <ul>
-    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>
@@ -24,14 +24,9 @@
     </thead>
     <tbody>
       <tr>
-        <td>TinyMCE</td>
-        <td>Free</td>
-        <td>YES!</td>
-      </tr>
-      <tr>
-        <td>Uploadcare</td>
-        <td>Free tier available</td>
-        <td>YES!</td>
+        <td style="text-align: center;">TinyMCE</td>
+        <td style="text-align: center;">Free</td>
+        <td style="text-align: center;">YES!</td>
       </tr>
     </tbody>
   </table>
@@ -43,7 +38,7 @@
 
   <h2>Finally ...</h2>
   <p>
-    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
+    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
   </p>
   <p>
     Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.

--- a/modules/ROOT/examples/live-demos/format-custom/index.html
+++ b/modules/ROOT/examples/live-demos/format-custom/index.html
@@ -29,8 +29,8 @@
         <td>YES!</td>
       </tr>
       <tr>
-        <td>Plupload</td>
-        <td>Free</td>
+        <td>Uploadcare</td>
+        <td>Free tier available</td>
         <td>YES!</td>
       </tr>
     </tbody>
@@ -43,7 +43,7 @@
 
   <h2>Finally ...</h2>
   <p>
-    Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.
+    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
   </p>
   <p>
     Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.

--- a/modules/ROOT/examples/live-demos/format-painter/index.html
+++ b/modules/ROOT/examples/live-demos/format-painter/index.html
@@ -6,7 +6,7 @@
   <h2>Got questions or need help?</h2>
 
   <ul>
-    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>
@@ -23,14 +23,9 @@
     </thead>
     <tbody>
       <tr>
-        <td>TinyMCE</td>
-        <td>Free</td>
-        <td>YES!</td>
-      </tr>
-      <tr>
-        <td>Uploadcare</td>
-        <td>Free tier available</td>
-        <td>YES!</td>
+        <td style="text-align: center;">TinyMCE</td>
+        <td style="text-align: center;">Free</td>
+        <td style="text-align: center;">YES!</td>
       </tr>
     </tbody>
   </table>
@@ -44,7 +39,7 @@
   <h2>Finally ...</h2>
 
   <p>
-    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
+    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
   </p>
   <p>
     Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.

--- a/modules/ROOT/examples/live-demos/format-painter/index.html
+++ b/modules/ROOT/examples/live-demos/format-painter/index.html
@@ -28,8 +28,8 @@
         <td>YES!</td>
       </tr>
       <tr>
-        <td>Plupload</td>
-        <td>Free</td>
+        <td>Uploadcare</td>
+        <td>Free tier available</td>
         <td>YES!</td>
       </tr>
     </tbody>
@@ -44,7 +44,7 @@
   <h2>Finally ...</h2>
 
   <p>
-    Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.
+    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
   </p>
   <p>
     Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.

--- a/modules/ROOT/examples/live-demos/full-featured/index.html
+++ b/modules/ROOT/examples/live-demos/full-featured/index.html
@@ -37,14 +37,9 @@
     </thead>
     <tbody>
       <tr>
-        <td>TinyMCE Cloud</td>
-        <td>Get started for free</td>
-        <td><strong>Yes!</strong></td>
-      </tr>
-      <tr>
-        <td>Uploadcare</td>
-        <td>Free tier available</td>
-        <td><strong>Yes!</strong></td>
+        <td style="text-align: center;">TinyMCE Cloud</td>
+        <td style="text-align: center;">Get started for free</td>
+        <td style="text-align: center;"><strong>Yes!</strong></td>
       </tr>
     </tbody>
   </table>
@@ -90,7 +85,7 @@
 
 <h2>Finally…</h2>
 
-<p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+<p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
 
 <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.</p>
 

--- a/modules/ROOT/examples/live-demos/full-featured/index.html
+++ b/modules/ROOT/examples/live-demos/full-featured/index.html
@@ -42,8 +42,8 @@
         <td><strong>Yes!</strong></td>
       </tr>
       <tr>
-        <td>Plupload</td>
-        <td>Free</td>
+        <td>Uploadcare</td>
+        <td>Free tier available</td>
         <td><strong>Yes!</strong></td>
       </tr>
     </tbody>
@@ -90,7 +90,7 @@
 
 <h2>Finally…</h2>
 
-<p>Don’t forget to check out our other product <a href="http://plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
+<p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
 
 <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.</p>
 

--- a/modules/ROOT/examples/live-demos/full-featured/index.js
+++ b/modules/ROOT/examples/live-demos/full-featured/index.js
@@ -408,8 +408,8 @@ const revisions = [
       <td>YES!</td>
       </tr>
       <tr>
-      <td>Plupload</td>
-      <td>Free</td>
+      <td>Uploadcare</td>
+      <td>Free tier available</td>
       <td>YES!</td>
       </tr>
       </tbody>
@@ -417,7 +417,7 @@ const revisions = [
       <h2>Found a bug?</h2>
       <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
       <h2>Finally ...</h2>
-      <p><s>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank" rel="noopener">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</s></p>
+      <p><s>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</s></p>
       <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
     `,
   },
@@ -454,8 +454,8 @@ const revisions = [
       <td>YES!</td>
       </tr>
       <tr>
-      <td>Plupload</td>
-      <td>Free</td>
+      <td>Uploadcare</td>
+      <td>Free tier available</td>
       <td>YES!</td>
       </tr>
       </tbody>
@@ -463,7 +463,7 @@ const revisions = [
       <h2>Found a bug?</h2>
       <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
       <h2>Finally ...</h2>
-      <p>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank" rel="noopener">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
+      <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
       <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
     `,
   },
@@ -500,8 +500,8 @@ const revisions = [
       <td>YES!</td>
       </tr>
       <tr>
-      <td>Plupload</td>
-      <td>Free</td>
+      <td>Uploadcare</td>
+      <td>Free tier available</td>
       <td>YES!</td>
       </tr>
       </tbody>
@@ -509,7 +509,7 @@ const revisions = [
       <h2>Found a bug?</h2>
       <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
       <h2>Finally ...</h2>
-      <p>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank" rel="noopener">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
+      <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
       <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
     `,
   }

--- a/modules/ROOT/examples/live-demos/full-featured/index.js
+++ b/modules/ROOT/examples/live-demos/full-featured/index.js
@@ -403,21 +403,16 @@ const revisions = [
       </thead>
       <tbody>
       <tr>
-      <td>TinyMCE</td>
-      <td>Free</td>
-      <td>YES!</td>
-      </tr>
-      <tr>
-      <td>Uploadcare</td>
-      <td>Free tier available</td>
-      <td>YES!</td>
+      <td style="text-align: center;">TinyMCE</td>
+      <td style="text-align: center;">Free</td>
+      <td style="text-align: center;">YES!</td>
       </tr>
       </tbody>
       </table>
       <h2>Found a bug?</h2>
       <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
       <h2>Finally ...</h2>
-      <p><s>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</s></p>
+      <p><s>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</s></p>
       <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
     `,
   },
@@ -449,21 +444,16 @@ const revisions = [
       </thead>
       <tbody>
       <tr>
-      <td>TinyMCE</td>
-      <td>Free</td>
-      <td>YES!</td>
-      </tr>
-      <tr>
-      <td>Uploadcare</td>
-      <td>Free tier available</td>
-      <td>YES!</td>
+      <td style="text-align: center;">TinyMCE</td>
+      <td style="text-align: center;">Free</td>
+      <td style="text-align: center;">YES!</td>
       </tr>
       </tbody>
       </table>
       <h2>Found a bug?</h2>
       <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
       <h2>Finally ...</h2>
-      <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+      <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
       <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
     `,
   },
@@ -495,21 +485,16 @@ const revisions = [
       </thead>
       <tbody>
       <tr>
-      <td>TinyMCE</td>
-      <td>Free</td>
-      <td>YES!</td>
-      </tr>
-      <tr>
-      <td>Uploadcare</td>
-      <td>Free tier available</td>
-      <td>YES!</td>
+      <td style="text-align: center;">TinyMCE</td>
+      <td style="text-align: center;">Free</td>
+      <td style="text-align: center;">YES!</td>
       </tr>
       </tbody>
       </table>
       <h2>Found a bug?</h2>
       <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
       <h2>Finally ...</h2>
-      <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+      <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
       <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
     `,
   }

--- a/modules/ROOT/examples/live-demos/ie-template-creation/index.html
+++ b/modules/ROOT/examples/live-demos/ie-template-creation/index.html
@@ -97,7 +97,7 @@ The demonstration template, however, will.
 <h2>Got questions or need help?</h2>
 
   <ul>
-    <li>Our <a href="*{site-url}*/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="*{site-url}*/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="*{communitysupporturl}*" target="_blank" rel="noopener"><code>*{prodnamecode}*</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="*{pricingpage}*">TinyMCE premium plans</a>.</li>
   </ul>
@@ -108,7 +108,7 @@ The demonstration template, however, will.
 
   <h2>Finally…</h2>
 
-  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
 </div>
 </textarea>

--- a/modules/ROOT/examples/live-demos/ie-template-creation/index.html
+++ b/modules/ROOT/examples/live-demos/ie-template-creation/index.html
@@ -108,7 +108,7 @@ The demonstration template, however, will.
 
   <h2>Finally…</h2>
 
-  <p>Don’t forget to check out our other product <a href="http://www.plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
 </div>
 </textarea>

--- a/modules/ROOT/examples/live-demos/linkchecker/index.html
+++ b/modules/ROOT/examples/live-demos/linkchecker/index.html
@@ -15,7 +15,7 @@
 <p>Note each of them is:
 
 <ol>
-<li>turned into a clickable link by the <a href="https://tiny.cloud/docs/tinymce/6/autolink">Autolink</a> plugin; and then, after a short delay,
+<li>turned into a clickable link by the <a href="https://tiny.cloud/docs/tinymce/7/autolink">Autolink</a> plugin; and then, after a short delay,
 <li>highlighted in red by the <strong>Link Checker</strong> plugin.</li>
 </ol>
 
@@ -36,7 +36,7 @@
 <p>Note each of them is:</p>
 
 <ol>
-<li>turned into a clickable link by the <a href="https://tiny.cloud/docs/tinymce/6/autolink">Autolink</a> plugin; and then
+<li>turned into a clickable link by the <a href="https://tiny.cloud/docs/tinymce/7/autolink">Autolink</a> plugin; and then
 <li><strong>not</strong> highlighted in red by the <strong>Link Checker</strong> plugin.</li>
 </ol>
 

--- a/modules/ROOT/examples/live-demos/linkchecker/index.html
+++ b/modules/ROOT/examples/live-demos/linkchecker/index.html
@@ -29,7 +29,7 @@
 
 <ol>
 <li>www.tiny.cloud</li>
-<li>www.plupload.com</li>
+<li>www.uploadcare.com</li>
 <li>www.ephox.com</li>
 </ol>
 

--- a/modules/ROOT/examples/live-demos/mentions/index.html
+++ b/modules/ROOT/examples/live-demos/mentions/index.html
@@ -21,14 +21,9 @@
     </thead>
     <tbody>
       <tr>
-        <td>TinyMCE Cloud</td>
-        <td>Get started for free</td>
-        <td><strong>Yes!</strong></td>
-      </tr>
-      <tr>
-        <td>Uploadcare</td>
-        <td>Free tier available</td>
-        <td><strong>Yes!</strong></td>
+        <td style="text-align: center;">TinyMCE Cloud</td>
+        <td style="text-align: center;">Get started for free</td>
+        <td style="text-align: center;"><strong>Yes!</strong></td>
       </tr>
     </tbody>
   </table>
@@ -39,7 +34,7 @@
 
   <h2>Finally…</h2>
 
-  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE. We hope it helps you and your users create great content.</p>
   <p>All the best from the TinyMCE team.</p>
 

--- a/modules/ROOT/examples/live-demos/mentions/index.html
+++ b/modules/ROOT/examples/live-demos/mentions/index.html
@@ -26,8 +26,8 @@
         <td><strong>Yes!</strong></td>
       </tr>
       <tr>
-        <td>Plupload</td>
-        <td>Free</td>
+        <td>Uploadcare</td>
+        <td>Free tier available</td>
         <td><strong>Yes!</strong></td>
       </tr>
     </tbody>
@@ -39,7 +39,7 @@
 
   <h2>Finally…</h2>
 
-  <p>Don't forget to check out <a href="http://www.plupload.com" target="_blank" rel="noopener">Plupload</a>, the upload solution featuring HTML5 upload support.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE. We hope it helps you and your users create great content.</p>
   <p>All the best from the TinyMCE team.</p>
 

--- a/modules/ROOT/examples/live-demos/noneditable-class/index.html
+++ b/modules/ROOT/examples/live-demos/noneditable-class/index.html
@@ -19,7 +19,7 @@
 
   <h2>Finally…</h2>
 
-  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE. We hope it helps you and your users create great content.</p>
   <p>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/noneditable-class/index.html
+++ b/modules/ROOT/examples/live-demos/noneditable-class/index.html
@@ -19,7 +19,7 @@
 
   <h2>Finally…</h2>
 
-  <p>Don’t forget to check out <a href="http://www.plupload.com" target="_blank">Plupload</a>, the upload solution featuring HTML5 upload support.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE. We hope it helps you and your users create great content.</p>
   <p>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/noneditable-regexp/index.html
+++ b/modules/ROOT/examples/live-demos/noneditable-regexp/index.html
@@ -29,7 +29,7 @@
 
   <h2>Finally…</h2>
 
-  <p>Don’t forget to check out <a href="http://www.plupload.com" target="_blank">Plupload</a>, the upload solution featuring HTML5 upload support.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE. We hope it helps you and your users create great content.</p>
   <p>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/noneditable-regexp/index.html
+++ b/modules/ROOT/examples/live-demos/noneditable-regexp/index.html
@@ -29,7 +29,7 @@
 
   <h2>Finally…</h2>
 
-  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE. We hope it helps you and your users create great content.</p>
   <p>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/notifications/index.html
+++ b/modules/ROOT/examples/live-demos/notifications/index.html
@@ -5,7 +5,7 @@
   <h2>Got questions or need help?</h2>
 
   <ul>
-    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>
@@ -22,9 +22,9 @@
     </thead>
     <tbody>
       <tr>
-        <td>TinyMCE</td>
-        <td>Free</td>
-        <td>YES!</td>
+        <td style="text-align: center;">TinyMCE</td>
+        <td style="text-align: center;">Free</td>
+        <td style="text-align: center;">YES!</td>
       </tr>
     </tbody>
   </table>

--- a/modules/ROOT/examples/live-demos/open-source-plugins/index.html
+++ b/modules/ROOT/examples/live-demos/open-source-plugins/index.html
@@ -26,8 +26,8 @@
         <td>YES!</td>
       </tr>
       <tr>
-        <td>Plupload</td>
-        <td>Free</td>
+        <td>Uploadcare</td>
+        <td>Free tier available</td>
         <td>YES!</td>
       </tr>
     </tbody>
@@ -37,6 +37,6 @@
   <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
 
   <h2>Finally ...</h2>
-  <p>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/open-source-plugins/index.html
+++ b/modules/ROOT/examples/live-demos/open-source-plugins/index.html
@@ -5,7 +5,7 @@
 
   <h2>Got questions or need help?</h2>
   <ul>
-    <li>Our <a class="mceNonEditable" href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a class="mceNonEditable" href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>
@@ -21,14 +21,9 @@
     </thead>
     <tbody>
       <tr>
-        <td>TinyMCE Cloud</td>
-        <td>Get started for free</td>
-        <td>YES!</td>
-      </tr>
-      <tr>
-        <td>Uploadcare</td>
-        <td>Free tier available</td>
-        <td>YES!</td>
+        <td style="text-align: center;">TinyMCE Cloud</td>
+        <td style="text-align: center;">Get started for free</td>
+        <td style="text-align: center;">YES!</td>
       </tr>
     </tbody>
   </table>
@@ -37,6 +32,6 @@
   <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
 
   <h2>Finally ...</h2>
-  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/page-embed/index.html
+++ b/modules/ROOT/examples/live-demos/page-embed/index.html
@@ -6,7 +6,7 @@
   <h2>Got questions or need help?</h2>
 
   <ul>
-    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>
@@ -23,14 +23,9 @@
     </thead>
     <tbody>
       <tr>
-        <td>TinyMCE</td>
-        <td>Free</td>
-        <td>YES!</td>
-      </tr>
-      <tr>
-        <td>Uploadcare</td>
-        <td>Free tier available</td>
-        <td>YES!</td>
+        <td style="text-align: center;">TinyMCE</td>
+        <td style="text-align: center;">Free</td>
+        <td style="text-align: center;">YES!</td>
       </tr>
     </tbody>
   </table>
@@ -44,7 +39,7 @@
   <h2>Finally ...</h2>
 
   <p>
-    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
+    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
   </p>
   <p>
     Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.

--- a/modules/ROOT/examples/live-demos/page-embed/index.html
+++ b/modules/ROOT/examples/live-demos/page-embed/index.html
@@ -28,8 +28,8 @@
         <td>YES!</td>
       </tr>
       <tr>
-        <td>Plupload</td>
-        <td>Free</td>
+        <td>Uploadcare</td>
+        <td>Free tier available</td>
         <td>YES!</td>
       </tr>
     </tbody>
@@ -44,7 +44,7 @@
   <h2>Finally ...</h2>
 
   <p>
-    Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.
+    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
   </p>
   <p>
     Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.

--- a/modules/ROOT/examples/live-demos/paste-from-word/index.html
+++ b/modules/ROOT/examples/live-demos/paste-from-word/index.html
@@ -1,7 +1,7 @@
 <textarea id="paste-from-word">
   {{logofordemoshtmlright}}
   <h2>TinyMCE demo: PowerPaste plugin!</h2>
-  <p>PREMIUM PLUGIN: The TinyMCE <a href="{{site-url}}/tinymce/6/introduction-to-powerpaste/">PowerPaste plugin</a> automatically cleans up and transfers content &amp; images from Microsoft Word and HTML sources to ensure clean, compliant content that matches the look and feel of the site.</p>
+  <p>PREMIUM PLUGIN: The TinyMCE <a href="{{site-url}}/tinymce/7/introduction-to-powerpaste/">PowerPaste plugin</a> automatically cleans up and transfers content &amp; images from Microsoft Word and HTML sources to ensure clean, compliant content that matches the look and feel of the site.</p>
   <p>COPY AND PASTE FROM WORD or EXCEL</p>
   <ol>
     <li>Copy and paste content from Microsoft Word or Excel into this editor.</li>
@@ -19,7 +19,7 @@
   <hr>
   <h2>Got questions or need help?</h2>
   <ul>
-    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>

--- a/modules/ROOT/examples/live-demos/permanent-pen/index.html
+++ b/modules/ROOT/examples/live-demos/permanent-pen/index.html
@@ -6,7 +6,7 @@
    <h2>Got questions or need help?</h2>
 
   <ul>
-    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>
@@ -23,14 +23,9 @@
     </thead>
     <tbody>
       <tr>
-        <td>TinyMCE</td>
-        <td>Free</td>
-        <td>YES!</td>
-      </tr>
-      <tr>
-        <td>Uploadcare</td>
-        <td>Free tier available</td>
-        <td>YES!</td>
+        <td style="text-align: center;">TinyMCE</td>
+        <td style="text-align: center;">Free</td>
+        <td style="text-align: center;">YES!</td>
       </tr>
     </tbody>
   </table>
@@ -44,7 +39,7 @@
   <h2>Finally ...</h2>
 
   <p>
-    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
+    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
   </p>
   <p>
     Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.

--- a/modules/ROOT/examples/live-demos/permanent-pen/index.html
+++ b/modules/ROOT/examples/live-demos/permanent-pen/index.html
@@ -28,8 +28,8 @@
         <td>YES!</td>
       </tr>
       <tr>
-        <td>Plupload</td>
-        <td>Free</td>
+        <td>Uploadcare</td>
+        <td>Free tier available</td>
         <td>YES!</td>
       </tr>
     </tbody>
@@ -44,7 +44,7 @@
   <h2>Finally ...</h2>
 
   <p>
-    Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.
+    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
   </p>
   <p>
     Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.

--- a/modules/ROOT/examples/live-demos/revisionhistory/index.html
+++ b/modules/ROOT/examples/live-demos/revisionhistory/index.html
@@ -18,14 +18,9 @@
     </thead>
     <tbody>
       <tr>
-        <td>TinyMCE Cloud</td>
-        <td>Get started for free</td>
-        <td><strong>Yes!</strong></td>
-      </tr>
-      <tr>
-        <td>Uploadcare</td>
-        <td>Free tier available</td>
-        <td><strong>Yes!</strong></td>
+        <td style="text-align: center;">TinyMCE Cloud</td>
+        <td style="text-align: center;">Get started for free</td>
+        <td style="text-align: center;"><strong>Yes!</strong></td>
       </tr>
     </tbody>
   </table>
@@ -44,7 +39,7 @@
 
   <h2>Finally…</h2>
 
-  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
 
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.</p>
 

--- a/modules/ROOT/examples/live-demos/revisionhistory/index.html
+++ b/modules/ROOT/examples/live-demos/revisionhistory/index.html
@@ -23,8 +23,8 @@
         <td><strong>Yes!</strong></td>
       </tr>
       <tr>
-        <td>Plupload</td>
-        <td>Free</td>
+        <td>Uploadcare</td>
+        <td>Free tier available</td>
         <td><strong>Yes!</strong></td>
       </tr>
     </tbody>
@@ -44,7 +44,7 @@
 
   <h2>Finally…</h2>
 
-  <p>Don’t forget to check out our other product <a href="http://plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
 
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.</p>
 

--- a/modules/ROOT/examples/live-demos/revisionhistory/index.js
+++ b/modules/ROOT/examples/live-demos/revisionhistory/index.js
@@ -29,8 +29,8 @@ const revisions = [
       <td>YES!</td>
       </tr>
       <tr>
-      <td>Plupload</td>
-      <td>Free</td>
+      <td>Uploadcare</td>
+      <td>Free tier available</td>
       <td>YES!</td>
       </tr>
       </tbody>
@@ -38,7 +38,7 @@ const revisions = [
       <h2>Found a bug?</h2>
       <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
       <h2>Finally ...</h2>
-      <p><s>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank" rel="noopener">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</s></p>
+      <p><s>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</s></p>
       <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
     `,
   },
@@ -75,8 +75,8 @@ const revisions = [
       <td>YES!</td>
       </tr>
       <tr>
-      <td>Plupload</td>
-      <td>Free</td>
+      <td>Uploadcare</td>
+      <td>Free tier available</td>
       <td>YES!</td>
       </tr>
       </tbody>
@@ -84,7 +84,7 @@ const revisions = [
       <h2>Found a bug?</h2>
       <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
       <h2>Finally ...</h2>
-      <p>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank" rel="noopener">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
+      <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
       <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
     `,
   },
@@ -121,8 +121,8 @@ const revisions = [
       <td>YES!</td>
       </tr>
       <tr>
-      <td>Plupload</td>
-      <td>Free</td>
+      <td>Uploadcare</td>
+      <td>Free tier available</td>
       <td>YES!</td>
       </tr>
       </tbody>
@@ -130,7 +130,7 @@ const revisions = [
       <h2>Found a bug?</h2>
       <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
       <h2>Finally ...</h2>
-      <p>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank" rel="noopener">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
+      <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
       <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
     `,
   }

--- a/modules/ROOT/examples/live-demos/revisionhistory/index.js
+++ b/modules/ROOT/examples/live-demos/revisionhistory/index.js
@@ -24,21 +24,16 @@ const revisions = [
       </thead>
       <tbody>
       <tr>
-      <td>TinyMCE</td>
-      <td>Free</td>
-      <td>YES!</td>
-      </tr>
-      <tr>
-      <td>Uploadcare</td>
-      <td>Free tier available</td>
-      <td>YES!</td>
+      <td style="text-align: center;">TinyMCE</td>
+      <td style="text-align: center;">Free</td>
+      <td style="text-align: center;">YES!</td>
       </tr>
       </tbody>
       </table>
       <h2>Found a bug?</h2>
       <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
       <h2>Finally ...</h2>
-      <p><s>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</s></p>
+      <p><s>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</s></p>
       <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
     `,
   },
@@ -70,21 +65,16 @@ const revisions = [
       </thead>
       <tbody>
       <tr>
-      <td>TinyMCE</td>
-      <td>Free</td>
-      <td>YES!</td>
-      </tr>
-      <tr>
-      <td>Uploadcare</td>
-      <td>Free tier available</td>
-      <td>YES!</td>
+      <td style="text-align: center;">TinyMCE</td>
+      <td style="text-align: center;">Free</td>
+      <td style="text-align: center;">YES!</td>
       </tr>
       </tbody>
       </table>
       <h2>Found a bug?</h2>
       <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
       <h2>Finally ...</h2>
-      <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+      <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
       <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
     `,
   },
@@ -116,21 +106,16 @@ const revisions = [
       </thead>
       <tbody>
       <tr>
-      <td>TinyMCE</td>
-      <td>Free</td>
-      <td>YES!</td>
-      </tr>
-      <tr>
-      <td>Uploadcare</td>
-      <td>Free tier available</td>
-      <td>YES!</td>
+      <td style="text-align: center;">TinyMCE</td>
+      <td style="text-align: center;">Free</td>
+      <td style="text-align: center;">YES!</td>
       </tr>
       </tbody>
       </table>
       <h2>Found a bug?</h2>
       <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
       <h2>Finally ...</h2>
-      <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+      <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
       <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
     `,
   }

--- a/modules/ROOT/examples/live-demos/tableofcontents/index.html
+++ b/modules/ROOT/examples/live-demos/tableofcontents/index.html
@@ -42,7 +42,7 @@
 
   <h2 id="conclusion">Finally...</h2>
   <p>
-    Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.
+    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
   </p>
   <p>
     Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.

--- a/modules/ROOT/examples/live-demos/tableofcontents/index.html
+++ b/modules/ROOT/examples/live-demos/tableofcontents/index.html
@@ -30,7 +30,7 @@
 
   <h2 id="got-questions-or-need-help">Got questions or need help?</h2>
   <ul>
-    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>
@@ -42,7 +42,7 @@
 
   <h2 id="conclusion">Finally...</h2>
   <p>
-    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
+    Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.
   </p>
   <p>
     Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.

--- a/modules/ROOT/examples/live-demos/ui-mode/index.html
+++ b/modules/ROOT/examples/live-demos/ui-mode/index.html
@@ -10,7 +10,7 @@
 
     <h2>Got questions or need help?</h2>
     <ul>
-      <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+      <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
       <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
       <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium subscriptions</a>.</li>
     </ul>
@@ -26,14 +26,9 @@
       </thead>
       <tbody>
         <tr>
-          <td>TinyMCE Cloud</td>
-          <td>Get started for free</td>
-          <td>YES!</td>
-        </tr>
-        <tr>
-          <td>Uploadcare</td>
-          <td>Free tier available</td>
-          <td>YES!</td>
+          <td style="text-align: center;">TinyMCE Cloud</td>
+          <td style="text-align: center;">Get started for free</td>
+          <td style="text-align: center;">YES!</td>
         </tr>
       </tbody>
     </table>
@@ -42,7 +37,7 @@
     <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
 
     <h2>Finally ...</h2>
-    <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+    <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
     <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
   </textarea>
 </div> 

--- a/modules/ROOT/examples/live-demos/ui-mode/index.html
+++ b/modules/ROOT/examples/live-demos/ui-mode/index.html
@@ -31,8 +31,8 @@
           <td>YES!</td>
         </tr>
         <tr>
-          <td>Plupload</td>
-          <td>Free</td>
+          <td>Uploadcare</td>
+          <td>Free tier available</td>
           <td>YES!</td>
         </tr>
       </tbody>
@@ -42,7 +42,7 @@
     <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
 
     <h2>Finally ...</h2>
-    <p>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
+    <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
     <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
   </textarea>
 </div> 

--- a/modules/ROOT/examples/live-demos/valid-elements/index.html
+++ b/modules/ROOT/examples/live-demos/valid-elements/index.html
@@ -25,8 +25,8 @@
         <td>YES!</td>
       </tr>
       <tr>
-        <td>Plupload</td>
-        <td>Free</td>
+        <td>Uploadcare</td>
+        <td>Free tier available</td>
         <td>YES!</td>
       </tr>
     </tbody>
@@ -36,6 +36,6 @@
   <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
 
   <h2>Finally ...</h2>
-  <p>Don't forget to check out our other product <a href="http://www.plupload.com" target="_blank">Plupload</a>, your ultimate upload solution featuring HTML5 upload support.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
 </textarea>

--- a/modules/ROOT/examples/live-demos/valid-elements/index.html
+++ b/modules/ROOT/examples/live-demos/valid-elements/index.html
@@ -4,7 +4,7 @@
 
   <h2>Got questions or need help?</h2>
   <ul>
-    <li>Our <a href="{{site-url}}/tinymce/6/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
+    <li>Our <a href="{{site-url}}/tinymce/7/">documentation</a> is a great resource for learning how to configure TinyMCE.</li>
     <li>Have a specific question? Try the <a href="{{communitysupporturl}}" target="_blank" rel="noopener"><code>{{prodnamecode}}</code> tag at Stack Overflow</a>.</li>
     <li>We also offer enterprise grade support as part of <a href="{{pricingpage}}">TinyMCE premium plans</a>.</li>
   </ul>
@@ -20,14 +20,9 @@
     </thead>
     <tbody>
       <tr>
-        <td>TinyMCE</td>
-        <td>Free</td>
-        <td>YES!</td>
-      </tr>
-      <tr>
-        <td>Uploadcare</td>
-        <td>Free tier available</td>
-        <td>YES!</td>
+        <td style="text-align: center;">TinyMCE</td>
+        <td style="text-align: center;">Free</td>
+        <td style="text-align: center;">YES!</td>
       </tr>
     </tbody>
   </table>
@@ -36,6 +31,6 @@
   <p>If you think you have found a bug please create an issue on the <a href="https://github.com/tinymce/tinymce/issues">GitHub repo</a> to report it to the developers.</p>
 
   <h2>Finally ...</h2>
-  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/latest/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
+  <p>Need file uploads in your app? Consider using <a href="https://www.tiny.cloud/docs/tinymce/7/uploadcare/" target="_blank" rel="noopener noreferrer">Uploadcare</a> with TinyMCE for a fast, modern upload experience.</p>
   <p>Thanks for supporting TinyMCE! We hope it helps you and your users create great content.<br>All the best from the TinyMCE team.</p>
 </textarea>


### PR DESCRIPTION
Ticket: DOC-3321

Example demo update: [basic-demo](http://docs-hotfix-7-doc-3321v7.staging.tiny.cloud/docs/tinymce/7/basic-example/)

Changes:
* Remove link to `plupload` and point to `uploadcare` in `/latest` docs.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed