### PR TITLE
DOC-3405 - Update AI Assistant docs to reflect end-of-sale and TinyMCE AI replacement (v7)

### DIFF
--- a/modules/ROOT/pages/ai.adoc
+++ b/modules/ROOT/pages/ai.adoc
@@ -1,5 +1,5 @@
-= AI Assistant plugin
-:navtitle: AI Assistant
+= AI Assistant plugin (Legacy)
+:navtitle: AI Assistant (Legacy)
 :description: Sends queries to registered AI APIs and sets the results in the document or temporarily stores the results.
 :description_short: Query AI APIs and accept results.
 :keywords: plugin, ai, artificial intelligence, query, search, llm, gpt, assistant

--- a/modules/ROOT/partials/misc/admon-ai-pricing.adoc
+++ b/modules/ROOT/partials/misc/admon-ai-pricing.adoc
@@ -1,1 +1,1 @@
-NOTE: This plugin is only available as a link:{aipricingurl}/[paid add-on] to link:{pricingpage}/[a TinyMCE subscription].
+IMPORTANT: As of March 31, 2026, {pluginname} is no longer available for purchase. It has been replaced by link:https://www.tiny.cloud/docs/tinymce/latest/tinymceai-introduction/[TinyMCE AI].


### PR DESCRIPTION
## Ticket

DOC-3405

## Site

https://pr-4045.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/7/ai/

## Changes

Backport of #4044 to the `tinymce/7` branch.

- **Updated AI Assistant pricing notice** (`modules/ROOT/partials/misc/admon-ai-pricing.adoc`): Replaced the paid add-on subscription notice with an end-of-sale notice informing that AI Assistant is no longer available for purchase as of March 31, 2026, with an external link to TinyMCE AI documentation (xref not available on v7 since TinyMCE AI pages only exist on v8). This change applies to all AI Assistant documentation pages that include this partial.

- **Updated AI Assistant landing page title** (`modules/ROOT/pages/ai.adoc`): Changed the page heading from "AI Assistant plugin" to "AI Assistant plugin (Legacy)" and updated the navtitle accordingly.

Prepared for documentation team review.