### PR TITLE
TCLOUD-4780: Add workflows to create and delete previews for TinyMCE 5 branches

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 Ticket: DOC-<num>
 
-Site: [DOC-<num> site](http://docs-<hotfix/feature>-5-doc-<num>.staging.tiny.cloud/docs/tinymce/5/)
+Site: [DOC-<num> site](http://pr-<PR#>.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/5/)
 
 Changes:
 * <placeholder-text>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 Ticket: DOC-<num>
 
-Site: [DOC-<num> site](http://pr-<PR#>.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/5/)
+Site: [DOC-<num> site](https://pr-<PR#>.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/5/)
 
 Changes:
 * <placeholder-text>

--- a/.github/workflows/preview_create.yml
+++ b/.github/workflows/preview_create.yml
@@ -1,0 +1,76 @@
+name: Preview Create/Update
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+
+# Need ID token write permission to use OIDC
+permissions:
+  id-token: write
+
+env:
+  PR: pr-${{ github.event.number }}
+  RUN: run-${{ github.run_number }}-${{ github.run_attempt }}
+
+jobs:
+
+  build:
+    name: Update Docs Preview
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Checkout branch
+      uses: actions/checkout@v5
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v5
+      with:
+        cache: 'yarn'
+        node-version: 24
+
+    - name: Install dependencies
+      run: yarn install
+
+    - name: Build Website
+      run: yarn antora ./antora-playbook.yml
+
+    - name: Rename site folder to docs
+      run: |
+        mv ./build/site ./build/docs
+
+    - name: Rename sitemap.xml to antora-sitemap.xml
+      run: |
+        mv ./build/docs/sitemap.xml ./build/docs/antora-sitemap.xml
+
+    - name: configure aws credentials
+      uses: aws-actions/configure-aws-credentials@v5.0.0
+      with:
+        role-to-assume: arn:aws:iam::327995277200:role/staging-tinymce-docs-update
+        role-session-name: tinymce-docs-update
+        aws-region: us-east-1
+
+    - name: Upload website preview to S3
+      run: |
+        aws s3 sync ./build s3://tiny-cloud-antora-docs-preview/${PR}/${RUN}
+
+    - name: Create redirects on S3
+      uses: tinymce/tinymce-docs-generate-redirects-action@v1.0
+      with:
+        build: ./build/
+        redirects: https://raw.githubusercontent.com/tinymce/tinymce-docs/refs/heads/main/redirects.json
+        bucket: tiny-cloud-antora-docs-preview
+        prefix: ${{ env.PR }}/${{ env.RUN }}
+        parallel: 10
+
+    - name: Update pointer to current run output
+      run: |
+        aws s3api put-object --bucket tiny-cloud-antora-docs-preview --key ${PR}/index.html --body .github/workflows/resources/empty.html --content-type text/html --metadata pointer=${RUN}

--- a/.github/workflows/preview_delete.yml
+++ b/.github/workflows/preview_delete.yml
@@ -1,0 +1,44 @@
+name: Preview Delete
+
+on:
+  pull_request:
+    types:
+      - closed
+
+# Need ID token write permission to use OIDC
+permissions:
+  id-token: write
+
+env:
+  PR: pr-${{ github.event.number }}
+
+jobs:
+  cleanup:
+    name: Cleanup Docs Preview
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Checkout branch
+      uses: actions/checkout@v5
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v5
+      with:
+        cache: 'yarn'
+        node-version: 24
+
+    - name: configure aws credentials
+      uses: aws-actions/configure-aws-credentials@v5.0.0
+      with:
+        role-to-assume: arn:aws:iam::327995277200:role/staging-tinymce-docs-update
+        role-session-name: tinymce-docs-delete
+        aws-region: us-east-2
+
+    - name: Remove website preview from S3
+      run: |
+        aws s3 rm --recursive s3://tiny-cloud-antora-docs-preview/${PR}

--- a/.github/workflows/resources/empty.html
+++ b/.github/workflows/resources/empty.html
@@ -1,0 +1,1 @@
+<!doctype html><title>?</title>


### PR DESCRIPTION
Ticket: TCLOUD-4780

Site: [Staging branch](https://pr-3921.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/5/)

Changes:
* Added workflows to create and delete previews at `https://pr-NUM.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/`
* Updated pull request template to use new docs preview.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed