### PR TITLE
DOC-3355: Prevent valid iframe and script elements from being removed by DOMPurify

### DIFF
--- a/modules/ROOT/pages/8.5.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.5.0-release-notes.adoc
@@ -120,7 +120,7 @@ In {productname} {release-version}, `script` elements that are considered valid 
 === Iframe elements with children would incorrectly be removed by DOMPurify
 // #TINY-9655
 
-Previously, `iframe` elements that contained child nodes were removed entirely during the sanitization process, even when the editor configuration allowed iframes. DOMPurify treated the presence of child nodes within an `iframe` as a potential mXSS risk and stripped the entire element from the content.
+Previously, `iframe` elements that contained child nodes were removed entirely during the sanitization process. DOMPurify treated the presence of child nodes within an `iframe` as a potential mXSS risk and stripped the entire element from the content.
 
 In {productname} {release-version}, `iframe` elements are preserved during sanitization. Any child nodes and unsafe or invalid attributes are removed, but the `iframe` element itself remains in the editor content.
 

--- a/modules/ROOT/pages/8.5.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.5.0-release-notes.adoc
@@ -110,6 +110,20 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Script elements would incorrectly be removed by DOMPurify when considered valid in the schema
+// #TINY-9655
+
+Previously, `script` elements that were explicitly allowed through xref:content-filtering.adoc#valid_elements[`+valid_elements+`] or xref:content-filtering.adoc#extended_valid_elements[`+extended_valid_elements+`] were removed during the sanitization process when xref:content-filtering.adoc#xss_sanitization[`+xss_sanitization+`] was enabled. DOMPurify flagged these elements as potential mXSS vectors and removed them entirely, even when the schema configuration indicated they were valid.
+
+In {productname} {release-version}, `script` elements that are considered valid in the schema are retained during sanitization. The sanitization process still removes unsafe attributes and content, but no longer removes the entire element when the schema explicitly allows it.
+
+=== Iframe elements with children would incorrectly be removed by DOMPurify
+// #TINY-9655
+
+Previously, `iframe` elements that contained child nodes were removed entirely during the sanitization process, even when the editor configuration allowed iframes. DOMPurify treated the presence of child nodes within an `iframe` as a potential mXSS risk and stripped the entire element from the content.
+
+In {productname} {release-version}, `iframe` elements are preserved during sanitization. Any child nodes and unsafe or invalid attributes are removed, but the `iframe` element itself remains in the editor content.
+
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/pages/8.5.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.5.0-release-notes.adoc
@@ -110,12 +110,12 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
-=== Script elements would incorrectly be removed by DOMPurify when considered valid in the schema
+=== Script and style elements would incorrectly be removed by DOMPurify when considered valid in the schema
 // #TINY-9655
 
-Previously, `script` elements that were explicitly allowed through xref:content-filtering.adoc#valid_elements[`+valid_elements+`] or xref:content-filtering.adoc#extended_valid_elements[`+extended_valid_elements+`] were removed during the sanitization process when xref:content-filtering.adoc#xss_sanitization[`+xss_sanitization+`] was enabled. DOMPurify flagged these elements as potential mXSS vectors and removed them entirely, even when the schema configuration indicated they were valid.
+Previously, `script` and `style` elements that were explicitly allowed through xref:content-filtering.adoc#valid_elements[`+valid_elements+`] or xref:content-filtering.adoc#extended_valid_elements[`+extended_valid_elements+`] were removed during the sanitization process when xref:content-filtering.adoc#xss_sanitization[`+xss_sanitization+`] was enabled. DOMPurify flagged these elements as potential mXSS vectors and removed them entirely, even when the schema configuration indicated they were valid.
 
-In {productname} {release-version}, `script` elements that are considered valid in the schema are retained during sanitization. The sanitization process still removes unsafe attributes and content, but no longer removes the entire element when the schema explicitly allows it.
+In {productname} {release-version}, `script` and `style` elements that are considered valid in the schema are retained during sanitization. The sanitization process still removes unsafe attributes and content, but no longer removes the entire element when the schema explicitly allows it.
 
 === Iframe elements with children would incorrectly be removed by DOMPurify
 // #TINY-9655

--- a/modules/ROOT/pages/fullpagehtml.adoc
+++ b/modules/ROOT/pages/fullpagehtml.adoc
@@ -41,7 +41,7 @@ include::partial$misc/bundling-guide-link.adoc[]
 [WARNING]
 ====
 **Certain elements may be removed by XSS sanitization**  
-By default, {productname} sanitizes HTML content to protect against XSS attacks. Elements outside the HTML5 specification, such as `<script>`, are removed. Standard `<meta>` tags are preserved, but attributes not defined in the HTML5 spec (for example, the RDFa `property` attribute) require explicit configuration to be retained.
+By default, {productname} sanitizes HTML content to protect against XSS attacks. Elements outside the HTML5 specification, such as `<script>`, are removed unless explicitly allowed through xref:content-filtering.adoc#valid_elements[`+valid_elements+`] or xref:content-filtering.adoc#extended_valid_elements[`+extended_valid_elements+`]. Standard `<meta>` tags are preserved, but attributes not defined in the HTML5 spec (for example, the RDFa `property` attribute) require explicit configuration to be retained.
 
 If integrators encounter issues with required elements being removed, the following configuration options are available. These options reduce security and should be used with caution:
 


### PR DESCRIPTION
**Ticket:** DOC-3355

**Site:** [Staging](https://pr-4083.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.5.0-release-notes/#script-elements-would-incorrectly-be-removed-by-dompurify-when-considered-valid-in-the-schema)

**Changes:**
* Added two release note entries for TINY-9655 to `modules/ROOT/pages/8.5.0-release-notes.adoc` (Bug fixes section):
  - Script elements would incorrectly be removed by DOMPurify when considered valid in the schema.
  - Iframe elements with children would incorrectly be removed by DOMPurify.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.