### PR TITLE
DOC-3497 - Fix self-referencing canonical URLs on v6 pages

### DIFF
--- a/modules/ROOT/pages/export.adoc
+++ b/modules/ROOT/pages/export.adoc
@@ -1,4 +1,5 @@
 = Export plugin
+:page-canonical-url: https://www.tiny.cloud/docs/tinymce/latest/exportpdf/
 :navtitle: Export
 :description: Export content from TinyMCE, into various formats.
 :keywords: plugin, export, pdf

--- a/modules/ROOT/pages/template.adoc
+++ b/modules/ROOT/pages/template.adoc
@@ -1,4 +1,5 @@
 = Template plugin
+:page-canonical-url: https://www.tiny.cloud/docs/tinymce/latest/advanced-templates/
 :navtitle: Template
 :description: Custom templates for your content.
 :keywords: insert, template_cdate_classes, template_cdate_format, template_mdate_classes, template_mdate_format, template_replace_values, template_selected_content_classes, template_preview_replace_values


### PR DESCRIPTION
## Ticket

DOC-3497 / TINY-14151

## Site

- https://pr-4119.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/6/template/
- https://pr-4119.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/6/export/

## Changes

Adds `:page-canonical-url:` attributes to 2 pages on the `tinymce/6` branch that were renamed in v8. These pages currently have self-referencing canonical URLs because Antora cannot match their page IDs to a v8 equivalent.

- `template.adoc` → `/latest/advanced-templates/`
- `export.adoc` → `/latest/exportpdf/`

Each change is a single metadata line addition; no content changes.

**Companion PR:** #4118 (v5 branch — 14 pages)