### PR TITLE
fix(deps): liquidjs — GHSA-v273-448j-v4qj (medium)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     "jsdom": "^24.1.0",
     "nodemon": "^3.1.10",
     "npm-run-all": "^4.1.5"
+  },
+  "resolutions": {
+    "liquidjs": ">=10.25.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -507,6 +507,11 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
+  integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
+
 commander@^7.0.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
@@ -1384,10 +1389,12 @@ json5@~2.2:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-liquidjs@^9.37.0:
-  version "9.37.0"
-  resolved "https://registry.yarnpkg.com/liquidjs/-/liquidjs-9.37.0.tgz#58e0dd2fa779635ead589e82cfa9baffe49f490e"
-  integrity sha512-qDj9iiNdB+QNZTR4iKjiQzoHQma7V8Itx5oZG/ZCP7xjebh1LI+s5IG2ZYUbs1ALO6hBzmW36Ptd8RR4eohuDA==
+liquidjs@>=10.25.5, liquidjs@^9.37.0:
+  version "10.25.6"
+  resolved "https://registry.yarnpkg.com/liquidjs/-/liquidjs-10.25.6.tgz#dddf7ee43cd3c7a2d7768063937bf14e77079afb"
+  integrity sha512-h5ki5HS1PiL9/NmLw3iUcTF1jQswKJd8KLEXNrtSf8XHF0v3c5+d+8llz3N9I5IUdc5rsOuVLb9AVnqvqqscPg==
+  dependencies:
+    commander "^10.0.0"
 
 load-json-file@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
> ⚠️ **Generated by `dependabot-autopilot` — human review required before merge. Do not auto-merge.**

## What was run
This branch was produced by `dependabot-autopilot`, an autonomous agent that:
1. Cloned the repo from `main`
2. Analysed the Dependabot advisory and the project's manifest
3. Edited `package.json` with the minimal change to resolve the vulnerability (the agent has no shell / no network access — it can only read and edit files in the workspace)
4. Re-ran `yarn install` so the lockfile reflects the fix
5. Ran the full validation suite below and only pushed the branch once validation completed
6. Opened this PR for **human review** — it will never be auto-merged by the tool

## Advisory
- **Alert:** #94 — [view](https://github.com/tinymce/tinymce-docs/security/dependabot/94)
- **Advisory:** [GHSA-v273-448j-v4qj](https://github.com/advisories/GHSA-v273-448j-v4qj)
- **Package:** `liquidjs`
- **Severity:** medium
- **Vulnerable range:** `<= 10.25.4`
- **Patched in:** `10.25.5`
- **Summary:** LiquidJS: `renderFile()` / `parseFile()` bypass configured `root` and allow arbitrary file read

## Agent summary
Perfect! I have successfully fixed Dependabot alert #94 by adding a Yarn `resolutions` field to package.json that forces the use of liquidjs version 10.25.5 or later, which is the first patched version that fixes the security vulnerability GHSA-v273-448j-v4qj.

## Summary

I fixed Dependabot alert #94 by adding a `resolutions` field to package.json that overrides the transitive liquidjs dependency (coming from @tinymce/antora-extension-livedemos) to use version 10.25.5 or later. The vulnerability (GHSA-v273-448j-v4qj) affects all liquidjs versions ≤10.25.4 and allows `renderFile()`/`parseFile()` to bypass the configured root directory for arbitrary file reads. Since the direct dependency @tinymce/antora-extension-livedemos@0.1.0 specifies liquidjs ^9.37.0, which only allows 9.x versions, the Yarn resolutions mechanism is required to force the use of the patched 10.25.5+ version without waiting for an upstream package update.

## Validation results
| Stage | Result | Duration | Notes |
|---|---|---|---|
| `yarn install` (regenerates lockfile) | ✅ pass | 35.7s | Ensures the dependency change actually takes effect |
| `yarn build:production` (Antora build) | ✅ pass | 46.6s | Full site build must succeed |
| Playwright smoke (`/` + dynamically discovered internal link) | ✅ pass | 3.1s | Real Chromium, HTTP 200 + rendered content |

**All validation stages passed on the patched code.** This is still a draft-level change — please review the diff and advisory link before merging.

_Visual evidence: 2 Playwright screenshots were captured during the smoke test. They are visible on the autopilot dashboard at the run detail page._

<details><summary>Validation log (tail)</summary>

```
=== stage: yarn install ===
yarn install v1.22.22
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 35.52s.


=== stage: yarn build:production ===
o missing attribute: version"}
{"level":"warn","time":1776817358704,"name":"asciidoctor","file":{"path":"modules/ROOT/pages/tinymceai-models.adoc"},"source":{"url":"https://github.com/tinymce/tinymce-docs.git","refname":"tinymce/8","reftype":"branch"},"msg":"skipping reference to missing attribute: version"}
{"level":"warn","time":1776817358704,"name":"asciidoctor","file":{"path":"modules/ROOT/pages/tinymceai-models.adoc"},"source":{"url":"https://github.com/tinymce/tinymce-docs.git","refname":"tinymce/8","reftype":"branch"},"msg":"skipping reference to missing attribute: version"}
{"level":"warn","time":1776817358705,"name":"asciidoctor","file":{"path":"modules/ROOT/pages/tinymceai-models.adoc"},"source":{"url":"https://github.com/tinymce/tinymce-docs.git","refname":"tinymce/8","reftype":"branch"},"msg":"skipping reference to missing attribute: version"}
{"level":"warn","time":1776817358706,"name":"asciidoctor","file":{"path":"modules/ROOT/pages/tinymceai-models.adoc"},"source":{"url":"https://github.com/tinymce/tinymce-docs.git","refname":"tinymce/8","reftype":"branch"},"msg":"skipping reference to missing attribute: version"}
{"level":"warn","time":1776817358712,"name":"asciidoctor","file":{"path":"modules/ROOT/pages/tinymceai-limits.adoc"},"source":{"url":"https://github.com/tinymce/tinymce-docs.git","refname":"tinymce/8","reftype":"branch"},"msg":"skipping reference to missing attribute: version"}
{"level":"warn","time":1776817358714,"name":"asciidoctor","file":{"path":"modules/ROOT/pages/tinymceai-limits.adoc"},"source":{"url":"https://github.com/tinymce/tinymce-docs.git","refname":"tinymce/8","reftype":"branch"},"msg":"skipping reference to missing attribute: version"}
{"level":"warn","time":1776817358714,"name":"asciidoctor","file":{"path":"modules/ROOT/pages/tinymceai-limits.adoc"},"source":{"url":"https://github.com/tinymce/tinymce-docs.git","refname":"tinymce/8","reftype":"branch"},"msg":"skipping reference to missing attribute: version"}
Done in 46.47s.


=== stage: playwright smoke ===
GET http://127.0.0.1:4000/ → 200 — "TinyMCE 8 Documentation | TinyMCE Documentation"
  screenshot: /runs/89/screenshot/01-root.png
  deep page: /tinymce/latest/
GET http://127.0.0.1:4000/tinymce/latest/ → 200 — "TinyMCE 8 Documentation | TinyMCE Documentation"
  screenshot: /runs/89/screenshot/02-deep.png
```

</details>

<details><summary>Diff summary</summary>

```
commit c7354581c579f7d32d0a0f00598fa321b70459cf
Author: dependabot-autopilot <dependabot-autopilot@users.noreply.github.com>
Date:   Wed Apr 22 00:22:57 2026 +0000

    chore(deps): regenerate yarn.lock

 yarn.lock | 15 +++++++++++----
 1 file changed, 11 insertions(+), 4 deletions(-)

```

</details>

---
_Do not auto-merge this PR. Every change here must be reviewed by a human._
