### PR TITLE
DOC-3497 - Fix self-referencing canonical URLs on v5 pages

### DIFF
--- a/modules/ROOT/pages/bootstrap.adoc
+++ b/modules/ROOT/pages/bootstrap.adoc
@@ -1,4 +1,5 @@
 = Bootstrap integration
+:page-canonical-url: https://www.tiny.cloud/docs/tinymce/latest/bootstrap-cloud/
 :description: How to override the built-in block on `focusin` in Bootstrap dialogs when using TinyMCE.
 :keywords: integration integrate bootstrap
 :title_nav: Bootstrap

--- a/modules/ROOT/pages/django.adoc
+++ b/modules/ROOT/pages/django.adoc
@@ -1,4 +1,5 @@
 = Django integration
+:page-canonical-url: https://www.tiny.cloud/docs/tinymce/latest/django-cloud/
 :description: Django TinyMCE component.
 :keywords: integration integrate Django django django-tinymce python
 :title_nav: Django

--- a/modules/ROOT/pages/export.adoc
+++ b/modules/ROOT/pages/export.adoc
@@ -1,4 +1,5 @@
 = Export plugin
+:page-canonical-url: https://www.tiny.cloud/docs/tinymce/latest/exportpdf/
 :description: Export content from TinyMCE, into various formats.
 :keywords: plugin export pdf
 :title_nav: Export

--- a/modules/ROOT/pages/laravel.adoc
+++ b/modules/ROOT/pages/laravel.adoc
@@ -1,4 +1,5 @@
 = Using TinyMCE with the Laravel framework
+:page-canonical-url: https://www.tiny.cloud/docs/tinymce/latest/laravel-tiny-cloud/
 :description: A guide to using TinyMCE with the PHP-based Laravel framework.
 :description_short: A guide to using TinyMCE with the PHP-based Laravel framework.
 :title_nav: Laravel

--- a/modules/ROOT/pages/noneditable.adoc
+++ b/modules/ROOT/pages/noneditable.adoc
@@ -1,4 +1,5 @@
 = Noneditable plugin
+:page-canonical-url: https://www.tiny.cloud/docs/tinymce/latest/non-editable-content-options/
 :description: Prevent users from changing content within elements. Ideal for templates.
 :keywords: noneditable contenteditable editable mceNonEditable noneditable_editable_class noneditable_noneditable_class noneditable_regexp
 :title_nav: Noneditable

--- a/modules/ROOT/pages/paste.adoc
+++ b/modules/ROOT/pages/paste.adoc
@@ -1,4 +1,5 @@
 = Paste plugin
+:page-canonical-url: https://www.tiny.cloud/docs/tinymce/latest/copy-and-paste/
 :controls: toolbar button, menu item
 :description: Standard version of features for copying-and-pasting content from Microsoft Word.
 :keywords: microsoft word excel cut copy paste_data_images paste_as_text paste_enable_default_filters paste_filter_drop paste_preprocess paste_postprocess paste_word_valid_elements paste_webkit_styles paste_retain_style_properties paste_merge_formats paste_convert_word_fake_lists paste_remove_styles_if_webkit

--- a/modules/ROOT/pages/quick-start.adoc
+++ b/modules/ROOT/pages/quick-start.adoc
@@ -1,4 +1,5 @@
 = Quick start
+:page-canonical-url: https://www.tiny.cloud/docs/tinymce/latest/cloud-quick-start/
 :description: Get an instance of TinyMCE 5 up and running using the Tiny Cloud.
 :description_short: Setup a basic TinyMCE 5 editor using the Tiny Cloud.
 :keywords: tinymce script textarea

--- a/modules/ROOT/pages/rails.adoc
+++ b/modules/ROOT/pages/rails.adoc
@@ -1,4 +1,5 @@
 = Rails integration
+:page-canonical-url: https://www.tiny.cloud/docs/tinymce/latest/rails-cloud/
 :description: Seamlessly integrates TinyMCE into the Rails asset pipeline.
 :keywords: integration integrate rails
 :title_nav: Rails

--- a/modules/ROOT/pages/react.adoc
+++ b/modules/ROOT/pages/react.adoc
@@ -1,4 +1,5 @@
 = React integration
+:page-canonical-url: https://www.tiny.cloud/docs/tinymce/latest/react-cloud/
 :description: React TinyMCE component.
 :keywords: integration integrate react reactjs create-react-app tinymce-react
 :title_nav: React

--- a/modules/ROOT/pages/spellchecker.adoc
+++ b/modules/ROOT/pages/spellchecker.adoc
@@ -1,4 +1,5 @@
 = Spell Checker plugin
+:page-canonical-url: https://www.tiny.cloud/docs/tinymce/latest/spelling/
 :controls: toolbar button, menu item
 :description: Enables TinyMCE's spellcheck functionality.
 :keywords: spellchecker spellchecker_callback spellchecker_language spellchecker_languages spellchecker_rpc_url spellchecker_wordchar_pattern

--- a/modules/ROOT/pages/svelte.adoc
+++ b/modules/ROOT/pages/svelte.adoc
@@ -1,4 +1,5 @@
 = Svelte integration
+:page-canonical-url: https://www.tiny.cloud/docs/tinymce/latest/svelte-cloud/
 :description: Svelte TinyMCE component.
 :keywords: integration integrate svelte sveltejs tinymce-svelte
 :title_nav: Svelte

--- a/modules/ROOT/pages/template.adoc
+++ b/modules/ROOT/pages/template.adoc
@@ -1,4 +1,5 @@
 = Template plugin
+:page-canonical-url: https://www.tiny.cloud/docs/tinymce/latest/advanced-templates/
 :controls: toolbar button, menu item
 :description: Custom templates for your content.
 :keywords: insert template_cdate_classes template_cdate_format template_mdate_classes template_mdate_format  template_replace_values template_selected_content_classes template_preview_replace_values

--- a/modules/ROOT/pages/vue.adoc
+++ b/modules/ROOT/pages/vue.adoc
@@ -1,4 +1,5 @@
 = Vue integration
+:page-canonical-url: https://www.tiny.cloud/docs/tinymce/latest/vue-cloud/
 :description: The Official TinyMCE Vue.js component
 :keywords: integration integrate vue vuejs
 :title_nav: Vue

--- a/modules/ROOT/pages/webcomponent.adoc
+++ b/modules/ROOT/pages/webcomponent.adoc
@@ -1,4 +1,5 @@
 = The TinyMCE Web Component integration
+:page-canonical-url: https://www.tiny.cloud/docs/tinymce/latest/webcomponent-cloud/
 :description: The TinyMCE Web Component integration guide
 :keywords: integration integrate web-component
 :title_nav: Web Components


### PR DESCRIPTION
## Ticket

DOC-3497 / TINY-14151

## Site

- [5/react](https://pr-4118.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/5/react/)
- [5/vue](https://pr-4118.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/5/vue/)

## Changes

Adds `:page-canonical-url:` attributes to 14 pages on the `tinymce/5` branch that were renamed or restructured in v6+. These pages currently have self-referencing canonical URLs because Antora cannot match their page IDs to a v8 equivalent, causing Google to treat them as authoritative and rank them above the current documentation.

**Framework integrations (8 pages):**
- `react.adoc` → `/latest/react-cloud/`
- `vue.adoc` → `/latest/vue-cloud/`
- `svelte.adoc` → `/latest/svelte-cloud/`
- `webcomponent.adoc` → `/latest/webcomponent-cloud/`
- `rails.adoc` → `/latest/rails-cloud/`
- `django.adoc` → `/latest/django-cloud/`
- `bootstrap.adoc` → `/latest/bootstrap-cloud/`
- `laravel.adoc` → `/latest/laravel-tiny-cloud/`

**Plugin/feature pages (6 pages):**
- `paste.adoc` → `/latest/copy-and-paste/`
- `quick-start.adoc` → `/latest/cloud-quick-start/`
- `spellchecker.adoc` → `/latest/spelling/`
- `noneditable.adoc` → `/latest/non-editable-content-options/`
- `template.adoc` → `/latest/advanced-templates/`
- `export.adoc` → `/latest/exportpdf/`

Each change is a single metadata line addition; no content changes.

**Companion PR:** #4119 (v6 branch — 2 pages)