### PR TITLE
DOC-3371: Remove general /docs/demo/ redirect causing catch-all issue for other redirects.

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -509,10 +509,6 @@
     "redirect": "/docs/tinymce/latest/url-handling/"
   },
   {
-    "location": "/docs/demo/",
-    "redirect": "/docs/tinymce/latest/examples/"
-  },
-  {
     "location": "/docs/demo/basic-example/",
     "redirect": "/docs/tinymce/latest/basic-example/"
   },


### PR DESCRIPTION
Ticket: DOC-3371

Changes:

Looking at some redirects, it seem that by simply removing the general `/docs/demo/` redirect, this should allow the specific `/docs/demo/...` redirects to work as expected.- currently they are not. The general `/docs/demo/` rule seems to be catching requests like `/docs/demo/basic-example/` before the specific rule runs, and depending on order and matching logic this is causing issues.

What happens now:
✅ `/docs/demo/basic-example/` → `/docs/tinymce/latest/basic-example/`
✅ `/docs/demo/casechange/` → `/docs/tinymce/latest/casechange/`
✅ All other specific /docs/demo/... paths → their specific destinations

The specific redirects should now work without the catch-all interfering.

Review:
- [ ] Documentation Team Lead has reviewed