### PR TITLE
DOC-3393: Add plugins and toolbar multi-plugin example to quickstart

### DIFF
--- a/modules/ROOT/partials/install/basic-quickstart-base.adoc
+++ b/modules/ROOT/partials/install/basic-quickstart-base.adoc
@@ -183,6 +183,21 @@ Adding this content to an HTML file and opening it in a web browser will load a 
 
 liveDemo::default[]
 
+== Configure plugins and toolbar
+
+To enable specific plugins and customize the toolbar, use the `+plugins+` and `+toolbar+` options. For example, to add the `+image+` and `+code+` plugins with their toolbar buttons:
+
+[source,js]
+----
+tinymce.init({
+  selector: '#mytextarea',
+  plugins: 'image code',
+  toolbar: 'undo redo | image code'
+});
+----
+
+Plugin names are space-separated. Toolbar items can include plugin-provided buttons (such as `+image+` and `+code+`) and separators (`+|+`). For a full list of available plugins, see xref:plugins.adoc[Plugins].
+
 ifeval::["{productSource}" == "cloud"]
 == Add your API key
 


### PR DESCRIPTION
## Summary
- Adds "Configure plugins and toolbar" section to `basic-quickstart-base.adoc` with multi-plugin example
- Shows `plugins: 'image code'` and `toolbar: 'undo redo | image code'`
- Uses `selector: '#mytextarea'` for consistency with existing examples
- Addresses Context7 benchmark Q2 (score 56/100)

## Source validation
- `plugins` and `toolbar` options are core init options used throughout existing docs
- Space-separated plugin format confirmed in existing quickstart examples
- `selector: '#mytextarea'` matches the textarea ID in the same partial

## Test plan
- [x] Example uses standard init options (`plugins`, `toolbar`, `selector`)
- [x] Plugin names 'image' and 'code' are valid open-source plugins
- [x] Section placement is after liveDemo and before "Add your API key"
- [x] Antora build passes with no errors