### PR TITLE
DOC-3366: Update Converters API ref links to v1.

### DIFF
--- a/modules/ROOT/pages/exportpdf.adoc
+++ b/modules/ROOT/pages/exportpdf.adoc
@@ -92,4 +92,4 @@ include::partial$commands/{plugincode}-cmds.adoc[]
 
 == API Reference
 
-> Explore the comprehensive API documentation for the {pluginname} Premium plugin at https://exportpdf.api.tiny.cloud/docs[{pluginname} API Reference Documentation.^]
+> Explore the comprehensive API documentation for the {pluginname} Premium plugin at https://exportpdf.api.tiny.cloud/v1/convert/docs[{pluginname} API Reference Documentation.^]

--- a/modules/ROOT/pages/html-to-pdf-converter-api.adoc
+++ b/modules/ROOT/pages/html-to-pdf-converter-api.adoc
@@ -27,9 +27,9 @@ The {servicename} is a powerful tool that seamlessly integrates advanced documen
 
 Tailor your PDF documents to suit your needs:
 
-* **Custom CSS Styling:** Apply link:https://exportpdf.api.tiny.cloud/docs#section/General/CSS[custom CSS^] styles to your PDFs for brand consistency and enhanced presentation.
-* **Header and Footer Options:** Add link:https://exportpdf.api.tiny.cloud/docs#section/PDF-options/Header-and-footer[headers, footers^], and other branding elements to your PDF documents for a professional touch.
-* **Page Formatting:** Control page settings such as orientation, link:https://exportpdf.api.tiny.cloud/docs#section/PDF-options/Margins[margins^], and link:https://exportpdf.api.tiny.cloud/docs#section/PDF-options/Page-format[page size] to optimize readability.
+* **Custom CSS Styling:** Apply link:https://exportpdf.api.tiny.cloud/v1/convert/docs#section/General/CSS[custom CSS^] styles to your PDFs for brand consistency and enhanced presentation.
+* **Header and Footer Options:** Add link:https://exportpdf.api.tiny.cloud/v1/convert/docs#section/PDF-options/Header-and-footer[headers, footers^], and other branding elements to your PDF documents for a professional touch.
+* **Page Formatting:** Control page settings such as orientation, link:https://exportpdf.api.tiny.cloud/v1/convert/docs#section/PDF-options/Margins[margins^], and link:https://exportpdf.api.tiny.cloud/v1/convert/docs#section/PDF-options/Page-format[page size] to optimize readability.
 
 == Ideal for Various Use Cases
 
@@ -40,4 +40,4 @@ Tailor your PDF documents to suit your needs:
 
 == PDF Converter API Reference
 
-> Explore the comprehensive API documentation at link:https://exportpdf.api.tiny.cloud/docs[PDF Converter API Reference documentation.^]
+> Explore the comprehensive API documentation at link:https://exportpdf.api.tiny.cloud/v1/convert/docs[PDF Converter API Reference documentation.^]

--- a/modules/ROOT/partials/configuration/exportpdf_converter_options.adoc
+++ b/modules/ROOT/partials/configuration/exportpdf_converter_options.adoc
@@ -39,4 +39,4 @@ tinymce.init({
 [NOTE]
 The `exportpdf_service_url` option must be configured for the {pluginname} plugin to work.
 
-> For comprehensive details regarding the `exportpdf_converter_options`, please refer to the https://exportpdf.api.tiny.cloud/docs[API documentation^] available for the {pluginname} Premium plugin.
+> For comprehensive details regarding the `exportpdf_converter_options`, please refer to the https://exportpdf.api.tiny.cloud/v1/convert/docs[API documentation^] available for the {pluginname} Premium plugin.

--- a/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-api-usage.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-api-usage.adoc
@@ -7,7 +7,7 @@ The API is available on `+http://localhost:[port]+` (by default the `port` is `8
 
 [NOTE]
 The REST API documentation is available at `+http://localhost:[port]/docs+`.
-Alternatively, refer to the specifications in link:https://exportpdf.api.tiny.cloud/docs[https://exportpdf.api.tiny.cloud/docs^].
+Alternatively, refer to the specifications in link:https://exportpdf.api.tiny.cloud/v1/convert/docs[https://exportpdf.api.tiny.cloud/v1/convert/docs^].
 
 If the authorization for the API is enabled, provided an authorization token. More instructions can be found in the xref:individual-export-to-pdf-on-premises.adoc#authorization[authorization] section.
 

--- a/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-autorization.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-autorization.adoc
@@ -91,7 +91,7 @@ axios.post( 'http://localhost:8080/v1/convert', data, config )
 
 `SECRET_KEY` it’s the key which has been passed to the {pluginname} On-Premises instance
 
-Please refer to the link:https://exportpdf.api.tiny.cloud/docs[{pluginname} REST API documentation] to start using the service.
+Please refer to the link:https://exportpdf.api.tiny.cloud/v1/convert/docs[{pluginname} REST API documentation] to start using the service.
 
 [NOTE]
 If API clients like Postman or Insomnia are used, then set the JWT token as an `Authorization` header in the `Headers` tab. Do not use the built-in token authorization as this will generate invalid header with a `Bearer` prefix added to the token.

--- a/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-fonts.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-fonts.adoc
@@ -5,7 +5,7 @@ During document writing, the possibility of using many different fonts can be ve
 
 Using the appropriate font can change the appearance of the document and emphasize its style.
 
-{pluginname} Converter allows link:https://exportpdf.api.tiny.cloud/docs#section/Web-Fonts[Web Fonts^] to be used, which provided the integrator with the ability to use standard operating system fonts or use custom fonts without the need to import them using CSS.
+{pluginname} Converter allows link:https://exportpdf.api.tiny.cloud/v1/convert/docs#section/Web-Fonts[Web Fonts^] to be used, which provided the integrator with the ability to use standard operating system fonts or use custom fonts without the need to import them using CSS.
 
 Below is a list of the basic fonts included in the image:
 
@@ -31,7 +31,7 @@ However, additional fonts can be added to {pluginname} Converter in two ways:
 ** See Use Windows fonts in PDF Converter section.
 
 [NOTE]
-The fonts inside the mounted volume will be installed on the docker image operating system. Only the `.ttf` and `.otf` font formats are supported. If other font formats are used, these will need to be converted to the supported format prior or use fonts such as link:https://exportpdf.api.tiny.cloud/docs#section/Web-Fonts[Web Fonts^].
+The fonts inside the mounted volume will be installed on the docker image operating system. Only the `.ttf` and `.otf` font formats are supported. If other font formats are used, these will need to be converted to the supported format prior or use fonts such as link:https://exportpdf.api.tiny.cloud/v1/convert/docs#section/Web-Fonts[Web Fonts^].
 
 [TIP]
 Ensure that the converted fonts can be installed and used on your local machine first, before installing them on the docker container.


### PR DESCRIPTION
Ticket: DOC-3366

Site: [Link](https://pr-3977.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/exportpdf/#api-reference)

Changes:
* Update Converters API ref links to v1

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.
- [x] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed