### PR TITLE
DOC-3411: Remove erroneous supported-versions xref from Svelte tech ref

### DIFF
--- a/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/svelte-tech-ref.adoc
@@ -1,6 +1,5 @@
 Covered in this section:
 
-* xref:supported-versions[Supported versions]
 * xref:configuring-the-tinymce-svelte-integration[Configuring the {productname} Svelte integration]
 ** xref:apikey[apiKey]
 ** xref:licensekey[licenseKey]


### PR DESCRIPTION
## Summary

- Removes the `* xref:supported-versions[Supported versions]` line from `svelte-tech-ref.adoc`, which was added by mistake.

## Test plan

- [x] Verify the Svelte integration tech ref page renders without the broken/unwanted cross-reference.