### PR TITLE
DOC-3337: View would close when resource was still loading.

### DIFF
--- a/modules/ROOT/pages/8.3.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.3.1-release-notes.adoc
@@ -25,17 +25,19 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
-=== <Premium plugin name 1> <Premium plugin name 1 version>
+=== Suggested Edits
 
-The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+The {productname} {release-version} release includes an accompanying release of the **Suggested Edits** premium plugin.
 
-**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+**Suggested Edits** includes the following fix.
 
-==== <Premium plugin name 1 change 1>
+==== View would close when the resource was still loading.
 
-// CCFR here.
+In previous versions of {productname}, the Suggested Edits view could automatically close while the integration script was still loading. As a result, the view was exited during editor initialization, requiring users to manually reopen it.
 
-For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+This issue has been resolved in {productname} {release-version}. The editor now enters a loading state while the integration script is loading, preventing the Suggested Edits view from closing automatically during initialization.
+
+For information on the **Suggested Edits** plugin, see: xref:suggestededits.adoc[Suggested Edits].
 
 
 [[bug-fixes]]

--- a/modules/ROOT/pages/8.3.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.3.1-release-notes.adoc
@@ -35,7 +35,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 In previous versions of {productname}, opening the Suggested Edits view when the integration script was not yet loaded would cause the view to immediately close, requiring users to manually reopen it until the script was loaded.
 
-This issue has been resolved in {productname} {release-version}. The editor now enters a loading state while the integration script is loading, preventing the Suggested Edits view from closing automatically during initialization.
+This issue has been resolved in {productname} {release-version}. The editor now enters a loading state if the Suggested Edits view is opened while the integration script is loading, instead of immediately closing, and exits this state once the script has loaded.
 
 For information on the **Suggested Edits** plugin, see: xref:suggestededits.adoc[Suggested Edits].
 

--- a/modules/ROOT/pages/8.3.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.3.1-release-notes.adoc
@@ -33,7 +33,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 ==== View would close when the resource was still loading.
 
-In previous versions of {productname}, the Suggested Edits view could automatically close while the integration script was still loading. As a result, the view was exited during editor initialization, requiring users to manually reopen it.
+In previous versions of {productname}, opening the Suggested Edits view when the integration script was not yet loaded would cause the view to immediately close, requiring users to manually reopen it until the script was loaded.
 
 This issue has been resolved in {productname} {release-version}. The editor now enters a loading state while the integration script is loading, preventing the Suggested Edits view from closing automatically during initialization.
 


### PR DESCRIPTION
Ticket: DOC-3337

Site: [Staging branch](https://pr-3947.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.3.1-release-notes/#view-would-close-when-resource-was-still-loading)

Changes:
* Documented the bug fix for TINY-13427

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed