### PR TITLE
DOC-3367: Add new bundling guide overview page.

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -149,6 +149,7 @@
 *** xref:annotations.adoc[Using the Annotations API]
 ** Bundling {productname}
 *** xref:introduction-to-bundling-tinymce.adoc[Introduction]
+*** xref:bundling-guide.adoc[Bundling overview]
 *** Webpack
 **** xref:webpack-es6-npm.adoc[ES6 and npm]
 **** xref:webpack-cjs-npm.adoc[CommonJS and npm]

--- a/modules/ROOT/pages/a11ychecker.adoc
+++ b/modules/ROOT/pages/a11ychecker.adoc
@@ -33,6 +33,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 [[accessibility-rules]]
 == Accessibility Rules
 

--- a/modules/ROOT/pages/accordion.adoc
+++ b/modules/ROOT/pages/accordion.adoc
@@ -30,6 +30,8 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
 == Options
 
 The following configuration options affect the behavior of the {pluginname} plugin.

--- a/modules/ROOT/pages/advanced-templates.adoc
+++ b/modules/ROOT/pages/advanced-templates.adoc
@@ -144,6 +144,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 NOTE: The undefined options in the above example must be defined. See the xref:options[Options] below for specific details on each function.
 
 

--- a/modules/ROOT/pages/advanced-typography.adoc
+++ b/modules/ROOT/pages/advanced-typography.adoc
@@ -79,6 +79,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == Options
 
 The following configuration options affect the behavior of the {pluginname} plugin.

--- a/modules/ROOT/pages/advcode.adoc
+++ b/modules/ROOT/pages/advcode.adoc
@@ -38,6 +38,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == Enable full-screen mode
 
 To enable the full-screen mode button in the {pluginname}, configure the plugin to run in inline mode and include the fullscreen plugin:

--- a/modules/ROOT/pages/advlist.adoc
+++ b/modules/ROOT/pages/advlist.adoc
@@ -22,6 +22,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == Interactive demo
 
 liveDemo::advlist[]

--- a/modules/ROOT/pages/advtable.adoc
+++ b/modules/ROOT/pages/advtable.adoc
@@ -32,6 +32,7 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
 
 == Sorting table rows and columns
 

--- a/modules/ROOT/pages/ai.adoc
+++ b/modules/ROOT/pages/ai.adoc
@@ -44,6 +44,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == Using a proxy server with {pluginname}
 
 NOTE: As per OpenAI’s https://help.openai.com/en/articles/5112595-best-practices-for-api-key-safety[best practices for API key safety], deployment of an API key in a client-side environment is specifically not recommended.

--- a/modules/ROOT/pages/anchor.adoc
+++ b/modules/ROOT/pages/anchor.adoc
@@ -24,6 +24,8 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
 == Options
 
 include::partial$configuration/allow_html_in_named_anchor.adoc[leveloffset=+1]

--- a/modules/ROOT/pages/autocorrect.adoc
+++ b/modules/ROOT/pages/autocorrect.adoc
@@ -27,6 +27,8 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
 [[usage-notes]]
 == Usage notes
 

--- a/modules/ROOT/pages/autolink.adoc
+++ b/modules/ROOT/pages/autolink.adoc
@@ -20,6 +20,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == Options
 
 include::partial$configuration/link_default_target.adoc[leveloffset=+1]

--- a/modules/ROOT/pages/autoresize.adoc
+++ b/modules/ROOT/pages/autoresize.adoc
@@ -22,6 +22,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == How it works
 
 The Autoresize plugin monitors content changes and automatically adjusts the editor height to accommodate the content. When enabled:

--- a/modules/ROOT/pages/autosave.adoc
+++ b/modules/ROOT/pages/autosave.adoc
@@ -26,6 +26,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == Options
 
 These settings affect the execution of the `+autosave+` plugin. The settings described here will affect the interval, duration and behavior of locally stored drafts of the current editor instance.

--- a/modules/ROOT/pages/bundling-guide.adoc
+++ b/modules/ROOT/pages/bundling-guide.adoc
@@ -118,7 +118,7 @@ When using skins, you must import both:
 
 [NOTE]
 ====
-Importing the `+skin.js+` and `+content.js+` files is an alternative way to load skin styles. For bundlers like Webpack and Browserify that support CSS imports, the CSS examples in xref:bundling-skins.adoc[Bundling skins] remain valid.
+Importing the `+skin.js+` and `+content.js+` files is an alternative way to load skin styles besides CSS imports. For bundlers like Webpack and Browserify that require additional setup to support CSS imports, the CSS examples in xref:bundling-skins.adoc[Bundling skins] remain valid.
 ====
 
 For more information, see xref:bundling-skins.adoc[Bundling skins].

