### PR TITLE
DOC-3224:  `powerpaste_emf_processor` function that takes an emf blob and should return a promise of a png blob.

### DIFF
--- a/modules/ROOT/pages/8.3.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.3.0-release-notes.adoc
@@ -40,7 +40,7 @@ Before October 2025, copying and pasting content from Microsoft Word containing 
 
 This change negatively affected the user experience. After October 2025, users would see a low-quality image alongside an error message stating `Some images failed to import`, which caused confusion since the image was, in fact, visible in the editor—albeit with degraded quality.
 
-{productname} {release-version} introduces a new option, xref:powerpaste_emf_processor.adoc#powerpaste_emf_processor[powerpaste_emf_processor], to address this issue. This option accepts a function that receives an `emf` blob and returns a promise resolving to a `png` blob (i.e. `(blob: Blob) => Promise<Blob>`).
+{productname} {release-version} introduces a new option, xref:powerpaste-options.adoc#powerpaste_emf_processor[powerpaste_emf_processor], to address this issue. This option accepts a function that receives an `emf` blob and returns a promise resolving to a `png` blob (i.e. `(blob: Blob) => Promise<Blob>`).
 
 * If this option is provided, the editor will invoke the supplied function to convert `emf` image blobs into `png` image blobs before inserting them into the editor.
 

--- a/modules/ROOT/pages/8.3.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.3.0-release-notes.adoc
@@ -28,13 +28,27 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
-// === <Premium plugin name 1> <Premium plugin name 1 version>
+=== PowerPaste
 
-// The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+The {productname} {release-version} release includes an accompanying release of the **PowerPaste** premium plugin.
 
-// **<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+**PowerPaste** includes the following addition.
 
-// ==== <Premium plugin name 1 change 1>
+==== `powerpaste_emf_processor` function that takes an `emf` blob and returns a promise of a `png` blob.
+
+Before October 2025, copying and pasting content from Microsoft Word containing `emf` images resulted in those images not being pasted and an error message being displayed. After October 2025, this behavior changed where the images began appearing in the editor, but only at low resolution, accompanied by an error message in Chrome and Firefox. Safari displayed the low-resolution images without showing an error message.
+
+This change negatively affected the user experience. After October 2025, users would see a low-quality image alongside an error message stating `Some images failed to import`, which caused confusion since the image was, in fact, visible in the editor—albeit with degraded quality.
+
+{productname} {release-version} introduces a new option, xref:powerpaste_emf_processor.adoc#powerpaste_emf_processor[powerpaste_emf_processor], to address this issue. This option accepts a function that receives an `emf` blob and returns a promise resolving to a `png` blob (i.e. `(blob: Blob) => Promise<Blob>`).
+
+* If this option is provided, the editor will invoke the supplied function to convert `emf` image blobs into `png` image blobs before inserting them into the editor.
+
+* If this option is **not** provided, the editor will remove the low-quality images and display an error message, restoring the pre–October 2025 behavior.
+
+NOTE: If only the image is selected, pasting it will succeed and the image will be inserted correctly. However, if the image is selected together with other types of content, such as text, the image will not be pasted and an error message will be displayed.
+
+For information on the **PowerPaste** plugin, see: xref:introduction-to-powerpaste.adoc[PowerPaste].
 
 // // CCFR here.
 
@@ -128,4 +142,3 @@ There <is one | are <number> known issue<s> in {productname} {release-version}.
 // #TINY-vwxyz1
 
 // CCFR here.
-

--- a/modules/ROOT/pages/powerpaste-options.adoc
+++ b/modules/ROOT/pages/powerpaste-options.adoc
@@ -23,6 +23,8 @@ include::partial$configuration/powerpaste_autolink_urls.adoc[leveloffset=+1]
 
 include::partial$configuration/powerpaste_allow_local_images.adoc[leveloffset=+1]
 
+include::partial$configuration/powerpaste_emf_processor.adoc[leveloffset=+1]
+
 include::partial$configuration/paste_block_drop.adoc[leveloffset=+1]
 
 include::partial$configuration/powerpaste_clean_filtered_inline_elements.adoc[leveloffset=+1]

--- a/modules/ROOT/partials/configuration/powerpaste_emf_processor.adoc
+++ b/modules/ROOT/partials/configuration/powerpaste_emf_processor.adoc
@@ -1,7 +1,7 @@
 [[powerpaste_emf_processor]]
 == `+powerpaste_emf_processor+`
 
-This option controls how `emf` images are handled. If this option **is** provided, `emf` image blobs will be converted into `png` image blobs, which will then be pasted into the editor. If this option is **not** provided, the editor will remove the poor quality images, and show an error message.
+This option controls how `emf` images are handled. If this option **is** provided, `emf` image blobs will be converted into `png` image blobs using the supplied function, which will then be pasted into the editor. If this option is **not** provided, the editor will remove the poor quality images, and show an error message.
 
 *Type:* `+Function+`
 

--- a/modules/ROOT/partials/configuration/powerpaste_emf_processor.adoc
+++ b/modules/ROOT/partials/configuration/powerpaste_emf_processor.adoc
@@ -1,0 +1,20 @@
+[[powerpaste_emf_processor]]
+== `+powerpaste_emf_processor+`
+
+This option controls how `emf` images are handled. If this option **is** provided, `emf` image blobs will be converted into `png` image blobs, which will then be pasted into the editor. If this option is **not** provided, the editor will remove the poor quality images, and show an error message.
+
+*Type:* `+Function+`
+
+=== Example: `+powerpaste_emf_processor+`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  plugins: 'powerpaste',
+  powerpaste_word_import: 'clean',
+  powerpaste_emf_processor: (blob) => {
+	  return fetch('YOUR_IMAGE_URL').then(res => res.blob())
+	}
+  });
+----

--- a/modules/ROOT/partials/configuration/powerpaste_emf_processor.adoc
+++ b/modules/ROOT/partials/configuration/powerpaste_emf_processor.adoc
@@ -18,3 +18,5 @@ tinymce.init({
 	}
   });
 ----
+
+NOTE: If only the image is selected, pasting it will succeed and the image will be inserted correctly. However, if the image is selected together with other types of content, such as text, the image will not be pasted and an error message will be displayed.


### PR DESCRIPTION
Ticket: DOC-3224

Site: [Release note entry](https://pr-3932.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.3.0-release-notes/#powerpaste_emf_processor-function-that-takes-an-emf-blob-and-returns-a-promise-of-a-png-blob)

Site: [Option documentation](https://pr-3932.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/powerpaste-options/#powerpaste_emf_processor)

Changes:
* Documented the new `powerpaste_emf_processor` option.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed