### PR TITLE
fix(deps): follow-redirects — GHSA-r4q5-vmmm-2653 (medium)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   },
   "author": "Tiny Technologies Inc",
   "license": "CC-BY-NC-SA-3.0",
+  "resolutions": {
+    "follow-redirects": "^1.16.0"
+  },
   "nodemonConfig": {
     "execMap": {
       "build": "antora ./antora-playbook-dev.yml"

--- a/yarn.lock
+++ b/yarn.lock
@@ -897,10 +897,10 @@ fill-range@^7.1.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-follow-redirects@^1.0.0:
-  version "1.15.6"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
-  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
+follow-redirects@^1.0.0, follow-redirects@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
 form-data@^4.0.0:
   version "4.0.5"


### PR DESCRIPTION
> ⚠️ **Generated by `dependabot-autopilot` — human review required before merge. Do not auto-merge.**

## What was run
This branch was produced by `dependabot-autopilot`, an autonomous agent that:
1. Cloned the repo from `main`
2. Analysed the Dependabot advisory and the project's manifest
3. Edited `package.json` with the minimal change to resolve the vulnerability (the agent has no shell / no network access — it can only read and edit files in the workspace)
4. Re-ran `yarn install` so the lockfile reflects the fix
5. Ran the full validation suite below and only pushed the branch once validation completed
6. Opened this PR for **human review** — it will never be auto-merged by the tool

## Advisory
- **Alert:** #95 — [view](https://github.com/tinymce/tinymce-docs/security/dependabot/95)
- **Advisory:** [GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653)
- **Package:** `follow-redirects`
- **Severity:** medium
- **Vulnerable range:** `<= 1.15.11`
- **Patched in:** `1.16.0`
- **Summary:** follow-redirects leaks Custom Authentication Headers to Cross-Domain Redirect Targets

## Agent summary
Perfect! The fix has been applied successfully. 

## Summary

I've resolved Dependabot alert #95 (GHSA-r4q5-vmmm-2653) by adding a Yarn `resolutions` field to package.json that forces `follow-redirects` to use version ^1.16.0 or later. The vulnerable package (version 1.15.6) was a transitive dependency coming through `http-proxy` (used by the `http-server` devDependency), so a direct version bump wasn't possible. The `resolutions` field instructs Yarn to override the transitive dependency version across the entire dependency tree, ensuring the patched version 1.16.0+ is installed instead of the vulnerable 1.15.6. When the lockfile is regenerated, it will reflect this resolution and eliminate the security vulnerability.

## Validation results
| Stage | Result | Duration | Notes |
|---|---|---|---|
| `yarn install` (regenerates lockfile) | ✅ pass | 4.4s | Ensures the dependency change actually takes effect |
| `yarn build:production` (Antora build) | ✅ pass | 23.6s | Full site build must succeed |
| Playwright smoke (`/` + dynamically discovered internal link) | ✅ pass | 2.7s | Real Chromium, HTTP 200 + rendered content |

**All validation stages passed on the patched code.** This is still a draft-level change — please review the diff and advisory link before merging.

_Visual evidence: 2 Playwright screenshots were captured during the smoke test. They are visible on the autopilot dashboard at the run detail page._

<details><summary>Validation log (tail)</summary>

```
=== stage: yarn install ===
yarn install v1.22.22
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 4.29s.


=== stage: yarn build:production ===
o missing attribute: version"}
{"level":"warn","time":1776760051420,"name":"asciidoctor","file":{"path":"modules/ROOT/pages/tinymceai-models.adoc"},"source":{"url":"https://github.com/tinymce/tinymce-docs.git","refname":"tinymce/8","reftype":"branch"},"msg":"skipping reference to missing attribute: version"}
{"level":"warn","time":1776760051420,"name":"asciidoctor","file":{"path":"modules/ROOT/pages/tinymceai-models.adoc"},"source":{"url":"https://github.com/tinymce/tinymce-docs.git","refname":"tinymce/8","reftype":"branch"},"msg":"skipping reference to missing attribute: version"}
{"level":"warn","time":1776760051420,"name":"asciidoctor","file":{"path":"modules/ROOT/pages/tinymceai-models.adoc"},"source":{"url":"https://github.com/tinymce/tinymce-docs.git","refname":"tinymce/8","reftype":"branch"},"msg":"skipping reference to missing attribute: version"}
{"level":"warn","time":1776760051421,"name":"asciidoctor","file":{"path":"modules/ROOT/pages/tinymceai-models.adoc"},"source":{"url":"https://github.com/tinymce/tinymce-docs.git","refname":"tinymce/8","reftype":"branch"},"msg":"skipping reference to missing attribute: version"}
{"level":"warn","time":1776760051424,"name":"asciidoctor","file":{"path":"modules/ROOT/pages/tinymceai-limits.adoc"},"source":{"url":"https://github.com/tinymce/tinymce-docs.git","refname":"tinymce/8","reftype":"branch"},"msg":"skipping reference to missing attribute: version"}
{"level":"warn","time":1776760051424,"name":"asciidoctor","file":{"path":"modules/ROOT/pages/tinymceai-limits.adoc"},"source":{"url":"https://github.com/tinymce/tinymce-docs.git","refname":"tinymce/8","reftype":"branch"},"msg":"skipping reference to missing attribute: version"}
{"level":"warn","time":1776760051424,"name":"asciidoctor","file":{"path":"modules/ROOT/pages/tinymceai-limits.adoc"},"source":{"url":"https://github.com/tinymce/tinymce-docs.git","refname":"tinymce/8","reftype":"branch"},"msg":"skipping reference to missing attribute: version"}
Done in 23.49s.


=== stage: playwright smoke ===
GET http://127.0.0.1:4000/ → 200 — "TinyMCE 8 Documentation | TinyMCE Documentation"
  screenshot: /runs/1/screenshot/01-root.png
GET http://127.0.0.1:4000/tinymce/latest/ → 200 — "TinyMCE 8 Documentation | TinyMCE Documentation"
  screenshot: /runs/1/screenshot/02-deep.png
```

</details>

<details><summary>Diff summary</summary>

```
commit 00d2734c551384f5e5dbb6624bfb236c216247e3
Author: dependabot-autopilot <dependabot-autopilot@users.noreply.github.com>
Date:   Tue Apr 21 18:27:39 2026 +1000

    chore(deps): regenerate yarn.lock

 yarn.lock | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)

```

</details>

---
_Do not auto-merge this PR. Every change here must be reviewed by a human._
