### PR TITLE
DOC-3402 - Update LLM files with TinyMCE AI pages and fix categorization

### DIFF
--- a/-scripts/generate-llm-files.js
+++ b/-scripts/generate-llm-files.js
@@ -493,7 +493,8 @@ function categorizeUrl(urlPath) {
   }
   
   // Premium Features - AI Features
-  if (urlPath === 'ai' || urlPath.startsWith('ai-')) {
+  if (urlPath === 'ai' || urlPath.startsWith('ai-') ||
+      urlPath === 'tinymceai' || urlPath.startsWith('tinymceai-')) {
     return { category: 'Premium Features', subcategory: 'AI Features' };
   }
   
@@ -1047,7 +1048,8 @@ export default {
     { category: 'Release Information', subcategory: null },
     { category: 'Accessibility & Security', subcategory: null },
     { category: 'Support & Resources', subcategory: null },
-    { category: 'Legacy & Other', subcategory: null }
+    { category: 'Legacy & Other', subcategory: null },
+    { category: 'Other', subcategory: null }
   ];
 
   let currentMainCategory = null;
@@ -1175,6 +1177,24 @@ function App() {
 - [Table Plugin](${BASE_URL}/table/): Table editing capabilities
 - [Image Plugin](${BASE_URL}/image/): Image handling and editing
 - [Link Plugin](${BASE_URL}/link/): Link management
+
+## TinyMCE AI (Premium)
+
+TinyMCE AI (\`tinymceai\` plugin) is the current AI writing assistant for TinyMCE. It provides chat, review, and quick actions powered by multiple LLM providers. The earlier AI Assistant (\`ai\` plugin) is legacy; new integrations should use TinyMCE AI.
+
+- [TinyMCE AI Introduction](${BASE_URL}/tinymceai-introduction/): Overview of TinyMCE AI features and capabilities
+- [Chat](${BASE_URL}/tinymceai-chat/): Conversational AI with history and persistent context
+- [Review](${BASE_URL}/tinymceai-review/): Content analysis and proofreading
+- [Actions](${BASE_URL}/tinymceai-actions/): Fast, stateless AI operations for specific tasks
+- [AI Models](${BASE_URL}/tinymceai-models/): Supported AI models and configuration
+- [Plugin Configuration](${BASE_URL}/tinymceai/): \`tinymceai\` plugin options and setup
+- [Integration Options](${BASE_URL}/tinymceai-integration-options/): Cloud and self-hosted integration paths
+- [API Overview](${BASE_URL}/tinymceai-api-overview/): TinyMCE AI API for use inside and outside the editor
+- [API Quick Start](${BASE_URL}/tinymceai-api-quick-start/): Get started with the TinyMCE AI API
+- [Streaming](${BASE_URL}/tinymceai-streaming/): Streaming responses from the AI API
+- [JWT Authentication](${BASE_URL}/tinymceai-jwt-authentication-intro/): Authentication setup for TinyMCE AI
+- [Limits](${BASE_URL}/tinymceai-limits/): Rate limits and usage constraints
+- [AI Assistant (legacy)](${BASE_URL}/ai/): Earlier \`ai\` plugin — use TinyMCE AI for new projects
 
 ## API Reference
 

--- a/modules/ROOT/attachments/llms-full.txt
+++ b/modules/ROOT/attachments/llms-full.txt
@@ -219,7 +219,7 @@ export default {
 
 ## Complete Documentation Index
 
-This section provides a complete list of all 395 documentation pages available in TinyMCE 8, organized by category. This comprehensive index ensures LLMs have access to every documentation page, reducing the risk of hallucinations or missing important details.
+This section provides a complete list of all 411 documentation pages available in TinyMCE 8, organized by category. This comprehensive index ensures LLMs have access to every documentation page, reducing the risk of hallucinations or missing important details.
 
 ### Getting Started & Installation
 
@@ -433,6 +433,21 @@ This section provides a complete list of all 395 documentation pages available i
 - **Azure AI integration guide**: https://www.tiny.cloud/docs/tinymce/latest/ai-azure/
 - **Google Gemini integration guide**: https://www.tiny.cloud/docs/tinymce/latest/ai-gemini/
 - **OpenAI ChatGPT integration guide**: https://www.tiny.cloud/docs/tinymce/latest/ai-openai/
+- **TinyMCE AI API Overview**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-api-overview/
+- **TinyMCE AI API Quick Start**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-api-quick-start/
+- **TinyMCE AI Chat**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-chat/
+- **TinyMCE AI Integration Options**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-integration-options/
+- **TinyMCE AI Introduction**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-introduction/
+- **TinyMCE AI JWT Authentication**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-jwt-authentication-intro/
+- **TinyMCE AI JWT Permissions**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-permissions/
+- **TinyMCE AI Limits**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-limits/
+- **TinyMCE AI Models**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-models/
+- **TinyMCE AI Plugin**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai/
+- **TinyMCE AI Quick Actions**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-actions/
+- **TinyMCE AI Review**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-review/
+- **TinyMCE AI Streaming**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-streaming/
+- **TinyMCE AI with JWT authentication (Node.js) Guide**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-with-jwt-authentication-nodejs/
+- **TinyMCE AI with JWT authentication (PHP) Guide**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-with-jwt-authentication-php/
 
 #### Comments & Collaboration
 - **Commands, Events and APIs for the Comments plugin**: https://www.tiny.cloud/docs/tinymce/latest/comments-commands-events-apis/
@@ -450,14 +465,17 @@ This section provides a complete list of all 395 documentation pages available i
 #### Export & Import
 - **Docx to HTML Converter API**: https://www.tiny.cloud/docs/tinymce/latest/docx-to-html-converter-api/
 - **Export to PDF plugin**: https://www.tiny.cloud/docs/tinymce/latest/exportpdf/
-- **Export to PDF with JWT authentication (Node.js) Guide**: https://www.tiny.cloud/docs/tinymce/latest/export-to-pdf-with-jwt-authentication-nodejs/
-- **Export to PDF with JWT authentication (PHP) Guide**: https://www.tiny.cloud/docs/tinymce/latest/export-to-pdf-with-jwt-authentication-php/
+- **Export to PDF with JWT authentication (Node.js) Guide (nodejs)**: https://www.tiny.cloud/docs/tinymce/latest/export-to-pdf-v2-with-jwt-authentication-nodejs/
+- **Export to PDF with JWT authentication (Node.js) Guide (nodejs)**: https://www.tiny.cloud/docs/tinymce/latest/export-to-pdf-with-jwt-authentication-nodejs/
+- **Export to PDF with JWT authentication (PHP) Guide (php)**: https://www.tiny.cloud/docs/tinymce/latest/export-to-pdf-v2-with-jwt-authentication-php/
+- **Export to PDF with JWT authentication (PHP) Guide (php)**: https://www.tiny.cloud/docs/tinymce/latest/export-to-pdf-with-jwt-authentication-php/
 - **Export to Word plugin**: https://www.tiny.cloud/docs/tinymce/latest/exportword/
 - **Export to Word Standalone Service**: https://www.tiny.cloud/docs/tinymce/latest/export-to-word-standalone-service/
 - **Export to Word with JWT authentication (Node.js) Guide**: https://www.tiny.cloud/docs/tinymce/latest/export-to-word-with-jwt-authentication-nodejs/
 - **Export to Word with JWT authentication (PHP) Guide**: https://www.tiny.cloud/docs/tinymce/latest/export-to-word-with-jwt-authentication-php/
 - **HTML to Docx Converter API**: https://www.tiny.cloud/docs/tinymce/latest/html-to-docx-converter-api/
-- **HTML to PDF Converter API**: https://www.tiny.cloud/docs/tinymce/latest/html-to-pdf-converter-api/
+- **HTML to PDF Converter API (api)**: https://www.tiny.cloud/docs/tinymce/latest/html-to-pdf-converter-api/
+- **HTML to PDF Converter API (v2)**: https://www.tiny.cloud/docs/tinymce/latest/html-to-pdf-converter-api-v2/
 - **Import from Word Standalone Service**: https://www.tiny.cloud/docs/tinymce/latest/import-from-word-standalone-service/
 - **Import from Word with JWT authentication (Node.js) Guide**: https://www.tiny.cloud/docs/tinymce/latest/import-from-word-with-jwt-authentication-nodejs/
 - **Import from Word with JWT authentication (PHP) Guide**: https://www.tiny.cloud/docs/tinymce/latest/import-from-word-with-jwt-authentication-php/
@@ -543,6 +561,7 @@ This section provides a complete list of all 395 documentation pages available i
 - **Bundling an NPM version of TinyMCE with CommonJS and Browserify**: https://www.tiny.cloud/docs/tinymce/latest/browserify-cjs-npm/
 - **Bundling an NPM version of TinyMCE with ES6 and Rollup.js**: https://www.tiny.cloud/docs/tinymce/latest/rollup-es6-npm/
 - **Bundling the User Interface localizations for TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/bundling-localization/
+- **Bundling TinyMCE - Overview**: https://www.tiny.cloud/docs/tinymce/latest/bundling-guide/
 - **Bundling TinyMCE content CSS using module loading**: https://www.tiny.cloud/docs/tinymce/latest/bundling-content-css/
 - **Bundling TinyMCE from NPM using Webpack and CommonJS**: https://www.tiny.cloud/docs/tinymce/latest/webpack-cjs-npm/
 - **Bundling TinyMCE from NPM with ES6 and Vite**: https://www.tiny.cloud/docs/tinymce/latest/vite-es6-npm/
@@ -624,11 +643,8 @@ This section provides a complete list of all 395 documentation pages available i
 ### Migration Guides
 
 - **Migrating from Froala to TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/migration-from-froala/
-- **Migrating from TinyMCE 4 to TinyMCE 7.0**: https://www.tiny.cloud/docs/tinymce/latest/migration-from-4x/
 - **Migrating from TinyMCE 4 to TinyMCE 8**: https://www.tiny.cloud/docs/tinymce/latest/migration-from-4x-to-8x/
-- **Migrating from TinyMCE 5 to TinyMCE 7.0**: https://www.tiny.cloud/docs/tinymce/latest/migration-from-5x/
 - **Migrating from TinyMCE 5 to TinyMCE 8**: https://www.tiny.cloud/docs/tinymce/latest/migration-from-5x-to-8x/
-- **Migrating from TinyMCE 6 to TinyMCE 7.0**: https://www.tiny.cloud/docs/tinymce/latest/migration-from-6x/
 - **Migrating from TinyMCE 6 to TinyMCE 8**: https://www.tiny.cloud/docs/tinymce/latest/migration-from-6x-to-8x/
 - **Migrating from TinyMCE 7 to TinyMCE 8**: https://www.tiny.cloud/docs/tinymce/latest/migration-from-7x/
 - **TinyMCE Migration Guides**: https://www.tiny.cloud/docs/tinymce/latest/migration-guides/
@@ -673,6 +689,7 @@ This section provides a complete list of all 395 documentation pages available i
 - **TinyMCE 8.3.0**: https://www.tiny.cloud/docs/tinymce/latest/8.3.0-release-notes/
 - **TinyMCE 8.3.1**: https://www.tiny.cloud/docs/tinymce/latest/8.3.1-release-notes/
 - **TinyMCE 8.3.2**: https://www.tiny.cloud/docs/tinymce/latest/8.3.2-release-notes/
+- **TinyMCE 8.4.0**: https://www.tiny.cloud/docs/tinymce/latest/8.4.0-release-notes/
 
 
 ### Accessibility & Security
@@ -689,11 +706,25 @@ This section provides a complete list of all 395 documentation pages available i
 
 - **Premium upgrade promotion**: https://www.tiny.cloud/docs/tinymce/latest/promotions/
 - **Support**: https://www.tiny.cloud/docs/tinymce/latest/support/
-- **Tiny Docs Ai**: https://www.tiny.cloud/docs/tinymce/latest/tiny-docs-ai/
 
 
 ### Legacy & Other
 
 - **Interactive integration example**: https://www.tiny.cloud/docs/tinymce/latest/ie-template-creation/
 - **MoxieManager plugin**: https://www.tiny.cloud/docs/tinymce/latest/moxiemanager/
+
+
+### Other
+
+- **Adding or changing the editor content CSS**: https://www.tiny.cloud/docs/tinymce/latest/add-css-options/
+- **Autocompleter**: https://www.tiny.cloud/docs/tinymce/latest/autocompleter/
+- **Changing user formatting controls**: https://www.tiny.cloud/docs/tinymce/latest/user-formatting-options/
+- **Copy & paste options**: https://www.tiny.cloud/docs/tinymce/latest/copy-and-paste/
+- **Creating custom URL dialogs**: https://www.tiny.cloud/docs/tinymce/latest/urldialog/
+- **Custom sidebar**: https://www.tiny.cloud/docs/tinymce/latest/customsidebar/
+- **Inline CSS plugin**: https://www.tiny.cloud/docs/tinymce/latest/inline-css/
+- **Localization options**: https://www.tiny.cloud/docs/tinymce/latest/ui-localization/
+- **Non-editable content**: https://www.tiny.cloud/docs/tinymce/latest/non-editable-content-options/
+- **TinyMCE 8 Documentation**: https://www.tiny.cloud/docs/tinymce/latest/
+- **User Lookup API**: https://www.tiny.cloud/docs/tinymce/latest/userlookup/
 

--- a/modules/ROOT/attachments/llms.txt
+++ b/modules/ROOT/attachments/llms.txt
@@ -89,6 +89,24 @@ function App() {
 - [Image Plugin](https://www.tiny.cloud/docs/tinymce/latest/image/): Image handling and editing
 - [Link Plugin](https://www.tiny.cloud/docs/tinymce/latest/link/): Link management
 
+## TinyMCE AI (Premium)
+
+TinyMCE AI (`tinymceai` plugin) is the current AI writing assistant for TinyMCE. It provides chat, review, and quick actions powered by multiple LLM providers. The earlier AI Assistant (`ai` plugin) is legacy; new integrations should use TinyMCE AI.
+
+- [TinyMCE AI Introduction](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-introduction/): Overview of TinyMCE AI features and capabilities
+- [Chat](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-chat/): Conversational AI with history and persistent context
+- [Review](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-review/): Content analysis and proofreading
+- [Actions](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-actions/): Fast, stateless AI operations for specific tasks
+- [AI Models](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-models/): Supported AI models and configuration
+- [Plugin Configuration](https://www.tiny.cloud/docs/tinymce/latest/tinymceai/): `tinymceai` plugin options and setup
+- [Integration Options](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-integration-options/): Cloud and self-hosted integration paths
+- [API Overview](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-api-overview/): TinyMCE AI API for use inside and outside the editor
+- [API Quick Start](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-api-quick-start/): Get started with the TinyMCE AI API
+- [Streaming](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-streaming/): Streaming responses from the AI API
+- [JWT Authentication](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-jwt-authentication-intro/): Authentication setup for TinyMCE AI
+- [Limits](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-limits/): Rate limits and usage constraints
+- [AI Assistant (legacy)](https://www.tiny.cloud/docs/tinymce/latest/ai/): Earlier `ai` plugin — use TinyMCE AI for new projects
+
 ## API Reference
 
 - [Editor API](https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.editor/): Core editor API
@@ -101,5 +119,5 @@ function App() {
 
 ## Complete Documentation
 
-For a complete list of all 395 documentation pages, see [llms-full.txt](https://www.tiny.cloud/docs/llms-full.txt).
+For a complete list of all 411 documentation pages, see [llms-full.txt](https://www.tiny.cloud/docs/llms-full.txt).
 


### PR DESCRIPTION
## Ticket

DOC-3402

## Site

https://pr-4041.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/

## Changes

- **`-scripts/generate-llm-files.js`**:
  - Added `tinymceai` and `tinymceai-*` to the AI Features categorization rule in `categorizeUrl()`. Previously only `ai` and `ai-*` were matched, causing all 15 TinyMCE AI pages to be silently excluded.
  - Added `'Other'` to `categoryStructure` so uncategorized pages are no longer silently dropped from output.
  - Added a dedicated "TinyMCE AI (Premium)" section to the `llms.txt` template with links to all TinyMCE AI pages and a note that AI Assistant (`ai` plugin) is legacy.

- **`modules/ROOT/attachments/llms-full.txt`**: Regenerated — all 15 TinyMCE AI pages now appear under Premium Features > AI Features.

- **`modules/ROOT/attachments/llms.txt`**: Regenerated with new TinyMCE AI section.

Prepared for documentation team review.