### PR TITLE
DOC-3243: New view_show option to display a specified view on initialization

### DIFF
--- a/modules/ROOT/examples/live-demos/custom-view/index.js
+++ b/modules/ROOT/examples/live-demos/custom-view/index.js
@@ -19,7 +19,7 @@ tinymce.init({
           text: 'Save code',
           buttonType: 'primary',
           onAction: () => {
-            const codeContent = document.querySelector('.tox-view__pane_panel').value;
+            const codeContent = document.querySelector('.my-textarea').value;
             ed.setContent(codeContent);
             ed.execCommand('ToggleView', false, 'code');
             console.log('save');
@@ -31,9 +31,9 @@ tinymce.init({
         const container = api.getContainer();
         container.innerHTML = `
           <div style="height: 100%">
-            <textarea class="tox-view__pane_panel" style="width: 100%; height: 100%; resize: none; padding: 0.5em"></textarea>
+            <textarea class="my-textarea" style="width: 100%; height: 100%; resize: none; padding: 0.5em"></textarea>
           </div>`;
-        container.querySelector('.tox-view__pane_panel').value = editorContent;
+        container.querySelector('.my-textarea').value = editorContent;
       },
       onHide: (api) => {
         console.log('Deactivate code', api.getContainer());

--- a/modules/ROOT/examples/live-demos/custom-view/index.js
+++ b/modules/ROOT/examples/live-demos/custom-view/index.js
@@ -28,12 +28,12 @@ tinymce.init({
       ],
       onShow: (api) => {
         const editorContent = ed.getContent();
-        api.getContainer().innerHTML = `
+        const container = api.getContainer();
+        container.innerHTML = `
           <div style="height: 100%">
-            <textarea class="tox-view__pane_panel" style="width: 100%; height: 100%; resize: none; padding: 0.5em">
-              ${editorContent}
-            </textarea>
-          </div>`.replace(/\s+/g, '');
+            <textarea class="tox-view__pane_panel" style="width: 100%; height: 100%; resize: none; padding: 0.5em"></textarea>
+          </div>`;
+        container.querySelector('.tox-view__pane_panel').value = editorContent;
       },
       onHide: (api) => {
         console.log('Deactivate code', api.getContainer());

--- a/modules/ROOT/pages/8.4.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.4.0-release-notes.adoc
@@ -128,7 +128,6 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === New `view_show` option to display a specified view on initialization.
 // #TINY-11967
 
-Previously, integrators could not configure the editor to open with a specific view (such as Suggested Edits or Revision History) displayed on initialization. This was needed when users would only need to resolve suggested changes or review content, or when the current user had permission only to review changes.
 
 In {productname} {release-version}, the new xref:custom-view.adoc#view_show[`+view_show+`] option allows specifying which view to display when the editor is initialized. The option behaves similarly to `+sidebar_show+` but takes precedence for views; both sidebars and views can be configured to show on init.
 

--- a/modules/ROOT/pages/8.4.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.4.0-release-notes.adoc
@@ -125,6 +125,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== New `view_show` option to display a specified view on initialization.
+// #TINY-11967
+
+Previously, integrators could not configure the editor to open with a specific view (such as Suggested Edits or Revision History) displayed on initialization. This was needed when users would only need to resolve suggested changes or review content, or when the current user had permission only to review changes.
+
+In {productname} {release-version}, the new xref:custom-view.adoc#view_show[`+view_show+`] option allows specifying which view to display when the editor is initialized. The option behaves similarly to `+sidebar_show+` but takes precedence for views; both sidebars and views can be configured to show on init.
+
 
 [[changes]]
 == Changes

--- a/modules/ROOT/pages/advcode.adoc
+++ b/modules/ROOT/pages/advcode.adoc
@@ -66,6 +66,8 @@ include::partial$configuration/advcode_prettify_getcontent.adoc[leveloffset=+1]
 
 include::partial$configuration/advcode_prettify_editor.adoc[leveloffset=+1]
 
+include::partial$plugins/advcode-open-view.adoc[]
+
 include::partial$misc/advcode-shortcuts.adoc[]
 
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]

--- a/modules/ROOT/pages/custom-view.adoc
+++ b/modules/ROOT/pages/custom-view.adoc
@@ -57,6 +57,10 @@ To query the state of the custom view (whether it is currently visible or hidden
 editor.queryCommandValue('ToggleView') == 'myCustomView';
 ----
 
+== Options
+
+include::partial$configuration/view_show.adoc[leveloffset=+1]
+
 == Interactive example
 
 This example shows how to integrate a custom view using the `addView` API.

--- a/modules/ROOT/pages/revisionhistory.adoc
+++ b/modules/ROOT/pages/revisionhistory.adoc
@@ -121,6 +121,8 @@ include::partial$configuration/revisionhistory_css_url.adoc[leveloffset=+1]
 
 include::partial$configuration/revisionhistory_diff_classes.adoc[leveloffset=+1]
 
+include::partial$plugins/revisionhistory-open-view.adoc[]
+
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 include::partial$misc/plugin-menu-item-id-boilerplate.adoc[]

--- a/modules/ROOT/pages/suggestededits.adoc
+++ b/modules/ROOT/pages/suggestededits.adoc
@@ -127,6 +127,8 @@ include::partial$configuration/suggestededits_access.adoc[leveloffset=+1]
 
 include::partial$configuration/suggestededits_auto_approve.adoc[leveloffset=+1]
 
+include::partial$plugins/suggestededits-open-view.adoc[]
+
 include::partial$configuration/user_id.adoc[leveloffset=+1]
 
 include::partial$configuration/fetch_users.adoc[leveloffset=+1]

--- a/modules/ROOT/partials/configuration/view_show.adoc
+++ b/modules/ROOT/partials/configuration/view_show.adoc
@@ -1,7 +1,7 @@
 [[view_show]]
 == `+view_show+`
 
-This option allows the specified view to be displayed on editor initialization. It behaves similarly to xref:customsidebar.adoc#sidebar_show[`+sidebar_show+`] but applies to views and takes precedence when both are configured. Views and sidebars can both be set to show on init.
+This option allows the specified view to be displayed on editor initialization. It behaves similarly to xref:customsidebar.adoc#sidebar_show[`+sidebar_show+`] but applies to views and takes precedence when both are configured. Views and sidebars can both be set to show on init, with the sidebar shown once the view is closed.
 
 The value must match the name of a registered view. Premium plugins that register views include:
 

--- a/modules/ROOT/partials/configuration/view_show.adoc
+++ b/modules/ROOT/partials/configuration/view_show.adoc
@@ -1,0 +1,61 @@
+[[view_show]]
+== `+view_show+`
+
+This option allows the specified view to be displayed on editor initialization. It behaves similarly to xref:customsidebar.adoc#sidebar_show[`+sidebar_show+`] but applies to views and takes precedence when both are configured. Views and sidebars can both be set to show on init.
+
+The value must match the name of a registered view. Premium plugins that register views include:
+
+* xref:suggestededits.adoc[Suggested Edits] (`+suggestededits+`)
+* xref:revisionhistory.adoc[Revision History] (`+revision+`)
+* xref:advcode.adoc[Enhanced Code Editor] (`+code+`)
+
+Custom views registered via xref:custom-view.adoc[`+addView+`] can also be specified.
+
+include::partial$misc/admon-iframe-only.adoc[]
+
+*Type:* `+String+`
+
+=== Example: using `+view_show+` with a premium plugin
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea', // change this value according to your HTML
+  plugins: 'suggestededits',
+  toolbar: 'suggestededits',
+  view_show: 'suggestededits',
+  // ... other Suggested Edits options (suggestededits_model, user_id, fetch_users)
+});
+----
+
+=== Example: using `+view_show+` with a custom view
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea', // change this value according to your HTML
+  menubar: false,
+  toolbar: 'view',
+  view_show: 'view',
+  setup: (editor) => {
+    const toggleView = () => editor.execCommand('ToggleView', false, 'view');
+    editor.ui.registry.addView('view', {
+      onShow: (api) => {
+        api.getContainer().innerHTML = '<p>You opened the view!</p>';
+      },
+      onHide: (api) => {
+        api.getContainer().innerHTML = '';
+      },
+      buttons: [{
+        type: 'button',
+        text: 'Close',
+        onAction: toggleView
+      }]
+    });
+    editor.ui.registry.addButton('view', {
+      text: 'Open view',
+      onAction: toggleView
+    });
+  }
+});
+----

--- a/modules/ROOT/partials/plugins/advcode-open-view.adoc
+++ b/modules/ROOT/partials/plugins/advcode-open-view.adoc
@@ -1,0 +1,14 @@
+== Show view on editor load
+
+The xref:custom-view.adoc#view_show[`+view_show+`] option can be used to show the {pluginname} view when the editor is loaded.
+
+.For example:
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  plugins: 'advcode',
+  toolbar: 'code',
+  view_show: 'code',
+});
+----

--- a/modules/ROOT/partials/plugins/revisionhistory-open-view.adoc
+++ b/modules/ROOT/partials/plugins/revisionhistory-open-view.adoc
@@ -1,0 +1,15 @@
+== Show view on editor load
+
+The xref:custom-view.adoc#view_show[`+view_show+`] option can be used to show the {pluginname} view when the editor is loaded.
+
+.For example:
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  plugins: 'revisionhistory',
+  toolbar: 'revisionhistory',
+  view_show: 'revision',
+  revisionhistory_fetch: () => Promise.resolve([]), // Replace with API request to get saved revisions
+});
+----

--- a/modules/ROOT/partials/plugins/suggestededits-open-view.adoc
+++ b/modules/ROOT/partials/plugins/suggestededits-open-view.adoc
@@ -1,0 +1,15 @@
+== Show view on editor load
+
+The xref:custom-view.adoc#view_show[`+view_show+`] option can be used to show the {pluginname} view when the editor is loaded.
+
+.For example:
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  plugins: 'suggestededits',
+  toolbar: 'suggestededits',
+  view_show: 'suggestededits',
+  // ... other Suggested Edits options (e.g. suggestededits_model, user_id, fetch_users)
+});
+----


### PR DESCRIPTION
**Ticket:** DOC-3243

**Site:** Staging links:
* [8.4.0 Release notes – Additions](https://pr-4021.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.4.0-release-notes/#new-view_show-option-to-display-a-specified-view-on-initialization)
* [Custom view – Options / view_show](https://pr-4021.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/custom-view/#view_show)
* [Suggested Edits – Show view on editor load](https://pr-4021.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/suggestededits/#show-view-on-editor-load)
* [Revision History – Show view on editor load](https://pr-4021.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/revisionhistory/#show-view-on-editor-load)
* [Enhanced Code Editor – Show view on editor load](https://pr-4021.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/advcode/#show-view-on-editor-load)
* [Custom view – Interactive example](https://pr-4021.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/custom-view/#interactive-example)

**Changes:**
* Added release note entry for TINY-11967 to `modules/ROOT/pages/8.4.0-release-notes.adoc` (Additions section): New `view_show` option to display a specified view on initialization.
* Created `modules/ROOT/partials/configuration/view_show.adoc` – configuration option partial with description, plugin links, and examples (premium plugin and custom view).
* Updated `modules/ROOT/pages/custom-view.adoc` – added Options section including view_show partial; restructured so Toggling and Querying remain under Editor View API.
* Created `modules/ROOT/partials/plugins/suggestededits-open-view.adoc` and included in `modules/ROOT/pages/suggestededits.adoc`.
* Created `modules/ROOT/partials/plugins/revisionhistory-open-view.adoc` and included in `modules/ROOT/pages/revisionhistory.adoc`.
* Created `modules/ROOT/partials/plugins/advcode-open-view.adoc` and included in `modules/ROOT/pages/advcode.adoc`.
* Fixed `modules/ROOT/examples/live-demos/custom-view/index.js` – removed `.replace(/\s+/g, '')` that stripped spaces from editor content; set textarea value separately to preserve content. - broken 2 years ago.

---

### **Pre-checks:**

- [x] Branch is correctly prefixed (feature/8.4.0/DOC-3243_TINY-11967)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] Files added for **New product features** include a release note entry.
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.