### PR TITLE
fix(deps): picomatch — GHSA-3v7f-55p6-f55p (medium)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   },
   "author": "Tiny Technologies Inc",
   "license": "CC-BY-NC-SA-3.0",
+  "resolutions": {
+    "picomatch": "^2.3.2"
+  },
   "nodemonConfig": {
     "execMap": {
       "build": "antora ./antora-playbook-dev.yml"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1707,15 +1707,10 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
-
-picomatch@~4.0:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
-  integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1, picomatch@^2.3.2, picomatch@~4.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 pidtree@^0.3.0:
   version "0.3.1"


### PR DESCRIPTION
> ⚠️ **Generated by `dependabot-autopilot` — human review required before merge. Do not auto-merge.**

## What was run
This branch was produced by `dependabot-autopilot`, an autonomous agent that:
1. Cloned the repo from `main`
2. Analysed the Dependabot advisory and the project's manifest
3. Edited `package.json` with the minimal change to resolve the vulnerability (the agent has no shell / no network access — it can only read and edit files in the workspace)
4. Re-ran `yarn install` so the lockfile reflects the fix
5. Ran the full validation suite below and only pushed the branch once validation completed
6. Opened this PR for **human review** — it will never be auto-merged by the tool

## Advisory
- **Alert:** #75 — [view](https://github.com/tinymce/tinymce-docs/security/dependabot/75)
- **Advisory:** [GHSA-3v7f-55p6-f55p](https://github.com/advisories/GHSA-3v7f-55p6-f55p)
- **Package:** `picomatch`
- **Severity:** medium
- **Vulnerable range:** `< 2.3.2`
- **Patched in:** `2.3.2`
- **Summary:** Picomatch: Method Injection in POSIX Character Classes causes incorrect Glob Matching

## Agent summary
Perfect! The fix has been applied successfully.

## Summary

I've successfully fixed Dependabot alert #75 by adding a **resolutions** field to package.json that forces all transitive dependencies to use picomatch version ^2.3.2 or later (the first patched version). The vulnerable picomatch 2.3.1 was being pulled in as a transitive dependency through anymatch, micromatch, and readdirp packages. Since picomatch was not a direct dependency, using Yarn's resolutions feature is the correct approach to ensure all instances of picomatch across the dependency tree are upgraded to the patched version 2.3.2+, which fixes the POSIX character class method injection vulnerability (GHSA-3v7f-55p6-f55p).

## Validation results
| Stage | Result | Duration | Notes |
|---|---|---|---|
| `yarn install` (regenerates lockfile) | ✅ pass | 42.4s | Ensures the dependency change actually takes effect |
| `yarn build:production` (Antora build) | ✅ pass | 45.0s | Full site build must succeed |
| Playwright smoke (`/` + dynamically discovered internal link) | ✅ pass | 4.1s | Real Chromium, HTTP 200 + rendered content |

**All validation stages passed on the patched code.** This is still a draft-level change — please review the diff and advisory link before merging.

_Visual evidence: 2 Playwright screenshots were captured during the smoke test. They are visible on the autopilot dashboard at the run detail page._

<details><summary>Validation log (tail)</summary>

```
=== stage: yarn install ===
yarn install v1.22.22
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 42.19s.


=== stage: yarn build:production ===
te: version"}
{"level":"warn","time":1776852945307,"name":"asciidoctor","file":{"path":"modules/ROOT/pages/tinymceai-jwt-authentication-intro.adoc"},"source":{"url":"https://github.com/tinymce/tinymce-docs.git","refname":"tinymce/8","reftype":"branch"},"msg":"skipping reference to missing attribute: apikey"}
{"level":"warn","time":1776852945321,"name":"asciidoctor","file":{"path":"modules/ROOT/pages/tinymceai-models.adoc"},"source":{"url":"https://github.com/tinymce/tinymce-docs.git","refname":"tinymce/8","reftype":"branch"},"msg":"skipping reference to missing attribute: version"}
{"level":"warn","time":1776852945322,"name":"asciidoctor","file":{"path":"modules/ROOT/pages/tinymceai-models.adoc"},"source":{"url":"https://github.com/tinymce/tinymce-docs.git","refname":"tinymce/8","reftype":"branch"},"msg":"skipping reference to missing attribute: version"}
{"level":"warn","time":1776852945322,"name":"asciidoctor","file":{"path":"modules/ROOT/pages/tinymceai-models.adoc"},"source":{"url":"https://github.com/tinymce/tinymce-docs.git","refname":"tinymce/8","reftype":"branch"},"msg":"skipping reference to missing attribute: version"}
{"level":"warn","time":1776852945322,"name":"asciidoctor","file":{"path":"modules/ROOT/pages/tinymceai-models.adoc"},"source":{"url":"https://github.com/tinymce/tinymce-docs.git","refname":"tinymce/8","reftype":"branch"},"msg":"skipping reference to missing attribute: version"}
{"level":"warn","time":1776852945323,"name":"asciidoctor","file":{"path":"modules/ROOT/pages/tinymceai-models.adoc"},"source":{"url":"https://github.com/tinymce/tinymce-docs.git","refname":"tinymce/8","reftype":"branch"},"msg":"skipping reference to missing attribute: version"}
{"level":"warn","time":1776852945323,"name":"asciidoctor","file":{"path":"modules/ROOT/pages/tinymceai-models.adoc"},"source":{"url":"https://github.com/tinymce/tinymce-docs.git","refname":"tinymce/8","reftype":"branch"},"msg":"skipping reference to missing attribute: version"}
Done in 44.87s.


=== stage: playwright smoke ===
GET http://127.0.0.1:4000/ → 200 — "TinyMCE 8 Documentation | TinyMCE Documentation"
  screenshot: /runs/90/screenshot/01-root.png
  deep page: /tinymce/latest/
GET http://127.0.0.1:4000/tinymce/latest/ → 200 — "TinyMCE 8 Documentation | TinyMCE Documentation"
  screenshot: /runs/90/screenshot/02-deep.png
```

</details>

<details><summary>Diff summary</summary>

```
commit 184f76b18474859c4691e22a18000e38b4ac775b
Author: dependabot-autopilot <dependabot-autopilot@users.noreply.github.com>
Date:   Wed Apr 22 10:16:04 2026 +0000

    chore(deps): regenerate yarn.lock

 yarn.lock | 13 ++++---------
 1 file changed, 4 insertions(+), 9 deletions(-)

```

</details>

---
_Do not auto-merge this PR. Every change here must be reviewed by a human._
