### PR TITLE
DOC-3350: Media Optimizer buttons missing from list of available toolbar buttons

### DIFF
--- a/modules/ROOT/pages/available-toolbar-buttons.adoc
+++ b/modules/ROOT/pages/available-toolbar-buttons.adoc
@@ -194,6 +194,12 @@ include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 :plugincategory: premium
+:pluginname: Media Optimizer
+:plugincode: uploadcare
+:pluginpage: uploadcare.adoc
+include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
+
+:plugincategory: premium
 :pluginname: Merge Tags
 :plugincode: mergetags
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]

--- a/modules/ROOT/partials/toolbar-button-ids/uploadcare-toolbar-buttons.adoc
+++ b/modules/ROOT/partials/toolbar-button-ids/uploadcare-toolbar-buttons.adoc
@@ -31,3 +31,12 @@ ifeval::["{pluginfeature}" == "uc-documents"]
 | `+link+` | Opens the Insert/edit link dialog so the user can upload files via file picker or by dropping files to be uploaded. Uploaded files are processed through Uploadcare's infrastructure and automatically linked in the content.
 |===
 endif::[]
+
+ifndef::pluginfeature[]
+[cols="1,3",options="header"]
+|===
+|Toolbar button identifier |Description
+|`+uploadcare+` |Inserts an image placeholder element. This placeholder supports image uploads via drag-and-drop, file selection, or by providing a URL.
+|`+uploadcare-video+` |Inserts a video placeholder element. This placeholder supports video uploads via drag-and-drop, file selection, or by providing a URL.
+|===
+endif::[]


### PR DESCRIPTION
Ticket: DOC-3350

Site: [Staging branch](https://pr-3971.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/available-toolbar-buttons/#media-optimizer-plugin)

Changes:
* Update list of available toolbar buttons to include Media Optimizer

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed