### PR TITLE
DOC-3355: AI Review suggestion cards now stay available when you close and reopen the review sidebar while suggestions are still loading

### DIFF
--- a/modules/ROOT/pages/8.5.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.5.0-release-notes.adoc
@@ -29,6 +29,21 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following fix.
+
+==== AI Review suggestion cards now stay available when you close and reopen the review sidebar while suggestions are still loading
+// #TINY-14197
+
+Previously, closing the TinyMCE AI Review sidebar immediately after starting a review and then reopening it after the AI finished generating suggestions would reset the sidebar state. The suggestion cards associated with the review were not displayed, and instead the list of available reviews appeared alongside the preview. This prevented the generated suggestions from being actioned.
+
+In {productname} {release-version}, the sidebar state is now correctly preserved when the sidebar is closed and reopened during or after suggestion generation. The review suggestion cards remain visible and actionable, even if the sidebar was closed while the AI was still streaming results.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 === <Premium plugin name 1> <Premium plugin name 1 version>
 
 The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.


### PR DESCRIPTION
**Ticket:** DOC-3355

**Site:** [Staging branch](https://pr-4099.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.5.0-release-notes/#ai-review-suggestion-cards-now-stay-available-when-you-close-and-reopen-the-review-sidebar-while-suggestions-are-still-loading)

**Changes:**
* Added release note entry for TINY-14197 to `modules/ROOT/pages/8.5.0-release-notes.adoc` (Accompanying Premium plugin changes > TinyMCE AI section): AI Review suggestion cards now stay available when you close and reopen the review sidebar while suggestions are still loading.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.