### PR TITLE
DOC-3486: Update AI Assistant end-of-sale copy

### DIFF
--- a/modules/ROOT/partials/misc/admon-ai-pricing.adoc
+++ b/modules/ROOT/partials/misc/admon-ai-pricing.adoc
@@ -1,1 +1,1 @@
-IMPORTANT: As of March 31, 2026, {pluginname} is no longer available for purchase. It has been replaced by xref:tinymceai-introduction.adoc[TinyMCE AI].
+NOTE: {pluginname} was {productname}'s first iteration of integrating AI functionality into the editor. xref:tinymceai-introduction.adoc[TinyMCE AI] is the current AI solution, providing deep document-aware AI functionality through Chat, Quick Actions, and a Review mode. TinyMCE AI is currently available via cloud deployment; on-premise deployment is coming in a future release.


### PR DESCRIPTION
**Ticket:** DOC-3486

**Site:** [Staging](https://pr-4088.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/8/ai/)

**Changes:**
* Updated `modules/ROOT/partials/misc/admon-ai-pricing.adoc` — replaced the end-of-sale `IMPORTANT` admonition with updated `NOTE` copy describing AI Assistant as the legacy solution and TinyMCE AI as the current AI offering.
* Affects all 6 AI Assistant pages that include this partial: `ai.adoc`, `ai-openai.adoc`, `ai-azure.adoc`, `ai-bedrock.adoc`, `ai-gemini.adoc`, `ai-proxy.adoc`.

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: `hotfix/8/DOC-3486`
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.