### PR TITLE
DOC-3376: Update .gitignore for Cursor workflow and local config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ vendor
 
 # Antora tmp files
 _site/
+
+# Cursor setup (local only, do not push)
+.cursor/
+AGENTS.md
+.cursorignore
+context7.json


### PR DESCRIPTION
**Ticket:** DOC-3376

**Changes:**
* Add entries to .gitignore for local Cursor setup and config:
  - `.cursor/` – Cursor rules, commands, skills, agents
  - `AGENTS.md` – Local agent instructions
  - `.cursorignore` – Local ignore rules
  - `context7.json` – Context7 MCP config

These are local development artifacts and should not be committed to the repo.