### PR TITLE
DOC-3390: Add editor.on('change') example to events page

### DIFF
--- a/modules/ROOT/pages/events.adoc
+++ b/modules/ROOT/pages/events.adoc
@@ -97,6 +97,24 @@ tinymce.init({
 });
 ----
 
+=== Example: content change callback
+
+To run a callback when the editor content changes, use the `+Change+` event with `+editor.on()+` inside the `+setup+` option:
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',
+  setup: (editor) => {
+    editor.on('change', () => {
+      console.log('Content was modified.');
+    });
+  }
+});
+----
+
+The `+Change+` event fires when content changes are committed, such as when moving focus away from the editor. For real-time updates as the user types, use the `+input+` event instead.
+
 [[browser-native-events]]
 == Supported browser-native events
 


### PR DESCRIPTION
## Summary
- Adds content change callback example using `setup` option and `editor.on('change')` to `events.adoc`
- Placed after the ExecCommand example and before browser-native events section
- Addresses Context7 benchmark Q4 (score 30/100)

## Source validation
- `Change` event confirmed in `events.adoc` line 191: fires `{ level: UndoLevel }` when content changes are committed
- `editor.on()` method confirmed as standard EventDispatcher API
- `setup` callback pattern matches existing examples in the same file

## Test plan
- [x] Example uses `editor.on('change', fn)` inside `setup` callback
- [x] Example is complete and copy-paste runnable
- [x] Change event description matches source (fires on committed changes)
- [x] Antora build passes with no errors