### PR TITLE
DOC-3407: Remove placeholder Known Issues section from 8.4.0 release notes

### DIFF
--- a/modules/ROOT/pages/8.4.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.4.0-release-notes.adoc
@@ -2,7 +2,7 @@
 :release-version: 8.4.0
 :navtitle: {productname} {release-version}
 :description: Release notes for {productname} {release-version}
-:keywords: releasenotes, new, changes, bugfixes, new features, improvements, changes, removals, deprecated, known issues
+:keywords: releasenotes, new, changes, bugfixes, new features, improvements, changes, removals, deprecated
 :page-toclevels: 1
 
 include::partial$misc/admon-releasenotes-for-stable.adoc[]
@@ -21,7 +21,6 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 * xref:changes[Changes]
 * xref:bug-fixes[Bug fixes]
 * xref:security-fixes[Security fixes]
-* xref:known-issues[Known issues]
 
 
 [[new-premium-plugin]]
@@ -385,16 +384,3 @@ A link:https://owasp.org/www-community/attacks/xss/[cross-site scripting] (XSS) 
 GHSA: link:https://github.com/advisories/GHSA-v2wj-7wpq-c8vv[GitHub Advisory]
 
 CVE: link:https://nvd.nist.gov/vuln/detail/CVE-2026-0540[CVE-2026-0540]
-
-
-[[known-issues]]
-== Known issues
-
-This section describes issues that users of {productname} {release-version} may encounter and possible workarounds for these issues.
-
-The following known issues affect {productname} {release-version}.
-
-=== <TINY-vwxyz 1 changelog entry>
-// #TINY-vwxyz1
-
-// CCFR here.


### PR DESCRIPTION
## Summary

- Removed the placeholder Known Issues section from the 8.4.0 release notes page that contained unfilled template text (`<TINY-vwxyz 1 changelog entry>`)
- Removed the "Known issues" bullet from the overview list and the `known issues` keyword
- There are no known issues for 8.4.0; the section should not have been published

## JIRA

[DOC-3407](https://ephocks.atlassian.net/browse/DOC-3407)
**Site:** [Staging](https://pr-4047.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.4.0-release-notes/)

## Test plan

- [x] Verify the 8.4.0 release notes page no longer shows a Known Issues section
- [x] Verify the overview bullet list no longer links to Known Issues
- [x] Verify the Antora build passes without new errors
- [x] Verify the staging build renders correctly

Review:
- [x] Documentation Team Lead has reviewed

[DOC-3407]: https://ephocks.atlassian.net/browse/DOC-3407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