### PR TITLE
DOC-2898: Documentation enhancements: for https://www.tiny.cloud/docs/tinymce/latest/custom-toggle-toolbar-button/

### DIFF
--- a/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
@@ -52,7 +52,7 @@ The first (`+customStrikethrough+`) button applies and removes strikethrough for
 
 The second button (`+customToggleStrikethrough+`) addresses this by using xref:apis/tinymce.formatter.adoc#formatChanged[`+editor.formatter.formatChanged+`] in its `+onSetup+` callback to monitor the formatting state of the current selection.
 
-Note: The format name passed to +mceToggleFormat+ via +editor.execCommand(command, ui, args)+ is the same as the one used in +editor.formatter.formatChanged(formatName, callback)+.
+NOTE: The format name passed to `+mceToggleFormat+` via `+editor.execCommand(command, ui, args)+` is the same as the one used in `+editor.formatter.formatChanged(formatName, callback)+`.
 
 The `+formatChanged+` method accepts the following parameters:
 

--- a/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
@@ -1,9 +1,9 @@
-= Creating custom Toggle toolbar buttons
+= Creating custom toggle toolbar buttons
 :navtitle: Toggle toolbar button
-:description: Creating custom Toggle toolbar buttons for TinyMCE
-:keywords: toolbar, toolbarbuttons, buttons, toolbarbuttonsapi
+:description: Creating custom toggle toolbar buttons for {productname}
+:keywords: toolbar, toolbarbuttons, buttons, toolbarbuttonsapi, toggle, formatChanged
 
-A toggle button triggers an action when clicked but also has a concept of state. This means it can be toggled `+on+` and `+off+`. A toggle button gives the user visual feedback for its state through CSS styling. An example of this behavior is the *Bold* button that is highlighted when the cursor is in a word with bold formatting.
+A toggle button triggers an action when clicked and maintains an active state. This means it can be toggled `+on+` or `+off+`. The toggle button provides the user visual feedback of its state through CSS styling. An example of this behavior is the *Bold*, which becomes highlighted when the cursor is within text that has bold formatting.  
 
 == Options
 
@@ -14,8 +14,8 @@ A toggle button triggers an action when clicked but also has a concept of state.
 |icon |string |optional |
 include::partial$misc/admon-predefined-icons-only.adoc[]
 |tooltip |string |optional |Text for button tooltip.
-|enabled |boolean |optional |default: `true` - Represents the button's state. When `false`, the button is unclickable. Toggled by the button's API.
-|active |boolean |optional |default: `false` - Represents the button's state. When `true`, the button is highlighted. Toggled by the button's API.
+|enabled |boolean |optional |default: `true` - Represents the button's enabled state. When `false`, the button is unclickable. Can be changed using `+setEnabled+` from the button's API.
+|active |boolean |optional |default: `false` - Represents the button's active state. When `true`, the button is highlighted. Can be changed using `+setActive+` from the button's API.
 |onSetup |`+(api) => (api) => void+` |optional |default: `+() => () => {}+` - Function invoked when the button is rendered. For details, see: xref:using-onsetup[Using `+onSetup+`].
 |onAction |`+(api) => void+` |required |Function invoked when the button is clicked.
 4+|
@@ -31,8 +31,8 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 |Name |Value |Description
 |isEnabled |`+() => boolean+` |Checks if the button is enabled.
 |setEnabled |`+(state: boolean) => void+` |Sets the button's enabled state.
-|isActive |`+() => boolean+` |Checks if the button is `+on+`.
-|setActive |`+(state: boolean) => void+` |Sets the button's toggle state.
+|isActive |`+() => boolean+` |Checks if the button is in the active (toggled on) state.
+|setActive |`+(state: boolean) => void+` |Sets the button's active (toggled) state.
 3+|
 |setText |`+(text: string) => void+` |Sets the text label to display.
 |setIcon |`+(icon: string) => void+` |Sets the icon of the button.
@@ -42,20 +42,31 @@ include::partial$misc/admon-predefined-icons-only.adoc[]
 
 liveDemo::custom-toolbar-toggle-button[tab="js"]
 
