### PR TITLE
DOC-3384 - Fix broken NPM and Yarn links on docs homepage

### DIFF
--- a/modules/ROOT/pages/creating-a-skin.adoc
+++ b/modules/ROOT/pages/creating-a-skin.adoc
@@ -11,8 +11,8 @@ This guide explains how to manually create a new skin to customize the appearanc
 Before beginning, ensure that:
 
 * Familiarity with the command line and basic commands is established.
-* link:https://nodejs.org/en/[Node.js] and link:https://yarnpkg.com/en/[Yarn] are already installed.
-* A basic understanding of link:http://lesscss.org[Less], the CSS preprocessor used to build skins, is required. Specifically, review the link:http://lesscss.org/features/#variables-feature[section on variables].
+* link:https://nodejs.org/en/[Node.js^] and link:https://yarnpkg.com/[Yarn^] are already installed.
+* A basic understanding of link:http://lesscss.org[Less^], the CSS preprocessor used to build skins, is required. Specifically, review the link:http://lesscss.org/features/#variables-feature[section on variables^].
 
 == Preparation
 

--- a/modules/ROOT/pages/installation-self-hosted.adoc
+++ b/modules/ROOT/pages/installation-self-hosted.adoc
@@ -157,7 +157,7 @@ You can install {productname} using various package managers:
 |link:https://www.npmjs.com/package/tinymce[npm^]
 |`npm install tinymce`
 
-|link:https://classic.yarnpkg.com/en/package/tinymce[Yarn^]
+|link:https://yarnpkg.com/package/tinymce[Yarn^]
 |`yarn add tinymce`
 
 |link:https://packagist.org/packages/tinymce/tinymce[Composer (PHP)^]

--- a/modules/ROOT/partials/what-is-tinymce.adoc
+++ b/modules/ROOT/partials/what-is-tinymce.adoc
@@ -25,7 +25,7 @@ The fastest way to get started with {productname}. Load from the {cloudname} CDN
 [.lead]
 xref:installation-self-hosted.adoc[Using a package manager]
 
-Install {productname} locally using link:https://www.npmjs.com/package/tinymce^[NPM], link:https://classic.yarnpkg.com/en/package/tinymce^[Yarn], or other package managers for self-hosted solutions.
+Install {productname} locally using link:https://www.npmjs.com/package/tinymce[NPM^], link:https://yarnpkg.com/package/tinymce[Yarn^], or other package managers for self-hosted solutions.
 
 |
 [.lead]


### PR DESCRIPTION
**Ticket:** DOC-3384

**Site:** Links to affected pages:

- [TinyMCE 8 Documentation – Integration Options (NPM and Yarn links)](https://pr-4026.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/8/)
- [Introduction to TinyMCE – Integration Options (NPM and Yarn links)](https://pr-4026.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/8/introduction-to-tinymce/)
- [Self-hosted installation – Package managers table](https://pr-4026.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/8/installation-self-hosted/#package-managers)
- [Create a Skin – Prerequisites](https://pr-4026.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/8/creating-a-skin/#prerequisites)

**Changes:**

- Fixed NPM and Yarn link syntax in `modules/ROOT/partials/what-is-tinymce.adoc`: corrected AsciiDoc caret placement for new-tab behavior (`[text^]` not `^[text]`) and updated Yarn URL from classic.yarnpkg.com to yarnpkg.com/package/tinymce.
- Fixed link syntax in `modules/ROOT/pages/installation-self-hosted.adoc`: npm, Yarn, Composer (PHP), and NuGet (.NET) in package manager table.
- Fixed link syntax in `modules/ROOT/pages/creating-a-skin.adoc`: Node.js, Yarn, Less, and section-on-variables in Prerequisites.

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: hotfix/8/DOC-3384
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable).
- [x] Files have been included where required (if applicable).
- [x] Files removed have been deleted, not just excluded from the build (if applicable).
- [x] Files added for **New product features** include a `release note` entry.
- [x] Major or minor version changes have updated the `supported-versions.adoc` table.
- [x] Build passes without console errors, warnings, or issues.