### PR TITLE
TCLOUD-4780: Fixed the credentials used to delete closed PR previews

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 Ticket: DOC-<num>
 
-Site: [Staging branch](http://docs-<hotfix|feature>-<version>-doc-<num>.staging.tiny.cloud/docs/tinymce/<version>/)
+Site: [Staging branch](https://pr-<PR#>.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/<version>/)
 
 Changes:
 * <placeholder-text>

--- a/.github/workflows/preview_delete.yml
+++ b/.github/workflows/preview_delete.yml
@@ -35,8 +35,8 @@ jobs:
     - name: configure aws credentials
       uses: aws-actions/configure-aws-credentials@v5.0.0
       with:
-        role-to-assume: arn:aws:iam::327995277200:role/staging-docs-preview-update
-        role-session-name: docs-preview-delete
+        role-to-assume: arn:aws:iam::327995277200:role/staging-tinymce-docs-update
+        role-session-name: tinymce-docs-delete
         aws-region: us-east-2
 
     - name: Remove website preview from S3

--- a/.github/workflows/preview_delete.yml
+++ b/.github/workflows/preview_delete.yml
@@ -41,4 +41,4 @@ jobs:
 
     - name: Remove website preview from S3
       run: |
-        aws s3 rm s3://tiny-cloud-antora-docs-preview/${PR}
+        aws s3 rm --recursive s3://tiny-cloud-antora-docs-preview/${PR}


### PR DESCRIPTION
Changes:
* Allow previews to be successfully deleted by assuming an IAM role that actually exists...

This problem was identified when the previous PR in this chain was closed and the deletion task failed:
https://github.com/tinymce/tinymce-docs/actions/runs/19491415346

Review:
- [x] Documentation Team Lead has reviewed