### PR TITLE
DOC-3243: Directionality of Hebrew was incorrect

### DIFF
--- a/modules/ROOT/pages/8.4.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.4.0-release-notes.adoc
@@ -157,7 +157,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 // #TINY-vwxyz1
 
 // CCFR here.
+=== Directionality of Hebrew was incorrect
+// #TINY-13667
 
+Previously, right-to-left (RTL) directionality was not correctly set for Hebrew in the language pack. This caused the editor to render the wrong directionality when Hebrew was set as the language.
+
+In {productname} {release-version}, this issue has been addressed by ensuring that the directionality is correctly set for Hebrew in the language pack.
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
**Ticket:** DOC-3243

**Site:** [Staging](https://pr-4032.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.4.0-release-notes/#directionality-of-hebrew-was-incorrect)

**Changes:**
* Added release note entry for TINY-13667 to `modules/ROOT/pages/8.4.0-release-notes.adoc` (Bug fixes section): Directionality of Hebrew was incorrect.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.