### PR TITLE
DOC-3224: Accordions could be toggled when the editor was disabled.

### DIFF
--- a/modules/ROOT/pages/8.3.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.3.0-release-notes.adoc
@@ -93,9 +93,9 @@ The following premium plugin updates were released alongside {productname} {rele
 === Accordions could be toggled when the editor was disabled.
 // #TINY-12315
 
-In earlier versions of {productname}, an issue allowed accordions to remain interactive (expandable) even when the editor was disabled. This resulted in unexpected behavior when used alongside the xref:autoresize.adoc[Autoresize plugin].
+Earlier versions of {productname} allowed accordions to remain expandable even when the editor was disabled, creating inconsistent and unexpected behavior, particularly when used with the xref:autoresize.adoc[Autoresize plugin].
 
-This issue has been resolved in {release-version}. Accordions are now non-interactive in disabled mode, ensuring the editor behaves as intended. Users can no longer interact with accordions when the editor is disabled.
+This could lead to content changes when none were expected and caused interaction patterns to shift between the intended custom behavior and the browser’s default handling. In {release-version}, this issue has been resolved by ensuring accordions are fully non-interactive when the editor is disabled, preventing unintended state changes and maintaining consistent editor behavior.
 
 
 [[security-fixes]]

--- a/modules/ROOT/pages/8.3.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.3.0-release-notes.adoc
@@ -90,10 +90,12 @@ The following premium plugin updates were released alongside {productname} {rele
 
 {productname} {release-version} also includes the following bug fixes:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Accordions could be toggled when the editor was disabled.
+// #TINY-12315
 
-// CCFR here.
+In earlier versions of {productname}, an issue allowed accordions to remain interactive (expandable) even when the editor was disabled. This resulted in unexpected behavior when used alongside the xref:autoresize.adoc[Autoresize plugin].
+
+This issue has been resolved in {release-version}. Accordions are now non-interactive in disabled mode, ensuring the editor behaves as intended. Users can no longer interact with accordions when the editor is disabled.
 
 
 [[security-fixes]]
@@ -128,4 +130,3 @@ There <is one | are <number> known issue<s> in {productname} {release-version}.
 // #TINY-vwxyz1
 
 // CCFR here.
-


### PR DESCRIPTION
Ticket: DOC-3224

Site: [Staging branch](https://pr-3936.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.3.0-release-notes/#accordions-could-be-toggled-when-the-editor-was-disabled)

Changes:
* Documented the bug fix for TINY-12315

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed