### PR TITLE
DOC-3355: Premium content CSS files contained extraneous styles from the default theme

### DIFF
--- a/modules/ROOT/pages/8.5.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.5.0-release-notes.adoc
@@ -49,9 +49,16 @@ The {productname} {release-version} release includes an accompanying release of 
 
 === Enhanced Skins & Icon Packs
 
-The **Enhanced Skins & Icon Packs** release includes the following updates:
+The **Enhanced Skins & Icon Packs** release includes the following updates and fix.
 
 The **Enhanced Skins & Icon Packs** were rebuilt to pull in the changes also incorporated into the default {productname} {release-version} skin, Oxide.
+
+==== Premium content CSS files contained extraneous styles from the default theme
+// #TINY-14129
+
+Previously, premium skin content CSS files for the fabric, fluent, material-classic, and material-outline skins imported styles from the default theme's content UI. This caused duplicate styles to load into the editor and unnecessarily increased the size of the premium content CSS files.
+
+In {productname} {release-version}, the outdated import has been removed from the premium content CSS files. The premium content CSS files now contain only the styles specific to each skin, reducing file size and eliminating duplicate style loading.
 
 For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-and-icon-packs.adoc[Enhanced Skins & Icon Packs].
 


### PR DESCRIPTION
**Ticket:** DOC-3355

**Site:** [Staging](https://pr-4109.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.5.0-release-notes/#premium-content-css-files-contained-extraneous-styles-from-the-default-theme)

**Changes:**
* Added release note entry for TINY-14129 to `modules/ROOT/pages/8.5.0-release-notes.adoc` (Accompanying Enhanced Skins & Icon Packs changes section): Premium content CSS files contained extraneous styles from the default theme.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.