### PR TITLE
DOC-3397: Fix Context7 branch config to index tinymce/8

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,26 @@
 {
+  "$schema": "https://context7.com/schema/context7.json",
   "url": "https://context7.com/tinymce/tinymce-docs",
-  "public_key": "pk_zfLsHseHKUL2Ys96GNqA5"
+  "public_key": "pk_zfLsHseHKUL2Ys96GNqA5",
+  "projectTitle": "TinyMCE",
+  "description": "TinyMCE rich text editor documentation — setup, configuration, plugins, APIs, and integration guides",
+  "branch": "tinymce/8",
+  "folders": [
+    "modules/ROOT/pages",
+    "modules/ROOT/partials",
+    "modules/ROOT/examples"
+  ],
+  "excludeFolders": [
+    "-new-material-templates",
+    "-scripts",
+    ".github",
+    "modules/ROOT/images",
+    "modules/ROOT/attachments"
+  ],
+  "excludeFiles": [
+    "LICENSE.txt",
+    "CODE_OF_CONDUCT.md",
+    "antora-playbook-local.yml",
+    ".env"
+  ]
 }


### PR DESCRIPTION
## Summary

- Fix Context7 configuration to index `tinymce/8` instead of `main`
- The previous claim-only config (url + public_key) caused Context7 to default to `main`, which has zero documentation pages — all doc content lives on `tinymce/8`
- Add `branch`, `folders`, `excludeFolders`, and `excludeFiles` settings for proper parser configuration

## Changes

- `context7.json`: Add `branch: "tinymce/8"`, folder inclusions (`modules/ROOT/pages`, `modules/ROOT/partials`, `modules/ROOT/examples`), folder exclusions (templates, scripts, images, attachments), file exclusions, schema reference, and project metadata

## Context

Benchmark score dropped from 27.3 to 22.7 despite DOC-3387 improvements because Context7 was indexing `main` (infrastructure files only) rather than `tinymce/8` (actual documentation). This PR targets `main` so Context7 can discover the config when fetching from the default branch.

Companion PR targets `tinymce/8`.