### PR TITLE
DOC-3224: Show editor notification when a premium plugin is not allowed for a given license key.

### DIFF
--- a/modules/ROOT/pages/8.3.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.3.0-release-notes.adoc
@@ -46,10 +46,12 @@ The following premium plugin updates were released alongside {productname} {rele
 
 {productname} {release-version} also includes the following improvements:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Show editor notification when a premium plugin is not allowed for a given license key.
+// #TINY-12937
 
-// CCFR here.
+Previously, when a premium plugin was not permitted for a given license key, the plugin would be disabled without any corresponding editor message. As of {release-version}, this behaviour has been improved: the editor now displays a notification when a plugin is disabled due to license restrictions, reducing ambiguity.
+
+For more informaton on license keys, see: xref:license-key.adoc[License Key].
 
 
 [[additions]]
@@ -128,4 +130,3 @@ There <is one | are <number> known issue<s> in {productname} {release-version}.
 // #TINY-vwxyz1
 
 // CCFR here.
-

--- a/modules/ROOT/pages/license-key.adoc
+++ b/modules/ROOT/pages/license-key.adoc
@@ -298,7 +298,7 @@ a| * Add the `license_key` parameter to your {productname} configuration
 
 | xref:invalid-plugin[Invalid plugin]
 | The "+${pluginCode}+" plugin requires a valid {productname} license key
-| _No editor message_
+| One or more premium plugins are disabled due to license key restrictions.
 a| * Verify that your license includes access to the premium plugin
 * Check if your license key is valid and not expired
 * Visit the link:https://support.tiny.cloud[Support Portal] if you believe you should have access to this plugin


### PR DESCRIPTION
Ticket: DOC-3224

Release Note Entry: [Staging branch](https://pr-3933.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.3.0-release-notes/#show-editor-notification-when-a-premium-plugin-is-not-allowed-for-a-given-license-key)

Updated License Key error messages table: [Staging branch](https://pr-3933.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/license-key/#license-key-error-messages)

Changes:
* Documented the license key improvement for TINY-12937. Updated the license key error message table to now contain the message `One or more premium plugins are disabled due to license key restrictions.` for the `invalid plugin` case.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed