### PR TITLE
DOC-3349: Fix broken tiny logo to new path (v5).

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -55,9 +55,9 @@ asciidoc:
     virt_ellps: '&#8942;'
     ellps: '&#133;'
     # Demo logos
-    logofordemos: 'https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png'
-    logofordemoshtml: '<p><img style="display: block; margin-left: auto; margin-right: auto;" title="Tiny Logo" src="https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128" /></p>'
-    logofordemoshtmlright: '<p><img style="float: right;" title="Tiny Logo" src="https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128" /></p>'
+    logofordemos: 'https://www.tiny.cloud/docs/tinymce/latest/_images/logos/android-chrome-256x256.png'
+    logofordemoshtml: '<p><img style="display: block; margin-left: auto; margin-right: auto;" title="Tiny Logo" src="https://www.tiny.cloud/docs/tinymce/latest/_images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128" /></p>'
+    logofordemoshtmlright: '<p><img style="float: right;" title="Tiny Logo" src="https://www.tiny.cloud/docs/tinymce/latest/_images/logos/android-chrome-256x256.png" alt="TinyMCE Logo" width="128" height="128" /></p>'
 
 nav:
 - modules/ROOT/nav.adoc


### PR DESCRIPTION
Ticket: DOC-3349

Site: [Staging branch](https://pr-3970.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/5/)

Changes:
* Fix broken tiny logo URL to new path in antora.yml file

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed