### PR TITLE
DOC-3411 - Update Svelte integration docs for tinymce-svelte 4.x / Svelte 5 (v7 backport)

### DIFF
--- a/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
@@ -1,6 +1,7 @@
 Covered in this section:
 
-* xref:configuring-the-tinymce-svelte-integration[Configuring the TinyMCE Svelte integration]
+* xref:supported-versions[Supported versions]
+* xref:configuring-the-tinymce-svelte-integration[Configuring the {productname} Svelte integration]
 ** xref:apikey[apiKey]
 ** xref:licensekey[licenseKey]
 ** xref:channel[channel]
@@ -12,6 +13,21 @@ Covered in this section:
 ** xref:conf[conf]
 * xref:component-binding[Component binding]
 * xref:event-binding[Event binding]
+
+[[supported-versions]]
+== Supported versions
+
+[cols="1,1", options="header"]
+|===
+|`+@tinymce/tinymce-svelte+`
+|Svelte
+
+|4.x
+|5 or later
+
+|\<= 3.x
+|4 (also compatible with Svelte 5 in legacy mode)
+|===
 
 [[configuring-the-tinymce-svelte-integration]]
 == Configuring the TinyMCE Svelte integration
@@ -254,9 +270,9 @@ let text = '';
 
 Functions can be bound to editor events, such as:
 
-[source,jsx]
+[source,svelte]
 ----
-<Editor on:resizeeditor={this.handlerFunction} />
+<Editor resizeeditor={handlerFunction} />
 ----
 
 When the handler is called (*handlerFunction* in this example), it is called with two arguments:
@@ -265,8 +281,26 @@ When the handler is called (*handlerFunction* in this example), it is called wit
 
 `+editor+`:: A reference to the editor.
 
+=== Example of event binding
+
+[source,svelte]
+----
+<script>
+import Editor from '@tinymce/tinymce-svelte';
+
+function handlerFunction(event, editor) {
+  console.log('Editor event:', event);
+  console.log('Editor instance:', editor);
+}
+</script>
+
+<main>
+  <Editor resizeeditor={handlerFunction} />
+</main>
+----
+
 [TIP]
-Ensure event names are specified in lower-case (event names are case-sensitive).
+Specify event names in lower-case (event names are case-sensitive).
 
 The following events are available:
 
@@ -282,10 +316,10 @@ The following events are available:
 * `+change+`
 * `+clearundos+`
 * `+click+`
-* `+CommentChange+`
-* `+CompositionEnd+`
-* `+CompositionStart+`
-* `+CompositionUpdate+`
+* `+commentchange+`
+* `+compositionend+`
+* `+compositionstart+`
+* `+compositionupdate+`
 * `+contextmenu+`
 * `+copy+`
 * `+cut+`

--- a/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
@@ -288,7 +288,7 @@ When the handler is called (*handlerFunction* in this example), it is called wit
 <script>
 import Editor from '@tinymce/tinymce-svelte';
 
-function handlerFunction(event, editor) {
+function eventHandler(event, editor) {
   console.log('Editor event:', event);
   console.log('Editor instance:', editor);
 }

--- a/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
@@ -295,7 +295,7 @@ function eventHandler(event, editor) {
 </script>
 
 <main>
-  <Editor resizeeditor={handlerFunction} />
+  <Editor resizeeditor={this.eventHandler} />
 </main>
 ----
 

--- a/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
@@ -14,20 +14,6 @@ Covered in this section:
 * xref:component-binding[Component binding]
 * xref:event-binding[Event binding]
 
-[[supported-versions]]
-== Supported versions
-
-[cols="1,1", options="header"]
-|===
-|`+@tinymce/tinymce-svelte+`
-|Svelte
-
-|4.x
-|5 or later
-
-|\<= 3.x
-|4 (also compatible with Svelte 5 in legacy mode)
-|===
 
 [[configuring-the-tinymce-svelte-integration]]
 == Configuring the TinyMCE Svelte integration

--- a/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
@@ -1,6 +1,5 @@
 Covered in this section:
 
-* xref:supported-versions[Supported versions]
 * xref:configuring-the-tinymce-svelte-integration[Configuring the {productname} Svelte integration]
 ** xref:apikey[apiKey]
 ** xref:licensekey[licenseKey]


### PR DESCRIPTION
**Ticket:** DOC-3411

**Site:** Staging branch

**Changes:**

* Cherry-pick of #4063 from tinymce/8 into tinymce/7
* Update event binding section: remove `on:` directive prefix per Svelte 5 syntax (`on:resizeeditor` → `resizeeditor`)
* Fix mixed-case event names (`CommentChange`, `CompositionEnd`, etc.) to lowercase, matching actual prop names
* Add supported versions table (4.x → Svelte 5+, 3.x → Svelte 4)

Related: INT-3421, tinymce/tinymce-svelte#92

---

### **Pre-checks:**

- [x] Branch is correctly prefixed:
- [x] Major or minor version changes have updated the `supported-versions.adoc` table.
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.