### PR TITLE
DOC-3370: Fix to prevent invalid URLs from matching the redirect and causing traffic spikes

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -19,6 +19,12 @@
   },
   {
     "location": "/docs/",
+    "pattern": "^/docs/?$",
+    "redirect": "/docs/tinymce/latest/"
+  },
+  {
+    "location": "/docs/",
+    "pattern": "^/docs/tinymce/?$",
     "redirect": "/docs/tinymce/latest/"
   },
   {


### PR DESCRIPTION
Ticket: DOC-3370

Changes:

Replaced the catch-all redirect at `/docs/` with two pattern-based redirects:
- Pattern `^/docs/?$` — matches exactly `/docs` or `/docs/`
- Pattern `^/docs/tinymce/?$` — matches exactly `/docs/tinymce` or `/docs/tinymce/`

This prevents invalid URLs from matching the redirect and causing traffic spikes.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed