### PR TITLE
DOC-3243: Pasting an HTML document was vulnerable to XSS attacks on link element href attribute

### DIFF
--- a/modules/ROOT/pages/8.4.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.4.0-release-notes.adoc
@@ -75,7 +75,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 **Full Page HTML** includes the following fix.
 
-==== Pasting an HTML document was vulnerable to XSS attacks on link element href attribute
+==== Pasting an HTML document was vulnerable to XSS attacks
 // #TINY-13673
 
 A cross-site scripting (XSS) vulnerability was discovered in the Full Page HTML plugin. Previously, malicious code within the document `<head>` was able to be executed when pasted.

--- a/modules/ROOT/pages/8.4.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.4.0-release-notes.adoc
@@ -69,6 +69,20 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Full Page HTML
+
+The {productname} {release-version} release includes an accompanying release of the **Full Page HTML** premium plugin.
+
+**Full Page HTML** includes the following fix.
+
+==== Pasting an HTML document was vulnerable to XSS attacks on link element href attribute
+// #TINY-13673
+
+A cross-site scripting (XSS) vulnerability was discovered in the Full Page HTML plugin. Previously, malicious code within the document `<head>` was able to be executed when pasted.
+
+This vulnerability has been patched in {productname} {release-version} by ensuring that content in the document `<head>` is properly encoded.
+
+For information on the **Full Page HTML** plugin, see: xref:fullpagehtml.adoc[Full Page HTML].
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement


### PR DESCRIPTION
**Ticket:** DOC-3243

**Site:** [Staging](https://pr-4031.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.4.0-release-notes/#pasting-an-html-document-was-vulnerable-to-xss-attacks-on-link-element-href-attribute)

**Changes:**
* Added release note entry for TINY-13673 to `modules/ROOT/pages/8.4.0-release-notes.adoc`

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.