### PR TITLE
DOC-3488: Update Suggested Edits demos to use `view_show` option

### DIFF
--- a/modules/ROOT/examples/live-demos/suggestededits-access-feedback/index.js
+++ b/modules/ROOT/examples/live-demos/suggestededits-access-feedback/index.js
@@ -13,15 +13,11 @@ tinymce.init({
   suggestededits_model: model,
   suggestededits_access: 'feedback', // Set this value to restrict the permissions in the Suggested Edits view
   suggestededits_content: 'html',
-
+  view_show: 'suggestededits',
   user_id: 'kai-nakamura',
   fetch_users: (userIds) => Promise.all(userIds
     .map((userId) =>
       fetch(`${API_URL}/${userId}`)
         .then((response) => response.json())
-        .catch(() => ({ id: userId })))),
-  
-  init_instance_callback: (editor) => { 
-    editor.execCommand('suggestededits'); 
-  }
+        .catch(() => ({ id: userId }))))
 });

--- a/modules/ROOT/examples/live-demos/suggestededits-access-read/index.js
+++ b/modules/ROOT/examples/live-demos/suggestededits-access-read/index.js
@@ -13,15 +13,11 @@ tinymce.init({
   suggestededits_model: model,
   suggestededits_access: 'read', // Set this value to restrict the permissions in the Suggested Edits view
   suggestededits_content: 'html',
-
+  view_show: 'suggestededits',
   user_id: 'kai-nakamura',
   fetch_users: (userIds) => Promise.all(userIds
     .map((userId) =>
       fetch(`${API_URL}/${userId}`)
         .then((response) => response.json())
-        .catch(() => ({ id: userId })))),
-  
-  init_instance_callback: (editor) => { 
-    editor.execCommand('suggestededits'); 
-  }
+        .catch(() => ({ id: userId }))))
 });

--- a/modules/ROOT/examples/live-demos/suggestededits-auto-approve/index.js
+++ b/modules/ROOT/examples/live-demos/suggestededits-auto-approve/index.js
@@ -14,15 +14,11 @@ tinymce.init({
   suggestededits_access: 'full',
   suggestededits_content: 'html',
   suggestededits_auto_approve: true,
-
+  view_show: 'suggestededits',
   user_id: 'kai-nakamura',
   fetch_users: (userIds) => Promise.all(userIds
     .map((userId) =>
       fetch(`${API_URL}/${userId}`)
         .then((response) => response.json())
-        .catch(() => ({ id: userId })))),
-  
-  init_instance_callback: (editor) => { 
-    editor.execCommand('suggestededits'); 
-  }
+        .catch(() => ({ id: userId }))))
 });

--- a/modules/ROOT/examples/live-demos/suggestededits/index.js
+++ b/modules/ROOT/examples/live-demos/suggestededits/index.js
@@ -13,15 +13,11 @@ tinymce.init({
   suggestededits_model: model,
   suggestededits_access: 'full',
   suggestededits_content: 'html',
-
+  view_show: 'suggestededits',
   user_id: 'kai-nakamura',
   fetch_users: (userIds) => Promise.all(userIds
     .map((userId) =>
       fetch(`${API_URL}/${userId}`)
         .then((response) => response.json())
-        .catch(() => ({ id: userId })))),
-  
-  init_instance_callback: (editor) => { 
-    editor.execCommand('suggestededits'); 
-  }
+        .catch(() => ({ id: userId }))))
 });

--- a/modules/ROOT/pages/suggestededits.adoc
+++ b/modules/ROOT/pages/suggestededits.adoc
@@ -129,7 +129,7 @@ include::partial$configuration/suggestededits_access.adoc[leveloffset=+1]
 
 include::partial$configuration/suggestededits_auto_approve.adoc[leveloffset=+1]
 
-include::partial$plugins/suggestededits-open-view.adoc[]
+include::partial$plugins/suggestededits-open-view.adoc[leveloffset=+1]
 
 include::partial$configuration/user_id.adoc[leveloffset=+1]
 

--- a/modules/ROOT/partials/plugins/suggestededits-open-view.adoc
+++ b/modules/ROOT/partials/plugins/suggestededits-open-view.adoc
@@ -1,4 +1,5 @@
-== Show view on editor load
+[[view_show]]
+== `+view_show+`
 
 The xref:custom-view.adoc#view_show[`+view_show+`] option can be used to show the {pluginname} view when the editor is loaded.
 


### PR DESCRIPTION
Ticket: DOC-3488

Site: [Staging branch](https://pr-4101.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/suggestededits/)

Changes:
* Update Suggested Edits demos to use `view_show` option
* Fixes issue with Suggested Edits demos causing page to unexpectedly scroll down
  * See [live docs](https://www.tiny.cloud/docs/tinymce/latest/suggestededits/)

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.

Review:
- [x] Documentation Team Lead has reviewed