--- a/modules/ROOT/pages/bundling-guide.adoc
+++ b/modules/ROOT/pages/bundling-guide.adoc
@@ -90,20 +90,10 @@ For detailed information on bundling plugins, see xref:bundling-plugins.adoc[Bun
 
 Some plugins require additional resource files (JS, CSS, or language files) to function properly. These must be explicitly imported when bundling:
 
-[IMPORTANT]
-====
-Key points about plugin resources:
-
-* Core plugin resources typically use relative paths without file extensions
-* Premium plugin resources (from `+tinymce-premium+`) MUST include the `.js` or `.css` file extension in the import path
-* Plugins lazy-load additional resources at runtime, so these files must be included in the bundle or accessible as static assets
-====
-
 === Plugins requiring additional resources
 
-* **Emoticons**: Requires an emoji database file (`+js/emojis+`)
-* **Help**: Requires a keyboard navigation language file (`+js/i18n/keynav/<lang>+`)
-* **Page Embed**: Requires a CSS file (`+css/empa30.css+`)
+* **Emoticons**: Requires an emoji database file (`+js/emojis.js+`)
+* **Help**: Requires a keyboard navigation language file (`+js/i18n/keynav/<lang>.js+`)
 * **Autocorrect**: Requires a word list file (`+js/en.js+`)
 * **Uploadcare**: Requires a webcomponent file (`+js/uc-video.js+`)
 
@@ -119,12 +109,17 @@ Always import dependent plugins before the plugin that requires them.
 
 == CSS files
 
-Plugin CSS files are typically included automatically when importing plugins. However, some plugins may require explicit CSS imports for proper styling.
+Some plugins require additional CSS files. Plugin CSS files are included automatically when importing plugins via their JS file.
 
 When using skins, you must import both:
 
 * The skin CSS file (`+skin.css+` or `+skin.js+`)
 * The content UI CSS file (`+content.css+` or `+content.js+`)
+
+[NOTE]
+====
+Importing the `+skin.js+` and `+content.js+` files is an alternative way to load skin styles. For bundlers like Webpack and Browserify that support CSS imports, the CSS examples in xref:bundling-skins.adoc[Bundling skins] remain valid.
+====
 
 For more information, see xref:bundling-skins.adoc[Bundling skins].
 
@@ -133,6 +128,8 @@ For more information, see xref:bundling-skins.adoc[Bundling skins].
 Language files are optional and used for localizing the {productname} UI and plugin interfaces.
 
 === Core UI language files
+
+For community packages:
 
 [source,js]
 ----
@@ -148,21 +145,21 @@ import 'tinymce-premium/langs/<language>.js';
 
 === Plugin language files
 
-Plugin language files are separate from the main UI language files:
+Plugin language files are separate from the main UI language files. The editor's `+language+` option must be set to the desired language for the plugin's language file to take effect.
 
 [source,js]
 ----
 // Community plugin language file
 import 'tinymce/plugins/<plugincode>/langs/<language>.js';
 
-// Premium plugin language file (note: .js extension required)
+// Premium plugin language file
 import 'tinymce-premium/plugins/<plugincode>/langs/<language>.js';
 ----
 
 [NOTE]
 ====
-* English is the default language, so `+en.js+` language files don't exist
-* For premium plugins, the language file path must include the `.js` extension
+* US English is the default language, so the language packs do not include `+en.js+` language files (see xref:ui-localization.adoc#language[`+language+` option]). Note that the Help and Autocorrect plugins have their own `+en.js+` files.
+* Examples include the `.js` extension for clarity; most bundlers can resolve file extensions automatically.
 ====
 
 For more information, see xref:bundling-localization.adoc[UI localizations].

--- a/modules/ROOT/pages/bundling-guide.adoc
+++ b/modules/ROOT/pages/bundling-guide.adoc
@@ -8,7 +8,7 @@ This guide provides an overview of bundling {productname} with module bundlers s
 
 [NOTE]
 ====
-When using TinyMCE Cloud, dependencies and additional resources are automatically loaded. The information below applies to self-hosted installations using NPM or ZIP packages.
+When using {cloudname}, dependencies and additional resources are automatically loaded. The information below applies to self-hosted installations using NPM or ZIP packages. All examples in this guide use NPM package import paths.
 ====
 
 == Module syntax support
@@ -24,7 +24,7 @@ Both syntaxes are supported, but this documentation uses ES6 module syntax in al
 
 include::partial$module-loading/bundling-required-components.adoc[]
 
-=== Example: Basic required imports
+=== Example: Basic recommended imports
 
 [source,js]
 ----
@@ -105,7 +105,7 @@ Some plugins depend on other plugins. For example:
 
 * The `+advtable+` plugin requires the `+table+` plugin
 
-Always import dependent plugins before the plugin that requires them.
+Always import dependent plugins before the plugin that requires them. For a full list of plugin dependencies, see each plugin's documentation page.
 
 == CSS files
 

--- a/modules/ROOT/pages/bundling-guide.adoc
+++ b/modules/ROOT/pages/bundling-guide.adoc
@@ -1,0 +1,179 @@
+= Bundling {productname} - Overview
+:navtitle: Bundling overview
+:description_short: Overview of bundling TinyMCE with module bundlers
+:description: Overview of bundling TinyMCE with module bundlers including required imports, plugins, and resources
+:keywords: bundling, webpack, vite, rollup, modules, imports, es6, commonjs
+
+This guide provides an overview of bundling {productname} with module bundlers such as Webpack, Vite, Rollup, or Browserify. For bundler-specific setup instructions, see xref:introduction-to-bundling-tinymce.adoc[Introduction to bundling {productname}].
+
+[NOTE]
+====
+When using TinyMCE Cloud, dependencies and additional resources are automatically loaded. The information below applies to self-hosted installations using NPM or ZIP packages.
+====
+
+== Module syntax support
+
+{productname} supports both ES6 modules and CommonJS modules:
+
+* **ES6 modules**: Use `+import+` statements (shown in all documentation examples)
+* **CommonJS modules**: Use `+require()+` statements
+
+Both syntaxes are supported, but this documentation uses ES6 module syntax in all examples.
+
+== Required imports
+
+include::partial$module-loading/bundling-required-components.adoc[]
+
+=== Example: Basic required imports
+
+[source,js]
+----
+/* Import TinyMCE */
+import tinymce from 'tinymce';
+
+/* Default icons are required */
+import 'tinymce/icons/default';
+
+/* Required TinyMCE components */
+import 'tinymce/themes/silver';
+import 'tinymce/models/dom';
+
+/* Import a skin (oxide is the default) */
+import 'tinymce/skins/ui/oxide/skin.js';
+import 'tinymce/skins/ui/oxide/content.js';
+
+/* Content CSS for editor content styling */
+import 'tinymce/skins/content/default/content.js';
+----
+
+For more information on:
+
+* Icons, see xref:bundling-icons.adoc[Bundling icons]
+* Themes, see xref:bundling-themes.adoc[Bundling themes]
+* Models, see xref:bundling-models.adoc[Bundling models]
+* Skins, see xref:bundling-skins.adoc[Bundling skins]
+* Content CSS, see xref:bundling-content-css.adoc[Bundling content CSS]
+
+== Importing plugins
+
+Most plugins can be imported directly using their plugin code. The import path depends on whether the plugin is a community or premium plugin:
+
+=== Community plugins
+
+[source,js]
+----
+import 'tinymce/plugins/<plugincode>';
+----
+
+=== Premium plugins
+
+[source,js]
+----
+import 'tinymce-premium/plugins/<plugincode>';
+----
+
+[IMPORTANT]
+====
+When using premium plugins with a commercial license, you must include the `+licensekeymanager+` plugin:
+
+[source,js]
+----
+import 'tinymce-premium/plugins/licensekeymanager';
+----
+
+For more information, see xref:bundling-plugins.adoc#using-premium-plugins[Using premium plugins].
+====
+
+For detailed information on bundling plugins, see xref:bundling-plugins.adoc[Bundling plugins].
+
+== Plugin gotchas
+
+Some plugins require additional resource files (JS, CSS, or language files) to function properly. These must be explicitly imported when bundling:
+
+[IMPORTANT]
+====
+Key points about plugin resources:
+
+* Core plugin resources typically use relative paths without file extensions
+* Premium plugin resources (from `+tinymce-premium+`) MUST include the `.js` or `.css` file extension in the import path
+* Plugins lazy-load additional resources at runtime, so these files must be included in the bundle or accessible as static assets
+====
+
+=== Plugins requiring additional resources
+
+* **Emoticons**: Requires an emoji database file (`+js/emojis+`)
+* **Help**: Requires a keyboard navigation language file (`+js/i18n/keynav/<lang>+`)
+* **Page Embed**: Requires a CSS file (`+css/empa30.css+`)
+* **Autocorrect**: Requires a word list file (`+js/en.js+`)
+* **Uploadcare**: Requires a webcomponent file (`+js/uc-video.js+`)
+
+For specific import examples, see xref:bundling-plugins.adoc#plugin-resources[Additional plugin resources].
+
+=== Plugin dependencies
+
+Some plugins depend on other plugins. For example:
+
+* The `+advtable+` plugin requires the `+table+` plugin
+
+Always import dependent plugins before the plugin that requires them.
+
+== CSS files
+
+Plugin CSS files are typically included automatically when importing plugins. However, some plugins may require explicit CSS imports for proper styling.
+
+When using skins, you must import both:
+
+* The skin CSS file (`+skin.css+` or `+skin.js+`)
+* The content UI CSS file (`+content.css+` or `+content.js+`)
+
+For more information, see xref:bundling-skins.adoc[Bundling skins].
+
+== Language files
+
+Language files are optional and used for localizing the {productname} UI and plugin interfaces.
+
+=== Core UI language files
+
+[source,js]
+----
+import 'tinymce/langs/<language>.js';
+----
+
+For premium packages:
+
+[source,js]
+----
+import 'tinymce-premium/langs/<language>.js';
+----
+
+=== Plugin language files
+
+Plugin language files are separate from the main UI language files:
+
+[source,js]
+----
+// Community plugin language file
+import 'tinymce/plugins/<plugincode>/langs/<language>.js';
+
+// Premium plugin language file (note: .js extension required)
+import 'tinymce-premium/plugins/<plugincode>/langs/<language>.js';
+----
+
+[NOTE]
+====
+* English is the default language, so `+en.js+` language files don't exist
+* For premium plugins, the language file path must include the `.js` extension
+====
+
+For more information, see xref:bundling-localization.adoc[UI localizations].
+
+== Next steps
+
+* xref:introduction-to-bundling-tinymce.adoc[Introduction to bundling {productname}] - Bundler-specific guides
+* xref:bundling-themes.adoc[Bundling themes] - Theme configuration and customization
+* xref:bundling-models.adoc[Bundling models] - Model configuration
+* xref:bundling-plugins.adoc[Bundling plugins] - Detailed plugin bundling information
+* xref:bundling-skins.adoc[Bundling skins] - Skin configuration and customization
+* xref:bundling-icons.adoc[Bundling icons] - Icon pack configuration
+* xref:bundling-content-css.adoc[Content CSS] - Content styling configuration
+* xref:bundling-localization.adoc[UI localizations] - Language file configuration

--- a/modules/ROOT/pages/bundling-guide.adoc
+++ b/modules/ROOT/pages/bundling-guide.adoc
@@ -114,7 +114,7 @@ Some plugins require additional CSS files. Plugin CSS files are included automat
 When using skins, you must import both:
 
 * The skin CSS file (`+skin.css+` or `+skin.js+`)
-* The content UI CSS file (`+content.css+` or `+content.js+`)
+* The content skin CSS file (`+content.css+` or `+content.js+`)
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/casechange.adoc
+++ b/modules/ROOT/pages/casechange.adoc
@@ -16,6 +16,8 @@ liveDemo::casechange[]
 
 // include::partial$misc/purchase-premium-plugins.adoc[]
 
+include::partial$misc/bundling-guide-link.adoc[]
+
 == Changing the case of selected text
 
 Perform the following steps to change the case of selected text in a document to lowercase, UPPERCASE, or Title Case:

--- a/modules/ROOT/pages/charmap.adoc
+++ b/modules/ROOT/pages/charmap.adoc
@@ -18,6 +18,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == Options
 
 The default map of unicode characters can be overridden or extended through the options below.

--- a/modules/ROOT/pages/checklist.adoc
+++ b/modules/ROOT/pages/checklist.adoc
@@ -48,6 +48,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 NOTE: The *Checklist* plugin has to be used together with the xref:lists.adoc[Lists] plugin to work.
 
 == CSS

--- a/modules/ROOT/pages/code.adoc
+++ b/modules/ROOT/pages/code.adoc
@@ -18,6 +18,8 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
 include::partial$misc/code-dialog-and-selection-state.adoc[]
 
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]

--- a/modules/ROOT/pages/codesample.adoc
+++ b/modules/ROOT/pages/codesample.adoc
@@ -18,6 +18,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 By default, `+codesample+` uses `+http://prismjs.com/+` to embed the code samples within the editor and works out of the box. That is, when a user copies valid code syntax into the editable area the code will be automatically formatted according to Prism default CSS rules.
 
 NOTE: Prism.js and prism.css need to be added to a page for syntax highlighting to work. See the instructions below to learn how to do this.

--- a/modules/ROOT/pages/directionality.adoc
+++ b/modules/ROOT/pages/directionality.adoc
@@ -19,6 +19,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 == Commands

--- a/modules/ROOT/pages/editimage.adoc
+++ b/modules/ROOT/pages/editimage.adoc
@@ -40,6 +40,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == Self-hosted Installation
 
 To enable the {productname} Image Editing plugin:

--- a/modules/ROOT/pages/emoticons.adoc
+++ b/modules/ROOT/pages/emoticons.adoc
@@ -22,6 +22,8 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
 == Browser emoji support
 
 By default, the emoticon plugin inserts Unicode character codes, such as `+\ud83d\ude03+` for the smiley emoji. How emoji are rendered is dependent on the web browser and operating system of the user. As a result of this, some emoji may be rendered in black and white, or may not render. To ensure emoji render consistently across browsers and operating systems, {companyname} recommends adding an emoji-compatible web font to the default font-family using xref:add-css-options.adoc#content_css[`+content_css+`].

--- a/modules/ROOT/pages/exportpdf.adoc
+++ b/modules/ROOT/pages/exportpdf.adoc
@@ -39,6 +39,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 For more infomation on the exportpdf_token_provider option, see xref:exportpdf.adoc#exportpdf-token-provider[exportpdf_token_provider].
 
 include::partial$misc/admon-jwt-authentication-requirements.adoc[]

--- a/modules/ROOT/pages/exportword.adoc
+++ b/modules/ROOT/pages/exportword.adoc
@@ -47,6 +47,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 For more infomation on the exportword_token_provider option, see xref:exportword.adoc#exportword-token-provider[exportword_token_provider]
 
 include::partial$misc/admon-jwt-authentication-requirements.adoc[]

--- a/modules/ROOT/pages/footnotes.adoc
+++ b/modules/ROOT/pages/footnotes.adoc
@@ -31,6 +31,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 The footnotes section, which is placed at the bottom of the {productname} editor, is created when the first footnote is added.
 
 Footnotes can be inserted with

--- a/modules/ROOT/pages/formatpainter.adoc
+++ b/modules/ROOT/pages/formatpainter.adoc
@@ -34,6 +34,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == Using Format Painter
 
 The format painter is accessed using either keyboard shortcuts or a toolbar button.

--- a/modules/ROOT/pages/fullpagehtml.adoc
+++ b/modules/ROOT/pages/fullpagehtml.adoc
@@ -35,6 +35,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 [WARNING]
 ====
 **Certain elements may be removed by XSS sanitization**  

--- a/modules/ROOT/pages/fullscreen.adoc
+++ b/modules/ROOT/pages/fullscreen.adoc
@@ -23,6 +23,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 [NOTE]
 This feature is supported only when {productname} is operating in classic mode. It is **not supported** in inline mode. For details on the differences between editing modes, refer to xref:use-tinymce-classic.adoc[Classic editing mode].
 

--- a/modules/ROOT/pages/help.adoc
+++ b/modules/ROOT/pages/help.adoc
@@ -39,6 +39,8 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
 == Options
 
 include::partial$configuration/help_accessibility.adoc[leveloffset=+1]

--- a/modules/ROOT/pages/image.adoc
+++ b/modules/ROOT/pages/image.adoc
@@ -22,6 +22,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 NOTE: This is not drag-drop functionality and the user is required to enter the path to the image. Optionally the user can also enter the image description, dimensions, and whether image proportions should be constrained (selected via a checkbox). Some of these settings can be preset using the plugin's configuration options.
 
 :includedSection: imagePlugin

--- a/modules/ROOT/pages/importcss.adoc
+++ b/modules/ROOT/pages/importcss.adoc
@@ -19,6 +19,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == Options
 
 These settings affect the execution of the `+importcss+` plugin, specifically the way that these operations are handled.

--- a/modules/ROOT/pages/importword.adoc
+++ b/modules/ROOT/pages/importword.adoc
@@ -40,6 +40,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 For more infomation on the importword_token_provider option, see xref:importword.adoc#importword-token-provider[importword_token_provider].
 
 include::partial$misc/admon-jwt-authentication-requirements.adoc[]

--- a/modules/ROOT/pages/inline-css.adoc
+++ b/modules/ROOT/pages/inline-css.adoc
@@ -31,6 +31,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == Usage notes
 
 The {pluginname} plugin does not support

--- a/modules/ROOT/pages/insertdatetime.adoc
+++ b/modules/ROOT/pages/insertdatetime.adoc
@@ -18,6 +18,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == Options
 
 These settings affect the execution of the `+insertdatetime+` plugin. Formats for both dates and times can be set in these configuration options.

--- a/modules/ROOT/pages/introduction-to-bundling-tinymce.adoc
+++ b/modules/ROOT/pages/introduction-to-bundling-tinymce.adoc
@@ -4,6 +4,11 @@
 :description: Introduction to bundling TinyMCE with Webpack, Rollup.js, or Browserify.
 :keywords: webpack, browserify, es6, rollup, commonjs, modules, tinymce, es2015
 
+[NOTE]
+====
+For a general overview of bundling {productname}, including required imports, plugin gotchas, and common patterns, see xref:bundling-guide.adoc[Bundling {productname} - Overview].
+====
+
 The following guides and reference pages assist with bundling {productname} into your project using a module bundler, such as Webpack, Rollup.js, and Browserify.
 
 == Webpack

--- a/modules/ROOT/pages/link.adoc
+++ b/modules/ROOT/pages/link.adoc
@@ -22,6 +22,8 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
 == Options
 
 These settings affect the execution of the `+link+` plugin. Predefined links, targets, and more can be specified here.

--- a/modules/ROOT/pages/linkchecker.adoc
+++ b/modules/ROOT/pages/linkchecker.adoc
@@ -32,6 +32,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == Self-hosted Instructions
 
 Customers using a Self-hosted environment will need to provide a URL to their deployment of the link checking service via the `+linkchecker_service_url+` parameter

--- a/modules/ROOT/pages/lists.adoc
+++ b/modules/ROOT/pages/lists.adoc
@@ -20,6 +20,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == Example adding the `listprops` menu item to the Tools menu
 
 The `listprops` xref:#menu-items[menu item] opens the List Properties dialog.

--- a/modules/ROOT/pages/markdown.adoc
+++ b/modules/ROOT/pages/markdown.adoc
@@ -50,6 +50,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == Interactive examples
 
 liveDemo::{plugincode}[]

--- a/modules/ROOT/pages/math.adoc
+++ b/modules/ROOT/pages/math.adoc
@@ -32,6 +32,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == How to Use
 
 To work with math elements, follow these steps:

--- a/modules/ROOT/pages/media.adoc
+++ b/modules/ROOT/pages/media.adoc
@@ -20,6 +20,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == Options
 
 These options affect the execution of the `+media+` plugin, making it possible to disable parts of the media dialog made available to an end-user inserting or editing media items.

--- a/modules/ROOT/pages/mentions.adoc
+++ b/modules/ROOT/pages/mentions.adoc
@@ -16,6 +16,8 @@ liveDemo::mentions[height="400"]
 
 // include::partial$misc/purchase-premium-plugins.adoc[]
 
+include::partial$misc/bundling-guide-link.adoc[]
+
 == Options
 
 These configuration options affect the execution of the `+mentions+` plugin. The main option that needs to be implemented is the `+mentions_fetch+` callback.

--- a/modules/ROOT/pages/mergetags.adoc
+++ b/modules/ROOT/pages/mergetags.adoc
@@ -47,6 +47,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 The {pluginname} plugin provides an xref:autocompleter.adoc[autocompleter] for adding a merge tag without using the toolbar button or menu item.
 
 The autocompleter is triggered by typing a specified prefix, controlled by the xref:#mergetags_prefix[`+mergetags_prefix+`] option.

--- a/modules/ROOT/pages/nonbreaking.adoc
+++ b/modules/ROOT/pages/nonbreaking.adoc
@@ -18,6 +18,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == Options
 
 include::partial$configuration/nonbreaking_force_tab.adoc[leveloffset=+1]

--- a/modules/ROOT/pages/pagebreak.adoc
+++ b/modules/ROOT/pages/pagebreak.adoc
@@ -20,6 +20,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == Options
 
 These settings affect the execution of the `+pagebreak+` plugin. They enable you to specify how the page break should be generated in the HTML source code and determine whether the page break element(s) should be wrapped in `+<p>+` tags.

--- a/modules/ROOT/pages/pageembed.adoc
+++ b/modules/ROOT/pages/pageembed.adoc
@@ -34,6 +34,8 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
 *Result*: The image:icons/embed-page.svg[Page Embed](*Page Embed*) button appears in the toolbar menu.
 
 == Using Page Embed

--- a/modules/ROOT/pages/permanentpen.adoc
+++ b/modules/ROOT/pages/permanentpen.adoc
@@ -108,6 +108,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == Options
 
 include::partial$configuration/permanentpen_properties.adoc[leveloffset=+1]

--- a/modules/ROOT/pages/preview.adoc
+++ b/modules/ROOT/pages/preview.adoc
@@ -18,6 +18,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]

