### PR TITLE
TCLOUD-4860: Create a workflow for releasing docs

### DIFF
--- a/.github/workflows/deploy_docs_v2.yml
+++ b/.github/workflows/deploy_docs_v2.yml
@@ -54,33 +54,33 @@ jobs:
       run: |
         mv ./build/docs/sitemap.xml ./build/docs/antora-sitemap.xml
 
-    # - name: configure aws credentials
-    #   uses: aws-actions/configure-aws-credentials@v5.0.0
-    #   with:
-    #     role-to-assume: 'arn:aws:iam::${{ env.ACCT }}:role/${{ inputs.environment }}-tinymce-docs-update'
-    #     role-session-name: tinymce-docs-${{ inputs.environment }}-release
-    #     aws-region: us-east-1
+    - name: configure aws credentials
+      uses: aws-actions/configure-aws-credentials@v5.0.0
+      with:
+        role-to-assume: 'arn:aws:iam::${{ env.ACCT }}:role/${{ inputs.environment }}-tinymce-docs-update'
+        role-session-name: tinymce-docs-${{ inputs.environment }}-release
+        aws-region: us-east-1
 
-    # - name: Upload website preview to S3
-    #   run: |
-    #     aws s3 sync ./build s3://${BUCKET}/main/${RUN}
+    - name: Upload website preview to S3
+      run: |
+        aws s3 sync ./build s3://${BUCKET}/main/${RUN}
 
-    # - name: Create redirects on S3
-    #   uses: tinymce/tinymce-docs-generate-redirects-action@v1.0
-    #   with:
-    #     build: ./build/
-    #     redirects: ./redirects.json
-    #     bucket: ${{ env.BUCKET }}
-    #     prefix: main/${{ env.RUN }}
-    #     parallel: 10
+    - name: Create redirects on S3
+      uses: tinymce/tinymce-docs-generate-redirects-action@v1.0
+      with:
+        build: ./build/
+        redirects: ./redirects.json
+        bucket: ${{ env.BUCKET }}
+        prefix: main/${{ env.RUN }}
+        parallel: 10
 
-    # - name: Update pointer to current run output
-    #   run: |
-    #     aws s3api put-object --bucket ${BUCKET} --key main/index.html --body .github/workflows/resources/empty.html --content-type text/html --metadata pointer=${RUN}
+    - name: Update pointer to current run output
+      run: |
+        aws s3api put-object --bucket ${BUCKET} --key main/index.html --body .github/workflows/resources/empty.html --content-type text/html --metadata pointer=${RUN}
 
-    # - name: Tag old versions for cleanup
-    #   uses: tinymce/tinymce-docs-cleanup-action@v0.1
-    #   with:
-    #     bucket: ${{ env.BUCKET }}
-    #     folder: main
-    #     parallel: 20
+    - name: Tag old versions for cleanup
+      uses: tinymce/tinymce-docs-cleanup-action@v0.1
+      with:
+        bucket: ${{ env.BUCKET }}
+        folder: main
+        parallel: 20

--- a/.github/workflows/deploy_docs_v2.yml
+++ b/.github/workflows/deploy_docs_v2.yml
@@ -84,7 +84,7 @@ jobs:
         aws s3api put-object --bucket ${BUCKET} --key main/index.html --body .github/workflows/resources/empty.html --content-type text/html --metadata pointer=${RUN}
 
     - name: Tag old versions for cleanup
-      uses: tinymce/tinymce-docs-cleanup-action@v0.1
+      uses: tinymce/tinymce-docs-cleanup-action@v1.0
       with:
         bucket: ${{ env.BUCKET }}
         folder: main

--- a/.github/workflows/deploy_docs_v2.yml
+++ b/.github/workflows/deploy_docs_v2.yml
@@ -11,7 +11,6 @@ on:
         options:
         - 'staging'
         - 'production'
-  push:
 
 # Need ID token write permission to use OIDC
 permissions:

--- a/.github/workflows/deploy_docs_v2.yml
+++ b/.github/workflows/deploy_docs_v2.yml
@@ -18,8 +18,10 @@ permissions:
   id-token: write
 
 env:
-  # inputs are only defined on a dispatch event, so to test we provide a default...
   TARGET: ${{ inputs.environment || 'staging' }}
