### PR TITLE
DOC-3355: New optional id property to tinymceai_quickactions_custom to register the action as custom menu item

### DIFF
--- a/modules/ROOT/pages/8.5.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.5.0-release-notes.adoc
@@ -42,6 +42,22 @@ The {productname} {release-version} release includes an accompanying release of 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following addition.
+
+==== New optional `id` property to `tinymceai_quickactions_custom` to register the action as custom menu item
+// #TINY-14229
+
+Previously, custom quick actions defined through the xref:tinymceai.adoc#tinymceai_quickactions_custom[`+tinymceai_quickactions_custom+`] option could only appear inside a dedicated Custom submenu within the Quick Actions menu. This limited integrators who wanted custom actions to appear as top-level menu items alongside predefined actions or in other toolbar and menu configurations.
+
+In {productname} {release-version}, an optional `id` property can be included in each custom quick action object. When an `id` is set, the custom action can be listed in the xref:tinymceai.adoc#tinymceai_quickactions_menu[`+tinymceai_quickactions_menu+`] array as its own top-level menu item, added to the xref:quickbars.adoc#quickbars_selection_toolbar[`+quickbars_selection_toolbar+`], or included in any other toolbar or menu configuration that accepts control identifiers.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
+
 [[accompanying-enhanced-skins-and-icon-packs-changes]]
 == Accompanying Enhanced Skins & Icon Packs changes
 

--- a/modules/ROOT/pages/8.5.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.5.0-release-notes.adoc
@@ -51,9 +51,9 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== New optional `id` property to `tinymceai_quickactions_custom` to register the action as custom menu item
 // #TINY-14229
 
-Previously, custom quick actions defined through the xref:tinymceai.adoc#tinymceai_quickactions_custom[`+tinymceai_quickactions_custom+`] option could only appear inside a dedicated Custom submenu within the Quick Actions menu. This limited integrators who wanted custom actions to appear as top-level menu items alongside predefined actions or in other toolbar and menu configurations.
+Previously, custom quick actions defined through the xref:tinymceai.adoc#tinymceai_quickactions_custom[`+tinymceai_quickactions_custom+`] option could only appear inside a dedicated Custom submenu within the Quick Actions menu. This limited integrators who wanted custom actions to appear as top-level menu items alongside predefined actions or in other menu configurations.
 
-In {productname} {release-version}, an optional `id` property can be included in each custom quick action object. When an `id` is set, the custom action can be listed in the xref:tinymceai.adoc#tinymceai_quickactions_menu[`+tinymceai_quickactions_menu+`] array as its own top-level menu item, added to the xref:quickbars.adoc#quickbars_selection_toolbar[`+quickbars_selection_toolbar+`], or included in any other toolbar or menu configuration that accepts control identifiers.
+In {productname} {release-version}, an optional `id` property can be included in each custom quick action object. When an `id` is set, the custom action can be listed in the xref:tinymceai.adoc#tinymceai_quickactions_menu[`+tinymceai_quickactions_menu+`] array as its own top-level menu item, or included in any menubar menu or menu button configuration that accepts control identifiers.
 
 For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
 


### PR DESCRIPTION
**Ticket:** DOC-3355

**Site:** [Staging](https://pr-4081.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.5.0-release-notes/#new-optional-id-property-to-tinymceai_quickactions_custom-to-register-the-action-as-custom-menu-item)

**Changes:**
* Added release note entry for TINY-14229 to `modules/ROOT/pages/8.5.0-release-notes.adoc` (Accompanying Premium plugin changes — TinyMCE AI section): New optional `id` property to `tinymceai_quickactions_custom` to register the action as custom menu item.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.