### PR TITLE
DOC-3337: Views could not be opened during the `init` event.

### DIFF
--- a/modules/ROOT/pages/8.3.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.3.1-release-notes.adoc
@@ -46,4 +46,4 @@ For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode
 === Views could not be opened during the `init` event.
 // #TINY-13463
 
-Prior to {release-version}, the `init` event did not open editor views, which meant that views triggered during initialization were not visible when the editor finished loading. {release-version} addresses this by ensuring that views can now be opened during the editor’s `init` event, ensuring that any views initialized at this stage are visible immediately after initialization completes.
+Prior to {release-version}, editor views were not registered until after the CSS was loaded, which meant that they could not be opened until after editor initialization. {release-version} addresses this by registering views sooner, before editor initialization.

--- a/modules/ROOT/pages/8.3.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.3.1-release-notes.adoc
@@ -43,7 +43,7 @@ For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
+=== Views could not be opened during the `init` event.
+// #TINY-13463
 
-// CCFR here.
+Prior to {release-version}, the `init` event did not open editor views, which meant that views triggered during initialization were not visible when the editor finished loading. {release-version} addresses this by ensuring that views can now be opened during the editor’s `init` event, ensuring that any views initialized at this stage are visible immediately after initialization completes.


### PR DESCRIPTION
Ticket: DOC-3337

Site: [Staging branch](https://pr-3946.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.3.1-release-notes/#views-could-not-be-opened-during-the-init-event)

Changes:
* Documented the bug fix for TINY-13463

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed