### PR TITLE
DOC-3389: Strengthen add-css-options page for custom content CSS

### DIFF
--- a/modules/ROOT/pages/add-css-options.adoc
+++ b/modules/ROOT/pages/add-css-options.adoc
@@ -1,6 +1,9 @@
 = Adding or changing the editor content CSS
 :navtitle: Add CSS
-:description: Options for changing the editor content CSS.
+:description: Apply custom CSS to the editor content area using content_css and content_style. Control typography, colors, margins, and layout in the editable region.
+:keywords: content_css, content_style, custom CSS, content area, stylesheet, editor styling
+
+Use `+content_css+` to load external stylesheets into the editable area, or `+content_style+` to inject inline CSS. Both options apply only to the editor content (the iframe body in classic mode), not the surrounding UI.
 
 == Add CSS and styles to the editor
 


### PR DESCRIPTION
## Summary
- Updates description and adds keywords for `content_css` and `content_style` on `add-css-options.adoc`
- Adds intro paragraph explaining content_css vs content_style
- Addresses Context7 benchmark Q8 (score 0/100)

## Source validation
- `content_css` and `content_style` options confirmed in tinymce source Settings and existing config partials
- Existing `content_css.adoc` and `content_style.adoc` partials already included in this page

## Test plan
- [x] Description mentions content_css and content_style
- [x] Keywords include "content_css", "content_style", "custom CSS"
- [x] Intro paragraph is factually correct (iframe body in classic mode)
- [x] Antora build passes with no errors