-The example above adds two custom *strikethrough* buttons with the same `+onAction+` configuration. The configuration uses `+editor.execCommand(command, ui, args)+` to execute `+mceToggleFormat+`. This editor method toggles the specified format on and off, but only works for xref:content-formatting.adoc#formats[formats] that are already registered with the editor. In this example, `+strikethrough+` is the registered format.
+The example above adds two custom *strikethrough* toggle buttons. Both buttons use the xref:editor-command-identifiers.adoc[`+mceToggleFormat+`] command to apply and remove strikethrough formatting. This command toggles a specified format on and off, but only works for xref:content-formatting.adoc#formats[formats] already registered with the editor. In this example, `+strikethrough+` is the registered format.
 
-The first button applies and removes strikethrough formatting, and its state toggles on click using `+api.setActive(!api.isActive())+`. However, the expected behavior is that the button's state will reflect whether the selected content has strikethrough formatting. For example, if the cursor is moved into editor content that has strikethrough formatting the button will become *active* and if it is moved into content that does not have strikethrough formatting the button will become *inactive*. The first button in the example does not do this, since its state only toggles when the button is clicked.
+=== Basic togle: manual state management
 
-To achieve this, the second button uses `+onSetup+` to register a callback for strikethrough content using `+editor.formatter.formatChanged(formatName, callback)+`. This method executes the specified callback function when the selected content has the specified formatting.
+The first (`+customStrikethrough+`) button applies and removes strikethrough formatting. Its state toggles upon click using `+api.setActive(!api.isActive())+`. However, this button does not reflect whether the selected content has strikethrough formatting which is its expected behavior. Moving the cursor into content with strikethrough formatting does not activate the button, and moving it out does not deactivate it.
 
-NOTE: The format name given to `+mceToggleFormat+` via `+editor.execCommand(command, ui, args)+` and to `+editor.formatter.formatChanged(formatName, callback)+` is the same.
+=== State-synced toggle: automatic state updates 
 
-The callback given to `+editor.formatter.formatChanged+` is a function that takes a `+state+` boolean representing whether the currently selected content contains the applied format. This `+state+` boolean is used to set the button's active state to match if the selected content has the specified formatting by using `+api.setActive(state)+` from the button's API. This ensures the `+customToggleStrikethrough+` button is only *active* when the selected content contains the strikethrough formatting.
+The second button (`+customToggleStrikethrough+`) addresses this by using xref:apis/tinymce.formatter.adoc#formatChanged[`+editor.formatter.formatChanged+`] in its `+onSetup+` callback to monitor the formatting state of the current selection.
 
-For formats that require variables, the `+editor.formatter.formatChanged+` function takes two extra arguments: `+similar+` and `+vars+`.
+Note: The format name passed to +mceToggleFormat+ via +editor.execCommand(command, ui, args)+ is the same as the one used in +editor.formatter.formatChanged(formatName, callback)+.
 
-When the `+similar+` argument is `+true+`, similar formats will all be treated as the same by `+formatChanged+`. Similar formats are those with the same `+formatName+` but different variables. This argument will default to `+false+`.
+The `+formatChanged+` method accepts the following parameters:
 
-The `+vars+` argument controls which variables are used to match the content when determining whether to run the callback. This argument is only used when `+similar+` is `+false+`.
+The `+formatChanged+` method accepts the following parameters:
+
+* `+formats+` (String, required) -- The name of the registered format to monitor.
+* `+callback+` (Function, required) -- A function called when the formatting state changes. The callback receives a `+state+` boolean indicating whether the format is present (`+true+`) or absent (`+false+`) in the current selection.
+* `+similar+` (Boolean, optional) -- When `+true+`, treats all similar variants of the same format name as equivalent, regardless of variables. Defaults to `+false+`.
+* `+vars+` (Object, optional) -- When `+similar+` is `+false+`, specifies which format variables must match for the callback to execute.
+
+The method returns an object with an `+unbind+` function. Calling `+unbind()+` removes the format listener, which is essential for cleanup when the button is destroyed.
+
+In the example, `+onSetup+` first checks if the current selection matches strikethrough formatting using `+editor.formatter.match('strikethrough')+` and sets the initial active state accordingly. It then registers a `+formatChanged+` listener that calls `+api.setActive(state)+` whenever the strikethrough state changes. The teardown function returned from `+onSetup+` calls `+changed.unbind()+` to clean up the listener.
+
+This approach ensures `+customToggleStrikethrough+` is highlighted whenever the cursor is within strikethrough-formatted content and deactivated when it is not, regardless of how the formatting was applied.
 
 include::partial$misc/onSetup.adoc[]

--- a/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
@@ -58,7 +58,7 @@ The `+formatChanged+` method accepts the following parameters:
 
 The `+formatChanged+` method accepts the following parameters:
 
-* `+formats+` (String, required) -- The name of the registered format to monitor.
+* `+formats+` (String, required) -- A comma-separated list of registered format names to monitor.
 * `+callback+` (Function, required) -- A function called when the formatting state changes. The callback receives a `+state+` boolean indicating whether the format is present (`+true+`) or absent (`+false+`) in the current selection.
 * `+similar+` (Boolean, optional) -- When `+true+`, treats all similar variants of the same format name as equivalent, regardless of variables. Defaults to `+false+`.
 * `+vars+` (Object, optional) -- When `+similar+` is `+false+`, specifies which format variables must match for the callback to execute.

--- a/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
@@ -48,7 +48,7 @@ The example above adds two custom *strikethrough* toggle buttons. Both buttons u
 
 The first (`+customStrikethrough+`) button applies and removes strikethrough formatting. Its state toggles upon click using `+api.setActive(!api.isActive())+`. However, this button does not reflect whether the selected content has strikethrough formatting which is its expected behavior. Moving the cursor into content with strikethrough formatting does not activate the button, and moving it out does not deactivate it.
 
-=== State-synced toggle: automatic state updates 
+=== State-synced toggle: automatic state updates
 
 The second button (`+customToggleStrikethrough+`) addresses this by using xref:apis/tinymce.formatter.adoc#formatChanged[`+editor.formatter.formatChanged+`] in its `+onSetup+` callback to monitor the formatting state of the current selection.
 

--- a/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
@@ -44,7 +44,7 @@ liveDemo::custom-toolbar-toggle-button[tab="js"]
 
 The example above adds two custom *strikethrough* toggle buttons. Both buttons use the xref:editor-command-identifiers.adoc[`+mceToggleFormat+`] command to apply and remove strikethrough formatting. This command toggles a specified format on and off, but only works for xref:content-formatting.adoc#formats[formats] already registered with the editor. In this example, `+strikethrough+` is the registered format.
 
-=== Basic togle: manual state management
+=== Basic toggle: manual state management
 
 The first (`+customStrikethrough+`) button applies and removes strikethrough formatting. Its state toggles upon click using `+api.setActive(!api.isActive())+`. However, this button does not reflect whether the selected content has strikethrough formatting which is its expected behavior. Moving the cursor into content with strikethrough formatting does not activate the button, and moving it out does not deactivate it.
 

--- a/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
@@ -56,12 +56,10 @@ NOTE: The format name passed to `+mceToggleFormat+` via `+editor.execCommand(com
 
 The `+formatChanged+` method accepts the following parameters:
 
-The `+formatChanged+` method accepts the following parameters:
-
 * `+formats+` (String, required) -- A comma-separated list of registered format names to monitor.
 * `+callback+` (Function, required) -- A function called when the formatting state changes. The callback receives a `+state+` boolean indicating whether the format is present (`+true+`) or absent (`+false+`) in the current selection.
 * `+similar+` (Boolean, optional) -- When `+true+`, treats all similar variants of the same format name as equivalent, regardless of variables. Defaults to `+false+`.
-* `+vars+` (Object, optional) -- When `+similar+` is `+false+`, specifies which format variables must match for the callback to execute.
+* `+vars+` (Object, optional) -- Restricts the listener to only match when the applied format variables are equal to `+vars+`.
 
 The method returns an object with an `+unbind+` function. Calling `+unbind()+` removes the format listener, which is essential for cleanup when the button is destroyed.
 

--- a/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
+++ b/modules/ROOT/pages/custom-toggle-toolbar-button.adoc
@@ -3,7 +3,7 @@
 :description: Creating custom toggle toolbar buttons for {productname}
 :keywords: toolbar, toolbarbuttons, buttons, toolbarbuttonsapi, toggle, formatChanged
 
-A toggle button triggers an action when clicked and maintains an active state. This means it can be toggled `+on+` or `+off+`. The toggle button provides the user visual feedback of its state through CSS styling. An example of this behavior is the *Bold*, which becomes highlighted when the cursor is within text that has bold formatting.  
+A toggle button triggers an action when clicked and maintains an active state. This means it can be toggled `+on+` or `+off+`. The toggle button provides the user visual feedback of its state through CSS styling. An example of this behavior is the *Bold* button, which becomes highlighted when the cursor is within text that has bold formatting.
 
 == Options
 

--- a/modules/ROOT/partials/misc/onSetup.adoc
+++ b/modules/ROOT/partials/misc/onSetup.adoc
@@ -1,25 +1,27 @@
 [[using-onsetup]]
 == Using `+onSetup+`
 
-`+onSetup+` is a complex property. It takes a function that is passed the component's API and should return a callback that is passed the component's API and returns nothing. This occurs because `+onSetup+` runs whenever the component is rendered, and the returned callback is executed when the component is destroyed. This is essentially an `+onTeardown+` handler, and can be used to unbind events and callbacks.
+`+onSetup+` accepts a function that receives the component’s API. This function should return a callback that returns nothing after being passed the component’s API. This occurs because `+onSetup+` runs whenever the component is rendered, and the callback returned by `+onSetup+` is executed when the component is destroyed. The function returned from `+onSetup+` is essentially an `+onTeardown+` handler, and can be used to unbind events and callbacks.
 
 To clarify, in code `+onSetup+` may look like this:
 
 [source,js]
 ----
 onSetup: (api) => {
-  // Do something here on component render, like set component properties or bind an event listener
+  // Runs when the component is created
+  // Configure the component or bind event listeners
 
   return (api) => {
-    // Do something here on teardown, like unbind an event listener
+    // Runs when the component is destroyed
+    // Unbind event listeners or clean up resources
   };
 };
 ----
 
-To bind a callback function to an editor event use `+editor.on(eventName, callback)+`. To unbind an event listener use `+editor.off(eventName, callback)+`. Any event listeners _should_ be unbound in the teardown callback. The only editor event which does not need to be unbound is `+init+` e.g. `+editor.on('init', callback)+`.
+To bind a callback function to an editor event use `xref:apis/tinymce.editor.adoc#on[`+editor.off(eventName, callback)+`]. To unbind an event listener use `xref:apis/tinymce.editor.adoc#off[`+editor.off(eventName, callback)+`]. Any event listeners _should_ be unbound in the teardown callback. The only editor event which does not need to be unbound is `+init+` e.g. `+editor.on('init', callback)+`.
 
 [NOTE]
 ====
-* The callback function for `+editor.off()+` should be the same function passed to `+editor.on()+`. For example, if a `+editorEventCallback+` function is bound to the `+NodeChange+` event when the button is created, `+onSetup+` should return `+(api) => editor.off('NodeChange', editorEventCallback)+`.
-* If `+onSetup+` does not have any event listeners or only listens to the `+init+` event, `+onSetup+` can return an empty function e.g. `+return () => {};+`.
+* The callback function passed to `+editor.off()+` should be the same function passed to `+editor.on()+`. For example, if an `+editorEventCallback+` function is bound to the `+NodeChange+` event when the button is created, `+onSetup+` should return `+(api) => editor.off('NodeChange', editorEventCallback)+`.
+* If `+onSetup+` does not register any event listeners or only listens to the `+init+` event, `+onSetup+` can return an empty function e.g. `+return () => {};+`.
 ====

--- a/modules/ROOT/partials/misc/onSetup.adoc
+++ b/modules/ROOT/partials/misc/onSetup.adoc
@@ -18,7 +18,7 @@ onSetup: (api) => {
 };
 ----
 
-To bind a callback function to an editor event use `xref:apis/tinymce.editor.adoc#on[`+editor.off(eventName, callback)+`]. To unbind an event listener use `xref:apis/tinymce.editor.adoc#off[`+editor.off(eventName, callback)+`]. Any event listeners _should_ be unbound in the teardown callback. The only editor event which does not need to be unbound is `+init+` e.g. `+editor.on('init', callback)+`.
+To bind a callback function to an editor event use xref:apis/tinymce.editor.adoc#on[`+editor.on(eventName, callback)+`]. To unbind an event listener use xref:apis/tinymce.editor.adoc#off[`+editor.off(eventName, callback)+`]. Any event listeners _should_ be unbound in the teardown callback. The only editor event which does not need to be unbound is `+init+` e.g. `+editor.on('init', callback)+`.
 
 [NOTE]
 ====


### PR DESCRIPTION
Ticket: DOC-2898

Site: [Staging branch](https://pr-4071.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/custom-toggle-toolbar-button/)

Changes:
* Simplified onSetup event handling and teardown logic
* Replacing plain inline code with a cross-referenced API link
* Edited comments for onSetup demo
* Ensure {product name} is being used correctly

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.
- [x] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed