### PR TITLE
DOC-3355: Menus no longer close on mouse out.

### DIFF
--- a/modules/ROOT/pages/8.5.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.5.0-release-notes.adoc
@@ -41,6 +41,21 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following fix.
+
+==== Menus no longer close on mouse out.
+// #TINY-14055
+
+Previously, submenus in the TinyMCE AI plugin closed when the mouse pointer moved outside the menu area. This did not match the behavior of other {productname} menus, where submenus remain open until another item in the parent menu is selected or the entire menu is dismissed. The inconsistency made submenu navigation unreliable and could cause confusion during use.
+
+In {productname} {release-version}, submenus in the TinyMCE AI plugin no longer close on mouse out. Submenus now remain open until another parent menu item is selected or the menu is dismissed, matching the behavior of all other {productname} menus.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 
 [[accompanying-enhanced-skins-and-icon-packs-changes]]
 == Accompanying Enhanced Skins & Icon Packs changes


### PR DESCRIPTION
**Ticket:** DOC-3355

**Site:** [Staging](https://pr-4051.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.5.0-release-notes/#menus-no-longer-close-on-mouse-out)

**Changes:**
* Added release note entry for TINY-14055 to `modules/ROOT/pages/8.5.0-release-notes.adoc` (Accompanying Premium plugin changes > TinyMCE AI section): Menus no longer close on mouse out.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.