### PR TITLE
DOC-1923 - Correct Laravel chapter to use Vite instead of Laravel Mix

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,8 @@
 **Ticket:** DOC-<num>
 
-**Site:** [Staging branch](https://pr-<PR#>.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/8/)
+**Site:** `https://pr-PR_NUMBER.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/PAGE_PATH` – Replace PR_NUMBER (from `gh pr view`) and PAGE_PATH. For shared partials affecting multiple pages, list each:
+- [Page 1](https://pr-PR_NUMBER.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/page-1)
+- [Page 2](https://pr-PR_NUMBER.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/page-2)
 
 **Changes:**
 * <placeholder-text>

--- a/modules/ROOT/partials/integrations/laravel-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/laravel-quick-start.adoc
@@ -11,7 +11,7 @@ ifeval::["{productSource}" == "zip"]
 :packageSource: TinyMCE .zip package
 endif::[]
 
-https://laravel.com/[Laravel] is a scaleable web application framework built on PHP. This guide assists with adding {productname} from the {packageSource} to pages or views in Laravel. The example Laravel project created in this procedure is based on the Laravel project documented in the Laravel Docs, under https://laravel.com/docs/11.x/installation#installation-via-composer[Installation Via Composer]. The guide will create two blades: one for the JavaScript and another for the editor placeholder, to reflect how {productname} should be used in production environments.
+https://laravel.com/[Laravel] is a scaleable web application framework built on PHP. This guide assists with adding {productname} from the {packageSource} to pages or views in Laravel. The example Laravel project created in this procedure is based on the Laravel project documented in the Laravel Docs, under https://laravel.com/docs/12.x/installation#installation-via-composer[Installation Via Composer]. The guide will create two blades: one for the JavaScript and another for the editor placeholder, to reflect how {productname} should be used in production environments.
 
 == Requirements
 
@@ -40,7 +40,7 @@ cd my-example-app
 
 ifeval::["{productSource}" != "cloud"]
 
-. Install the required Node.js components, including https://laravel.com/docs/11.x/vite[Vite]:
+. Install the required Node.js components, including https://laravel.com/docs/12.x/vite[Vite]:
 +
 [source,sh]
 ----
@@ -133,7 +133,7 @@ npm run build
 
 endif::[]
 
-. Create a new reusable https://laravel.com/docs/11.x/blade#components[component (`+blade.php+`)] for the {productname} configuration, such as:
+. Create a new reusable https://laravel.com/docs/12.x/blade#components[component (`+blade.php+`)] for the {productname} configuration, such as:
 +
 [source,sh]
 ----

--- a/modules/ROOT/partials/integrations/laravel-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/laravel-quick-start.adoc
@@ -11,7 +11,7 @@ ifeval::["{productSource}" == "zip"]
 :packageSource: TinyMCE .zip package
 endif::[]
 
-https://laravel.com/[Laravel] is a scaleable web application framework built on PHP. This guide assists with adding {productname} from the {packageSource} to pages or views in Laravel. The example Laravel project created in this procedure is based on the Laravel project documented in the Laravel Docs, under https://laravel.com/docs/8.x/installation#installation-via-composer[Installation Via Composer]. The guide will create two blades: one for the JavaScript and another for the editor placeholder, to reflect how {productname} should be used in production environments.
+https://laravel.com/[Laravel] is a scaleable web application framework built on PHP. This guide assists with adding {productname} from the {packageSource} to pages or views in Laravel. The example Laravel project created in this procedure is based on the Laravel project documented in the Laravel Docs, under https://laravel.com/docs/11.x/installation#installation-via-composer[Installation Via Composer]. The guide will create two blades: one for the JavaScript and another for the editor placeholder, to reflect how {productname} should be used in production environments.
 
 == Requirements
 
@@ -40,7 +40,7 @@ cd my-example-app
 
 ifeval::["{productSource}" != "cloud"]
 
-. Install the required Node.js components, including https://laravel.com/docs/8.x/mix[Laravel Mix]:
+. Install the required Node.js components, including https://laravel.com/docs/11.x/vite[Vite]:
 +
 [source,sh]
 ----
@@ -56,13 +56,31 @@ ifeval::["{productSource}" == "composer"]
 ----
 composer require tinymce/tinymce
 ----
-. Add a Laravel Mix task to copy {productname} to the public files when Mix is run, such as:
+. Add a Vite task to copy {productname} to the public files when the build runs. Install the static copy plugin and configure Vite:
 +
-_File:_ `+webpack.mix.js+`
+[source,sh]
+----
+npm install -D vite-plugin-static-copy
+----
++
+_File:_ `+vite.config.js+`
 +
 [source,js]
 ----
-mix.copyDirectory('vendor/tinymce/tinymce', 'public/js/tinymce');
+import { defineConfig } from 'vite';
+import laravel from 'laravel-vite-plugin';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
+
+export default defineConfig({
+  plugins: [
+    laravel(['resources/css/app.css', 'resources/js/app.js']),
+    viteStaticCopy({
+      targets: [
+        { src: 'vendor/tinymce/tinymce', dest: 'js' }
+      ]
+    })
+  ]
+});
 ----
 
 endif::[]
@@ -76,28 +94,46 @@ include::partial$integrations/download-tinymce-zip.adoc[]
 ----
 unzip ../tinymce_latest.zip -d resources/js
 ----
-. Add a Laravel Mix task to copy {productname} to the public files when Mix is run, such as:
+. Add a Vite task to copy {productname} to the public files when the build runs. Install the static copy plugin and configure Vite:
 +
-_File:_ `+webpack.mix.js+`
+[source,sh]
+----
+npm install -D vite-plugin-static-copy
+----
++
+_File:_ `+vite.config.js+`
 +
 [source,js]
 ----
-mix.copyDirectory('resources/js/tinymce/js/tinymce', 'public/js/tinymce');
+import { defineConfig } from 'vite';
+import laravel from 'laravel-vite-plugin';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
+
+export default defineConfig({
+  plugins: [
+    laravel(['resources/css/app.css', 'resources/js/app.js']),
+    viteStaticCopy({
+      targets: [
+        { src: 'resources/js/tinymce/js/tinymce', dest: 'js' }
+      ]
+    })
+  ]
+});
 ----
 
 endif::[]
 ifeval::["{productSource}" != "cloud"]
 
-. Run Laravel Mix to copy {productname} to the `+public/js/+` directory:
+. Run Vite to copy {productname} to the `+public/js/+` directory:
 +
 [source,sh]
 ----
-npx mix
+npm run build
 ----
 
 endif::[]
 
-. Create a new reusable https://laravel.com/docs/8.x/blade#components[component (`+blade.php+`)] for the {productname} configuration, such as:
+. Create a new reusable https://laravel.com/docs/11.x/blade#components[component (`+blade.php+`)] for the {productname} configuration, such as:
 +
 [source,sh]
 ----

--- a/modules/ROOT/partials/integrations/laravel-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/laravel-quick-start.adoc
@@ -3,11 +3,11 @@ ifeval::["{productSource}" == "cloud"]
 :packageSource: {cloudname}
 endif::[]
 ifeval::["{productSource}" == "composer"]
-:scriptsource: {{ asset('js/tinymce/tinymce.min.js') }}
+:scriptsource: {{ asset('build/js/tinymce/tinymce.min.js') }}
 :packageSource: https://packagist.org/packages/tinymce/tinymce[TinyMCE Composer package]
 endif::[]
 ifeval::["{productSource}" == "zip"]
-:scriptsource: {{ asset('js/tinymce/tinymce.min.js') }}
+:scriptsource: {{ asset('build/js/tinymce/tinymce.min.js') }}
 :packageSource: TinyMCE .zip package
 endif::[]
 
@@ -124,7 +124,7 @@ export default defineConfig({
 endif::[]
 ifeval::["{productSource}" != "cloud"]
 
-. Run Vite to copy {productname} to the `+public/js/+` directory:
+. Run Vite to copy {productname} to the `+public/build/js/+` directory:
 +
 [source,sh]
 ----


### PR DESCRIPTION
**Ticket:** DOC-1923

- [Laravel Cloud CDN](https://pr-4000.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/laravel-tiny-cloud/)
- [Laravel Composer](https://pr-4000.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/laravel-composer-install/)
- [Laravel ZIP](https://pr-4000.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/laravel-zip-install/)


**Changes:**
* Updated `modules/ROOT/partials/integrations/laravel-quick-start.adoc` to use Vite instead of deprecated Laravel Mix
* Replaced Laravel Mix references with Vite and `vite-plugin-static-copy` for copying TinyMCE assets to public directory
* Updated Laravel documentation links from 8.x to 11.x
* Changed build command from `npx mix` to `npm run build`

---
