### PR TITLE
Fix llms-full.txt URL in generated llms.txt

### DIFF
--- a/-scripts/README-llm-files.md
+++ b/-scripts/README-llm-files.md
@@ -81,7 +81,7 @@ The files are generated in `modules/ROOT/attachments/`:
 
 **Post-build:** Files are moved to the root directory (handled in separate PR) and accessible at:
 - `https://www.tiny.cloud/docs/tinymce/latest/llms.txt`
-- `https://www.tiny.cloud/docs/tinymce/latest/llms-full.txt`
+- `https://www.tiny.cloud/docs/llms-full.txt`
 
 ## How It Works
 

--- a/-scripts/generate-llm-files.js
+++ b/-scripts/generate-llm-files.js
@@ -16,6 +16,7 @@ const http = require('http');
 const sanitizeHtml = require('sanitize-html');
 
 const BASE_URL = 'https://www.tiny.cloud/docs/tinymce/latest';
+const DOCS_ROOT_URL = 'https://www.tiny.cloud/docs';
 const OUTPUT_DIR = path.join(__dirname, '../modules/ROOT/attachments');
 
 // Fetch sitemap from URL or file
@@ -1187,7 +1188,7 @@ function App() {
 
 ## Complete Documentation
 
-For a complete list of all ${urls.length} documentation pages, see [llms-full.txt](${BASE_URL}/llms-full.txt).
+For a complete list of all ${urls.length} documentation pages, see [llms-full.txt](${DOCS_ROOT_URL}/llms-full.txt).
 
 `;
 }

--- a/modules/ROOT/attachments/llms.txt
+++ b/modules/ROOT/attachments/llms.txt
@@ -101,5 +101,5 @@ function App() {
 
 ## Complete Documentation
 
-For a complete list of all 395 documentation pages, see [llms-full.txt](https://www.tiny.cloud/docs/tinymce/latest/llms-full.txt).
+For a complete list of all 395 documentation pages, see [llms-full.txt](https://www.tiny.cloud/docs/llms-full.txt).
 


### PR DESCRIPTION
## Summary
Fixes the llms-full.txt link in llms.txt which was pointing to the wrong URL.

**Current (wrong):** `https://www.tiny.cloud/docs/tinymce/latest/llms-full.txt`
**Correct:** `https://www.tiny.cloud/docs/llms-full.txt`

The llms-full.txt file is served at the docs root, not under tinymce/latest/.

## Changes
- Add `DOCS_ROOT_URL` constant to generate-llm-files.js for docs-root-level URLs
- Use `DOCS_ROOT_URL` for the llms-full.txt link in generated output
- Update README-llm-files.md with correct URL
- Fix current llms.txt attachment

## JIRA
DOC-3379