### PR TITLE
DOC-3397: Add context7.json for Context7 indexing configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@ _site/
 .cursor/
 AGENTS.md
 .cursorignore
-context7.json

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/tinymce/tinymce-docs",
+  "public_key": "pk_zfLsHseHKUL2Ys96GNqA5"
+}


### PR DESCRIPTION
## Summary
- Adds `context7.json` to the repository root to register tinymce-docs with Context7
- Removes the `context7.json` entry from `.gitignore` so the file is tracked

## Context
Context7 requires a `context7.json` file in the repository root to link the repo with its indexing platform. This enables documentation indexing and benchmark tracking at [context7.com/tinymce/tinymce-docs](https://context7.com/tinymce/tinymce-docs).

## Test plan
- [x] File contains valid JSON with `url` and `public_key`
- [x] `.gitignore` updated to allow tracking
- [x] Build unaffected (config file only)