### PR TITLE
DOC-3469 - Fix incorrect plugin categorizations in migration guides

### DIFF
--- a/modules/ROOT/pages/migration-from-4x-to-8x.adoc
+++ b/modules/ROOT/pages/migration-from-4x-to-8x.adoc
@@ -57,7 +57,7 @@ The {productname} plugin ecosystem was significantly restructured across version
 ** Consider using xref:apis/tinymce.editor.ui.registry.adoc#addContextMenu[`editor.ui.registry.addContextMenu`] for custom right-click actions. See xref:contextmenu.adoc[Context menus] for more information.
 * `bbcode` (removed in v6):
 ** Implement custom parsing or server-side processing if BBCode support is required.
-* `fullpage` (now premium in v6):
+* `fullpage` (now premium in v8):
 ** Use the premium xref:fullpagehtml.adoc[Full Page HTML] plugin (`+fullpagehtml+`) for full HTML document editing.
 * `template` (removed in v7):
 ** Use the premium xref:advanced-templates.adoc[advtemplate] plugin or implement custom modal dialogs.

--- a/modules/ROOT/pages/migration-from-4x-to-8x.adoc
+++ b/modules/ROOT/pages/migration-from-4x-to-8x.adoc
@@ -33,17 +33,18 @@ tinymce.init({
 The {productname} plugin ecosystem was significantly restructured across versions 5, 6, and 7, with several plugins being removed, folded into the {productname} core, or reclassified as premium features. The following breakdown clarifies the status of each affected plugin.
 
 * **Removed Plugins** (no longer available as of {productname} 6.0):
-** `bbcode`, `fullpage`, `legacyoutput`: Deprecated in 5.9.0. Removed in 6.0.
+** `bbcode`, `legacyoutput`: Deprecated in 5.9.0. Removed in 6.0.
 ** `imagetools`: Removed in 6.0. Replaced by the premium xref:editimage.adoc[Enhanced Image Editing] feature, available via the `+editimage+` plugin introduced in {productname} 6.0.
-** `textcolor`: Removed in 6.0. Use the xref:user-formatting-options.adoc#text-color-options[premium Color Picker] functionality instead.
 
 * **Integrated into {productname} core**:
 ** `paste`, `hr`, `noneditable`, `table`, `print`, `colorpicker` and `contextmenu`: These plugins were absorbed into {productname} core and no longer require separate installation. See xref:copy-and-paste.adoc[Copy and Paste], xref:non-editable-content-options.adoc[Non-editable Content], xref:table.adoc[Table], and xref:contextmenu.adoc[Context Menu] for more information.
+** `textcolor`: Removed as a separate plugin in 6.0. Text color functionality is now part of {productname} core via the xref:available-toolbar-buttons.adoc[`forecolor` and `backcolor`] toolbar buttons, which are available without additional plugins.
 ** `contextmenu`: Deprecated in version 5.0 following the integration of context menu functionality into {productname} core editor. Removed in version 6.0. For more information, see xref:contextmenu.adoc[contextmenu documentation].
 ** `tabfocus`: Removed in 6.0. Keyboard navigation via Tab is now handled by the browser and {productname} core.
 
 * **Now Premium Only**:
-** `mediaembed`, `tableofcontents`: These features are available through premium plugins. See xref:introduction-to-mediaembed.adoc[Media Embed] and xref:tableofcontents.adoc[Table of Contents] for more information.
+** `fullpage`: Removed in 6.0. Replaced by the premium xref:fullpagehtml.adoc[Full Page HTML] plugin (`+fullpagehtml+`).
+** `tableofcontents`: Previously available as the open-source `toc` plugin. Renamed to `tableofcontents` and now available as a premium plugin. See xref:tableofcontents.adoc[Table of Contents] for more information.
 ** `spellchecker`: Deprecated in 5.9.0. Removed in 6.0.
 *** Use xref:spelling.adoc#browser_spellcheck[`browser_spellcheck: true`] or the premium xref:introduction-to-tiny-spellchecker.adoc[Spell Checker] plugin.
 ** `advtemplate`: Replaces the `template` plugin for advanced templating use cases.
@@ -56,12 +57,12 @@ The {productname} plugin ecosystem was significantly restructured across version
 ** Consider using xref:apis/tinymce.editor.ui.registry.adoc#addContextMenu[`editor.ui.registry.addContextMenu`] for custom right-click actions. See xref:contextmenu.adoc[Context menus] for more information.
 * `bbcode` (removed in v6):
 ** Implement custom parsing or server-side processing if BBCode support is required.
-* `fullpage` (removed in v6):
-** Use custom templates or server-side logic to handle full HTML documents.
+* `fullpage` (now premium in v6):
+** Use the premium xref:fullpagehtml.adoc[Full Page HTML] plugin (`+fullpagehtml+`) for full HTML document editing.
 * `template` (removed in v7):
 ** Use the premium xref:advanced-templates.adoc[advtemplate] plugin or implement custom modal dialogs.
-* `textcolor` (removed in v6):
-** Use the xref:available-toolbar-buttons.adoc[`forecolor` and `backcolor`] toolbar buttons for text color functionality.
+* `textcolor` (integrated into core in v6):
+** Text color functionality is now built into {productname} core. Use the xref:available-toolbar-buttons.adoc[`forecolor` and `backcolor`] toolbar buttons, which are available without additional plugins.
 * `imagetools`: (removed in v6):
 ** Use the premium xref:editimage.adoc[Enhanced Image Editing] or xref:uploadcare.adoc[Image Optimizer Powered by Uploadcare] plugin for image editing capabilities.
 

--- a/modules/ROOT/pages/migration-from-5x-to-8x.adoc
+++ b/modules/ROOT/pages/migration-from-5x-to-8x.adoc
@@ -58,7 +58,7 @@ The {productname} plugin ecosystem underwent a significant overhaul starting in 
 ** Consider using xref:apis/tinymce.editor.ui.registry.adoc#addContextMenu[`editor.ui.registry.addContextMenu`] for custom right-click actions. See xref:contextmenu.adoc[Context menus] for more information.
 * `bbcode` (removed in v6):
 ** Implement custom parsing or server-side processing if BBCode support is required.
-* `fullpage` (now premium in v6):
+* `fullpage` (now premium in v8):
 ** Use the premium xref:fullpagehtml.adoc[Full Page HTML] plugin (`+fullpagehtml+`) for full HTML document editing.
 * `template` (removed in v7):
 ** Use the premium xref:advanced-templates.adoc[advtemplate] plugin or implement custom modal dialogs.

--- a/modules/ROOT/pages/migration-from-5x-to-8x.adoc
+++ b/modules/ROOT/pages/migration-from-5x-to-8x.adoc
@@ -34,22 +34,22 @@ tinymce.init({
 The {productname} plugin ecosystem underwent a significant overhaul starting in version 6.0, with many plugins either removed, integrated into the core, or made premium-only. The following summarizes these changes.
 
 * **Removed Plugins** (no longer available as of {productname} 6.0):
-** `bbcode`, `fullpage`, `legacyoutput`: Deprecated in 5.9.0. Removed in 6.0.
+** `bbcode`, `legacyoutput`: Deprecated in 5.9.0. Removed in 6.0.
 ** `imagetools`: Removed in 6.0. Replaced by the premium xref:editimage.adoc[Enhanced Image Editing] feature, available via the `+editimage+` plugin introduced in TinyMCE 6.0.
-** `textcolor`: Removed in 6.0. Use the xref:user-formatting-options.adoc#text-color-options[premium Color Picker] functionality instead.
 
 * **Integrated into {productname} core**:
 ** `paste`, `hr`, `table`, `noneditable`, `nonbreaking`, `print`, `colorpicker` and `contextmenu`: These plugins were absorbed into {productname} core and no longer require separate installation. See xref:copy-and-paste.adoc[Copy and Paste], xref:table.adoc[Table], xref:non-editable-content-options.adoc[Non-editable Content], and xref:contextmenu.adoc[Context Menu] for more information.
+** `textcolor`: Removed as a separate plugin in 6.0. Text color functionality is now part of {productname} core via the xref:available-toolbar-buttons.adoc[`forecolor` and `backcolor`] toolbar buttons, which are available without additional plugins.
 ** `contextmenu`: Deprecated in version 5.0 following the integration of context menu functionality into {productname} core editor. Removed in version 6.0. For more information, see xref:contextmenu.adoc[contextmenu documentation].
 ** `tabfocus`: Removed in 6.0. Keyboard navigation via Tab is now handled by the browser and {productname} core.
 
 * **Now Premium Only**:
-** `mediaembed`, `tableofcontents`: These features are available through premium plugins. See xref:introduction-to-mediaembed.adoc[Media Embed] and xref:tableofcontents.adoc[Table of Contents] for more information.
+** `fullpage`: Removed in 6.0. Replaced by the premium xref:fullpagehtml.adoc[Full Page HTML] plugin (`+fullpagehtml+`).
+** `tableofcontents`: Previously available as the open-source `toc` plugin. Renamed to `tableofcontents` and now available as a premium plugin. See xref:tableofcontents.adoc[Table of Contents] for more information.
 ** `spellchecker`: Deprecated in 5.9.0. Removed in 6.0.
 *** Use `browser_spellcheck: true` or the premium xref:introduction-to-tiny-spellchecker.adoc[Spell Checker] plugin.
 ** `advtemplate`: Replaces the `template` plugin for advanced templating use cases.
 ** `template`: Removed in 7.0. Replaced by the premium xref:advanced-templates.adoc[Templates] plugin.
-** `toc`: Renamed to `tableofcontents` and now premium.
 
 ==== Plugin Migration Examples
 
@@ -58,12 +58,12 @@ The {productname} plugin ecosystem underwent a significant overhaul starting in 
 ** Consider using xref:apis/tinymce.editor.ui.registry.adoc#addContextMenu[`editor.ui.registry.addContextMenu`] for custom right-click actions. See xref:contextmenu.adoc[Context menus] for more information.
 * `bbcode` (removed in v6):
 ** Implement custom parsing or server-side processing if BBCode support is required.
-* `fullpage` (removed in v6):
-** Use custom templates or server-side logic to handle full HTML documents.
+* `fullpage` (now premium in v6):
+** Use the premium xref:fullpagehtml.adoc[Full Page HTML] plugin (`+fullpagehtml+`) for full HTML document editing.
 * `template` (removed in v7):
 ** Use the premium xref:advanced-templates.adoc[advtemplate] plugin or implement custom modal dialogs.
-* `textcolor` (removed in v6):
-** Use the xref:available-toolbar-buttons.adoc[`forecolor` and `backcolor`] toolbar buttons for text color functionality.
+* `textcolor` (integrated into core in v6):
+** Text color functionality is now built into {productname} core. Use the xref:available-toolbar-buttons.adoc[`forecolor` and `backcolor`] toolbar buttons, which are available without additional plugins.
 * `imagetools`: (removed in v6):
 ** Use the premium xref:editimage.adoc[Enhanced Image Editing] or xref:uploadcare.adoc[Image Optimizer Powered by Uploadcare] plugin for image editing capabilities.
 

--- a/modules/ROOT/pages/migration-from-6x-to-8x.adoc
+++ b/modules/ROOT/pages/migration-from-6x-to-8x.adoc
@@ -20,13 +20,15 @@ The {productname} plugin ecosystem underwent changes starting in version 7.0, wi
 * **Removed Plugins** (no longer available as of {productname} 7.0):
 ** `template`: Removed in 7.0. Replaced by the premium xref:advanced-templates.adoc[Templates] plugin.
 
+* **Integrated into {productname} core** (removed in 6.0, before this migration path):
+** `textcolor`: Removed as a separate plugin in 6.0. Text color functionality is now part of {productname} core via the xref:available-toolbar-buttons.adoc[`forecolor` and `backcolor`] toolbar buttons, which are available without additional plugins.
+
 * **Now Premium Only** (removed in 6.0, before this migration path):
 ** `imagetools`: Removed in 6.0. Replaced by the premium xref:editimage.adoc[Enhanced Image Editing] feature, available via the `+editimage+` plugin introduced in TinyMCE 6.0.
-** `textcolor`: Removed in 6.0. Use the xref:user-formatting-options.adoc#text-color-options[premium Color Picker] functionality instead.
 
 [NOTE]
 ====
-If you're migrating from TinyMCE 6, these plugins (`imagetools` and `textcolor`) were already removed in version 6.0, so you won't need to migrate them. The sections below are included for reference only, in case you're upgrading from an older version or have legacy code.
+If migrating from TinyMCE 6, these plugins (`imagetools` and `textcolor`) were already removed in version 6.0, so they do not require migration. The sections below are included for reference only, in case the upgrade started from an older version or the codebase contains legacy references.
 ====
 
 ==== Plugin Migration Examples
@@ -39,9 +41,8 @@ If you're migrating from TinyMCE 6, these plugins (`imagetools` and `textcolor`)
 ** Use the premium xref:editimage.adoc[Enhanced Image Editing] feature.
 ** Ensure you have a valid commercial license for the Enhanced Image Editing feature.
 
-* `textcolor` (removed in v6):
-** Use the xref:user-formatting-options.adoc#text-color-options[premium Color Picker] functionality.
-** Ensure you have a valid commercial license for the Color Picker feature.
+* `textcolor` (integrated into core in v6):
+** Text color functionality is now built into {productname} core. Use the xref:available-toolbar-buttons.adoc[`forecolor` and `backcolor`] toolbar buttons, which are available without additional plugins.
 
 === Content Structure
 
@@ -453,22 +454,19 @@ tinymce.init({
 });
 ----
 
-=== Text Color Plugin Removal
+=== Text Color Plugin (integrated into core)
 
 [NOTE]
 ====
-This section applies only if you're upgrading from TinyMCE 5 or earlier. The `textcolor` plugin was removed in TinyMCE 6.0, so if you're migrating from TinyMCE 6, this plugin was already unavailable.
+This section applies only when upgrading from TinyMCE 5 or earlier. The `textcolor` plugin was removed in TinyMCE 6.0, so migrating from TinyMCE 6 does not require action.
 ====
 
-The `textcolor` plugin was removed in TinyMCE 6.0. If you were using this plugin, you need to migrate to the xref:user-formatting-options.adoc#text-color-options[premium Color Picker] functionality.
+The `textcolor` plugin was removed as a separate plugin in TinyMCE 6.0 because its functionality was integrated into {productname} core. The `forecolor` and `backcolor` toolbar buttons are available without additional plugins.
 
 **Migration checklist:**
 
-* [ ] Remove `textcolor` from plugins list
-* [ ] Add `colorpicker` to plugins list (premium feature)
-* [ ] Ensure you have a valid commercial license for Color Picker
-* [ ] Update any custom color picker configurations
-* [ ] Test color picker functionality
+* [ ] Remove `textcolor` from the plugins list
+* [ ] The `forecolor` and `backcolor` toolbar buttons remain available as core toolbar buttons
 
 .Example:
 [source,js]
@@ -480,10 +478,9 @@ tinymce.init({
   toolbar: "forecolor backcolor"
 });
 
-// New TinyMCE 6+ configuration
+// New TinyMCE 6+ configuration (no plugin required)
 tinymce.init({
   selector: "textarea",
-  plugins: "colorpicker",
   toolbar: "forecolor backcolor"
 });
 ----


### PR DESCRIPTION
## Ticket

DOC-3469

## Site

- https://pr-4072.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/migration-from-6x-to-8x/#_plugin_ecosystem
- https://pr-4072.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/migration-from-5x-to-8x/#_plugin_ecosystem
- https://pr-4072.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/migration-from-4x-to-8x/#_plugin_ecosystem

## Changes

Corrects three factual errors across all three migration guides (4→8, 5→8, 6→8) reported by @lostkeys 

1. **`textcolor`**: Moved from "Removed" / "Now Premium Only" to "Integrated into TinyMCE core". The plugin's functionality was absorbed into core via the `forecolor` and `backcolor` toolbar buttons — it was never replaced by a premium feature. Fixed incorrect code examples that referenced a non-existent `colorpicker` plugin.

2. **`mediaembed`**: Removed from "Now Premium Only" in the 4→8 and 5→8 guides. Media Embed has always been a premium plugin and was never open-source, so listing it under "Now Premium Only" was misleading.

3. **`fullpage`**: Moved from "Removed Plugins" to "Now Premium Only" in the 4→8 and 5→8 guides. The plugin became the premium `fullpagehtml` plugin — it was not simply removed.

### Files changed

- `modules/ROOT/pages/migration-from-6x-to-8x.adoc` — textcolor fix
- `modules/ROOT/pages/migration-from-5x-to-8x.adoc` — textcolor, mediaembed, and fullpage fixes
- `modules/ROOT/pages/migration-from-4x-to-8x.adoc` — textcolor, mediaembed, and fullpage fixes

-  [x] Documentation Lead review