### PR TITLE
DOC-3353: Fix Broken Logo URL Links external to TinyMCEs Documentation.

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -22,6 +22,11 @@
     "redirect": "/docs/tinymce/latest/"
   },
   {
+    "location": "/docs/images",
+    "pattern": "^/docs/images/(.*)$",
+    "redirect": "/docs/tinymce/latest/_images/%1"
+  },
+  {
     "location": "/docs/advanced/",
     "redirect": "/docs/tinymce/latest/how-to-guides"
   },


### PR DESCRIPTION
Ticket: DOC-3353

Changes:
* add new re-direct to handle legacy URLs
* fixes issue with server returning 304 for all requests to image source file.
* addresses issues with these projects failing to find resource [see more](https://github.com/search?q=org%3Atinymce+docs%2Fimages%2Flogos%2Fandroid-chrome-256x256.png&type=code&p=2)

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Post-merge-checks:
- [x] visit `https://www.tiny.cloud/docs/images/logos/android-chrome-256x256.png` ensuring that it re-directs to `https://www.tiny.cloud/docs/tinymce/latest/_images/logos/android-chrome-256x256.png`

Review:
- [x] Documentation Team Lead has reviewed