### PR TITLE
DOC-3349: Fix broken tiny logo URL to new path (v6).

### DIFF
--- a/-new-material-templates/release-notes-template/antora.yml
+++ b/-new-material-templates/release-notes-template/antora.yml
@@ -68,9 +68,9 @@ asciidoc:
     virt_ellps: '&#8942;'
     ellps: '&#133;'
     # Demo logos
-    logofordemos: 'https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png'
-    logofordemoshtml: '<p><img style="display: block; margin-left: auto; margin-right: auto;" title="Tiny Logo" src="https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128"></p>'
-    logofordemoshtmlright: '<p><img style="float: right;" title="Tiny Logo" src="https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128"></p>'
+    logofordemos: 'https://www.tiny.cloud/docs/tinymce/latest/_images/logos/android-chrome-256x256.png'
+    logofordemoshtml: '<p><img style="display: block; margin-left: auto; margin-right: auto;" title="Tiny Logo" src="https://www.tiny.cloud/docs/tinymce/latest/_images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128"></p>'
+    logofordemoshtmlright: '<p><img style="float: right;" title="Tiny Logo" src="https://www.tiny.cloud/docs/tinymce/latest/_images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128"></p>'
 
 nav:
 - modules/ROOT/nav.adoc

--- a/antora.yml
+++ b/antora.yml
@@ -69,9 +69,9 @@ asciidoc:
     prefix: '{{'
     suffix: '}}'
     # Demo logos
-    logofordemos: 'https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png'
-    logofordemoshtml: '<p><img style="display: block; margin-left: auto; margin-right: auto;" title="Tiny Logo" src="https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128"></p>'
-    logofordemoshtmlright: '<p><img style="float: right;" title="Tiny Logo" src="https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128"></p>'
+    logofordemos: 'https://www.tiny.cloud/docs/tinymce/latest/_images/logos/android-chrome-256x256.png'
+    logofordemoshtml: '<p><img style="display: block; margin-left: auto; margin-right: auto;" title="Tiny Logo" src="https://www.tiny.cloud/docs/tinymce/latest/_images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128"></p>'
+    logofordemoshtmlright: '<p><img style="float: right;" title="Tiny Logo" src="https://www.tiny.cloud/docs/tinymce/latest/_images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128"></p>'
 
 nav:
 - modules/ROOT/nav.adoc


### PR DESCRIPTION
Ticket: DOC-3349

Site: [Staging branch](https://pr-3969.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/6/)

Changes:
* Fix broken paths for tiny logo in antora.yml for v6

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed