### PR TITLE
DOC-3351: Fix broken outdated link to customer portal, copy edits.

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -55,7 +55,7 @@ asciidoc:
     download-community: https://www.tiny.cloud/get-tiny/self-hosted/
     download-enterprise: https://www.tiny.cloud/my-account/downloads/
     accountpageurl: https://www.tiny.cloud/my-account
-    accountkeyurl: https://www.tiny.cloud/my-account/key-manager/
+    accountkeyurl: https://www.tiny.cloud/my-account/
     accountjwturl: https://www.tiny.cloud/my-account/jwt/
     accountsignup: https://www.tiny.cloud/auth/signup
     pricingpage: https://www.tiny.cloud/pricing

--- a/antora.yml
+++ b/antora.yml
@@ -55,7 +55,6 @@ asciidoc:
     download-community: https://www.tiny.cloud/get-tiny/self-hosted/
     download-enterprise: https://www.tiny.cloud/my-account/downloads/
     accountpageurl: https://www.tiny.cloud/my-account
-    accountkeyurl: https://www.tiny.cloud/my-account/
     accountjwturl: https://www.tiny.cloud/my-account/jwt/
     accountsignup: https://www.tiny.cloud/auth/signup
     pricingpage: https://www.tiny.cloud/pricing

--- a/modules/ROOT/pages/tinydrive-dotnet.adoc
+++ b/modules/ROOT/pages/tinydrive-dotnet.adoc
@@ -13,7 +13,7 @@ This project will help you get started with {cloudfilemanager} using .NET and al
 Before you start your journey with {cloudfilemanager}, it will go a lot smoother if you have done these steps:
 
 . Login/register to {accountpageurl}[{accountpage}]
-. Get a link:{accountkeyurl}[{cloudname} API Key]
+. Get a link:{accountpageurl}[{cloudname} API Key]
 . Get a link:{accountjwturl}[JWT Key]
 
 Store the keys temporarily somewhere as you will need to copy & paste them later.

--- a/modules/ROOT/pages/tinydrive-dotnet.adoc
+++ b/modules/ROOT/pages/tinydrive-dotnet.adoc
@@ -37,12 +37,12 @@ $ git clone git@github.com:tinymce/tinydrive-dotnet-starter.git
 [[change-the-apikey-in-tinydrive-dotnet-mvc-starterappsettingsdevelopmentjson]]
 ==== 2. Change the `+apiKey+` in `+tinydrive-dotnet-mvc-starter/appsettings.Development.json+`
 
-The API key can be generated using the `+API Key Manager+` {accountpage} page at http://tiny.cloud.
+Get your API key from the link:{accountpageurl}[{accountpage}] and replace the placeholder value in the `+appsettings.Development.json+` file.
 
 [[create-a-tinydrive-dotnet-mvc-starterprivatekey-file-containing-your-generated-private-rsa-key]]
 ==== 3. Create a `+tinydrive-dotnet-mvc-starter/private.key+` file containing your generated private RSA key
 
-You get the private RSA key from the `+JWT Key Manager+` {accountpage} page at http://tiny.cloud.
+Use the "Generate New Keypair" option at link:{accountjwturl}[{accountpage} - JWT Keys] to create a key pair. Download the private key from the generated key pair and save it to the `+private.key+` file.
 
 [[go-to-the-directory-and-start-the-dev-server]]
 ==== 4. Go to the directory and start the dev server

--- a/modules/ROOT/pages/tinydrive-getting-started.adoc
+++ b/modules/ROOT/pages/tinydrive-getting-started.adoc
@@ -16,7 +16,7 @@ include::partial$plugins/tinydrive-starter-projects.adoc[]
 The steps required for setting up {cloudfilemanager} are:
 
 . Register for a {cloudname} API key.
-. Add a public key to the {cloudname} API key.
+. Add a public key in the JWT Keys section of your account portal.
 . Set up a JSON Web Token (JWT) Provider endpoint (or server).
 . Configure the required {productname} options.
 

--- a/modules/ROOT/pages/tinydrive-java.adoc
+++ b/modules/ROOT/pages/tinydrive-java.adoc
@@ -13,7 +13,7 @@ This project will help you get started with {cloudfilemanager} and allow you to 
 Before you start your journey with {cloudfilemanager}, it will go a lot smoother if you have done these steps:
 
 . Login/register to {accountpageurl}[{accountpage}]
-. Get a link:{accountkeyurl}[{cloudname} API Key]
+. Get a link:{accountpageurl}[{cloudname} API Key]
 . Get a link:{accountjwturl}[JWT Key]
 
 Store the keys temporarily somewhere as you will need to copy & paste them later.

--- a/modules/ROOT/pages/tinydrive-java.adoc
+++ b/modules/ROOT/pages/tinydrive-java.adoc
@@ -37,12 +37,12 @@ $ git clone git@github.com:tinymce/tinydrive-java-spring-starter.git
 [[change-the-apikey-in-tinydrive-java-spring-startersrcmainresourcesapplicationyml]]
 ==== 2. Change the `+apiKey+` in `+tinydrive-java-spring-startersrc/main/resources/application.yml+`
 
-The API key can be generated using the `+API Key Manager+` {accountpage} page at http://tiny.cloud.
+Get your API key from the link:{accountpageurl}[{accountpage}] and replace the placeholder value in the `+application.yml+` file.
 
 [[create-a-tinydrive-java-spring-startersrcmainresourcesprivatekey-file-containing-your-generated-private-rsa-key]]
 ==== 3. Create a `+tinydrive-java-spring-starter/src/main/resources/private.key+` file containing your generated private RSA key
 
-You get the private RSA key from the `+JWT Key Manager+` {accountpage} page at http://tiny.cloud.
+Use the "Generate New Keypair" option at link:{accountjwturl}[{accountpage} - JWT Keys] to create a key pair. Download the private key from the generated key pair and save it to the `+private.key+` file.
 
 [[go-to-the-directory-and-install-npm-packages-and-then-start-the-dev-server]]
 ==== 4. Go to the directory and install NPM packages and then start the dev server

--- a/modules/ROOT/pages/tinydrive-jwt-authentication.adoc
+++ b/modules/ROOT/pages/tinydrive-jwt-authentication.adoc
@@ -19,7 +19,7 @@ TIP: If you haven't tried any of the xref:tinydrive-getting-started.adoc#starter
 == Overview
 
 * xref:setting-up-jwt-authentication-for-tiny-drive[Setting up JWT authentication for Tiny Drive]
-* xref:add-a-public-key-to-the-tiny-cloud-api-key[Add a public key to the Tiny Cloud API key]
+* xref:add-a-public-key-to-the-tiny-cloud-api-key[Add a public key in the JWT Keys section of your account portal]
 * xref:set-up-a-json-web-token-jwt-endpoint[Set up a JSON Web Token (JWT) endpoint]
 * xref:jwt-endpoint-examples[JWT endpoint examples]
 

--- a/modules/ROOT/pages/tinydrive-nodejs.adoc
+++ b/modules/ROOT/pages/tinydrive-nodejs.adoc
@@ -37,12 +37,12 @@ $ git clone git@github.com:tinymce/tinydrive-nodejs-starter.git
 [[change-the-apikey-in-tinydrive-nodejs-starterconfigjs]]
 ==== 2. Change the `+apiKey+` in `+tinydrive-nodejs-starter/config.js+`
 
-You get the API key from the `+API Key Manager+` {accountpage} page at http://tiny.cloud.
+Get your API key from the link:{accountpageurl}[{accountpage}] and replace the placeholder value in the `+config.js+` file.
 
 [[create-a-tinydrive-nodejs-starterprivatekey-file-containing-your-generated-private-rsa-key]]
 ==== 3. Create a `+tinydrive-nodejs-starter/private.key+` file containing your generated private RSA key
 
-You get the private RSA key from the `+JWT Key Manager+` {accountpage} page at http://tiny.cloud.
+Use the "Generate New Keypair" option at link:{accountjwturl}[{accountpage} - JWT Keys] to create a key pair. Download the private key from the generated key pair and save it to the `+private.key+` file.
 
 [[go-to-the-directory-and-install-npm-packages-and-then-start-the-dev-server]]
 ==== 4. Go to the directory and install npm packages and then start the dev server

--- a/modules/ROOT/pages/tinydrive-nodejs.adoc
+++ b/modules/ROOT/pages/tinydrive-nodejs.adoc
@@ -13,7 +13,7 @@ This project will help you get started with {cloudfilemanager} and allow you to 
 Before you start your journey with {cloudfilemanager}, it will go a lot smoother if you have done these steps:
 
 . Login/register to {accountpageurl}[{accountpage}]
-. Get a link:{accountkeyurl}[{cloudname} API Key]
+. Get a link:{accountpageurl}[{cloudname} API Key]
 . Get a link:{accountjwturl}[JWT Key]
 
 Store the keys temporarily somewhere as you will need to copy & paste them later.

--- a/modules/ROOT/pages/tinydrive-php.adoc
+++ b/modules/ROOT/pages/tinydrive-php.adoc
@@ -13,7 +13,7 @@ This project will help you get started with {cloudfilemanager} and allow you to 
 Before you start your journey with {cloudfilemanager}, it will go a lot smoother if you have done these steps:
 
 . Login/register to link:{accountpageurl}[{accountpage}]
-. Get a link:{accountkeyurl}[{cloudname} API Key]
+. Get a link:{accountpageurl}[{cloudname} API Key]
 . Get a link:{accountjwturl}[JWT Key]
 
 Store the keys temporarily somewhere as you will need to copy & paste them later.

--- a/modules/ROOT/pages/tinydrive-php.adoc
+++ b/modules/ROOT/pages/tinydrive-php.adoc
@@ -37,12 +37,12 @@ $ git clone git@github.com:tinymce/tinydrive-php-starter.git
 [[change-the-apikey-in-tinydrive-php-starterconfigphp]]
 ==== 2. Change the `+apiKey+` in `+tinydrive-php-starter/config.php+`
 
-You get the API key from the `+API Key Manager+` {accountpage} page at http://tiny.cloud.
+Get your API key from the link:{accountpageurl}[{accountpage}] and replace the placeholder value in the `+config.php+` file.
 
 [[create-a-tinydrive-php-starterprivatekey-file-containing-your-generated-private-rsa-key]]
 ==== 3. Create a `+tinydrive-php-starter/private.key+` file containing your generated private RSA key
 
-You get the private RSA key from the `+JWT Key Manager+` {accountpage} page at http://tiny.cloud.
+Use the "Generate New Keypair" option at link:{accountjwturl}[{accountpage} - JWT Keys] to create a key pair. Download the private key from the generated key pair and save it to the `+private.key+` file.
 
 [[go-to-the-directory-and-start-the-dev-server]]
 ==== 4. Go to the directory and start the dev server

--- a/modules/ROOT/partials/auth/private-public-key-pairs-for-tiny-cloud-services.adoc
+++ b/modules/ROOT/partials/auth/private-public-key-pairs-for-tiny-cloud-services.adoc
@@ -1,13 +1,13 @@
 The **{pluginname}** Server requires a _public_ key generated from the same _private_ key that will be used on your JSON Web Token (JWT) provider endpoint. The public key(s) stored on the {pluginname} Server are used to ensure that content is sent by authorized users.
 
-There are two methods for generating and adding a public key to your API key:
+There are two methods for generating and adding a public key in the JWT Keys section of your account portal:
 
-. The secure key pair generator at link:{accountjwturl}[{accountpage} - JWT Keys] (recommended).
-. Generate a key pair locally and add the _public_ key to link:{accountjwturl}[{accountpage} - JWT Keys].
+. Generate New Keypair at link:{accountjwturl}[{accountpage} - JWT Keys] (recommended).
+. Generate a key pair locally and Import Public Key at link:{accountjwturl}[{accountpage} - JWT Keys].
 
 == Generate a key pair using the {accountpage} JWT Keys page
 
-The link:{accountjwturl}[{accountpage} - JWT Keys] page provides a private/public key generator, providing a quick and secure way of generating the required keys. This generator will store a copy of the _public_ key, and provide a downloadable file for both the public and private keys. {companyname} does **not store** the _private_ key and the key pair **cannot** be retrieved later.
+The link:{accountjwturl}[{accountpage} - JWT Keys] page provides a "Generate New Keypair" option, providing a quick and secure way of generating the required keys. This will store a copy of the _public_ key, and provide a downloadable file for both the public and private keys. {companyname} does **not store** the _private_ key and the key pair **cannot** be retrieved later.
 
 [[generate-a-key-pair-locally]]
 == Generate a key pair locally
@@ -19,11 +19,11 @@ For instructions on generating a key pair locally, see: xref:generate-rsa-key-pa
 
 [[add-a-public-key-to-the-tiny-cloud-api-key]]
 ifeval::[{numberedHeading} == true]
-= 2. Add a public key to the {cloudname} API key
+= 2. Add a public key in the JWT Keys section of your account portal
 endif::[]
 
 ifeval::[{numberedHeading} != true]
-== Add a public key to the {cloudname} API key
+== Add a public key in the JWT Keys section of your account portal
 endif::[]
 
-Once a public key has been generated, add the public key to the {cloudname} API key at: link:{accountjwturl}[{accountpage} - JWT Keys].
+Once a public key has been generated locally, use the "Import Public Key" option in the JWT Keys section of your account portal at: link:{accountjwturl}[{accountpage} - JWT Keys].

--- a/modules/ROOT/partials/private-public-key-pairs-for-tiny-cloud-services.adoc
+++ b/modules/ROOT/partials/private-public-key-pairs-for-tiny-cloud-services.adoc
@@ -1,10 +1,10 @@
 The {pluginname} Server requires a _public_ key generated from the same _private_ key that will be used on your JSON Web Token (JWT) provider endpoint. The public key(s) stored on the {pluginname} Server are used to ensure that content is sent by authorized users.
 
-There are two methods for generating and adding a public key to your API key:
+There are two methods for generating and adding a public key in the JWT Keys section of your account portal:
 
 == Generate a key pair using the {accountpage} JWT Keys page
 
-The link:{accountjwturl}[{accountpage} - JWT Keys] page provides a private/public key generator, providing a quick and secure way of generating the required keys. This generator will store a copy of the _public_ key, and provide a downloadable file for both the public and private keys. {companyname} does **not store** the _private_ key and the key pair **cannot** be retrieved later.
+The link:{accountjwturl}[{accountpage} - JWT Keys] page provides a "Generate New Keypair" option, providing a quick and secure way of generating the required keys. This will store a copy of the _public_ key, and provide a downloadable file for both the public and private keys. {companyname} does **not store** the _private_ key and the key pair **cannot** be retrieved later.
 
 [[generate-a-key-pair-locally]]
 == Generate a key pair locally


### PR DESCRIPTION
Ticket: DOC-3351

Site: [tinydrive-getting-started](https://pr-3966.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/tinydrive-getting-started/)

Site: [tinydrive-dotnet](https://pr-3966.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/tinydrive-dotnet/)
Site: [tinydrive-java](https://pr-3966.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/tinydrive-java/)
Site: [tinydrive-nodejs](https://pr-3966.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/tinydrive-nodejs/)
Site: [tinydrive-php](https://pr-3966.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/tinydrive-php/)

Site: [Improvements to overview list item](https://pr-3966.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/tinydrive-jwt-authentication/)

Changes:
* Fix broken customer portal links from various pages.
* Content improvements and wording.
* Remove duplicated var value from antora.yml file that is no longer required.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed