### PR TITLE
DOC-3396: Improve custom-toolbarbuttons and file-image-upload metadata

### DIFF
--- a/modules/ROOT/pages/custom-toolbarbuttons.adoc
+++ b/modules/ROOT/pages/custom-toolbarbuttons.adoc
@@ -1,7 +1,7 @@
 = Toolbar buttons
 :navtitle: Toolbar buttons
-:description: Add a custom buttons to the {productname} {productmajorversion} toolbar.
-:keywords: toolbar, toolbarbuttons, buttons, toolbarbuttonsapi
+:description: Add custom toolbar buttons using editor.ui.registry.addButton and the setup callback. Create buttons that trigger commands or custom actions.
+:keywords: toolbar, toolbarbuttons, buttons, toolbarbuttonsapi, custom button, addButton, editor.ui.registry, setup callback, onAction
 
 == Use cases
 

--- a/modules/ROOT/pages/file-image-upload.adoc
+++ b/modules/ROOT/pages/file-image-upload.adoc
@@ -1,6 +1,7 @@
 = Image and file options
 :navtitle: Images and files
-:description: These settings affect TinyMCE's image and file handling capabilities.
+:description: Configure image uploads to a server using images_upload_handler or images_upload_url. Handle file uploads with custom logic or a server endpoint.
+:keywords: images_upload_handler, images_upload_url, image upload, server, upload handler, file picker, images_file_types
 
 == Controlling or adjusting allowed image and file formats
 

--- a/modules/ROOT/pages/upload-images.adoc
+++ b/modules/ROOT/pages/upload-images.adoc
@@ -1,8 +1,8 @@
 = Handling image uploads
 :navtitle: Image uploads
 :description_short: How to manage asynchronous image uploads.
-:description: How to manage asynchronous image uploads.
-:keywords: uploader, uploadImages, image, handler, asynchronous, async, paste_data_images, image, cors
+:description: Configure and manage asynchronous image uploads using images_upload_handler or images_upload_url. Upload images to a server endpoint with custom handling.
+:keywords: uploader, uploadImages, image, handler, asynchronous, async, paste_data_images, image, cors, images_upload_handler, images_upload_url, image upload, server
 
 {productname} uploads edited images with the image uploader. This complements {productname}'s image editing functionality.
 


### PR DESCRIPTION
## Summary
- Updates `custom-toolbarbuttons.adoc` description and keywords (addButton, custom button, setup callback)
- Updates `file-image-upload.adoc` description and keywords (images_upload_handler, images_upload_url)
- Updates `upload-images.adoc` description and keywords (images_upload_handler, image upload)
- Addresses Context7 benchmark Q5 and Q6 (25/100 each)

## Source validation
- `editor.ui.registry.addButton` confirmed at `Registry.ts`
- `images_upload_handler` and `images_upload_url` confirmed as included partials in both pages
- Description text matches the actual behavior documented in the existing partial content

## Test plan
- [x] custom-toolbarbuttons has "addButton", "custom button" in keywords
- [x] file-image-upload has "images_upload_handler" in keywords
- [x] upload-images has "images_upload_handler", "image upload" in keywords
- [x] Antora build passes with no errors