### PR TITLE
DOC-3371_V2: Remove general `/docs/demo/` redirect causing catch-all issue for other redirects.

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -215,14 +215,6 @@
     "redirect": "/docs/tinymce/latest/webpack-es6-npm/"
   },
   {
-    "location": "/docs/advanced/yeoman-generator/",
-    "redirect": "/docs/tinymce/latest/yeoman-generator/"
-  },
-  {
-    "location": "/docs/api-reference/core/editor/editor/",
-    "redirect": "/docs/"
-  },
-  {
     "location": "/docs/api/",
     "redirect": "/docs/tinymce/latest/apis/tinymce.root/"
   },
@@ -291,10 +283,6 @@
     "redirect": "/docs/tinymce/latest/apis/tinymce.editor.ui.ui/"
   },
   {
-    "location": "/docs/api/tinymce.editor/",
-    "redirect": "/docs/"
-  },
-  {
     "location": "/docs/api/tinymce.geom/tinymce.geom.rect/",
     "redirect": "/docs/tinymce/latest/apis/tinymce.geom.rect/"
   },
@@ -329,126 +317,6 @@
   {
     "location": "/docs/api/tinymce.html/tinymce.html.writer/",
     "redirect": "/docs/tinymce/latest/apis/tinymce.html.writer/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.browsebutton/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.button/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.buttongroup/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.checkbox/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.collection/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.colorpicker/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.control/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.draghelper/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.factory/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.filepicker/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.flexlayout/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.form/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.formitem/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.iframe/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.listbox/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.menubar/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.menuitem/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.notification/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.panelbutton/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.path/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.progress/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.resizehandle/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.scrollable/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.slider/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.splitbutton/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.tabpanel/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.throbber/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.tooltip/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/api/tinymce.ui/tinymce.ui.window/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/api/tinymce.util/tinymce.util.color/",
-    "redirect": "/docs/tinymce/latest/"
   },
   {
     "location": "/docs/api/tinymce.util/tinymce.util.delay/",
@@ -503,10 +371,6 @@
     "redirect": "/docs/tinymce/latest/apis/tinymce.annotator/"
   },
   {
-    "location": "/docs/api/tinymce/tinymce.contentevent/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
     "location": "/docs/api/tinymce/tinymce.editor/",
     "redirect": "/docs/tinymce/latest/apis/tinymce.editor/"
   },
@@ -535,10 +399,6 @@
     "redirect": "/docs/tinymce/latest/apis/tinymce.plugin/"
   },
   {
-    "location": "/docs/api/tinymce/tinymce.progressstateevent/",
-    "redirect": "/docs/"
-  },
-  {
     "location": "/docs/api/tinymce/tinymce.shortcuts/",
     "redirect": "/docs/tinymce/latest/apis/tinymce.shortcuts/"
   },
@@ -553,14 +413,6 @@
   {
     "location": "/docs/api/tinymce/tinymce.windowmanager/",
     "redirect": "/docs/tinymce/latest/apis/tinymce.windowmanager/"
-  },
-  {
-    "location": "/docs/browser-compatibility/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/browser-extensions/",
-    "redirect": "/docs/"
   },
   {
     "location": "/docs/changelog/",
@@ -589,10 +441,6 @@
   {
     "location": "/docs/cloud-deployment-guide/plugin-editor-version-compatibility/",
     "redirect": "/docs/tinymce/latest/plugin-editor-version-compatibility/"
-  },
-  {
-    "location": "/docs/cms-web-application-settings/",
-    "redirect": "/docs/"
   },
   {
     "location": "/docs/configure/",
@@ -631,40 +479,12 @@
     "redirect": "/docs/tinymce/latest/user-formatting-options/"
   },
   {
-    "location": "/docs/configure/editor-settings/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/configure/editor/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/configure/file-image-link-tools/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/configure/file-image-pload/",
-    "redirect": "/docs/"
-  },
-  {
     "location": "/docs/configure/file-image-upload/",
     "redirect": "/docs/tinymce/latest/file-image-upload/"
   },
   {
     "location": "/docs/configure/integration-and-setup/",
     "redirect": "/docs/tinymce/latest/editor-important-options/"
-  },
-  {
-    "location": "/docs/configure/integration-and-setup/content-filtering/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/configure/integration/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/configure/jwt-authentication/",
-    "redirect": "/docs/"
   },
   {
     "location": "/docs/configure/localization/",
@@ -685,14 +505,6 @@
   {
     "location": "/docs/demo/",
     "redirect": "/docs/tinymce/latest/examples/"
-  },
-  {
-    "location": "/docs/demo/a11ychecker/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/demo/advcode/",
-    "redirect": "/docs/"
   },
   {
     "location": "/docs/demo/basic-example/",
@@ -739,10 +551,6 @@
     "redirect": "/docs/tinymce/latest/distraction-free-demo/"
   },
   {
-    "location": "/docs/demo/export/",
-    "redirect": "/docs/"
-  },
-  {
     "location": "/docs/demo/file-picker/",
     "redirect": "/docs/tinymce/latest/tinydrive-pick/"
   },
@@ -759,10 +567,6 @@
     "redirect": "/docs/tinymce/latest/formatpainter/"
   },
   {
-    "location": "/docs/demo/full-fateud/",
-    "redirect": "/docs/"
-  },
-  {
     "location": "/docs/demo/full-featured/",
     "redirect": "/docs/tinymce/latest/full-featured-premium-demo/"
   },
@@ -775,20 +579,8 @@
     "redirect": "/docs/tinymce/latest/inline-demo/"
   },
   {
-    "location": "/docs/demo/linkchecker/",
-    "redirect": "/docs/"
-  },
-  {
     "location": "/docs/demo/local-upload/",
     "redirect": "/docs/tinymce/latest/upload-images/"
-  },
-  {
-    "location": "/docs/demo/mediaembed/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/demo/mentions/",
-    "redirect": "/docs/"
   },
   {
     "location": "/docs/demo/pageembed/",
@@ -797,14 +589,6 @@
   {
     "location": "/docs/demo/permanentpen/",
     "redirect": "/docs/tinymce/latest/permanentpen/"
-  },
-  {
-    "location": "/docs/demo/powerpaste/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/demo/tiny-drive-demo/demo_files.json",
-    "redirect": "/docs/"
   },
   {
     "location": "/docs/demo/tiny-drive/",
@@ -975,44 +759,8 @@
     "redirect": "/docs/tinymce/latest/configure-required-services/"
   },
   {
-    "location": "/docs/enterprise/server/docker/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/enterprise/server/docker/docker-compose.yml",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/enterprise/server/docker/docker-compose.yml/openapi.json",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/enterprise/server/docker/setup/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/enterprise/server/docker/setup/aspnet.core/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/enterprise/server/docker/setup/java/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/enterprise/server/docker/setup/nodejs/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/enterprise/server/docker/setup/php/",
-    "redirect": "/docs/"
-  },
-  {
     "location": "/docs/enterprise/server/dockerservices/",
     "redirect": "/docs/tinymce/latest/bundle-intro-setup/"
-  },
-  {
-    "location": "/docs/enterprise/server/php/",
-    "redirect": "/docs/"
   },
   {
     "location": "/docs/enterprise/server/self-hosting-hunspell/",
@@ -1073,10 +821,6 @@
   {
     "location": "/docs/general-configuration-guide/localize-your-language/",
     "redirect": "/docs/tinymce/latest/localize-your-language/"
-  },
-  {
-    "location": "/docs/general-configuration-guide/mobile/",
-    "redirect": "/docs/tinymce/latest/"
   },
   {
     "location": "/docs/general-configuration-guide/multiple-editors/",
@@ -1143,10 +887,6 @@
     "redirect": "/docs/tinymce/latest/support/"
   },
   {
-    "location": "/docs/get-started/multiple-editors/",
-    "redirect": "/docs/"
-  },
-  {
     "location": "/docs/get-started/system-requirements/",
     "redirect": "/docs/tinymce/latest/support/"
   },
@@ -1191,20 +931,12 @@
     "redirect": "/docs/tinymce/latest/django-cloud/"
   },
   {
-    "location": "/docs/integrations/dojo/",
-    "redirect": "/docs/"
-  },
-  {
     "location": "/docs/integrations/expressjs/",
     "redirect": "/docs/tinymce/latest/expressjs-pm/"
   },
   {
     "location": "/docs/integrations/jquery/",
     "redirect": "/docs/tinymce/latest/jquery-cloud/"
-  },
-  {
-    "location": "/docs/integrations/knockout/",
-    "redirect": "/docs/tinymce/latest/"
   },
   {
     "location": "/docs/integrations/laravel/laravel-composer-install/",
@@ -1221,10 +953,6 @@
   {
     "location": "/docs/integrations/laravel/laravel-zip-install/",
     "redirect": "/docs/tinymce/latest/laravel-zip-install/"
-  },
-  {
-    "location": "/docs/integrations/python/",
-    "redirect": "/docs/tinymce/latest/"
   },
   {
     "location": "/docs/integrations/rails/",
@@ -1255,16 +983,8 @@
     "redirect": "/docs/tinymce/latest/wordpress/"
   },
   {
-    "location": "/docs/js-tutorial/understanding-the-api/",
-    "redirect": "/docs/"
-  },
-  {
     "location": "/docs/migration-from-4x/",
     "redirect": "/docs/tinymce/latest/migration-from-6x/"
-  },
-  {
-    "location": "/docs/migration-from-5x/",
-    "redirect": "/docs/"
   },
   {
     "location": "/docs/migration-from-froala/",
@@ -1273,14 +993,6 @@
   {
     "location": "/docs/mobile/",
     "redirect": "/docs/tinymce/latest/tinymce-for-mobile/"
-  },
-  {
-    "location": "/docs/php-integration/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/plugin-module-settings/",
-    "redirect": "/docs/"
   },
   {
     "location": "/docs/plugins/",
@@ -1353,10 +1065,6 @@
   {
     "location": "/docs/plugins/comments/",
     "redirect": "/docs/tinymce/latest/introduction-to-tiny-comments/"
-  },
-  {
-    "location": "/docs/plugins/compat3x/",
-    "redirect": "/docs/tinymce/latest/"
   },
   {
     "location": "/docs/plugins/contextmenu/",
@@ -1467,16 +1175,8 @@
     "redirect": "/docs/tinymce/6/migration-from-5x/#removed-plugins"
   },
   {
-    "location": "/docs/plugins/obscenewords/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
     "location": "/docs/plugins/opensource/",
     "redirect": "/docs/tinymce/latest/plugins/"
-  },
-  {
-    "location": "/docs/plugins/opensource/accordion/",
-    "redirect": "/docs/"
   },
   {
     "location": "/docs/plugins/opensource/advlist/",
@@ -1621,10 +1321,6 @@
   {
     "location": "/docs/plugins/opensource/template/",
     "redirect": "/docs/tinymce/latest/migration-from-6x/#removed-plugins"
-  },
-  {
-    "location": "/docs/plugins/opensource/textcolor/",
-    "redirect": "/docs/tinymce/latest/"
   },
   {
     "location": "/docs/plugins/opensource/textpattern/",
@@ -1833,10 +1529,6 @@
   {
     "location": "/docs/plugins/wordcount/",
     "redirect": "/docs/tinymce/latest/wordcount/"
-  },
-  {
-    "location": "/docs/plugins/xulrunner/",
-    "redirect": "/docs/tinymce/latest/"
   },
   {
     "location": "/docs/quick-start/",
@@ -2067,18 +1759,6 @@
     "redirect": "/docs/tinymce/6/rtc-troubleshooting/"
   },
   {
-    "location": "/docs/textbox-io/apis/editor/editorconfig/editor.html",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/textbox-io/apis/editor/editorconfig/toolbar.html",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/themes/modern/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
     "location": "/docs/tinydrive/",
     "redirect": "/docs/tinymce/latest/tinydrive-introduction/"
   },
@@ -2149,10 +1829,6 @@
   {
     "location": "/docs/tinydrive/tinydrive-api/standalone/",
     "redirect": "/docs/tinymce/latest/introduction-to-tinydrive-apis/"
-  },
-  {
-    "location": "/docs/tinymce-for-swing/",
-    "redirect": "/docs/"
   },
   {
     "location": "/docs/tinymce/5/advanced/annotations/",
@@ -3075,15 +2751,6 @@
     "redirect": "/docs/tinymce/7/exportpdf/"
   },
   {
-    "location": "/docs/tinymce/8/",
-    "pattern": "^/docs/tinymce/8/(.*)$",
-    "redirect": "/docs/tinymce/latest/%1"
-  },
-  {
-    "location": "/docs/tinymce/demo/url-dialog-demo/external-page.html",
-    "redirect": "/docs/"
-  },
-  {
     "location": "/docs/tinymce/latest/6.0-release-notes-core-changes/",
     "redirect": "/docs/tinymce/6/"
   },
@@ -3180,44 +2847,8 @@
     "redirect": "/docs/tinymce/6/"
   },
   {
-    "location": "/docs/tinymce/latest/bundle-hyperlinking-container/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/tinymce/latest/bundle-imageproxy-container/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/tinymce/latest/bundle-spelling-container/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/tinymce/latest/editor-premium-upgrade-promotion/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/tinymce/latest/export-to-pdf-with-jwt-authentication-with-php/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/tinymce/latest/export-to-word-with-jwt-authentication-with-php/",
-    "redirect": "/docs/"
-  },
-  {
     "location": "/docs/tinymce/latest/export/",
     "redirect": "/docs/tinymce/latest/exportpdf/"
-  },
-  {
-    "location": "/docs/tinymce/latest/how-the-rtc-plugin-encrypts-content/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/tinymce/latest/import-word-with-jwt-authentication-with-php/",
-    "redirect": "/docs/"
-  },
-  {
-    "location": "/docs/tinymce/latest/importword-with-jwt-authentication-nodejs/",
-    "redirect": "/docs/"
   },
   {
     "location": "/docs/tinymce/latest/integrations/",
@@ -3236,56 +2867,12 @@
     "redirect": "/docs/tinymce/latest/full-featured-premium-demo/"
   },
   {
-    "location": "/docs/tinymce/latest/premium-skins-and-icons/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
     "location": "/docs/tinymce/latest/react-pm/",
     "redirect": "/docs/tinymce/latest/react-pm-host/"
   },
   {
     "location": "/docs/tinymce/latest/react-zip/",
     "redirect": "/docs/tinymce/latest/react-zip-host/"
-  },
-  {
-    "location": "/docs/tinymce/latest/rtc-encryption/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/tinymce/latest/rtc-events/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/tinymce/latest/rtc-getting-started/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/tinymce/latest/rtc-introduction/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/tinymce/latest/rtc-jwt-authentication/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/tinymce/latest/rtc-options-optional/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/tinymce/latest/rtc-options-overview/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/tinymce/latest/rtc-options-required/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/tinymce/latest/rtc-supported-functionality/",
-    "redirect": "/docs/tinymce/latest/"
-  },
-  {
-    "location": "/docs/tinymce/latest/rtc-troubleshooting/",
-    "redirect": "/docs/tinymce/latest/"
   },
   {
     "location": "/docs/tinymce/latest/template/",
@@ -3296,20 +2883,12 @@
     "redirect": "/docs/tinymce/latest/advanced-templates/"
   },
   {
-    "location": "/docs/tinymce/latest/yeoman-generator/",
-    "redirect": "/docs/"
-  },
-  {
     "location": "/docs/ui-components/",
     "redirect": "/docs/tinymce/latest/ui-components/"
   },
   {
     "location": "/docs/ui-components/autocompleter/",
     "redirect": "/docs/tinymce/latest/autocompleter/"
-  },
-  {
-    "location": "/docs/ui-components/button/",
-    "redirect": "/docs/tinymce/latest/"
   },
   {
     "location": "/docs/ui-components/contextform/",
@@ -3354,9 +2933,5 @@
   {
     "location": "/docs/ui-components/urldialog/",
     "redirect": "/docs/tinymce/latest/urldialog/"
-  },
-  {
-    "location": "/docs/usage-limits/",
-    "redirect": "/docs/tinymce/latest/"
   }
 ]

--- a/redirects.json
+++ b/redirects.json
@@ -2751,6 +2751,11 @@
     "redirect": "/docs/tinymce/7/exportpdf/"
   },
   {
+    "location": "/docs/tinymce/8/",
+    "pattern": "^/docs/tinymce/8/(.*)$",
+    "redirect": "/docs/tinymce/latest/%1"
+  },
+  {
     "location": "/docs/tinymce/latest/6.0-release-notes-core-changes/",
     "redirect": "/docs/tinymce/6/"
   },

--- a/redirects.json
+++ b/redirects.json
@@ -503,10 +503,6 @@
     "redirect": "/docs/tinymce/latest/url-handling/"
   },
   {
-    "location": "/docs/demo/",
-    "redirect": "/docs/tinymce/latest/examples/"
-  },
-  {
     "location": "/docs/demo/basic-example/",
     "redirect": "/docs/tinymce/latest/basic-example/"
   },


### PR DESCRIPTION
Ticket: DOC-3371 ref

Changes:
Looking at some redirects, it seem that by simply removing the general `/docs/demo/` redirect, this should allow the specific `/docs/demo/...` redirects to work as expected.- currently they are not. The general `/docs/demo/` rule seems to be catching requests like `/docs/demo/basic-example/` before the specific rule runs, and depending on order and matching logic this is causing issues.

What happens now:
✅ `/docs/demo/basic-example/` → `/docs/tinymce/latest/basic-example/`
✅ `/docs/demo/casechange/` → `/docs/tinymce/latest/casechange/`
✅ All other specific /docs/demo/... paths → their specific destinations

The specific redirects should now work without the catch-all interfering.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed