### PR TITLE
DOC-3355: Fixed visual rendering glitch in Diff mode and Preview when a quick action was triggered during a review

### DIFF
--- a/modules/ROOT/pages/8.5.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.5.0-release-notes.adoc
@@ -110,6 +110,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Fixed visual rendering glitch in Diff mode and Preview when a quick action was triggered during a review
+// #TINY-14294
+
+Previously, if a custom quick action was triggered from the menu or toolbar while an AI Review session was active, the Diff mode and Preview views could render incorrectly. The selection styling for diff annotations relied on an explicit list of block elements for box-shadow styling, and elements not in that list — such as `ins` and `del` — received an inline background-image approach that did not display correctly in all contexts. This caused suggestions to appear visually broken and prevented them from being applied or dismissed.
+
+In {productname} {release-version}, the selection styling approach for diff annotations has been reversed. Box-shadow styling is now the default for all elements, while only `ins` and `del` elements use the tighter inline background-image approach suited to text-level content. This ensures consistent rendering across all element types in Diff mode and Preview.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
**Ticket:** DOC-3355

**Site:** [Staging](https://pr-4085.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.5.0-release-notes/#fixed-visual-rendering-glitch-in-diff-mode-and-preview-when-a-quick-action-was-triggered-during-a-review)

**Changes:**
* Added release note entry for TINY-14294 to `modules/ROOT/pages/8.5.0-release-notes.adoc` (Bug fixes section): Fixed visual rendering glitch in Diff mode and Preview when a quick action was triggered during a review.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.