### PR TITLE
DOC-3395: Improve quickstart keywords for selector/ID discoverability

### DIFF
--- a/modules/ROOT/pages/cloud-quick-start.adoc
+++ b/modules/ROOT/pages/cloud-quick-start.adoc
@@ -1,8 +1,8 @@
 = Quick start: {productname} from {cloudname}
 :navtitle: Quick start: Cloud
 :description_short: Setup a basic {productname} {productmajorversion} editor using the {cloudname}.
-:description: Get an instance of {productname} {productmajorversion} up and running using the {cloudname}.
-:keywords: tinymce, script, textarea
+:description: Get an instance of {productname} {productmajorversion} up and running using the {cloudname}. Initialize the editor on a textarea element using its ID with tinymce.init and the selector option.
+:keywords: tinymce, script, textarea, selector, id, #mytextarea, tinymce.init, initialize, quick start
 :productSource: cloud
 
 

--- a/modules/ROOT/pages/dotnet-projects.adoc
+++ b/modules/ROOT/pages/dotnet-projects.adoc
@@ -1,7 +1,7 @@
 = Installing {productname} for .NET
 :navtitle: .NET projects
 :description: Learn how to install {productname} from NuGet.
-:keywords: nuget .net install
+:keywords: nuget, .net, install, selector, textarea, id, tinymce.init
 
 == Install {productname} using NuGet
 

--- a/modules/ROOT/pages/npm-projects.adoc
+++ b/modules/ROOT/pages/npm-projects.adoc
@@ -1,7 +1,7 @@
 = Quick start: {productname} from NPM or Yarn
 :navtitle: Quick start: NPM/Yarn
 :description: Learn how to install {productname} from NPM using NPM and Yarn, including premium plugins for commercial customers.
-:keywords: yarn, npm, javascript, install, premium plugins, tinymce-premium
+:keywords: yarn, npm, javascript, install, premium plugins, tinymce-premium, selector, textarea, id, tinymce.init
 
 == Install {productname} using NPM or Yarn
 

--- a/modules/ROOT/pages/php-projects.adoc
+++ b/modules/ROOT/pages/php-projects.adoc
@@ -1,7 +1,7 @@
 = Installing {productname} with Composer
 :navtitle: PHP projects
 :description: Learn how to install {productname} from Packagist using Composer.
-:keywords: php, composer, packagist, install
+:keywords: php, composer, packagist, install, selector, textarea, id, tinymce.init
 
 == Install {productname} using the Composer package manager
 

--- a/modules/ROOT/pages/zip-install.adoc
+++ b/modules/ROOT/pages/zip-install.adoc
@@ -1,7 +1,7 @@
 = Quick start: {productname} from .zip
 :navtitle: Quick start: ZIP
 :description: Learn how to use {productname} from a .zip archive.
-:keywords: zip, archive, unzip, install
+:keywords: zip, archive, unzip, install, selector, textarea, id, tinymce.init
 
 == Install {productname} using a .zip package
 


### PR DESCRIPTION
## Summary
- Adds `selector`, `textarea`, `id`, `tinymce.init` keywords to all quickstart pages
- Updated pages: cloud-quick-start, npm-projects, php-projects, dotnet-projects, zip-install
- Updates cloud-quick-start description to mention ID-based selector
- Addresses Context7 benchmark Q1 (score 62/100)

## Source validation
- `selector` option confirmed as core tinymce.init option (used in `basic-quickstart-base.adoc` line 139)
- `#mytextarea` selector pattern confirmed in existing quickstart examples
- All quickstart pages already show `selector: '#mytextarea'` in code examples

## Test plan
- [x] All 5 quickstart pages now include selector/ID keywords
- [x] Keywords match existing code examples in the pages
- [x] No structural changes to page content
- [x] Antora build passes with no errors