### PR TITLE
TCLOUD-4894: add stale-if-error cache-control header

### DIFF
--- a/.github/workflows/deploy_docs_v2.yml
+++ b/.github/workflows/deploy_docs_v2.yml
@@ -69,11 +69,11 @@ jobs:
       run: |
         aws s3 sync ./build s3://${BUCKET}/main/${RUN} \
           --exclude "*/index.html" \
-          --cache-control "public, max-age=3600, stale-while-revalidate=86400"
+          --cache-control "public, max-age=3600, stale-if-error=3600, stale-while-revalidate=86400"
         aws s3 sync ./build s3://${BUCKET}/main/${RUN} \
           --exclude "*" \
           --include "*/index.html" \
-          --cache-control "max-age=300, stale-while-revalidate=86400"
+          --cache-control "max-age=300, stale-if-error=3600, stale-while-revalidate=86400"
 
     - name: Create redirects on S3
       uses: tinymce/tinymce-docs-generate-redirects-action@v1.0


### PR DESCRIPTION
Ticket: TCLOUD-4894

Site: [Staging branch](https://www.staging.tiny.cloud/docs/tinymce/latest)

Changes:
* Adds stale-if-error to serve a stale response when errors occur with the proxy.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.
- [x] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed