### PR TITLE
DOC-3243: SVG images can now be uploaded.

### DIFF
--- a/modules/ROOT/pages/8.4.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.4.0-release-notes.adoc
@@ -57,17 +57,20 @@ For information on the **<Open source plugin name>** plugin, see xref:<plugincod
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
-=== <Premium plugin name 1> <Premium plugin name 1 version>
+=== Media Optimizer
 
-The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+The {productname} {release-version} release includes an accompanying release of the **Media Optimizer** premium plugin.
 
-**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+**Media Optimizer** includes the following addition.
 
-==== <Premium plugin name 1 change 1>
+==== SVG images can now be uploaded.
+// #TINY-13708
 
-// CCFR here.
+Previously, SVG images could not be uploaded through the Media Optimizer plugin because Uploadcare placed restrictions on SVG file handling. Users who needed to include SVG graphics in content were unable to upload them directly.
 
-For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+In {productname} {release-version}, SVG images can now be uploaded through the Media Optimizer plugin. Some CDN operations may have limitations on SVG files; for details, see the link:https://uploadcare.com/docs/cdn-operations/#limits[Uploadcare documentation on CDN operation limits].
+
+For information on the **Media Optimizer** plugin, see: xref:uploadcare.adoc[Media Optimizer].
 
 
 [[accompanying-premium-plugin-end-of-life-announcement]]


### PR DESCRIPTION
**Ticket:** DOC-3243

**Site:** [Staging](https://pr-4029.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.4.0-release-notes/#svg-images-can-now-be-uploaded)

**Changes:**
* Added release note entry for TINY-13708 to `modules/ROOT/pages/8.4.0-release-notes.adoc` (Accompanying Premium plugin changes section): SVG images can now be uploaded.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.