### PR TITLE
DOC-3373: Update site root path for where llms-full.txt is located.

### DIFF
--- a/-scripts/README-llm-files.md
+++ b/-scripts/README-llm-files.md
@@ -79,9 +79,9 @@ The files are generated in `modules/ROOT/attachments/`:
 - `llms.txt` - Simplified, curated documentation index (~105 lines)
 - `llms-full.txt` - Complete documentation index with all pages (~700 lines)
 
-**Post-build:** Files are moved to the root directory (handled in separate PR) and accessible at:
-- `https://www.tiny.cloud/docs/tinymce/latest/llms.txt`
-- `https://www.tiny.cloud/docs/tinymce/latest/llms-full.txt`
+**Post-build:** A script copies the files to the site root, making them accessible at:
+- `https://www.tiny.cloud/docs/llms.txt`
+- `https://www.tiny.cloud/docs/llms-full.txt`
 
 ## How It Works
 

--- a/-scripts/generate-llm-files.js
+++ b/-scripts/generate-llm-files.js
@@ -16,6 +16,7 @@ const http = require('http');
 const sanitizeHtml = require('sanitize-html');
 
 const BASE_URL = 'https://www.tiny.cloud/docs/tinymce/latest';
+const DOCS_ROOT_URL = 'https://www.tiny.cloud/docs';
 const OUTPUT_DIR = path.join(__dirname, '../modules/ROOT/attachments');
 
 // Fetch sitemap from URL or file
@@ -1187,7 +1188,7 @@ function App() {
 
 ## Complete Documentation
 
-For a complete list of all ${urls.length} documentation pages, see [llms-full.txt](${BASE_URL}/llms-full.txt).
+For a complete list of all ${urls.length} documentation pages, see [llms-full.txt](${DOCS_ROOT_URL}/llms-full.txt).
 
 `;
 }

--- a/modules/ROOT/attachments/llms.txt
+++ b/modules/ROOT/attachments/llms.txt
@@ -101,5 +101,5 @@ function App() {
 
 ## Complete Documentation
 
-For a complete list of all 395 documentation pages, see [llms-full.txt](https://www.tiny.cloud/docs/tinymce/latest/llms-full.txt).
+For a complete list of all 395 documentation pages, see [llms-full.txt](https://www.tiny.cloud/docs/llms-full.txt).
 


### PR DESCRIPTION
Ticket: DOC-3373

Site: [Staging branch](https://pr-3992.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* Update path for where generated file will point to fomr `llms.txt`

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed