### PR TITLE
DOC-837 - Add android unsupported details to the mobile page

### DIFF
--- a/modules/ROOT/pages/tinymce-for-mobile.adoc
+++ b/modules/ROOT/pages/tinymce-for-mobile.adoc
@@ -53,7 +53,7 @@ On Android devices, the GBoard keyboard and similar input methods intercept cont
 |Autocompleter (xref:emoticons.adoc[Emoticons], xref:charmap.adoc[Charmap], xref:mentions.adoc[Mentions])
 |Limited or non-functional on Android. The autocompleter popup does not appear reliably because Android processes content prior to insertion.
 
-|xref:textpattern.adoc[Text Patterns]
+|xref:content-behavior-options.adoc#text_patterns[Text Patterns]
 |Limited functionality on Android. Inline patterns may not apply when the pattern is immediately followed by a space. The plugin relies on keypress events, which do not work as expected on Android.
 |===
 

--- a/modules/ROOT/pages/tinymce-for-mobile.adoc
+++ b/modules/ROOT/pages/tinymce-for-mobile.adoc
@@ -41,6 +41,24 @@ Some plugins offer limited functionality or are unsupported when used on mobile 
 |Clipboard restrictions on mobile platforms prevent core PowerPaste functionality.
 |===
 
+=== Android-specific limitations
+
+On Android devices, the GBoard keyboard and similar input methods intercept content before it reaches the editor. This affects plugins that rely on the autocompleter API or keypress events:
+
+[cols="1,3", options="header"]
+|===
+|Feature
+|Limitation
+
+|Autocompleter (xref:emoticons.adoc[Emoticons], xref:charmap.adoc[Charmap], xref:mentions.adoc[Mentions])
+|Limited or non-functional on Android. The autocompleter popup does not appear reliably because Android processes content prior to insertion.
+
+|xref:textpattern.adoc[Text Patterns]
+|Limited functionality on Android. Inline patterns may not apply when the pattern is immediately followed by a space. The plugin relies on keypress events, which do not work as expected on Android.
+|===
+
+For more details, see the https://www.tiny.cloud/docs/release-notes/release-notes51/#textpatternspluginlimitedfunctionalityonandroiddevices[release notes for version 5.1].
+
 === Unsupported Plugins on Mobile
 
 [cols="1,3", options="header"]


### PR DESCRIPTION
**Ticket:** DOC-837

**Site:** [Staging branch](https://pr-3994.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/tinymce-for-mobile/#android-specific-limitations)

**Changes:**
* Added "Android-specific limitations" section to tinymce-for-mobile.adoc
* Documented autocompleter (Emoticons, Charmap, Mentions) limited/non-functional on Android due to GBoard keyboard behavior
* Documented Text Patterns plugin limited functionality on Android
* Added link to release notes 5.1 for additional details
* Fixed broken Text Patterns xref (was textpattern.adoc; corrected to content-behavior-options.adoc#text_patterns)

Prepared for documentation team review.

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: hotfix/8/DOC-837
- [ ] `modules/ROOT/nav.adoc` has been updated (if applicable).
- [ ] Files have been included where required (if applicable).
- [ ] Files removed have been deleted, not just excluded from the build (if applicable).
- [ ] Files added for **New product features** include a `release note` entry.
- [ ] Major or minor version changes have updated the `supported-versions.adoc` table.
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [ ] Documentation Team Lead has reviewed.