--- a/modules/ROOT/pages/quickbars.adoc
+++ b/modules/ROOT/pages/quickbars.adoc
@@ -31,6 +31,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 === Disabling specific quick toolbars
 
 The following examples show how to disable specific quick toolbars for editors where they are not required.

--- a/modules/ROOT/pages/revisionhistory.adoc
+++ b/modules/ROOT/pages/revisionhistory.adoc
@@ -59,6 +59,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == Understanding revision types
 
 The {pluginname} plugin offers three revision types:

--- a/modules/ROOT/pages/save.adoc
+++ b/modules/ROOT/pages/save.adoc
@@ -18,6 +18,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == Save error messages
 
 The `+"Error: Form submit field collision."+` error message will appear if you call the submit button of your form "submit", which causes a collision with the JS form `+submit+` function and makes it impossible to submit the form using code. This can easily be avoided by naming the submit button `+"submitbtn"+` or similar.

--- a/modules/ROOT/pages/searchreplace.adoc
+++ b/modules/ROOT/pages/searchreplace.adoc
@@ -18,6 +18,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]

--- a/modules/ROOT/pages/suggestededits.adoc
+++ b/modules/ROOT/pages/suggestededits.adoc
@@ -17,6 +17,8 @@ liveDemo::{plugincode}[]
 
 include::partial$misc/admon-iframe-only.adoc[]
 
+include::partial$misc/bundling-guide-link.adoc[]
+
 == How it works
 
 The {pluginname} plugin keeps track of every edit made to the document by the current user and stores this metadata in an internal model of the document. These suggestions can then be reviewed in the Review Edits view, where each edit is highlighted in the document, and where users can accept, reject, or provide feedback. The Review Edits view is accessible via either the `suggestededits` toolbar button or menu button within the `View` menu.

--- a/modules/ROOT/pages/table.adoc
+++ b/modules/ROOT/pages/table.adoc
@@ -18,6 +18,8 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
 == Options
 
 NOTE: For additional options that are provided by the core table functionality, see xref:table-options.adoc[Table Options].

--- a/modules/ROOT/pages/tableofcontents.adoc
+++ b/modules/ROOT/pages/tableofcontents.adoc
@@ -29,6 +29,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 The _Table of Contents_ will have a simple HTML structure - a wrapper `+div+` element, a header with _editable_ title and unordered nested list with navigation links. Nesting depth is customizable.
 
 Internally plugin does not apply inline styles. Basic formatting can be added via xref:editor-content-css.adoc[Boilerplate Content CSS], that can be customized to your needs.

--- a/modules/ROOT/pages/uploadcare-documents.adoc
+++ b/modules/ROOT/pages/uploadcare-documents.adoc
@@ -66,6 +66,8 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
 [NOTE]
 ====
 The {pluginname} plugin automatically configures the xref:link.adoc#files_upload_handler[`+files_upload_handler+`] and `+documents_file_types+` options when both the Link plugin and the {pluginname} plugin are enabled. This enables file uploads in the Link dialog without requiring manual configuration. However, you can customize the list of supported file types by explicitly setting the xref:uploadcare.adoc#documents-file-types[`+documents_file_types+`] option as shown in the example above.

--- a/modules/ROOT/pages/uploadcare-image.adoc
+++ b/modules/ROOT/pages/uploadcare-image.adoc
@@ -47,6 +47,8 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
 [NOTE]
 ====
 The {pluginname} plugin overrides the xref:quickbars.adoc[Quickbar] quickimage toolbar item. To ensure a better user experience and to avoid having two image buttons configure `quickbars_insert_toolbar` to omit the `quickimage` toolbar item.

--- a/modules/ROOT/pages/uploadcare-video.adoc
+++ b/modules/ROOT/pages/uploadcare-video.adoc
@@ -44,6 +44,8 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
 [NOTE]
 ====
 The {pluginname} plugin uses the same plugin code `+uploadcare+` as the Media Optimizer plugin. Video functionality is automatically enabled when video files are uploaded.

--- a/modules/ROOT/pages/uploadcare.adoc
+++ b/modules/ROOT/pages/uploadcare.adoc
@@ -50,6 +50,8 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
 == Features
 
 For a complete guide to the features provided by the {pluginname} plugin, see the following pages:

--- a/modules/ROOT/pages/visualblocks.adoc
+++ b/modules/ROOT/pages/visualblocks.adoc
@@ -18,6 +18,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == Options
 
 This setting affects the execution of the `+visualblocks+` plugin. You may specify whether blocks are visible by default here.

--- a/modules/ROOT/pages/visualchars.adoc
+++ b/modules/ROOT/pages/visualchars.adoc
@@ -18,6 +18,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 == Options
 
 This setting affects the execution of the `+visualchars+` plugin. Characters can be configured to be visible by default using this option.

--- a/modules/ROOT/pages/wordcount.adoc
+++ b/modules/ROOT/pages/wordcount.adoc
@@ -151,6 +151,9 @@ tinymce.init({
 });
 ----
 
+include::partial$misc/bundling-guide-link.adoc[]
+
+
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]

--- a/modules/ROOT/partials/misc/bundling-guide-link.adoc
+++ b/modules/ROOT/partials/misc/bundling-guide-link.adoc
@@ -1,0 +1,4 @@
+[NOTE]
+====
+For information on bundling this plugin with module bundlers, see xref:bundling-guide.adoc[Bundling {productname} - Overview].
+====

--- a/modules/ROOT/partials/module-loading/bundling-plugin-resources.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-plugin-resources.adoc
@@ -138,3 +138,82 @@ require('../tinymce/plugins/emoticons/js/emojis');
 ----
 |===
 
+[[autocorrect-plugin-resources]]
+==== Spelling Autocorrect plugin (`+autocorrect+`)
+
+The xref:autocorrect.adoc[Spelling Autocorrect plugin] requires a word list file. English is the only supported language.
+
+[cols='1,1,4']
+|===
+|Module Syntax |Source |Example
+
+.2+|ES6+
+|npm
+a|
+[source, js]
+----
+import 'tinymce-premium/plugins/autocorrect/js/en.js';
+----
+
+|`.zip`
+a|
+[source, js]
+----
+import '../plugins/autocorrect/js/en.js';
+----
+
+.2+|Common JS
+|npm
+a|
+[source, js]
+----
+require('tinymce-premium/plugins/autocorrect/js/en.js');
+----
+
+|`.zip`
+a|
+[source, js]
+----
+require('../plugins/autocorrect/js/en.js');
+----
+|===
+
+[[uploadcare-plugin-resources]]
+==== Media Optimizer plugin (`+uploadcare+`)
+
+The xref:uploadcare.adoc[Media Optimizer plugin] requires a webcomponent file for video functionality. The `+uc-video.js+` file is needed when using the video features of the plugin.
+
+[cols='1,1,4']
+|===
+|Module Syntax |Source |Example
+
+.2+|ES6+
+|npm
+a|
+[source, js]
+----
+import 'tinymce-premium/plugins/uploadcare/js/uc-video.js';
+----
+
+|`.zip`
+a|
+[source, js]
+----
+import '../plugins/uploadcare/js/uc-video.js';
+----
+
+.2+|Common JS
+|npm
+a|
+[source, js]
+----
+require('tinymce-premium/plugins/uploadcare/js/uc-video.js');
+----
+
+|`.zip`
+a|
+[source, js]
+----
+require('../plugins/uploadcare/js/uc-video.js');
+----
+|===

--- a/modules/ROOT/partials/module-loading/bundling-required-components.adoc
+++ b/modules/ROOT/partials/module-loading/bundling-required-components.adoc
@@ -8,11 +8,11 @@ The following components are required to bundle {productname}:
 - A _skin_ for styling the user interface, including toolbars and menus. This can be a community, premium or custom skin.
 - A _content skin_ for styling UI features within the content such as table and image resizing. This can be a community, premium or custom skin.
 
-The global must be first, the rest can be in any order.
+The global must be first, the rest can be in any order. When using premium plugins with a commercial license, the `licensekeymanager` plugin is also required.
 
 Additional components that are optional but recommended:
 
 - _Content CSS_ for styling editor content. There are community and premium style skins available, or use custom content CSS.
 - Plugins to be used with the editor.
-- A custom or premium _icon pack_ to extend or override the default icons for toolbar buttons, including contextual toolbars. This can be a premium or custom icon pack.
+- A custom or premium _icon pack_ to extend or override the default icons for toolbar buttons, including contextual toolbars.
 --


### PR DESCRIPTION
Ticket: DOC-3367

Site: [New: Bundling guide (page)](https://pr-3983.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/bundling-guide)

## Summary

Adds a new bundling overview guide and improves bundling documentation consistency across the codebase.

## Changes

### New Files

- **`modules/ROOT/pages/bundling-guide.adoc`** - New bundling overview page providing:
  - Overview of bundling TinyMCE with module bundlers (Webpack, Vite, Rollup, Browserify)
  - Required imports (TinyMCE core, silver theme, dom model, default icons, skins, content CSS)
  - Plugin import syntax for community and premium plugins
  - Plugin gotchas (plugins requiring additional resources, plugin dependencies)
  - CSS files information
  - Language files information
  - Links to all related bundling reference pages
- **60 plugin feature pages** - Added `include::partial$misc/bundling-guide-link.adoc[]` to all core and premium plugins.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.

Review:
- [x] Documentation Team Lead has reviewed