### PR TITLE
DOC-3394: Add content filtering intro to content-filtering page

### DIFF
--- a/modules/ROOT/pages/content-filtering.adoc
+++ b/modules/ROOT/pages/content-filtering.adoc
@@ -1,7 +1,10 @@
 = Content filtering options
 :navtitle: Content filtering
-:description_short: Learn how to create clean, maintainable and readable content.
-:description: These settings change the way the editor handles the input and output of content. This will help you to create clean, maintainable and readable content.
+:description_short: Control which HTML elements and attributes are allowed or removed using valid_elements, invalid_elements, and extended_valid_elements.
+:description: Configure content filtering and sanitization using valid_elements, invalid_elements, extended_valid_elements, and paste hooks. Control which HTML elements and attributes {productname} allows or removes when content is inserted or pasted.
+:keywords: valid_elements, invalid_elements, extended_valid_elements, allow_html_in_named_anchor, content filtering, sanitization, HTML elements, paste_preprocess, paste_postprocess
+
+Use `+valid_elements+` to define which elements and attributes are allowed, `+invalid_elements+` to block specific elements, and `+extended_valid_elements+` to add or modify rules. For paste-time filtering, use the `+PastePreProcess+` and `+PastePostProcess+` events or the xref:introduction-to-powerpaste.adoc[PowerPaste] plugin options.
 
 include::partial$configuration/allow_conditional_comments.adoc[]
 


### PR DESCRIPTION
## Summary
- Updates description and keywords on `content-filtering.adoc` to mention `valid_elements`, `invalid_elements`, `extended_valid_elements`
- Adds intro paragraph summarizing key filtering options and paste hooks
- Addresses Context7 benchmark Q10 (score 22/100)

## Source validation
- `valid_elements`, `invalid_elements`, `extended_valid_elements` confirmed as included partials in this page
- `PastePreProcess` and `PastePostProcess` events confirmed in `events.adoc` (lines 222-223, 386-387)
- PowerPaste plugin xref matches existing documentation structure

## Test plan
- [x] Description mentions all three key filtering options
- [x] Keywords include paste_preprocess, paste_postprocess, sanitization
- [x] Intro paragraph uses correct option names matching included partials
- [x] Antora build passes with no errors