+  ACCT: ${{ inputs.environment == 'production' && '990880627107' || '327995277200' }}
+  BUCKET: ${{ inputs.environment == 'production' && 'tiny-cloud-antora-docs-release' || 'tiny-cloud-antora-docs-preview' }}
+  RUN: run-${{ github.run_number }}-${{ github.run_attempt }}
 
 jobs:
   build:
@@ -27,12 +29,9 @@ jobs:
 
     if: github.repository == 'tinymce/tinymce-docs' && github.repository_owner == 'tinymce'
 
-    runs-on: ubuntu-latest
-
     env:
-      ACCT: ${{ env.TARGET == 'production' && '990880627107' || '327995277200' }}
-      BUCKET: ${{ env.TARGET == 'production' && 'tiny-cloud-antora-docs-release' || 'tiny-cloud-antora-docs-preview' }}
-      RUN: run-${{ github.run_number }}-${{ github.run_attempt }}
+
+    runs-on: ubuntu-latest
 
     defaults:
       run:

--- a/.github/workflows/deploy_docs_v2.yml
+++ b/.github/workflows/deploy_docs_v2.yml
@@ -18,6 +18,7 @@ permissions:
   id-token: write
 
 env:
+  ENVNAME: ${{ inputs.environment }}
   ACCT: ${{ inputs.environment == 'production' && '990880627107' || '327995277200' }}
   BUCKET: ${{ inputs.environment == 'production' && 'tiny-cloud-antora-docs-release' || 'tiny-cloud-antora-docs-preview' }}
   RUN: run-${{ github.run_number }}-${{ github.run_attempt }}
@@ -61,8 +62,8 @@ jobs:
     - name: configure aws credentials
       uses: aws-actions/configure-aws-credentials@v5.0.0
       with:
-        role-to-assume: 'arn:aws:iam::${{ env.ACCT }}:role/${{ inputs.environment }}-tinymce-docs-update'
-        role-session-name: tinymce-docs-${{ inputs.environment }}-release
+        role-to-assume: 'arn:aws:iam::${{ env.ACCT }}:role/${{ env.ENVNAME }}-tinymce-docs-update'
+        role-session-name: tinymce-docs-${{ env.ENVNAME }}-release
         aws-region: us-east-1
 
     - name: Upload website preview to S3

--- a/.github/workflows/deploy_docs_v2.yml
+++ b/.github/workflows/deploy_docs_v2.yml
@@ -13,6 +13,10 @@ on:
         - 'production'
   push:
 
+# Need ID token write permission to use OIDC
+permissions:
+  id-token: write
+
 env:
   ACCT: ${{ inputs.environment == 'production' && '990880627107' || '327995277200' }}
   BUCKET: ${{ inputs.environment == 'production' && 'tiny-cloud-antora-docs-release' || 'tiny-cloud-antora-docs-preview' }}

--- a/.github/workflows/deploy_docs_v2.yml
+++ b/.github/workflows/deploy_docs_v2.yml
@@ -1,0 +1,85 @@
+name: Deploy Tiny Docs v2
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Deployment Environment'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+        - 'staging'
+        - 'production'
+
+env:
+  ACCT: ${{ inputs.environment == 'production' && '990880627107' || '327995277200' }}
+  BUCKET: ${{ inputs.environment == 'production' && 'tiny-cloud-antora-docs-release' || 'tiny-cloud-antora-docs-preview' }}
+  RUN: run-${{ github.run_number }}-${{ github.run_attempt }}
+
+jobs:
+  build:
+    name: Build Docs and Deploy
+
+    if: github.repository == 'tinymce/tinymce-docs' && github.repository_owner == 'tinymce'
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Checkout branch
+      uses: actions/checkout@v5
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v5
+      with:
+        cache: 'yarn'
+        node-version: 24
+
+    - name: Install dependencies
+      run: yarn install
+
+    - name: Build Website
+      run: yarn antora ./antora-playbook.yml
+
+    - name: Rename site folder to docs
+      run: |
+        mv ./build/site ./build/docs
+
+    - name: Rename sitemap.xml to antora-sitemap.xml
+      run: |
+        mv ./build/docs/sitemap.xml ./build/docs/antora-sitemap.xml
+
+    - name: configure aws credentials
+      uses: aws-actions/configure-aws-credentials@v5.0.0
+      with:
+        role-to-assume: 'arn:aws:iam::${{ env.ACCT }}:role/${{ inputs.environment }}-tinymce-docs-update'
+        role-session-name: tinymce-docs-${{ inputs.environment }}-release
+        aws-region: us-east-1
+
+    - name: Upload website preview to S3
+      run: |
+        aws s3 sync ./build s3://${BUCKET}/main/${RUN}
+
+    - name: Create redirects on S3
+      uses: tinymce/tinymce-docs-generate-redirects-action@v1.0
+      with:
+        build: ./build/
+        redirects: ./redirects.json
+        bucket: ${{ env.BUCKET }}
+        prefix: main/${{ env.RUN }}
+        parallel: 10
+
+    - name: Update pointer to current run output
+      run: |
+        aws s3api put-object --bucket ${BUCKET} --key main/index.html --body .github/workflows/resources/empty.html --content-type text/html --metadata pointer=${RUN}
+
+    - name: Tag old versions for cleanup
+      uses: tinymce/tinymce-docs-cleanup-action@v0.1
+      with:
+        bucket: ${{ env.BUCKET }}
+        folder: main
+        parallel: 20

