### PR TITLE
DOC-3306: Remove broken redirect for `tinymce-and-csp.adoc`.

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -3291,10 +3291,6 @@
     "redirect": "/docs/tinymce/latest/advanced-templates/"
   },
   {
-    "location": "/docs/tinymce/latest/tinymce-and-csp/",
-    "redirect": "/docs/"
-  },
-  {
     "location": "/docs/tinymce/latest/yeoman-generator/",
     "redirect": "/docs/"
   },


### PR DESCRIPTION
Ticket: DOC-3306

Site: [Staging branch](https://pr-3962.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/tinymce-and-csp/)

Changes:
* Remove redirect for `tinymce-and-csp`.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed