### PR TITLE
DOC-3388: Add getContent and setContent examples to save-content partial

### DIFF
--- a/modules/ROOT/partials/install/save-content.adoc
+++ b/modules/ROOT/partials/install/save-content.adoc
@@ -4,3 +4,33 @@ To retrieve content from the editor, either process the content with a form hand
 
 If you use a form handler, once the `+<form>+` is submitted, {productname} {productmajorversion} will `+POST+` the content in the same way as a normal HTML `+<textarea>+`, including the HTML elements and inline CSS of the editor content. The host's form handler can process the submitted content in the same way as content from a regular `+<textarea>+`.
 
+=== Get and set content programmatically
+
+Use the xref:apis/tinymce.editor.adoc#getContent[`+getContent+`] and xref:apis/tinymce.editor.adoc#setContent[`+setContent+`] APIs to read and write editor content from JavaScript.
+
+==== Example: retrieve editor content as HTML
+
+[source,js]
+----
+const editor = tinymce.activeEditor;
+const html = editor.getContent();
+console.log(html);
+----
+
+To retrieve the content as plain text instead of HTML:
+
+[source,js]
+----
+const editor = tinymce.activeEditor;
+const text = editor.getContent({ format: 'text' });
+console.log(text);
+----
+
+==== Example: set editor content
+
+[source,js]
+----
+const editor = tinymce.activeEditor;
+editor.setContent('<p>New content</p>');
+----
+


### PR DESCRIPTION
## Summary
- Adds "Get and set content programmatically" section to `save-content.adoc` with runnable `editor.getContent()` and `editor.setContent()` examples
- Addresses Context7 benchmark Q3 (score 12/100)

## Source validation
- `editor.getContent(args?)` confirmed at `Editor.ts:880-883`
- `editor.setContent(content, args?)` confirmed at `Editor.ts:858-860`
- `getContent({ format: 'text' })` option confirmed in source JSDoc

## Test plan
- [x] API signatures verified against tinymce source (`Editor.ts`)
- [x] Examples use `tinymce.activeEditor` consistent with source JSDoc
- [x] Antora build passes with no errors on modified files
- [x] xref links to API docs match existing structure