### PR TITLE
DOC-3365 - Update code examples to use no-api-key placeholder for client-side injection

### DIFF
--- a/modules/ROOT/pages/editor-plugin-version.adoc
+++ b/modules/ROOT/pages/editor-plugin-version.adoc
@@ -106,7 +106,7 @@ The `plugins.min.js` script loads every premium plugin the API key is entitled t
 
 [source,html,subs="attributes+"]
 ----
-<script src="https://cdn.tiny.cloud/1/api-key/tinymce/{productmajorversion}/plugins.min.js" referrerpolicy="origin" crossorigin="anonymous"></script>
+<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}/plugins.min.js" referrerpolicy="origin" crossorigin="anonymous"></script>
 ----
 
 === `plugins.min.js` with Exclusions for Specific Plugins
@@ -115,7 +115,7 @@ To exclude specific premium plugins from `plugins.min.js` because you are self-h
 
 [source,html,subs="attributes+"]
 ----
-<script src="https://cdn.tiny.cloud/1/api-key/tinymce/{productmajorversion}/plugins.min.js?mentions=sdk&powerpaste=sdk" referrerpolicy="origin" crossorigin="anonymous"></script>
+<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}/plugins.min.js?mentions=sdk&powerpaste=sdk" referrerpolicy="origin" crossorigin="anonymous"></script>
 ----
 
 [NOTE]
@@ -131,7 +131,7 @@ The `cloud-plugins.min.js` script allows loading of specific premium plugins fro
 
 [source,html,subs="attributes+"]
 ----
-<script src="https://cdn.tiny.cloud/1/api-key/tinymce/{productmajorversion}/cloud-plugins.min.js?mentions&powerpaste&advcode" referrerpolicy="origin" crossorigin="anonymous"></script>
+<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/{productmajorversion}/cloud-plugins.min.js?mentions&powerpaste&advcode" referrerpolicy="origin" crossorigin="anonymous"></script>
 ----
 
 [NOTE]

--- a/modules/ROOT/partials/integrations/jquery-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/jquery-quick-start.adoc
@@ -76,7 +76,7 @@ https://code.jquery.com/[jQuery CDN page], which includes the `integrity` and
 <script src="{cdnurl}" referrerpolicy="origin" crossorigin="anonymous"></script>
 ----
 +
-Replace `no-api-key` in the source script (`<script src=...`) with a {cloudname}
+Replace `no-api-key` in the source script (`<script src=...>`) with a {cloudname}
 API key, which is created when signing up to the link:{accountsignup}/[{cloudname}].
 
 . Add the following `<script>` element to get the {productname} jQuery integration from the JS Delivr CDN:
@@ -105,7 +105,7 @@ ifeval::["{productSource}" == "cloud"]
 <script>
   $('textarea#tiny').tinymce({
     height: 500,
-    api_key: '<your api key>',
+    api_key: 'no-api-key',
     /* other settings... */,
   });
 </script>
@@ -190,7 +190,7 @@ ifeval::["{productSource}" == "cloud"]
     <script>
       $('textarea#tiny').tinymce({
         height: 500,
-        api_key: '<your api key>',
+        api_key: 'no-api-key',
         menubar: false,
         plugins: [
           'advlist', 'autolink', 'lists', 'link', 'image', 'charmap', 'preview',

--- a/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
@@ -21,7 +21,7 @@ The `+tinymce-svelte+` `+Editor+` component accepts the following properties:
 [source,jsx,subs="attributes+"]
 ----
 <Editor
-  apiKey="api-key"
+  apiKey="no-api-key"
   channel="{productmajorversion}"
   id="uuid"
   inline=false


### PR DESCRIPTION
**Ticket:** DOC-3365

**Site:** [Staging branch](https://pr-4038.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/8/)

**Related PR:** This docs PR pairs with the UI bundle PR that injects the API key at runtime:
* docs-antora-ui: https://github.com/tinymce/docs-antora-ui/pull/32

**Changes:**
* \`editor-plugin-version.adoc\` – Replace \`api-key\` with \`no-api-key\` in script src examples (plugins.min.js, cloud-plugins.min.js) so the client-side injection script can substitute the real key
* \`jquery-quick-start.adoc\` – Fix typo in parenthesis in instruction; update config examples to use \`api_key: 'no-api-key'\` placeholder
* \`svelte-tech-ref.adoc\` – Update Editor component example to use \`apiKey="no-api-key"\` placeholder

The approach uses \`no-api-key\` as a placeholder in docs because the UI footer script (in the UI PR) replaces it with the key from localStorage when users copy snippets after visiting the account portal. The script targets \`.doc pre.highlight\` and \`.doc .literalblock pre\` elements (all code blocks) and runs on DOMContentLoaded.

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: hotfix/8/DOC-3365
- [x] Build passes