### PR TITLE
DOC-3260 - Replace npx with yarn exec moxiedoc to eliminate npm warnings

### DIFF
--- a/-scripts/api-reference-local.sh
+++ b/-scripts/api-reference-local.sh
@@ -14,7 +14,7 @@ echo -e "\n > importing data files for tinymce api reference: local from $1\n"
 
 rm -rf "$API_TMPDIR"
 mkdir "$API_TMPDIR"
-npx moxiedoc "$1/modules/tinymce/src/core/main/ts" -t antora -o "$API_TMPDIR/tinymce-api-reference.zip"
+yarn exec moxiedoc -- "$1/modules/tinymce/src/core/main/ts" -t antora -o "$API_TMPDIR/tinymce-api-reference.zip"
 unzip -o "$API_TMPDIR/tinymce-api-reference.zip"
 
 # remove old api adoc pages

--- a/-scripts/api-reference.sh
+++ b/-scripts/api-reference.sh
@@ -13,7 +13,7 @@ rm -rf _data
 rm -rf "$API_TMPDIR"
 mkdir "$API_TMPDIR"
 curl -s "$TARBALL_URL" | tar xzf - -C "$API_TMPDIR" --strip-components 1
-npx moxiedoc "$API_TMPDIR/modules/tinymce/src/core/main/ts" -t antora -o "$API_TMPDIR/tinymce-api-reference.zip"
+yarn exec moxiedoc -- "$API_TMPDIR/modules/tinymce/src/core/main/ts" -t antora -o "$API_TMPDIR/tinymce-api-reference.zip"
 unzip -o "$API_TMPDIR/tinymce-api-reference.zip"
 
 # remove old api adoc pages


### PR DESCRIPTION
**Ticket:** DOC-3260

**Site:** [Staging branch](https://pr-<PR#>.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/8/)

**Changes:**
* `-scripts/api-reference.sh`: Replace `npx moxiedoc` with `yarn exec moxiedoc --` to eliminate npm deprecated env config warnings
* `-scripts/api-reference-local.sh`: Same change

Minimal fix for npm 11.2+ warnings when running `yarn build`. The `--` separator ensures yarn passes `-t` and `-o` to moxiedoc.