### PR TITLE
DOC-3243: Errors when creating new comments made the save button stuck in a saving state.

### DIFF
--- a/modules/ROOT/pages/8.4.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.4.0-release-notes.adoc
@@ -57,17 +57,20 @@ For information on the **<Open source plugin name>** plugin, see xref:<plugincod
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
-=== <Premium plugin name 1> <Premium plugin name 1 version>
+=== Comments
 
-The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+The {productname} {release-version} release includes an accompanying release of the **Comments** premium plugin.
 
-**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+**Comments** includes the following fix.
 
-==== <Premium plugin name 1 change 1>
+==== Errors when creating new comments made the save button stuck in a saving state.
+// #TINY-12224
 
-// CCFR here.
+Previously, when creating or editing a comment in Comments, the save button could remain in a saving state indefinitely if the save operation failed or if the component was not replaced. The saving state had no way to reset to false except by recreating the component, which misled users into thinking the operation was still in progress.
 
-For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+In {productname} {release-version}, the save logic now resets the saving state to false after the save operation completes, whether the operation succeeds or fails. The save button no longer remains stuck in a saving state.
+
+For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Comments].
 
 
 [[accompanying-premium-plugin-end-of-life-announcement]]

--- a/modules/ROOT/pages/8.4.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.4.0-release-notes.adoc
@@ -56,6 +56,17 @@ For information on the **<Open source plugin name>** plugin, see xref:<plugincod
 == Accompanying Premium plugin changes
 
 The following premium plugin updates were released alongside {productname} {release-version}.
+=== <Premium plugin name 1> <Premium plugin name 1 version>
+
+The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+
+**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+
+==== <Premium plugin name 1 change 1>
+
+// CCFR here.
+
+For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
 === Comments
 


### PR DESCRIPTION
**Ticket:** DOC-3243

**Site:** [Staging](https://pr-4030.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.4.0-release-notes/#errors-when-creating-new-comments-made-the-save-button-stuck-in-a-saving-state)

**Changes:**
* Added release note entry for TINY-12224 to `modules/ROOT/pages/8.4.0-release-notes.adoc` (Accompanying Premium plugin changes section): Errors when creating new comments made the save button stuck in a saving state.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.