### PR TITLE
DOC-3243: New argument `fullpagehtml` to `editor.getContent()` and `editor.setContent()` APIs to only get/set the body of the content while the full page plugin is active

### DIFF
--- a/modules/ROOT/pages/8.4.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.4.0-release-notes.adoc
@@ -57,6 +57,21 @@ For information on the **<Open source plugin name>** plugin, see xref:<plugincod
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
+=== Full Page HTML
+
+The {productname} {release-version} release includes an accompanying release of the **Full Page HTML** premium plugin.
+
+**Full Page HTML** includes the following addition.
+
+==== New argument `fullpagehtml` to `editor.getContent()` and `editor.setContent()` APIs to only get/set the body of the content while the full page plugin is active.
+// #TINY-13744
+
+Previously, setting and getting the editor content while the Full Page HTML plugin was active could be troublesome due to the presence of the full HTML document on all API calls, even when not needed. Attempting to get and act only on the body content (for example, for saving) was undocumented and required workarounds.
+
+In {productname} {release-version}, the `fullpagehtml` option has been added to the `editor.getContent()` and `editor.setContent()` APIs. When set to `false`, this option allows getting and setting only the body content while the Full Page HTML plugin is active, without interfering with the full document structure. The document is now more resistant to accidental changes, and content can be retrieved or updated without including the full HTML document. For details, see xref:fullpagehtml.adoc#fullpagehtml-getcontent-setcontent[`fullpagehtml` option for getContent/setContent].
+
+For information on the **Full Page HTML** plugin, see: xref:fullpagehtml.adoc[Full Page HTML].
+
 === <Premium plugin name 1> <Premium plugin name 1 version>
 
 The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.

--- a/modules/ROOT/pages/fullpagehtml.adoc
+++ b/modules/ROOT/pages/fullpagehtml.adoc
@@ -109,6 +109,8 @@ include::partial$configuration/fullpagehtml-default-body-style.adoc[leveloffset=
 
 include::partial$configuration/fullpagehtml-hide-in-source-view.adoc[leveloffset=+1]
 
+include::partial$configuration/fullpagehtml-getcontent-setcontent.adoc[leveloffset=+1]
+
 include::partial$misc/plugin-toolbar-button-id-boilerplate.adoc[]
 
 include::partial$toolbar-button-ids/{plugincode}-toolbar-buttons.adoc[leveloffset=+1]

--- a/modules/ROOT/partials/configuration/fullpagehtml-getcontent-setcontent.adoc
+++ b/modules/ROOT/partials/configuration/fullpagehtml-getcontent-setcontent.adoc
@@ -1,0 +1,22 @@
+[[fullpagehtml-getcontent-setcontent]]
+== `+fullpagehtml+` option for `+getContent()+` and `+setContent()+`
+
+When the {pluginname} plugin is active, `editor.getContent()` and `editor.setContent()` return and accept the full HTML document by default. The `fullpagehtml` option allows getting and setting only the body content when needed.
+
+Pass `fullpagehtml: false` in the options object to bypass full-page processing and work with body content only:
+
+* `editor.getContent({ fullpagehtml: false })` — Returns only the `<body>` content.
+* `editor.setContent(content, { fullpagehtml: false })` — Sets only the body content without modifying the document head.
+
+This option is useful when saving or loading body content separately (for example, when storing content in a database or when integrating with systems that expect body-only HTML). Unlike `fullpagehtml_hide_in_source_view`, which affects only the source code view display, the `fullpagehtml` option affects API behavior and requires no configuration.
+
+=== Example: getting and setting body content
+
+[source,js]
+----
+// Get only the body content for saving
+const bodyContent = editor.getContent({ fullpagehtml: false });
+
+// Set only the body content (preserves document head)
+editor.setContent(newBodyContent, { format: 'html', fullpagehtml: false });
+----


### PR DESCRIPTION
**Ticket:** DOC-3243

**Site:** Links to affected pages:

* [8.4.0 Release notes – Full Page HTML section](https://pr-4025.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.4.0-release-notes/#full-page-html)
* [Full Page HTML plugin – fullpagehtml option for getContent/setContent](https://pr-4025.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/fullpagehtml/#fullpagehtml-getcontent-setcontent)

**Changes:**

* Added release note entry for TINY-13744 to `modules/ROOT/pages/8.4.0-release-notes.adoc` (Accompanying Premium plugin changes section): New argument `fullpagehtml` to `editor.getContent()` and `editor.setContent()` APIs to only get/set the body of the content while the full page plugin is active.
* Created `modules/ROOT/partials/configuration/fullpagehtml-getcontent-setcontent.adoc` documenting the `fullpagehtml` option for `getContent`/`setContent`.
* Updated `modules/ROOT/pages/fullpagehtml.adoc` to include the new option documentation.
* Added xref from release notes to the new section.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.