### PR TITLE
DOC-3340: Placeholder loading had two progress indicators.

### DIFF
--- a/modules/ROOT/pages/8.3.2-release-notes.adoc
+++ b/modules/ROOT/pages/8.3.2-release-notes.adoc
@@ -29,8 +29,9 @@ The {productname} {release-version} release includes an accompanying release of 
 **Media Optimizer** includes the following improvement.
 
 === Placeholder loading had two progress indicators
+// #TINY-13163
 
-// TODO: add documentation
+Uploading a video in {productname} could display two progress indicators at the same time (a spinner and a progress bar), which unnecessarily cluttered the UI and made upload status harder to interpret. In {release-version}, the upload experience was updated to display only a single progress indicator: a progress bar when the upload duration can be estimated, or a spinner when the remaining time is unknown, resulting in a cleaner and clearer interface during video uploads.
 
 For information on the **Media Optimizer** plugin, see: xref:uploadcare.adoc[Media Optimizer].
 


### PR DESCRIPTION
Ticket: DOC-3340

Site: [Staging branch](https://pr-3960.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.3.2-release-notes/#placeholder-loading-had-two-progress-indicators)

Changes:
* Fix documentation for TINY-13163

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.
- [x] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed