### PR TITLE
DOC-3355: Add TINY-14158 release note for AI Review list accordion background color

### DIFF
--- a/modules/ROOT/pages/8.5.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.5.0-release-notes.adoc
@@ -88,6 +88,11 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Updated the Review list accordion item background color
+// #TINY-14158
+
+The background color of accordion items in the TinyMCE AI Review list has been updated from `#F7F7F7` to `#F0F0F0` to improve visual contrast and align with the current design specifications.
+
 
 [[removed]]
 == Removed


### PR DESCRIPTION
## Summary
- Adds a release note entry for TINY-14158 to the 8.5.0 release notes page.
- Documents the update to the TinyMCE AI Review list accordion item background color from `#F7F7F7` to `#F0F0F0` for improved visual contrast.

## Test plan
- [x] Verify the release note renders correctly in the 8.5.0 release notes page.
- [x] Confirm the entry appears under the correct section (Changed features and enhancements).