### PR TITLE
DOC-3355: Loader in the chat was normal size instead of small size

### DIFF
--- a/modules/ROOT/pages/8.5.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.5.0-release-notes.adoc
@@ -42,6 +42,22 @@ The {productname} {release-version} release includes an accompanying release of 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following fix.
+
+==== Loader in the chat was normal size instead of small size
+// #TINY-14155
+
+Previously, the loading spinner displayed in the AI Chat area while generating a response used the default size rather than the small size. This caused the spinner to appear visually larger than the adjacent AI response icon, creating an inconsistent appearance within the chat interface.
+
+In {productname} {release-version}, the AI Chat loading spinner is now sized to match the AI response icon dimensions, providing a consistent and polished visual experience.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
+
 [[accompanying-enhanced-skins-and-icon-packs-changes]]
 == Accompanying Enhanced Skins & Icon Packs changes
 


### PR DESCRIPTION
**Ticket:** DOC-3355

**Site:** [Staging](https://pr-4080.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.5.0-release-notes/#loader-in-the-chat-was-normal-size-instead-of-small-size)

**Changes:**
* Added release note entry for TINY-14155 to `modules/ROOT/pages/8.5.0-release-notes.adoc` (Accompanying Premium plugin changes — TinyMCE AI section): Loader in the chat was normal size instead of small size.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.