### PR TITLE
DOC-3347: Fix editor usage in suggested edits demos

### DIFF
--- a/modules/ROOT/examples/live-demos/suggestededits-access-feedback/index.js
+++ b/modules/ROOT/examples/live-demos/suggestededits-access-feedback/index.js
@@ -22,6 +22,6 @@ tinymce.init({
         .catch(() => ({ id: userId })))),
   
   init_instance_callback: (editor) => { 
-    tinymce.activeEditor.execCommand('suggestededits'); 
+    editor.execCommand('suggestededits'); 
   }
 });

--- a/modules/ROOT/examples/live-demos/suggestededits-access-read/index.js
+++ b/modules/ROOT/examples/live-demos/suggestededits-access-read/index.js
@@ -22,6 +22,6 @@ tinymce.init({
         .catch(() => ({ id: userId })))),
   
   init_instance_callback: (editor) => { 
-    tinymce.activeEditor.execCommand('suggestededits'); 
+    editor.execCommand('suggestededits'); 
   }
 });

--- a/modules/ROOT/examples/live-demos/suggestededits-auto-approve/index.js
+++ b/modules/ROOT/examples/live-demos/suggestededits-auto-approve/index.js
@@ -23,6 +23,6 @@ tinymce.init({
         .catch(() => ({ id: userId })))),
   
   init_instance_callback: (editor) => { 
-    tinymce.activeEditor.execCommand('suggestededits'); 
+    editor.execCommand('suggestededits'); 
   }
 });

--- a/modules/ROOT/examples/live-demos/suggestededits/index.js
+++ b/modules/ROOT/examples/live-demos/suggestededits/index.js
@@ -22,6 +22,6 @@ tinymce.init({
         .catch(() => ({ id: userId })))),
   
   init_instance_callback: (editor) => { 
-    tinymce.activeEditor.execCommand('suggestededits'); 
+    editor.execCommand('suggestededits'); 
   }
 });

--- a/modules/ROOT/partials/configuration/suggestededits_content.adoc
+++ b/modules/ROOT/partials/configuration/suggestededits_content.adoc
@@ -19,11 +19,14 @@ NOTE: You are responsible for saving the model and providing it on the next load
 .Example: using `suggestededits_content`
 [source,js]
 ----
+const tinymceElement = document.querySelector('textarea#suggestededits');
+const model = JSON.parse(tinymceElement.getAttribute('suggestededits-model'));
+
 tinymce.init({
   selector: 'textarea#suggestededits',  // Change this value according to your HTML
   plugins: 'suggestededits',
   toolbar: 'suggestededits',
-  suggestededits_model, // Load the saved model into the editor
+  suggestededits_model: model, // Load the saved model into the editor
   suggestededits_content: 'model' // Set to 'model' if you want to load the initial content from the `suggestededits_model` option
 });
 ----


### PR DESCRIPTION
Ticket: DOC-3347

Site: [Staging branch](https://pr-3965.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* Use provided editor in callbacks

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.
- [x] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed