### PR TITLE
DOC-3397: Add context7.json for Context7 indexing (main)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@ _site/
 .cursor/
 AGENTS.md
 .cursorignore
-context7.json

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/tinymce/tinymce-docs",
+  "public_key": "pk_zfLsHseHKUL2Ys96GNqA5"
+}


### PR DESCRIPTION
## Summary
- Cherry-pick of context7.json from hotfix/8/DOC-3397 to main branch
- Registers the tinymce-docs repository with Context7 on the main (development) branch
- Removes `context7.json` from `.gitignore` so the file is tracked

## Context
Context7 indexes branches independently. This ensures the `main` branch (mapped to `/latest`) is also registered alongside `tinymce/8`.