### PR TITLE
DOC-3343: Update editor toolbar menu on Media Optimizer docs for Files & Documents page. 

### DIFF
--- a/modules/ROOT/examples/live-demos/uploadcare-documents/example.js
+++ b/modules/ROOT/examples/live-demos/uploadcare-documents/example.js
@@ -1,7 +1,7 @@
 tinymce.init({
   selector: 'textarea',
   plugins: 'uploadcare link',
-  toolbar: 'link',
+  toolbar: "undo redo | styles | bold italic underline | forecolor | bullist numlist | link uploadcare uploadcare-video | code preview",
   uploadcare_public_key: '<your-public-key>',
   documents_file_types: [
     { mimeType: 'application/msword', extensions: [ 'doc' ] },

--- a/modules/ROOT/examples/live-demos/uploadcare-documents/index.js
+++ b/modules/ROOT/examples/live-demos/uploadcare-documents/index.js
@@ -1,7 +1,7 @@
 tinymce.init({
   selector: "textarea#uploadcare-documents",
   plugins: 'uploadcare link',
-  toolbar: 'link',
+  toolbar: "undo redo | styles | bold italic underline | forecolor | bullist numlist | link uploadcare uploadcare-video | code preview",
   uploadcare_public_key: '630992ad50fe2291c406',
   uploadcare_cdn_base_url: 'https://tiny.ucarecdn.com',
   uploadcare_store_type: 'temporary',


### PR DESCRIPTION
Ticket: DOC-3343

Site: [Staging branch](https://pr-3963.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/uploadcare-documents/#interactive-example)

Changes:
* Update toolbar to include general toolbar options to match other demos.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed