### PR TITLE
DOC-1723 - Update link_quicklink option and mceLink command documentation

### DIFF
--- a/modules/ROOT/partials/commands/link-cmds.adoc
+++ b/modules/ROOT/partials/commands/link-cmds.adoc
@@ -1,11 +1,18 @@
+[[mceLink]]
 [cols="1,3",options="header"]
 |===
 |Command |Description
-|mceLink |Opens the Link or Quicklink Dialog at the current cursor position or for the current selection.
+|mceLink |Opens the Link dialog or the link context toolbar at the current cursor position or for the current selection. The behaviour depends on the xref:link.adoc#link_quicklink[`+link_quicklink+`] option. Pass `+{ dialog: true }+` as the third argument to always open the full Link dialog, even when `+link_quicklink+` is enabled.
 |===
 
-.Example
+.Example: open link dialog or context toolbar (default behaviour)
 [source,js]
 ----
 tinymce.activeEditor.execCommand('mceLink');
+----
+
+.Example: always open the full Link dialog
+[source,js]
+----
+tinymce.activeEditor.execCommand('mceLink', false, { dialog: true });
 ----

--- a/modules/ROOT/partials/configuration/link_quicklink.adoc
+++ b/modules/ROOT/partials/configuration/link_quicklink.adoc
@@ -1,11 +1,13 @@
 [[link_quicklink]]
 == `+link_quicklink+`
 
-This option changes the behaviour of the `+CTRL + K+` shortcut and the xref:link.adoc#mceLink[`+mceLink+`] command. By default, pressing `+CTRL + K+` or executing the `+mceLink+` command opens the Link dialog. If `+link_quicklink+` is set to `+true+`, pressing `+CTRL + K+` will, by default, open the link context toolbar instead.
+This option changes the behaviour of the `+CTRL + K+` shortcut and the xref:link.adoc#mceLink[`+mceLink+`] command.
 
-Even when `+link_quicklink+` is set to `+true+`, the full Link dialog can still be invoked by running `+tinymce.activeEditor.execCommand('mceLink', false, { dialog: true });+`.
+When `+link_quicklink+` is set to `+false+`, pressing `+CTRL + K+` or executing the `+mceLink+` command will open the Link dialog.
 
-If the cursor is within an existing link, the context toolbar contains fields for modifying, removing and opening the selected link. If not, the context toolbar allows for the quick insertion of a link.
+When `+link_quicklink+` is set to `+true+`, pressing `+CTRL + K+` will open the link context toolbar instead, though the Link dialog can still be opened by running `+editor.execCommand('mceLink', false, { dialog: true })+`.
+
+When a link is selected, the link context toolbar contains fields and buttons for modifying, removing and opening the selected link. When the selection doesn't contain a link, the link context toolbar contains fields and buttons for quickly inserting a link.
 
 NOTE: This context toolbar is the same as the context toolbar mentioned in the xref:link.adoc#link_context_toolbar[`+link_context_toolbar+`] documentation above.
 

--- a/modules/ROOT/partials/configuration/link_quicklink.adoc
+++ b/modules/ROOT/partials/configuration/link_quicklink.adoc
@@ -1,7 +1,11 @@
 [[link_quicklink]]
 == `+link_quicklink+`
 
-This option changes the behaviour of the `+CTRL + K+` shortcut. By default, pressing `+CTRL + K+` will open the link dialog. If `+link_quicklink+` is set to `+true+`, pressing `+CTRL + K+` will instead open the link context toolbar. If the cursor is within an existing link, this context toolbar will contain fields for modifying, removing and opening the selected link. If not, the context toolbar allows for the quick insertion of a link.
+This option changes the behaviour of the `+CTRL + K+` shortcut and the xref:link.adoc#mceLink[`+mceLink+`] command. By default, pressing `+CTRL + K+` or executing the `+mceLink+` command opens the Link dialog. If `+link_quicklink+` is set to `+true+`, pressing `+CTRL + K+` will, by default, open the link context toolbar instead.
+
+Even when `+link_quicklink+` is set to `+true+`, the full Link dialog can still be invoked by running `+tinymce.activeEditor.execCommand('mceLink', false, { dialog: true });+`.
+
+If the cursor is within an existing link, the context toolbar contains fields for modifying, removing and opening the selected link. If not, the context toolbar allows for the quick insertion of a link.
 
 NOTE: This context toolbar is the same as the context toolbar mentioned in the xref:link.adoc#link_context_toolbar[`+link_context_toolbar+`] documentation above.
 


### PR DESCRIPTION
**Ticket:** DOC-1723

**Site:** [Staging build](https://pr-4002.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/link)

**Changes:**
* Updated `link_quicklink` configuration option to document that it affects both the CTRL+K shortcut and the `mceLink` command, and added note that the full Link dialog can be invoked with `execCommand('mceLink', false, { dialog: true })` when `link_quicklink` is enabled
* Updated `mceLink` command documentation to describe behaviour based on `link_quicklink`, and added the optional `{ dialog: true }` parameter to always open the full Link dialog
* Added cross-references between the option and command documentation