### PR TITLE
DOC-3243: The noneditable feature can now be disabled with the new `allow_noneditable` option.

### DIFF
--- a/modules/ROOT/pages/8.4.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.4.0-release-notes.adoc
@@ -125,6 +125,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== The noneditable feature can now be disabled with the new `allow_noneditable` option.
+// #TINY-10121
+
+Previously, the noneditable plugin was converted to a feature in core in {productname} 6. The feature was always enabled with no documented way to turn it off, which was not always desirable for integrators.
+
+In {productname} {release-version}, a new xref:non-editable-content-options.adoc#allow_noneditable[`+allow_noneditable+`] option is available. It is enabled by default. When set to `+false+`, the noneditable feature is disabled, equivalent to disabling the plugin prior to {productname} 6.
+
 
 [[changes]]
 == Changes

--- a/modules/ROOT/pages/non-editable-content-options.adoc
+++ b/modules/ROOT/pages/non-editable-content-options.adoc
@@ -13,6 +13,9 @@ liveDemo::editable-class-and-editable-root[]
 [NOTE]
 Visit xref:ie-template-creation.adoc[Template creation example] for a practical example of multi-root editing.
 
+// allow_noneditable
+include::partial$configuration/allow_noneditable.adoc[]
+
 // noneditable_class
 include::partial$configuration/noneditable_class.adoc[]
 

--- a/modules/ROOT/partials/configuration/allow_noneditable.adoc
+++ b/modules/ROOT/partials/configuration/allow_noneditable.adoc
@@ -1,0 +1,18 @@
+[[allow_noneditable]]
+== `+allow_noneditable+`
+
+This option controls whether the non-editable content feature is enabled. When set to `+false+`, the non-editable feature is disabled entirely, equivalent to disabling the `noneditable` plugin prior to {productname} 6.
+
+*Type:* `+Boolean+`
+
+*Default value:* `+true+`
+
+=== Example: using `+allow_noneditable+`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  allow_noneditable: false
+});
+----


### PR DESCRIPTION
**Ticket:** DOC-3243

**Site:** [Staging](https://pr-4035.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.4.0-release-notes/#the-noneditable-feature-can-now-be-disabled-with-the-new-allow_noneditable-option)

**Changes:**
* Added release note entry for TINY-10121 to `modules/ROOT/pages/8.4.0-release-notes.adoc`
* Added `allow_noneditable` configuration option partial and included it in `non-editable-content-options.adoc`.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.