### PR TITLE
DOC-3373: Add new .sh script to copy to root post build.

### DIFF
--- a/-scripts/copy-llms-files.sh
+++ b/-scripts/copy-llms-files.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Copy llms.txt files to site root after Antora build
+# This makes them accessible at /docs/llms.txt and /docs/llms-full.txt for AI/LLM discoverability
+
+set -e
+
+BUILD_DIR="${1:-build/site}"
+
+if [ ! -d "$BUILD_DIR" ]; then
+  echo "Error: Build directory not found: $BUILD_DIR"
+  exit 1
+fi
+
+# Find the latest version directory (usually 'latest' or version number)
+LATEST_DIR=$(find "$BUILD_DIR" -type d -path "*/tinymce/*/_attachments" -name "_attachments" | head -1 | xargs dirname)
+
+if [ -z "$LATEST_DIR" ]; then
+  echo "Error: Could not find _attachments directory in $BUILD_DIR"
+  exit 1
+fi
+
+ATTACHMENTS_DIR="$LATEST_DIR/_attachments"
+
+if [ ! -f "$ATTACHMENTS_DIR/llms.txt" ] || [ ! -f "$ATTACHMENTS_DIR/llms-full.txt" ]; then
+  echo "Error: llms.txt files not found in $ATTACHMENTS_DIR"
+  exit 1
+fi
+
+# Copy files to root
+cp "$ATTACHMENTS_DIR/llms.txt" "$BUILD_DIR/llms.txt"
+cp "$ATTACHMENTS_DIR/llms-full.txt" "$BUILD_DIR/llms-full.txt"
+
+echo "✓ Copied llms.txt files to $BUILD_DIR/"
+echo "  - $BUILD_DIR/llms.txt"
+echo "  - $BUILD_DIR/llms-full.txt"

--- a/-scripts/copy-llms-files.sh
+++ b/-scripts/copy-llms-files.sh
@@ -7,30 +7,15 @@ set -e
 
 BUILD_DIR="${1:-build/site}"
 
-if [ ! -d "$BUILD_DIR" ]; then
-  echo "Error: Build directory not found: $BUILD_DIR"
+echo "Copying llms.txt files to $BUILD_DIR/..."
+
+find "$BUILD_DIR" -mindepth 2 \( -name "llms.txt" -o -name "llms-full.txt" \) \
+    -exec cp {} "$BUILD_DIR/" \; \
+    -print
+
+if [ ! -f "$BUILD_DIR/llms.txt" ] || [ ! -f "$BUILD_DIR/llms-full.txt" ]; then
+  echo "Error: one or both llms.txt files were not copied to $BUILD_DIR"
   exit 1
 fi
 
-# Find the latest version directory (usually 'latest' or version number)
-LATEST_DIR=$(find "$BUILD_DIR" -type d -path "*/tinymce/*/_attachments" -name "_attachments" | head -1 | xargs dirname)
-
-if [ -z "$LATEST_DIR" ]; then
-  echo "Error: Could not find _attachments directory in $BUILD_DIR"
-  exit 1
-fi
-
-ATTACHMENTS_DIR="$LATEST_DIR/_attachments"
-
-if [ ! -f "$ATTACHMENTS_DIR/llms.txt" ] || [ ! -f "$ATTACHMENTS_DIR/llms-full.txt" ]; then
-  echo "Error: llms.txt files not found in $ATTACHMENTS_DIR"
-  exit 1
-fi
-
-# Copy files to root
-cp "$ATTACHMENTS_DIR/llms.txt" "$BUILD_DIR/llms.txt"
-cp "$ATTACHMENTS_DIR/llms-full.txt" "$BUILD_DIR/llms-full.txt"
-
-echo "✓ Copied llms.txt files to $BUILD_DIR/"
-echo "  - $BUILD_DIR/llms.txt"
-echo "  - $BUILD_DIR/llms-full.txt"
+echo "Done."

--- a/.github/workflows/deploy_docs_v2.yml
+++ b/.github/workflows/deploy_docs_v2.yml
@@ -50,6 +50,9 @@ jobs:
     - name: Build Website
       run: yarn antora ./antora-playbook.yml
 
+    - name: Copy llms.txt files to root
+      run: ./-scripts/copy-llms-files.sh build/site
+
     - name: Rename site folder to docs
       run: |
         mv ./build/site ./build/docs

--- a/.github/workflows/preview_create.yml
+++ b/.github/workflows/preview_create.yml
@@ -43,6 +43,9 @@ jobs:
     - name: Build Website
       run: yarn antora ./antora-playbook.yml
 
+    - name: Copy llms.txt files to root
+      run: ./-scripts/copy-llms-files.sh build/site
+
     - name: Rename site folder to docs
       run: |
         mv ./build/site ./build/docs


### PR DESCRIPTION
Ticket: DOC-3373

PR #1: Main Branch (Infrastructure & Build Tools)

Purpose: Add reusable build infrastructure for llms.txt files that will live in `/latest` version of tinymce-docs ie 8x
Why: Antora doesn't support root-level files by design. Post-build steps are the standard workaround to place files at the site root.

What it does:
- Adds utility script to -scripts/:
  - copy-llms-files.sh — Copies llms.txt files from _attachments/ to site root so they're accessible at /docs/llms.txt
- Updates .github/workflows/preview_create.yml:
  - Adds post-build step to copy llms.txt files to root

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed