### PR TITLE
DOC-3224: Toolbar split button chevron tooltip is now the same as the main button tooltip unless explicitly set otherwise.

### DIFF
--- a/modules/ROOT/pages/8.3.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.3.0-release-notes.adoc
@@ -90,10 +90,10 @@ The following premium plugin updates were released alongside {productname} {rele
 
 {productname} {release-version} also includes the following bug fixes:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Toolbar split button chevron tooltip is now the same as the main button tooltip unless explicitly set otherwise.
+// #TINY-13271
 
-// CCFR here.
+Previously, an issue was identified where the **Bullet list menu** and **Numbered list menu** did not include translations for the chevron icons. This has been resolved in {release-version}. The chevron icons for these list menus now display correctly translated tooltips on hover.
 
 
 [[security-fixes]]
@@ -128,4 +128,3 @@ There <is one | are <number> known issue<s> in {productname} {release-version}.
 // #TINY-vwxyz1
 
 // CCFR here.
-

--- a/modules/ROOT/pages/8.3.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.3.0-release-notes.adoc
@@ -90,7 +90,7 @@ The following premium plugin updates were released alongside {productname} {rele
 
 {productname} {release-version} also includes the following bug fixes:
 
-=== Toolbar split button chevron tooltip is now the same as the main button tooltip unless explicitly set otherwise.
+=== Tooltip is now translated correctly for the dropdown chevron of the bullet and number list toolbar buttons.
 // #TINY-13271
 
 Previously, an issue was identified where the tooltips for the dropdown chevrons for the **Bullet list** and **Numbered list** toolbar buttons were not translated correctly. This has been resolved in {release-version}. The dropdown chevron of these splitbuttons now displays correctly translated tooltips on hover.

--- a/modules/ROOT/pages/8.3.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.3.0-release-notes.adoc
@@ -93,7 +93,7 @@ The following premium plugin updates were released alongside {productname} {rele
 === Toolbar split button chevron tooltip is now the same as the main button tooltip unless explicitly set otherwise.
 // #TINY-13271
 
-Previously, an issue was identified where the **Bullet list menu** and **Numbered list menu** did not include translations for the chevron icons. This has been resolved in {release-version}. The chevron icons for these list menus now display correctly translated tooltips on hover.
+Previously, an issue was identified where the tooltips for the dropdown chevrons for the **Bullet list** and **Numbered list** toolbar buttons were not translated correctly. This has been resolved in {release-version}. The dropdown chevron of these splitbuttons now displays correctly translated tooltips on hover.
 
 
 [[security-fixes]]


### PR DESCRIPTION
Ticket: DOC-3224

Site: [Staging branch](https://pr-3939.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.3.0-release-notes/#toolbar-split-button-chevron-tooltip-is-now-the-same-as-the-main-button-tooltip-unless-explicitly-set-otherwise)

Changes:
* Documented the bug fix for TINY-13271

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed