### PR TITLE
TINY-12793: Deleting a selection in an `li` didn't trigger `beforeinput`

### DIFF
--- a/modules/ROOT/pages/8.4.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.4.0-release-notes.adoc
@@ -356,7 +356,12 @@ In {productname} {release-version}, an issue was identified where certain deleti
 
 {productname} {release-version} addresses this by updating the key handler registration to occur during the `init` phase, and additional checks now ensure that previously prevented events are respected.
 
+=== Deleting a selection in an `li` didn't trigger `beforeinput`.
+// #TINY-12793
 
+Previously, deleting a selection inside a list item or pressing Backspace at the start of a list item did not fire the native `beforeinput` event. The editor's list key handler prevented the `keydown` event before performing the deletion, which also suppressed the `beforeinput` event. This affected integrations and plugins that relied on `beforeinput` to intercept or customize deletion behavior in lists.
+
+In {productname} {release-version}, the editor now dispatches a synthetic `beforeinput` event before performing delete operations inside list items. Handlers can call `preventDefault()` on this event to intercept the deletion as expected.
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/pages/8.4.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.4.0-release-notes.adoc
@@ -356,7 +356,7 @@ In {productname} {release-version}, an issue was identified where certain deleti
 
 {productname} {release-version} addresses this by updating the key handler registration to occur during the `init` phase, and additional checks now ensure that previously prevented events are respected.
 
-=== Deleting a selection in an `li` didn't trigger `beforeinput`.
+=== Deleting a selection in a `li` didn't trigger `beforeinput`.
 // #TINY-12793
 
 Previously, deleting a selection inside a list item or pressing Backspace at the start of a list item did not fire the native `beforeinput` event. The editor's list key handler prevented the `keydown` event before performing the deletion, which also suppressed the `beforeinput` event. This affected integrations and plugins that relied on `beforeinput` to intercept or customize deletion behavior in lists.


### PR DESCRIPTION
**Ticket:** TINY-12793

**Site:** [Staging](https://pr-4046.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.4.0-release-notes/#deleting-a-selection-in-an-li-didnt-trigger-beforeinput)

**Changes:**
* Added release note entry for TINY-12793 to `modules/ROOT/pages/8.4.0-release-notes.adoc` (Bug fixes section): Deleting a selection in an `li` didn't trigger `beforeinput`.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (hotfix branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.