### PR TITLE
DOC-3243: The `border-color` style with multiple rgb colors would be compressed into `border` incorrectly

### DIFF
--- a/modules/ROOT/pages/8.4.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.4.0-release-notes.adoc
@@ -136,6 +136,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== The `border-color` style with multiple rgb colors would be compressed into `border` incorrectly
+// #TINY-13393
+
+Previously, when `border-color` used multiple rgb values (for example, for different sides of an element), the style compressor would incorrectly compress them into a single `border` shorthand. The `border` shorthand only supports one color, so this produced invalid CSS. This could affect tables and other elements with multi-colored borders.
+
+In {productname} {release-version}, a check was added to prevent compression when `border-color` contains multiple rgb values. The styles are no longer compressed into invalid shorthand.
+
 
 [[removed]]
 == Removed


### PR DESCRIPTION
**Ticket:** DOC-3243

**Site:** [Staging](https://pr-4015.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.4.0-release-notes/#the-border-color-style-with-multiple-rgb-colors-would-be-compressed-into-border-incorrectly)

**Changes:**
* Added release note entry for TINY-13393 to `modules/ROOT/pages/8.4.0-release-notes.adoc` (Changes section): The `border-color` style with multiple rgb colors would be compressed into `border` incorrectly.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.