--- a/.github/workflows/deploy_docs_v2.yml
+++ b/.github/workflows/deploy_docs_v2.yml
@@ -18,10 +18,8 @@ permissions:
   id-token: write
 
 env:
-  ENVNAME: ${{ inputs.environment }}
-  ACCT: ${{ inputs.environment == 'production' && '990880627107' || '327995277200' }}
-  BUCKET: ${{ inputs.environment == 'production' && 'tiny-cloud-antora-docs-release' || 'tiny-cloud-antora-docs-preview' }}
-  RUN: run-${{ github.run_number }}-${{ github.run_attempt }}
+  # inputs are only defined on a dispatch event, so to test we provide a default...
+  TARGET: ${{ inputs.environment || 'staging' }}
 
 jobs:
   build:
@@ -30,6 +28,11 @@ jobs:
     if: github.repository == 'tinymce/tinymce-docs' && github.repository_owner == 'tinymce'
 
     runs-on: ubuntu-latest
+
+    env:
+      ACCT: ${{ env.TARGET == 'production' && '990880627107' || '327995277200' }}
+      BUCKET: ${{ env.TARGET == 'production' && 'tiny-cloud-antora-docs-release' || 'tiny-cloud-antora-docs-preview' }}
+      RUN: run-${{ github.run_number }}-${{ github.run_attempt }}
 
     defaults:
       run:
@@ -62,8 +65,8 @@ jobs:
     - name: configure aws credentials
       uses: aws-actions/configure-aws-credentials@v5.0.0
       with:
-        role-to-assume: 'arn:aws:iam::${{ env.ACCT }}:role/${{ env.ENVNAME }}-tinymce-docs-update'
-        role-session-name: tinymce-docs-${{ env.ENVNAME }}-release
+        role-to-assume: 'arn:aws:iam::${{ env.ACCT }}:role/${{ env.TARGET }}-tinymce-docs-update'
+        role-session-name: tinymce-docs-${{ env.TARGET }}-release
         aws-region: us-east-1
 
     - name: Upload website preview to S3

--- a/.github/workflows/deploy_docs_v2.yml
+++ b/.github/workflows/deploy_docs_v2.yml
@@ -21,6 +21,7 @@ env:
   TARGET: ${{ inputs.environment || 'staging' }}
   ACCT: ${{ inputs.environment == 'production' && '990880627107' || '327995277200' }}
   BUCKET: ${{ inputs.environment == 'production' && 'tiny-cloud-antora-docs-release' || 'tiny-cloud-antora-docs-preview' }}
+  DISTRIBUTION: ${{ inputs.environment == 'production' && 'E3LFU502SQ5UR' || 'E7DUUPEI08HNW'}}
   RUN: run-${{ github.run_number }}-${{ github.run_attempt }}
 
 jobs:
@@ -89,3 +90,11 @@ jobs:
         bucket: ${{ env.BUCKET }}
         folder: main
         parallel: 20
+
+    - name: Invalidate Cloudfront Cache
+      # sleep to wait for envoy's version pointer caching to expire
+      run: |
+        sleep 30s
+        aws cloudfront create-invalidation --distribution-id ${{ env.DISTRIBUTION }} --paths "/docs/*"
+      env:
+        AWS_EC2_METADATA_DISABLED: true

