### PR TITLE
TCLOUD-4866: Remove cache invalidation and add cache control headers

### DIFF
--- a/.github/workflows/deploy_docs_v2.yml
+++ b/.github/workflows/deploy_docs_v2.yml
@@ -68,11 +68,11 @@ jobs:
     - name: Upload website to S3
       run: |
         aws s3 sync ./build s3://${BUCKET}/main/${RUN} \
-          --exclude "index.html" \
+          --exclude "*/index.html" \
           --cache-control "public, max-age=3600, stale-while-revalidate=86400"
         aws s3 sync ./build s3://${BUCKET}/main/${RUN} \
           --exclude "*" \
-          --include "index.html" \
+          --include "*/index.html" \
           --cache-control "max-age=300, stale-while-revalidate=86400"
 
     - name: Create redirects on S3

--- a/.github/workflows/deploy_docs_v2.yml
+++ b/.github/workflows/deploy_docs_v2.yml
@@ -20,7 +20,6 @@ env:
   TARGET: ${{ inputs.environment || 'staging' }}
   ACCT: ${{ inputs.environment == 'production' && '990880627107' || '327995277200' }}
   BUCKET: ${{ inputs.environment == 'production' && 'tiny-cloud-antora-docs-release' || 'tiny-cloud-antora-docs-preview' }}
-  DISTRIBUTION: ${{ inputs.environment == 'production' && 'E3LFU502SQ5UR' || 'E7DUUPEI08HNW'}}
   RUN: run-${{ github.run_number }}-${{ github.run_attempt }}
 
 jobs:
@@ -66,9 +65,15 @@ jobs:
         role-session-name: tinymce-docs-${{ env.TARGET }}-release
         aws-region: us-east-1
 
-    - name: Upload website preview to S3
+    - name: Upload website to S3
       run: |
-        aws s3 sync ./build s3://${BUCKET}/main/${RUN}
+        aws s3 sync ./build s3://${BUCKET}/main/${RUN} \
+          --exclude "index.html" \
+          --cache-control "public, max-age=3600, stale-while-revalidate=86400"
+        aws s3 sync ./build s3://${BUCKET}/main/${RUN} \
+          --exclude "*" \
+          --include "index.html" \
+          --cache-control "max-age=300, stale-while-revalidate=86400"
 
     - name: Create redirects on S3
       uses: tinymce/tinymce-docs-generate-redirects-action@v1.0
@@ -89,9 +94,3 @@ jobs:
         bucket: ${{ env.BUCKET }}
         folder: main
         parallel: 20
-
-    - name: Invalidate Cloudfront Cache
-      # sleep to wait for envoy's version pointer caching to expire
-      run: |
-        sleep 30s
-        aws cloudfront create-invalidation --distribution-id ${{ env.DISTRIBUTION }} --paths "/docs/*"


### PR DESCRIPTION
Ticket: TCLOUD-4866

Site: [Staging branch](https://pr-3949.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/8/)

Changes:
* Removed cache-invalidation step (it gets cached on the client side anyway so this is deceptive).
* Added caching headers to cache HTML for 5 minutes and other files (ie fonts, css, js) for 1 hour - this will hopefully reduce the excessive load from bots as they don't assume their copy is constantly out of date.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.
- [x] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed