### PR TITLE
DOC-3392: Add programmatic mode.set example to readonly docs

### DIFF
--- a/modules/ROOT/partials/configuration/readonly.adoc
+++ b/modules/ROOT/partials/configuration/readonly.adoc
@@ -21,6 +21,21 @@ tinymce.init({
 
 liveDemo::readonly-demo[]
 
+=== Example: switching modes programmatically
+
+Use the xref:apis/tinymce.editormode.adoc#set[`+editor.mode.set()+`] API to switch between `+readonly+` and `+design+` (editable) modes at runtime:
+
+[source,js]
+----
+const editor = tinymce.activeEditor;
+
+// Switch to read-only
+editor.mode.set('readonly');
+
+// Switch back to editable
+editor.mode.set('design');
+----
+
 === Behavior in `readonly` mode
 
 [cols="1,3,1", options="header"]


### PR DESCRIPTION
## Summary
- Adds "switching modes programmatically" example to `readonly.adoc`
- Shows `editor.mode.set('readonly')` and `editor.mode.set('design')`
- Addresses Context7 benchmark Q7 (score 25/100)

## Source validation
- `editor.mode.set(mode: string)` confirmed at `Mode.ts:93`
- Available modes are 'design' and 'readonly' (confirmed in `events.adoc` SwitchMode event and Mode.ts)
- xref to `tinymce.editormode.adoc#set` matches existing link in the same file (line 4)

## Test plan
- [x] `mode.set` signature matches source (`set: (mode: string) => ...`)
- [x] Mode values 'readonly' and 'design' confirmed in source
- [x] Example uses `tinymce.activeEditor` consistent with other examples
- [x] Antora build passes with no errors