--- a/.github/workflows/deploy_docs_v2.yml
+++ b/.github/workflows/deploy_docs_v2.yml
@@ -11,6 +11,7 @@ on:
         options:
         - 'staging'
         - 'production'
+  push:
 
 env:
   ACCT: ${{ inputs.environment == 'production' && '990880627107' || '327995277200' }}
@@ -53,33 +54,33 @@ jobs:
       run: |
         mv ./build/docs/sitemap.xml ./build/docs/antora-sitemap.xml
 
-    - name: configure aws credentials
-      uses: aws-actions/configure-aws-credentials@v5.0.0
-      with:
-        role-to-assume: 'arn:aws:iam::${{ env.ACCT }}:role/${{ inputs.environment }}-tinymce-docs-update'
-        role-session-name: tinymce-docs-${{ inputs.environment }}-release
-        aws-region: us-east-1
+    # - name: configure aws credentials
+    #   uses: aws-actions/configure-aws-credentials@v5.0.0
+    #   with:
+    #     role-to-assume: 'arn:aws:iam::${{ env.ACCT }}:role/${{ inputs.environment }}-tinymce-docs-update'
+    #     role-session-name: tinymce-docs-${{ inputs.environment }}-release
+    #     aws-region: us-east-1
 
-    - name: Upload website preview to S3
-      run: |
-        aws s3 sync ./build s3://${BUCKET}/main/${RUN}
+    # - name: Upload website preview to S3
+    #   run: |
+    #     aws s3 sync ./build s3://${BUCKET}/main/${RUN}
 
-    - name: Create redirects on S3
-      uses: tinymce/tinymce-docs-generate-redirects-action@v1.0
-      with:
-        build: ./build/
-        redirects: ./redirects.json
-        bucket: ${{ env.BUCKET }}
-        prefix: main/${{ env.RUN }}
-        parallel: 10
+    # - name: Create redirects on S3
+    #   uses: tinymce/tinymce-docs-generate-redirects-action@v1.0
+    #   with:
+    #     build: ./build/
+    #     redirects: ./redirects.json
+    #     bucket: ${{ env.BUCKET }}
+    #     prefix: main/${{ env.RUN }}
+    #     parallel: 10
 
-    - name: Update pointer to current run output
-      run: |
-        aws s3api put-object --bucket ${BUCKET} --key main/index.html --body .github/workflows/resources/empty.html --content-type text/html --metadata pointer=${RUN}
+    # - name: Update pointer to current run output
+    #   run: |
+    #     aws s3api put-object --bucket ${BUCKET} --key main/index.html --body .github/workflows/resources/empty.html --content-type text/html --metadata pointer=${RUN}
 
-    - name: Tag old versions for cleanup
-      uses: tinymce/tinymce-docs-cleanup-action@v0.1
-      with:
-        bucket: ${{ env.BUCKET }}
-        folder: main
-        parallel: 20
+    # - name: Tag old versions for cleanup
+    #   uses: tinymce/tinymce-docs-cleanup-action@v0.1
+    #   with:
+    #     bucket: ${{ env.BUCKET }}
+    #     folder: main
+    #     parallel: 20

--- a/.github/workflows/deploy_docs_v2.yml
+++ b/.github/workflows/deploy_docs_v2.yml
@@ -96,5 +96,3 @@ jobs:
       run: |
         sleep 30s
         aws cloudfront create-invalidation --distribution-id ${{ env.DISTRIBUTION }} --paths "/docs/*"
-      env:
-        AWS_EC2_METADATA_DISABLED: true

--- a/.github/workflows/deploy_docs_v2.yml
+++ b/.github/workflows/deploy_docs_v2.yml
@@ -29,8 +29,6 @@ jobs:
 
     if: github.repository == 'tinymce/tinymce-docs' && github.repository_owner == 'tinymce'
 
-    env:
-
     runs-on: ubuntu-latest
 
     defaults:


### PR DESCRIPTION
Ticket: TCLOUD-4860

Site: [Staging branch](https://pr-3943.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/8/)

Changes:
* Creates workflow for manual release of staging or production to new envoy server.
* Note that Cloudfront is not yet pointed at the new server - we'll need to release something to it before we take that step.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.
- [x] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed