### PR TITLE
DOC-3355: While the plugin is generating a review or quick action, the Stop button in the loading indicator receives focus

### DIFF
--- a/modules/ROOT/pages/8.5.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.5.0-release-notes.adoc
@@ -53,7 +53,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 Previously, the TinyMCE AI plugin displayed the “Stop generating” control inconsistently across different contexts. The review loading indicator used a text-based button, while the AI Chat sidebar used an icon-based button. In addition, the control did not receive focus when it appeared, which negatively impacted keyboard accessibility.
 
-In {productname} {release-version}, the stop button in the loading indicator now matches the icon button used in the AI Chat sidebar, providing a consistent visual experience. The button also receives immediate focus when displayed, improving keyboard navigation and accessibility during content generation.
+In {productname} {release-version}, the stop button in the loading indicator now matches the icon button used in the AI Chat sidebar, providing a more consistent visual experience. The button also receives focus when displayed, improving keyboard navigation and accessibility during content generation.
 
 For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
 

--- a/modules/ROOT/pages/8.5.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.5.0-release-notes.adoc
@@ -51,7 +51,7 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== While the plugin is generating a review or quick action, the Stop button in the loading indicator receives focus
 // #TINY-14083
 
-Previously, the TinyMCE AI plugin displayed the stop generating button inconsistently across different contexts. The review loading indicator used a text-based "Stop generating" button, while the AI Chat sidebar used a stop icon button. Additionally, the button did not receive focus when displayed, which compromised keyboard accessibility.
+Previously, the TinyMCE AI plugin displayed the “Stop generating” control inconsistently across different contexts. The review loading indicator used a text-based button, while the AI Chat sidebar used an icon-based button. In addition, the control did not receive focus when it appeared, which negatively impacted keyboard accessibility.
 
 In {productname} {release-version}, the stop button in the loading indicator now matches the icon button used in the AI Chat sidebar, providing a consistent visual experience. The button also receives immediate focus when displayed, improving keyboard navigation and accessibility during content generation.
 

--- a/modules/ROOT/pages/8.5.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.5.0-release-notes.adoc
@@ -42,6 +42,22 @@ The {productname} {release-version} release includes an accompanying release of 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following improvement.
+
+==== While the plugin is generating a review or quick action, the Stop button in the loading indicator receives focus
+// #TINY-14083
+
+Previously, the TinyMCE AI plugin displayed the stop generating button inconsistently across different contexts. The review loading indicator used a text-based "Stop generating" button, while the AI Chat sidebar used a stop icon button. Additionally, the button did not receive focus when displayed, which compromised keyboard accessibility.
+
+In {productname} {release-version}, the stop button in the loading indicator now matches the icon button used in the AI Chat sidebar, providing a consistent visual experience. The button also receives immediate focus when displayed, improving keyboard navigation and accessibility during content generation.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
+
 [[accompanying-enhanced-skins-and-icon-packs-changes]]
 == Accompanying Enhanced Skins & Icon Packs changes
 


### PR DESCRIPTION
**Ticket:** DOC-3355

**Site:** [Staging](https://pr-4079.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.5.0-release-notes/#while-the-plugin-is-generating-a-review-or-quick-action-the-stop-button-in-the-loading-indicator-receives-focus)

**Changes:**
* Added release note entry for TINY-14083 to `modules/ROOT/pages/8.5.0-release-notes.adoc` (Accompanying Premium plugin changes — TinyMCE AI section): While the plugin is generating a review or quick action, the Stop button in the loading indicator receives focus.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.