### PR TITLE
DOC-3355: Layout would shift causing the text to jump when action button appears on hover in the chat history list

### DIFF
--- a/modules/ROOT/pages/8.5.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.5.0-release-notes.adoc
@@ -29,6 +29,21 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following fix.
+
+==== Layout would shift causing the text to jump when action button appears on hover in the chat history list
+// #TINY-14157
+
+Previously, the actions container in the TinyMCE AI Chat History panel had no reserved space for the icon button that appears on hover. When hovering over a chat history item, the button became visible and caused the entire layout to shift, making content jump position unexpectedly. This resulted in jarring visual inconsistency and inconsistent spacing throughout the component.
+
+In {productname} {release-version}, the actions container now reserves minimum horizontal space to accommodate the icon button and its surrounding padding. Action buttons appear and disappear without causing layout shifts, providing smoother and more predictable interactions with the Chat History.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 === <Premium plugin name 1> <Premium plugin name 1 version>
 
 The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.


### PR DESCRIPTION
**Ticket:** DOC-3355

**Site:** [Staging branch](https://pr-4095.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.5.0-release-notes/#layout-would-shift-causing-the-text-to-jump-when-action-button-appears-on-hover-in-the-chat-history-list)

**Changes:**
* Added release note entry for TINY-14157 to `modules/ROOT/pages/8.5.0-release-notes.adoc` (Accompanying Premium plugin changes > TinyMCE AI section): Layout would shift causing the text to jump when action button appears on hover in the chat history list.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [ ] Documentation Team Lead has reviewed.