### PR TITLE
Fix live demo CDN URL from 8-testing to 8

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -10,7 +10,7 @@ asciidoc:
     companyurl: https://www.tiny.cloud
     cdnurl: https://cdn.tiny.cloud/1/no-api-key/tinymce/8/tinymce.min.js
     tdcdnurl: https://cdn.tiny.cloud/1/_your_api_key_/tinydrive/8/tinydrive.min.js
-    tinymce_live_demo_url: https://cdn.tiny.cloud/1/qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc/tinymce/8-testing/tinymce.min.js
+    tinymce_live_demo_url: https://cdn.tiny.cloud/1/qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc/tinymce/8/tinymce.min.js
     tinydrive_live_demo_url: https://cdn.tiny.cloud/1/qagffr3pkuv17a8on1afax661irst1hbr4e6tbv888sz91jc/tinydrive/8/tinydrive.min.js
     webcomponent_url: https://cdn.jsdelivr.net/npm/@tinymce/tinymce-webcomponent/dist/tinymce-webcomponent.min.js
     jquery_url: https://cdn.jsdelivr.net/npm/@tinymce/tinymce-jquery@2/dist/tinymce-jquery.min.js


### PR DESCRIPTION
## Summary

- Reverts the `tinymce_live_demo_url` in `antora.yml` from the `8-testing` CDN channel back to the production `8` channel.

## Changes

- **antora.yml**: Changed `tinymce_live_demo_url` from `.../tinymce/8-testing/tinymce.min.js` to `.../tinymce/8/tinymce.min.js`

## Test plan

- [x] Verify live demos on the staging site load TinyMCE from the correct `8` CDN channel