### PR TITLE
DOC-3243: Add table_default_header_rows and table_default_header_cols options to release notes and table options

### DIFF
--- a/modules/ROOT/pages/8.4.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.4.0-release-notes.adoc
@@ -125,7 +125,6 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 In {productname} {release-version}, integrators previously had no way to set default header rows and columns when creating tables through the editor UI. This affected the accessibility of tables and required manual intervention for integrators aiming to meet accessibility standards. The new xref:table-options.adoc#table_default_header_rows[`+table_default_header_rows+`] and xref:table-options.adoc#table_default_header_cols[`+table_default_header_cols+`] options enable integrators to set the number of default header rows and columns for new tables created through the editor's UI, providing a supported way to meet accessibility requirements.
 
-// CCFR here.
 
 === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1

--- a/modules/ROOT/pages/8.4.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.4.0-release-notes.adoc
@@ -120,6 +120,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following addition<s>:
 
+=== New `table_default_header_rows` and `table_default_header_cols` options to set the default header size for new tables
+// #TINY-13391
+
+In {productname} {release-version}, integrators previously had no way to set default header rows and columns when creating tables through the editor UI. This affected the accessibility of tables and required manual intervention for integrators aiming to meet accessibility standards. The new xref:table-options.adoc#table_default_header_rows[`+table_default_header_rows+`] and xref:table-options.adoc#table_default_header_cols[`+table_default_header_cols+`] options enable integrators to set the number of default header rows and columns for new tables created through the editor's UI, providing a supported way to meet accessibility requirements.
+
+// CCFR here.
+
 === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1
 

--- a/modules/ROOT/pages/8.4.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.4.0-release-notes.adoc
@@ -123,7 +123,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === New `table_default_header_rows` and `table_default_header_cols` options to set the default header size for new tables
 // #TINY-13391
 
-In {productname} {release-version}, integrators previously had no way to set default header rows and columns when creating tables through the editor UI. This affected the accessibility of tables and required manual intervention for integrators aiming to meet accessibility standards. The new xref:table-options.adoc#table_default_header_rows[`+table_default_header_rows+`] and xref:table-options.adoc#table_default_header_cols[`+table_default_header_cols+`] options enable integrators to set the number of default header rows and columns for new tables created through the editor's UI, providing a supported way to meet accessibility requirements.
+Previously, integrators had no way to set default header rows and columns when creating tables through the editor UI. This affected the accessibility of tables and required manual intervention for integrators aiming to meet accessibility standards. The new xref:table-options.adoc#table_default_header_rows[`+table_default_header_rows+`] and xref:table-options.adoc#table_default_header_cols[`+table_default_header_cols+`] options enable integrators to set the number of default header rows and columns for new tables created through the editor's UI, providing a supported way to meet accessibility requirements.
 
 
 === <TINY-vwxyz 1 changelog entry>

--- a/modules/ROOT/pages/table-options.adoc
+++ b/modules/ROOT/pages/table-options.adoc
@@ -20,6 +20,10 @@ include::partial$configuration/table_default_attributes.adoc[leveloffset=+1]
 
 include::partial$configuration/table_default_styles.adoc[leveloffset=+1]
 
+include::partial$configuration/table_default_header_rows.adoc[leveloffset=+1]
+
+include::partial$configuration/table_default_header_cols.adoc[leveloffset=+1]
+
 == Interacting with tables
 
 include::partial$configuration/table_clone_elements.adoc[leveloffset=+1]

--- a/modules/ROOT/partials/configuration/table_default_header_cols.adoc
+++ b/modules/ROOT/partials/configuration/table_default_header_cols.adoc
@@ -1,0 +1,18 @@
+[[table_default_header_cols]]
+== `+table_default_header_cols+`
+
+The `+table_default_header_cols+` option sets the number of default header columns for new tables created through the editor UI (for example, via the table picker or insert table dialog). This helps integrators meet accessibility standards by ensuring new tables have header columns by default without manual intervention.
+
+*Type:* `+Number+`
+
+*Default value:* `+0+`
+
+=== Example: using `+table_default_header_cols+`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  table_default_header_cols: 1
+});
+----

--- a/modules/ROOT/partials/configuration/table_default_header_rows.adoc
+++ b/modules/ROOT/partials/configuration/table_default_header_rows.adoc
@@ -1,0 +1,18 @@
+[[table_default_header_rows]]
+== `+table_default_header_rows+`
+
+The `+table_default_header_rows+` option sets the number of default header rows for new tables created through the editor UI (for example, via the table picker or insert table dialog). This helps integrators meet accessibility standards by ensuring new tables have header rows by default without manual intervention.
+
+*Type:* `+Number+`
+
+*Default value:* `+0+`
+
+=== Example: using `+table_default_header_rows+`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  table_default_header_rows: 1
+});
+----


### PR DESCRIPTION
**Ticket:** TINY-13391 (release notes for DOC-3243)

**Site:** [Staging](https://pr-4011.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.4.0-release-notes/#new-table_default_header_rows-and-table_default_header_cols-options-to-set-the-default-header-size-for-new-tables)

**Changes:**
* Added release note entry for new `table_default_header_rows` and `table_default_header_cols` options in `8.4.0-release-notes.adoc` (Additions section), with xref links to the new config option docs
* Created `table_default_header_rows.adoc` config option partial
* Created `table_default_header_cols.adoc` config option partial
* Included both partials in `table-options.adoc` under "Controlling how tables are inserted"

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: `feature/8.4.0/DOC-3243_TINY-13391`
- [x] Build passes