### PR TITLE
DOC-3408 - Clarify that both bundling and lazy loading are fully supported

### DIFF
--- a/modules/ROOT/pages/bundling-plugins.adoc
+++ b/modules/ROOT/pages/bundling-plugins.adoc
@@ -88,7 +88,12 @@ require('<path_to_tinymce_premium_zip>/plugins/<plugincode>');
 [[using-premium-plugins]]
 == Using premium plugins
 
-After installing the `+tinymce-premium+` package, you need to configure the plugins in your editor. There are two main approaches:
+After installing the `+tinymce-premium+` package, configure the plugins in the editor using one of two fully supported approaches. Both options are production-ready and will continue to be supported in future releases:
+
+* **<<bundling-recommended,Bundling>>** -- includes plugin code directly in the application bundle using a module bundler
+* **<<using-external-plugins,Loading with `+external_plugins+`>>** -- loads plugins at runtime from a specified URL, enabling lazy-loading and CDN hosting
+
+The right choice depends on the application architecture and deployment requirements.
 
 [IMPORTANT]
 ====
@@ -112,9 +117,9 @@ external_plugins: {
 ====
 
 [[bundling-recommended]]
-=== Bundling (Recommended)
+=== Bundling
 
-For most modern applications, bundling premium plugins is recommended. This includes the plugin code directly in your application bundle.
+Bundling includes the plugin code directly in the application bundle. This approach works well for applications that already use a module bundler such as Webpack, Vite, or Rollup.
 
 . Import the premium plugins you need:
 +
@@ -141,9 +146,9 @@ tinymce.init({
 For complete bundling examples, see the <<premium-plugins,Premium plugins>> and <<community-plugins,Community plugins>> sections below.
 
 [[using-external-plugins]]
-=== Using external_plugins (Non-bundling)
+=== Loading with external_plugins
 
-When bundling is not available or you want to lazy-load plugins, use the `+external_plugins+` option:
+The `+external_plugins+` option loads plugins at runtime from a specified URL. This approach enables lazy-loading, allows serving {productname} assets from a CDN or separate host, and avoids adding editor code to the application bundle. {cloudname} uses this same mechanism to load the editor.
 
 [source,js]
 ----

--- a/modules/ROOT/pages/bundling-plugins.adoc
+++ b/modules/ROOT/pages/bundling-plugins.adoc
@@ -148,7 +148,7 @@ For complete bundling examples, see the <<premium-plugins,Premium plugins>> and 
 [[using-external-plugins]]
 === Loading with external_plugins
 
-The `+external_plugins+` option loads plugins at runtime from a specified URL. This approach enables lazy-loading, allows serving {productname} assets from a CDN or separate host, and avoids adding editor code to the application bundle. {cloudname} uses this same mechanism to load the editor.
+The `+external_plugins+` option loads plugins at runtime from a specified URL. This approach uses lazy loading, serving {productname} assets from a CDN or separate host, and avoids adding editor code to the application bundle. {cloudname} uses this approach to load the editor.
 
 [source,js]
 ----

--- a/modules/ROOT/pages/license-key.adoc
+++ b/modules/ROOT/pages/license-key.adoc
@@ -74,7 +74,7 @@ tinymce.init({
 ====
 * The `+licensekeymanager+` plugin is included in the `+tinymce-premium+` package.
 * The `+tinymce-premium+` package version must match the `+tinymce+` package version (e.g., both at 8.3.0).
-* The `+external_plugins+` option allows loading the license key manager from any location, useful when bundling is not available or when lazy-loading plugins. For more information, see: xref:editor-important-options.adoc#external_plugins[`+external_plugins+` configuration option].
+* The `+external_plugins+` option allows loading the license key manager from any location, such as a CDN or separate host. For more information, see: xref:editor-important-options.adoc#external_plugins[`+external_plugins+` configuration option].
 ====
 
 == License Types and Deployment Options


### PR DESCRIPTION
**Ticket:** DOC-3408

**Site:** [Staging branch](https://pr-4048.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/bundling-plugins/#using-premium-plugins)

**Changes:**
* Removed "(Recommended)" label from the bundling section heading on the plugins bundling page
* Rewrote the "Using premium plugins" intro to explicitly state both bundling and loading with `external_plugins` are fully supported and production-ready
* Reframed the `external_plugins` section as an equal option rather than a fallback, noting that Tiny Cloud uses the same mechanism
* Updated `license-key.adoc` to use neutral language for the `external_plugins` reference

### **Pre-checks:**
- [x] Branch is correctly prefixed:
- [x] Build passes without console errors, warnings, or issues.

### **Review:**

- [x] Documentation Team Lead has reviewed.