### PR TITLE
DOC-3243: Bundled content CSS is now loaded into preview iframes

### DIFF
--- a/modules/ROOT/pages/8.4.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.4.0-release-notes.adoc
@@ -161,7 +161,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Bundled content CSS is now loaded into preview iframes
 // #TINY-13190
 
-Previously, when the editor content CSS was bundled, it was not loaded into the Preview Iframe. This caused a visual mismatch between the editor content area and what users saw in the Preview dialog.
+Previously, when the editor content CSS was bundled, it was not loaded into preview iframes. This caused a visual mismatch between the editor content area and what users saw in the Preview dialog, Suggested Edits view and Revision History view.
 
 In {productname} {release-version}, the fix checks if the content CSS is available as a bundled resource and applies it to the Preview Iframe through style tags. Bundled content CSS is now correctly loaded in the Preview Iframe.
 

--- a/modules/ROOT/pages/8.4.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.4.0-release-notes.adoc
@@ -158,6 +158,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Bundled content CSS is now loaded into preview iframes
+// #TINY-13190
+
+Previously, when the editor content CSS was bundled, it was not loaded into the Preview Iframe. This caused a visual mismatch between the editor content area and what users saw in the Preview dialog.
+
+In {productname} {release-version}, the fix checks if the content CSS is available as a bundled resource and applies it to the Preview Iframe through style tags. Bundled content CSS is now correctly loaded in the Preview Iframe.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
**Ticket:** DOC-3243

**Site:** [Staging](https://pr-4014.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.4.0-release-notes/#bundled-content-css-is-now-loaded-into-preview-iframes)

**Changes:**
* Added release note entry for TINY-13190 to `modules/ROOT/pages/8.4.0-release-notes.adoc` (Bug fixes section): Bundled content CSS is now loaded into preview iframes.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.