### PR TITLE
DOC-3471, DOC-3476: Markdown endpoints in LLM generator + Context7 MCP instructions

### DIFF
--- a/-scripts/generate-llm-files.js
+++ b/-scripts/generate-llm-files.js
@@ -19,6 +19,18 @@ const BASE_URL = 'https://www.tiny.cloud/docs/tinymce/latest';
 const DOCS_ROOT_URL = 'https://www.tiny.cloud/docs';
 const OUTPUT_DIR = path.join(__dirname, '../modules/ROOT/attachments');
 
+// Convert a trailing-slash doc URL to its Markdown endpoint.
+// e.g. https://www.tiny.cloud/docs/tinymce/latest/basic-setup/
+//   -> https://www.tiny.cloud/docs/tinymce/latest/basic-setup/index.md
+// Rewrite doc page URLs from trailing-slash to index.md Markdown endpoints.
+// Only affects URLs under /docs/tinymce/; CDN and file URLs are unchanged.
+function toMarkdownEndpoints(content) {
+  return content.replace(
+    /https:\/\/www\.tiny\.cloud\/docs\/tinymce\/[^\s)"]+/g,
+    (match) => match.endsWith('/') ? match + 'index.md' : match
+  );
+}
+
 // Fetch sitemap from URL or file
 async function getSitemap(source) {
   if (source.startsWith('http://') || source.startsWith('https://')) {
@@ -1206,6 +1218,33 @@ TinyMCE AI (\`tinymceai\` plugin) is the current AI writing assistant for TinyMC
 - [Upgrading TinyMCE](${BASE_URL}/upgrading/): Upgrade guide
 - [Migration from 7.x](${BASE_URL}/migration-from-7x/): Migrate from TinyMCE 7
 
+## AI-Assisted Development with MCP
+
+For up-to-date TinyMCE documentation directly in AI coding tools, set up the Context7 MCP server. TinyMCE docs are indexed at [context7.com/tinymce/tinymce-docs](https://context7.com/tinymce/tinymce-docs).
+
+### Cursor
+
+Add to \`.cursor/mcp.json\`:
+
+\`\`\`json
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"]
+    }
+  }
+}
+\`\`\`
+
+### Claude Code
+
+\`\`\`bash
+claude mcp add context7 -- npx -y @upstash/context7-mcp
+\`\`\`
+
+Add "use context7" to any prompt for live TinyMCE documentation lookups.
+
 ## Complete Documentation
 
 For a complete list of all ${urls.length} documentation pages, see [llms-full.txt](${DOCS_ROOT_URL}/llms-full.txt).
@@ -1225,11 +1264,11 @@ async function main() {
     const urls = parseSitemap(sitemapContent);
     console.log(`Found ${urls.length} unique URLs in sitemap`);
     
-    const llmsTxt = generateLLMsTxt(urls);
+    const llmsTxt = toMarkdownEndpoints(generateLLMsTxt(urls));
     fs.writeFileSync(path.join(OUTPUT_DIR, 'llms.txt'), llmsTxt);
     console.log('✓ Generated llms.txt');
     
-    const llmsFullTxt = await generateLLMsFullTxt(urls);
+    const llmsFullTxt = toMarkdownEndpoints(await generateLLMsFullTxt(urls));
     fs.writeFileSync(path.join(OUTPUT_DIR, 'llms-full.txt'), llmsFullTxt);
     console.log('✓ Generated llms-full.txt');
     

--- a/modules/ROOT/attachments/llms-full.txt
+++ b/modules/ROOT/attachments/llms-full.txt
@@ -12,82 +12,82 @@ TinyMCE is a rich text editor that provides a WYSIWYG editing experience. The la
 ## Getting Started
 
 ### Quick Start Guides
-- **Getting Started Overview**: https://www.tiny.cloud/docs/tinymce/latest/getting-started/
-- **Introduction to TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/introduction-to-tinymce/
-- **Installation Options**: https://www.tiny.cloud/docs/tinymce/latest/installation/
+- **Getting Started Overview**: https://www.tiny.cloud/docs/tinymce/latest/getting-started/index.md
+- **Introduction to TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/introduction-to-tinymce/index.md
+- **Installation Options**: https://www.tiny.cloud/docs/tinymce/latest/installation/index.md
 
 ### Cloud Deployment (Recommended)
-- **Cloud Quick Start**: https://www.tiny.cloud/docs/tinymce/latest/cloud-quick-start/
-- **Cloud Deployment Guide**: https://www.tiny.cloud/docs/tinymce/latest/cloud-deployment-guide/
-- **Editor and Features**: https://www.tiny.cloud/docs/tinymce/latest/editor-and-features/
-- **Specify Editor Version**: https://www.tiny.cloud/docs/tinymce/latest/editor-plugin-version/
-- **Cloud Troubleshooting**: https://www.tiny.cloud/docs/tinymce/latest/cloud-troubleshooting/
+- **Cloud Quick Start**: https://www.tiny.cloud/docs/tinymce/latest/cloud-quick-start/index.md
+- **Cloud Deployment Guide**: https://www.tiny.cloud/docs/tinymce/latest/cloud-deployment-guide/index.md
+- **Editor and Features**: https://www.tiny.cloud/docs/tinymce/latest/editor-and-features/index.md
+- **Specify Editor Version**: https://www.tiny.cloud/docs/tinymce/latest/editor-plugin-version/index.md
+- **Cloud Troubleshooting**: https://www.tiny.cloud/docs/tinymce/latest/cloud-troubleshooting/index.md
 
 ### Self-Hosted Deployment
-- **NPM Projects Quick Start**: https://www.tiny.cloud/docs/tinymce/latest/npm-projects/
-- **ZIP Installation Quick Start**: https://www.tiny.cloud/docs/tinymce/latest/zip-install/
-- **Self-Hosted Installation**: https://www.tiny.cloud/docs/tinymce/latest/installation-self-hosted/
+- **NPM Projects Quick Start**: https://www.tiny.cloud/docs/tinymce/latest/npm-projects/index.md
+- **ZIP Installation Quick Start**: https://www.tiny.cloud/docs/tinymce/latest/zip-install/index.md
+- **Self-Hosted Installation**: https://www.tiny.cloud/docs/tinymce/latest/installation-self-hosted/index.md
 
 ## Integration Guides
 
 ### Frontend Frameworks
-- **React**: https://www.tiny.cloud/docs/tinymce/latest/react-cloud/
-  - Package Manager: https://www.tiny.cloud/docs/tinymce/latest/react-pm-host/
-  - ZIP: https://www.tiny.cloud/docs/tinymce/latest/react-zip-host/
-- **Vue.js**: https://www.tiny.cloud/docs/tinymce/latest/vue-cloud/
-  - Package Manager: https://www.tiny.cloud/docs/tinymce/latest/vue-pm/
-  - ZIP: https://www.tiny.cloud/docs/tinymce/latest/vue-zip/
-- **Angular**: https://www.tiny.cloud/docs/tinymce/latest/angular-cloud/
-  - Package Manager: https://www.tiny.cloud/docs/tinymce/latest/angular-pm/
-  - ZIP: https://www.tiny.cloud/docs/tinymce/latest/angular-zip/
-- **Blazor**: https://www.tiny.cloud/docs/tinymce/latest/blazor-cloud/
-  - Package Manager: https://www.tiny.cloud/docs/tinymce/latest/blazor-pm/
-  - ZIP: https://www.tiny.cloud/docs/tinymce/latest/blazor-zip/
-- **Svelte**: https://www.tiny.cloud/docs/tinymce/latest/svelte-cloud/
-  - Package Manager: https://www.tiny.cloud/docs/tinymce/latest/svelte-pm/
-  - ZIP: https://www.tiny.cloud/docs/tinymce/latest/svelte-zip/
-- **Web Component**: https://www.tiny.cloud/docs/tinymce/latest/webcomponent-cloud/
-  - Package Manager: https://www.tiny.cloud/docs/tinymce/latest/webcomponent-pm/
-  - ZIP: https://www.tiny.cloud/docs/tinymce/latest/webcomponent-zip/
-- **jQuery**: https://www.tiny.cloud/docs/tinymce/latest/jquery-cloud/
-  - Package Manager: https://www.tiny.cloud/docs/tinymce/latest/jquery-pm/
+- **React**: https://www.tiny.cloud/docs/tinymce/latest/react-cloud/index.md
+  - Package Manager: https://www.tiny.cloud/docs/tinymce/latest/react-pm-host/index.md
+  - ZIP: https://www.tiny.cloud/docs/tinymce/latest/react-zip-host/index.md
+- **Vue.js**: https://www.tiny.cloud/docs/tinymce/latest/vue-cloud/index.md
+  - Package Manager: https://www.tiny.cloud/docs/tinymce/latest/vue-pm/index.md
+  - ZIP: https://www.tiny.cloud/docs/tinymce/latest/vue-zip/index.md
+- **Angular**: https://www.tiny.cloud/docs/tinymce/latest/angular-cloud/index.md
+  - Package Manager: https://www.tiny.cloud/docs/tinymce/latest/angular-pm/index.md
+  - ZIP: https://www.tiny.cloud/docs/tinymce/latest/angular-zip/index.md
+- **Blazor**: https://www.tiny.cloud/docs/tinymce/latest/blazor-cloud/index.md
+  - Package Manager: https://www.tiny.cloud/docs/tinymce/latest/blazor-pm/index.md
+  - ZIP: https://www.tiny.cloud/docs/tinymce/latest/blazor-zip/index.md
+- **Svelte**: https://www.tiny.cloud/docs/tinymce/latest/svelte-cloud/index.md
+  - Package Manager: https://www.tiny.cloud/docs/tinymce/latest/svelte-pm/index.md
+  - ZIP: https://www.tiny.cloud/docs/tinymce/latest/svelte-zip/index.md
+- **Web Component**: https://www.tiny.cloud/docs/tinymce/latest/webcomponent-cloud/index.md
+  - Package Manager: https://www.tiny.cloud/docs/tinymce/latest/webcomponent-pm/index.md
+  - ZIP: https://www.tiny.cloud/docs/tinymce/latest/webcomponent-zip/index.md
+- **jQuery**: https://www.tiny.cloud/docs/tinymce/latest/jquery-cloud/index.md
+  - Package Manager: https://www.tiny.cloud/docs/tinymce/latest/jquery-pm/index.md
 
 ### Backend Frameworks
-- **Django**: https://www.tiny.cloud/docs/tinymce/latest/django-cloud/
-  - ZIP: https://www.tiny.cloud/docs/tinymce/latest/django-zip/
-- **Laravel**: https://www.tiny.cloud/docs/tinymce/latest/laravel-tiny-cloud/
-  - Composer: https://www.tiny.cloud/docs/tinymce/latest/laravel-composer-install/
-  - ZIP: https://www.tiny.cloud/docs/tinymce/latest/laravel-zip-install/
-- **Ruby on Rails**: https://www.tiny.cloud/docs/tinymce/latest/rails-cloud/
-  - Package Manager: https://www.tiny.cloud/docs/tinymce/latest/rails-third-party/
-  - ZIP: https://www.tiny.cloud/docs/tinymce/latest/rails-zip/
-- **Node.js + Express**: https://www.tiny.cloud/docs/tinymce/latest/expressjs-pm/
+- **Django**: https://www.tiny.cloud/docs/tinymce/latest/django-cloud/index.md
+  - ZIP: https://www.tiny.cloud/docs/tinymce/latest/django-zip/index.md
+- **Laravel**: https://www.tiny.cloud/docs/tinymce/latest/laravel-tiny-cloud/index.md
+  - Composer: https://www.tiny.cloud/docs/tinymce/latest/laravel-composer-install/index.md
+  - ZIP: https://www.tiny.cloud/docs/tinymce/latest/laravel-zip-install/index.md
+- **Ruby on Rails**: https://www.tiny.cloud/docs/tinymce/latest/rails-cloud/index.md
+  - Package Manager: https://www.tiny.cloud/docs/tinymce/latest/rails-third-party/index.md
+  - ZIP: https://www.tiny.cloud/docs/tinymce/latest/rails-zip/index.md
+- **Node.js + Express**: https://www.tiny.cloud/docs/tinymce/latest/expressjs-pm/index.md
 
 ### Other Integrations
 - **Bootstrap**:
-  - Cloud: https://www.tiny.cloud/docs/tinymce/latest/bootstrap-cloud/
-  - ZIP: https://www.tiny.cloud/docs/tinymce/latest/bootstrap-zip/
-- **PHP Projects**: https://www.tiny.cloud/docs/tinymce/latest/php-projects/
-- **.NET Projects**: https://www.tiny.cloud/docs/tinymce/latest/dotnet-projects/
-- **WordPress**: https://www.tiny.cloud/docs/tinymce/latest/wordpress/
-- **Shadow DOM**: https://www.tiny.cloud/docs/tinymce/latest/shadow-dom/
-- **Java Swing**: https://www.tiny.cloud/docs/tinymce/latest/swing/
+  - Cloud: https://www.tiny.cloud/docs/tinymce/latest/bootstrap-cloud/index.md
+  - ZIP: https://www.tiny.cloud/docs/tinymce/latest/bootstrap-zip/index.md
+- **PHP Projects**: https://www.tiny.cloud/docs/tinymce/latest/php-projects/index.md
+- **.NET Projects**: https://www.tiny.cloud/docs/tinymce/latest/dotnet-projects/index.md
+- **WordPress**: https://www.tiny.cloud/docs/tinymce/latest/wordpress/index.md
+- **Shadow DOM**: https://www.tiny.cloud/docs/tinymce/latest/shadow-dom/index.md
+- **Java Swing**: https://www.tiny.cloud/docs/tinymce/latest/swing/index.md
 
 ## Configuration
 
 ### Basic Setup
-- **Basic Setup**: https://www.tiny.cloud/docs/tinymce/latest/basic-setup/
+- **Basic Setup**: https://www.tiny.cloud/docs/tinymce/latest/basic-setup/index.md
 - **Selector Configuration**: Required for all TinyMCE instances
-- **Plugin Configuration**: https://www.tiny.cloud/docs/tinymce/latest/work-with-plugins/
+- **Plugin Configuration**: https://www.tiny.cloud/docs/tinymce/latest/work-with-plugins/index.md
 - **Toolbar Configuration**: Part of basic setup
 - **Menu and Menu Bar**: Part of basic setup
 
 ### Common Configuration Options
-- **Content Filtering**: https://www.tiny.cloud/docs/tinymce/latest/filter-content/
-- **Localization**: https://www.tiny.cloud/docs/tinymce/latest/localize-your-language/
-- **Spell Checking**: https://www.tiny.cloud/docs/tinymce/latest/spell-checking/
-- **Content CSS**: https://www.tiny.cloud/docs/tinymce/latest/editor-content-css/
-- **URL Handling**: https://www.tiny.cloud/docs/tinymce/latest/url-handling/
+- **Content Filtering**: https://www.tiny.cloud/docs/tinymce/latest/filter-content/index.md
+- **Localization**: https://www.tiny.cloud/docs/tinymce/latest/localize-your-language/index.md
+- **Spell Checking**: https://www.tiny.cloud/docs/tinymce/latest/spell-checking/index.md
+- **Content CSS**: https://www.tiny.cloud/docs/tinymce/latest/editor-content-css/index.md
+- **URL Handling**: https://www.tiny.cloud/docs/tinymce/latest/url-handling/index.md
 
 ## CDN and Package URLs
 
@@ -203,18 +203,18 @@ export default {
 7. **Cloud vs Self-Hosted**: Cloud deployment is recommended for most use cases
 
 ## API Reference
-- **Editor API**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.editor/
-- **Plugin API**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.plugin/
+- **Editor API**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.editor/index.md
+- **Plugin API**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.plugin/index.md
 
 ## Migration Guides
-- **Upgrading TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/upgrading/
-- **Migration from 7.x**: https://www.tiny.cloud/docs/tinymce/latest/migration-from-7x/
+- **Upgrading TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/upgrading/index.md
+- **Migration from 7.x**: https://www.tiny.cloud/docs/tinymce/latest/migration-from-7x/index.md
 
 ## Support and Resources
-- **Documentation Home**: https://www.tiny.cloud/docs/tinymce/latest/
-- **Release Notes**: https://www.tiny.cloud/docs/tinymce/latest/release-notes/
-- **Examples**: https://www.tiny.cloud/docs/tinymce/latest/examples/
-- **How-to Guides**: https://www.tiny.cloud/docs/tinymce/latest/how-to-guides/
+- **Documentation Home**: https://www.tiny.cloud/docs/tinymce/latest/index.md
+- **Release Notes**: https://www.tiny.cloud/docs/tinymce/latest/release-notes/index.md
+- **Examples**: https://www.tiny.cloud/docs/tinymce/latest/examples/index.md
+- **How-to Guides**: https://www.tiny.cloud/docs/tinymce/latest/how-to-guides/index.md
 
 
 ## Complete Documentation Index
@@ -223,508 +223,508 @@ This section provides a complete list of all 411 documentation pages available i
 
 ### Getting Started & Installation
 
-- **About Tiny Cloud’s Usage-Based Billing (UBB)**: https://www.tiny.cloud/docs/tinymce/latest/usage-based-billing/
-- **Getting Started**: https://www.tiny.cloud/docs/tinymce/latest/getting-started/
-- **Installing TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/installation/
-- **Installing TinyMCE using a .zip file**: https://www.tiny.cloud/docs/tinymce/latest/installation-zip/
-- **Installing TinyMCE using a package manager**: https://www.tiny.cloud/docs/tinymce/latest/installation-self-hosted/
-- **Installing TinyMCE using the Tiny Cloud**: https://www.tiny.cloud/docs/tinymce/latest/installation-cloud/
-- **Introduction to TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/introduction-to-tinymce/
-- **Invalid API key**: https://www.tiny.cloud/docs/tinymce/latest/invalid-api-key/
-- **Quick start: TinyMCE from .zip**: https://www.tiny.cloud/docs/tinymce/latest/zip-install/
-- **Quick start: TinyMCE from NPM or Yarn**: https://www.tiny.cloud/docs/tinymce/latest/npm-projects/
-- **Quick start: TinyMCE from Tiny Cloud**: https://www.tiny.cloud/docs/tinymce/latest/cloud-quick-start/
+- **About Tiny Cloud’s Usage-Based Billing (UBB)**: https://www.tiny.cloud/docs/tinymce/latest/usage-based-billing/index.md
+- **Getting Started**: https://www.tiny.cloud/docs/tinymce/latest/getting-started/index.md
+- **Installing TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/installation/index.md
+- **Installing TinyMCE using a .zip file**: https://www.tiny.cloud/docs/tinymce/latest/installation-zip/index.md
+- **Installing TinyMCE using a package manager**: https://www.tiny.cloud/docs/tinymce/latest/installation-self-hosted/index.md
+- **Installing TinyMCE using the Tiny Cloud**: https://www.tiny.cloud/docs/tinymce/latest/installation-cloud/index.md
+- **Introduction to TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/introduction-to-tinymce/index.md
+- **Invalid API key**: https://www.tiny.cloud/docs/tinymce/latest/invalid-api-key/index.md
+- **Quick start: TinyMCE from .zip**: https://www.tiny.cloud/docs/tinymce/latest/zip-install/index.md
+- **Quick start: TinyMCE from NPM or Yarn**: https://www.tiny.cloud/docs/tinymce/latest/npm-projects/index.md
+- **Quick start: TinyMCE from Tiny Cloud**: https://www.tiny.cloud/docs/tinymce/latest/cloud-quick-start/index.md
 
 
 ### Framework Integrations
 
 #### Frontend Frameworks
-- **Bundling TinyMCE from a .zip package in Angular**: https://www.tiny.cloud/docs/tinymce/latest/angular-zip-bundle/
-- **Bundling TinyMCE from a .zip package in React**: https://www.tiny.cloud/docs/tinymce/latest/react-zip-bundle/
-- **Bundling TinyMCE in Angular**: https://www.tiny.cloud/docs/tinymce/latest/angular-pm-bundle/
-- **Bundling TinyMCE in React**: https://www.tiny.cloud/docs/tinymce/latest/react-pm-bundle/
-- **Bundling TinyMCE in Vue.js**: https://www.tiny.cloud/docs/tinymce/latest/vue-pm-bundle/
-- **Bundling TinyMCE with a Svelte application**: https://www.tiny.cloud/docs/tinymce/latest/svelte-pm-bundle/
-- **Lazy-loading TinyMCE from a .zip package in Angular**: https://www.tiny.cloud/docs/tinymce/latest/angular-zip/
-- **Lazy-loading TinyMCE from a .zip package in React**: https://www.tiny.cloud/docs/tinymce/latest/react-zip-host/
-- **Lazy-loading TinyMCE from a .zip package in Vue.js**: https://www.tiny.cloud/docs/tinymce/latest/vue-zip/
-- **Lazy-loading TinyMCE in Angular**: https://www.tiny.cloud/docs/tinymce/latest/angular-pm/
-- **Lazy-loading TinyMCE in Vue.js**: https://www.tiny.cloud/docs/tinymce/latest/vue-pm/
-- **Self-hosting TinyMCE in React**: https://www.tiny.cloud/docs/tinymce/latest/react-pm-host/
-- **TinyMCE jQuery integration quick start guide (cloud)**: https://www.tiny.cloud/docs/tinymce/latest/jquery-cloud/
-- **TinyMCE jQuery integration quick start guide (pm)**: https://www.tiny.cloud/docs/tinymce/latest/jquery-pm/
-- **Using the TinyMCE .zip package with the Blazor framework**: https://www.tiny.cloud/docs/tinymce/latest/blazor-zip/
-- **Using the TinyMCE .zip package with the Svelte framework**: https://www.tiny.cloud/docs/tinymce/latest/svelte-zip/
-- **Using the TinyMCE .zip package with the Web Component**: https://www.tiny.cloud/docs/tinymce/latest/webcomponent-zip/
-- **Using the TinyMCE package with the Blazor framework**: https://www.tiny.cloud/docs/tinymce/latest/blazor-pm/
-- **Using the TinyMCE package with the Svelte framework**: https://www.tiny.cloud/docs/tinymce/latest/svelte-pm/
-- **Using the TinyMCE package with the Web Component**: https://www.tiny.cloud/docs/tinymce/latest/webcomponent-pm/
-- **Using TinyMCE from the Tiny Cloud CDN with the Blazor framework**: https://www.tiny.cloud/docs/tinymce/latest/blazor-cloud/
-- **Using TinyMCE from the Tiny Cloud CDN with the Svelte framework**: https://www.tiny.cloud/docs/tinymce/latest/svelte-cloud/
-- **Using TinyMCE from the Tiny Cloud CDN with the Web Component**: https://www.tiny.cloud/docs/tinymce/latest/webcomponent-cloud/
-- **Using TinyMCE from Tiny Cloud in Angular**: https://www.tiny.cloud/docs/tinymce/latest/angular-cloud/
-- **Using TinyMCE from Tiny Cloud in React**: https://www.tiny.cloud/docs/tinymce/latest/react-cloud/
-- **Using TinyMCE from Tiny Cloud in Vue.js**: https://www.tiny.cloud/docs/tinymce/latest/vue-cloud/
+- **Bundling TinyMCE from a .zip package in Angular**: https://www.tiny.cloud/docs/tinymce/latest/angular-zip-bundle/index.md
+- **Bundling TinyMCE from a .zip package in React**: https://www.tiny.cloud/docs/tinymce/latest/react-zip-bundle/index.md
+- **Bundling TinyMCE in Angular**: https://www.tiny.cloud/docs/tinymce/latest/angular-pm-bundle/index.md
+- **Bundling TinyMCE in React**: https://www.tiny.cloud/docs/tinymce/latest/react-pm-bundle/index.md
+- **Bundling TinyMCE in Vue.js**: https://www.tiny.cloud/docs/tinymce/latest/vue-pm-bundle/index.md
+- **Bundling TinyMCE with a Svelte application**: https://www.tiny.cloud/docs/tinymce/latest/svelte-pm-bundle/index.md
+- **Lazy-loading TinyMCE from a .zip package in Angular**: https://www.tiny.cloud/docs/tinymce/latest/angular-zip/index.md
+- **Lazy-loading TinyMCE from a .zip package in React**: https://www.tiny.cloud/docs/tinymce/latest/react-zip-host/index.md
+- **Lazy-loading TinyMCE from a .zip package in Vue.js**: https://www.tiny.cloud/docs/tinymce/latest/vue-zip/index.md
+- **Lazy-loading TinyMCE in Angular**: https://www.tiny.cloud/docs/tinymce/latest/angular-pm/index.md
+- **Lazy-loading TinyMCE in Vue.js**: https://www.tiny.cloud/docs/tinymce/latest/vue-pm/index.md
+- **Self-hosting TinyMCE in React**: https://www.tiny.cloud/docs/tinymce/latest/react-pm-host/index.md
+- **TinyMCE jQuery integration quick start guide (cloud)**: https://www.tiny.cloud/docs/tinymce/latest/jquery-cloud/index.md
+- **TinyMCE jQuery integration quick start guide (pm)**: https://www.tiny.cloud/docs/tinymce/latest/jquery-pm/index.md
+- **Using the TinyMCE .zip package with the Blazor framework**: https://www.tiny.cloud/docs/tinymce/latest/blazor-zip/index.md
+- **Using the TinyMCE .zip package with the Svelte framework**: https://www.tiny.cloud/docs/tinymce/latest/svelte-zip/index.md
+- **Using the TinyMCE .zip package with the Web Component**: https://www.tiny.cloud/docs/tinymce/latest/webcomponent-zip/index.md
+- **Using the TinyMCE package with the Blazor framework**: https://www.tiny.cloud/docs/tinymce/latest/blazor-pm/index.md
+- **Using the TinyMCE package with the Svelte framework**: https://www.tiny.cloud/docs/tinymce/latest/svelte-pm/index.md
+- **Using the TinyMCE package with the Web Component**: https://www.tiny.cloud/docs/tinymce/latest/webcomponent-pm/index.md
+- **Using TinyMCE from the Tiny Cloud CDN with the Blazor framework**: https://www.tiny.cloud/docs/tinymce/latest/blazor-cloud/index.md
+- **Using TinyMCE from the Tiny Cloud CDN with the Svelte framework**: https://www.tiny.cloud/docs/tinymce/latest/svelte-cloud/index.md
+- **Using TinyMCE from the Tiny Cloud CDN with the Web Component**: https://www.tiny.cloud/docs/tinymce/latest/webcomponent-cloud/index.md
+- **Using TinyMCE from Tiny Cloud in Angular**: https://www.tiny.cloud/docs/tinymce/latest/angular-cloud/index.md
+- **Using TinyMCE from Tiny Cloud in React**: https://www.tiny.cloud/docs/tinymce/latest/react-cloud/index.md
+- **Using TinyMCE from Tiny Cloud in Vue.js**: https://www.tiny.cloud/docs/tinymce/latest/vue-cloud/index.md
 
 #### Backend Frameworks
-- **Integrating TinyMCE into an Express JS App**: https://www.tiny.cloud/docs/tinymce/latest/expressjs-pm/
-- **Using the TinyMCE .zip package with the Django framework**: https://www.tiny.cloud/docs/tinymce/latest/django-zip/
-- **Using the TinyMCE .zip package with the Laravel framework**: https://www.tiny.cloud/docs/tinymce/latest/laravel-zip-install/
-- **Using the TinyMCE .zip package with the Ruby on Rails framework**: https://www.tiny.cloud/docs/tinymce/latest/rails-zip/
-- **Using the TinyMCE composer package with the Laravel framework**: https://www.tiny.cloud/docs/tinymce/latest/laravel-composer-install/
-- **Using the TinyMCE package with the Ruby on Rails framework**: https://www.tiny.cloud/docs/tinymce/latest/rails-third-party/
-- **Using TinyMCE from the Tiny Cloud CDN with Ruby on Rails**: https://www.tiny.cloud/docs/tinymce/latest/rails-cloud/
-- **Using TinyMCE from the Tiny Cloud CDN with the Django framework**: https://www.tiny.cloud/docs/tinymce/latest/django-cloud/
-- **Using TinyMCE from the Tiny Cloud CDN with the Laravel framework**: https://www.tiny.cloud/docs/tinymce/latest/laravel-tiny-cloud/
+- **Integrating TinyMCE into an Express JS App**: https://www.tiny.cloud/docs/tinymce/latest/expressjs-pm/index.md
+- **Using the TinyMCE .zip package with the Django framework**: https://www.tiny.cloud/docs/tinymce/latest/django-zip/index.md
+- **Using the TinyMCE .zip package with the Laravel framework**: https://www.tiny.cloud/docs/tinymce/latest/laravel-zip-install/index.md
+- **Using the TinyMCE .zip package with the Ruby on Rails framework**: https://www.tiny.cloud/docs/tinymce/latest/rails-zip/index.md
+- **Using the TinyMCE composer package with the Laravel framework**: https://www.tiny.cloud/docs/tinymce/latest/laravel-composer-install/index.md
+- **Using the TinyMCE package with the Ruby on Rails framework**: https://www.tiny.cloud/docs/tinymce/latest/rails-third-party/index.md
+- **Using TinyMCE from the Tiny Cloud CDN with Ruby on Rails**: https://www.tiny.cloud/docs/tinymce/latest/rails-cloud/index.md
+- **Using TinyMCE from the Tiny Cloud CDN with the Django framework**: https://www.tiny.cloud/docs/tinymce/latest/django-cloud/index.md
+- **Using TinyMCE from the Tiny Cloud CDN with the Laravel framework**: https://www.tiny.cloud/docs/tinymce/latest/laravel-tiny-cloud/index.md
 
 #### Other Integrations
-- **Bootstrap skin demo**: https://www.tiny.cloud/docs/tinymce/latest/bootstrap-demo/
-- **Installing TinyMCE for .NET**: https://www.tiny.cloud/docs/tinymce/latest/dotnet-projects/
-- **Installing TinyMCE with Composer**: https://www.tiny.cloud/docs/tinymce/latest/php-projects/
-- **PHP image upload handler**: https://www.tiny.cloud/docs/tinymce/latest/php-upload-handler/
-- **Running TinyMCE in a Shadow DOM**: https://www.tiny.cloud/docs/tinymce/latest/shadow-dom/
-- **TinyMCE for Java Swing integration**: https://www.tiny.cloud/docs/tinymce/latest/swing/
-- **Using the TinyMCE .zip package with the Bootstrap framework**: https://www.tiny.cloud/docs/tinymce/latest/bootstrap-zip/
-- **Using TinyMCE from the Tiny Cloud CDN with the Bootstrap framework**: https://www.tiny.cloud/docs/tinymce/latest/bootstrap-cloud/
-- **WordPress integration**: https://www.tiny.cloud/docs/tinymce/latest/wordpress/
+- **Bootstrap skin demo**: https://www.tiny.cloud/docs/tinymce/latest/bootstrap-demo/index.md
+- **Installing TinyMCE for .NET**: https://www.tiny.cloud/docs/tinymce/latest/dotnet-projects/index.md
+- **Installing TinyMCE with Composer**: https://www.tiny.cloud/docs/tinymce/latest/php-projects/index.md
+- **PHP image upload handler**: https://www.tiny.cloud/docs/tinymce/latest/php-upload-handler/index.md
+- **Running TinyMCE in a Shadow DOM**: https://www.tiny.cloud/docs/tinymce/latest/shadow-dom/index.md
+- **TinyMCE for Java Swing integration**: https://www.tiny.cloud/docs/tinymce/latest/swing/index.md
+- **Using the TinyMCE .zip package with the Bootstrap framework**: https://www.tiny.cloud/docs/tinymce/latest/bootstrap-zip/index.md
+- **Using TinyMCE from the Tiny Cloud CDN with the Bootstrap framework**: https://www.tiny.cloud/docs/tinymce/latest/bootstrap-cloud/index.md
+- **WordPress integration**: https://www.tiny.cloud/docs/tinymce/latest/wordpress/index.md
 
 #### Technical References
-- **TinyMCE Angular integration technical reference**: https://www.tiny.cloud/docs/tinymce/latest/angular-ref/
-- **TinyMCE Blazor integration technical reference**: https://www.tiny.cloud/docs/tinymce/latest/blazor-ref/
-- **TinyMCE React integration technical reference**: https://www.tiny.cloud/docs/tinymce/latest/react-ref/
-- **TinyMCE Svelte integration technical reference**: https://www.tiny.cloud/docs/tinymce/latest/svelte-ref/
-- **TinyMCE Vue.js integration technical reference**: https://www.tiny.cloud/docs/tinymce/latest/vue-ref/
-- **TinyMCE Web Component technical reference**: https://www.tiny.cloud/docs/tinymce/latest/webcomponent-ref/
+- **TinyMCE Angular integration technical reference**: https://www.tiny.cloud/docs/tinymce/latest/angular-ref/index.md
+- **TinyMCE Blazor integration technical reference**: https://www.tiny.cloud/docs/tinymce/latest/blazor-ref/index.md
+- **TinyMCE React integration technical reference**: https://www.tiny.cloud/docs/tinymce/latest/react-ref/index.md
+- **TinyMCE Svelte integration technical reference**: https://www.tiny.cloud/docs/tinymce/latest/svelte-ref/index.md
+- **TinyMCE Vue.js integration technical reference**: https://www.tiny.cloud/docs/tinymce/latest/vue-ref/index.md
+- **TinyMCE Web Component technical reference**: https://www.tiny.cloud/docs/tinymce/latest/webcomponent-ref/index.md
 
 
 ### Configuration & Setup
 
-- **APIs for custom dialogs**: https://www.tiny.cloud/docs/tinymce/latest/dialog-apis/
-- **Basic setup**: https://www.tiny.cloud/docs/tinymce/latest/basic-setup/
-- **Check spelling in TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/spell-checking/
-- **Cloud Deployment Guide**: https://www.tiny.cloud/docs/tinymce/latest/cloud-deployment-guide/
-- **Cloud deployment of editor & plugins**: https://www.tiny.cloud/docs/tinymce/latest/editor-and-features/
-- **Cloud deployment of plugins Only**: https://www.tiny.cloud/docs/tinymce/latest/features-only/
-- **Cloud Troubleshooting**: https://www.tiny.cloud/docs/tinymce/latest/cloud-troubleshooting/
-- **Commands Available for TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/editor-command-identifiers/
-- **Configuring custom dialogs**: https://www.tiny.cloud/docs/tinymce/latest/dialog-configuration/
-- **Content appearance options**: https://www.tiny.cloud/docs/tinymce/latest/content-appearance/
-- **Content filtering options**: https://www.tiny.cloud/docs/tinymce/latest/content-filtering/
-- **Content formatting options**: https://www.tiny.cloud/docs/tinymce/latest/content-formatting/
-- **Content localization options**: https://www.tiny.cloud/docs/tinymce/latest/content-localization/
-- **Context Menu Items Available for TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/editor-context-menu-identifiers/
-- **CSS for rendering TinyMCE content outside the editor**: https://www.tiny.cloud/docs/tinymce/latest/editor-content-css/
-- **Custom dialog body components**: https://www.tiny.cloud/docs/tinymce/latest/dialog-components/
-- **Custom dialog footer buttons**: https://www.tiny.cloud/docs/tinymce/latest/dialog-footer-buttons/
-- **Editor content behaviors**: https://www.tiny.cloud/docs/tinymce/latest/content-behavior-options/
-- **Editor save and submit options**: https://www.tiny.cloud/docs/tinymce/latest/editor-save-and-submit/
-- **Editor size and resize options**: https://www.tiny.cloud/docs/tinymce/latest/editor-size-options/
-- **Events Available for TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/events/
-- **Filtering TinyMCE content**: https://www.tiny.cloud/docs/tinymce/latest/filter-content/
-- **Icons Available for TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/editor-icon-identifiers/
-- **Initial Configuration**: https://www.tiny.cloud/docs/tinymce/latest/initial-configuration/
-- **Interactive examples of custom dialogs**: https://www.tiny.cloud/docs/tinymce/latest/dialog-examples/
-- **Key editor options for adding TinyMCE to an application**: https://www.tiny.cloud/docs/tinymce/latest/editor-important-options/
-- **Localize TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/localize-your-language/
-- **Menu Items Available for TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/available-menu-items/
-- **Options for customizing the editor’s menus**: https://www.tiny.cloud/docs/tinymce/latest/menus-configuration-options/
-- **Options for customizing the editor’s statusbar**: https://www.tiny.cloud/docs/tinymce/latest/statusbar-configuration-options/
-- **Options for customizing the editor’s toolbars**: https://www.tiny.cloud/docs/tinymce/latest/toolbar-configuration-options/
-- **Options for customizing the editor’s UI mode**: https://www.tiny.cloud/docs/tinymce/latest/ui-mode-configuration-options/
-- **Specify Editor Version & Plugins**: https://www.tiny.cloud/docs/tinymce/latest/editor-plugin-version/
-- **The TinyMCE Content Security Policy guide**: https://www.tiny.cloud/docs/tinymce/latest/tinymce-and-csp/
-- **The TinyMCE Cross-Origin Resource Sharing guide**: https://www.tiny.cloud/docs/tinymce/latest/tinymce-and-cors/
-- **TinyMCE Icon options**: https://www.tiny.cloud/docs/tinymce/latest/editor-icons/
-- **TinyMCE Model options**: https://www.tiny.cloud/docs/tinymce/latest/editor-model/
-- **TinyMCE Skin options**: https://www.tiny.cloud/docs/tinymce/latest/editor-skin/
-- **TinyMCE Theme options**: https://www.tiny.cloud/docs/tinymce/latest/editor-theme/
-- **Toolbar Buttons Available for TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/available-toolbar-buttons/
-- **Understanding editor loads**: https://www.tiny.cloud/docs/tinymce/latest/understanding-editor-loads/
-- **URL handling options**: https://www.tiny.cloud/docs/tinymce/latest/url-handling/
-- **Use multiple TinyMCE instances in a single page**: https://www.tiny.cloud/docs/tinymce/latest/multiple-editors/
-- **Version compatibility reference**: https://www.tiny.cloud/docs/tinymce/latest/plugin-editor-version-compatibility/
-- **Work with plugins to extend TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/work-with-plugins/
+- **APIs for custom dialogs**: https://www.tiny.cloud/docs/tinymce/latest/dialog-apis/index.md
+- **Basic setup**: https://www.tiny.cloud/docs/tinymce/latest/basic-setup/index.md
+- **Check spelling in TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/spell-checking/index.md
+- **Cloud Deployment Guide**: https://www.tiny.cloud/docs/tinymce/latest/cloud-deployment-guide/index.md
+- **Cloud deployment of editor & plugins**: https://www.tiny.cloud/docs/tinymce/latest/editor-and-features/index.md
+- **Cloud deployment of plugins Only**: https://www.tiny.cloud/docs/tinymce/latest/features-only/index.md
+- **Cloud Troubleshooting**: https://www.tiny.cloud/docs/tinymce/latest/cloud-troubleshooting/index.md
+- **Commands Available for TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/editor-command-identifiers/index.md
+- **Configuring custom dialogs**: https://www.tiny.cloud/docs/tinymce/latest/dialog-configuration/index.md
+- **Content appearance options**: https://www.tiny.cloud/docs/tinymce/latest/content-appearance/index.md
+- **Content filtering options**: https://www.tiny.cloud/docs/tinymce/latest/content-filtering/index.md
+- **Content formatting options**: https://www.tiny.cloud/docs/tinymce/latest/content-formatting/index.md
+- **Content localization options**: https://www.tiny.cloud/docs/tinymce/latest/content-localization/index.md
+- **Context Menu Items Available for TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/editor-context-menu-identifiers/index.md
+- **CSS for rendering TinyMCE content outside the editor**: https://www.tiny.cloud/docs/tinymce/latest/editor-content-css/index.md
+- **Custom dialog body components**: https://www.tiny.cloud/docs/tinymce/latest/dialog-components/index.md
+- **Custom dialog footer buttons**: https://www.tiny.cloud/docs/tinymce/latest/dialog-footer-buttons/index.md
+- **Editor content behaviors**: https://www.tiny.cloud/docs/tinymce/latest/content-behavior-options/index.md
+- **Editor save and submit options**: https://www.tiny.cloud/docs/tinymce/latest/editor-save-and-submit/index.md
+- **Editor size and resize options**: https://www.tiny.cloud/docs/tinymce/latest/editor-size-options/index.md
+- **Events Available for TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/events/index.md
+- **Filtering TinyMCE content**: https://www.tiny.cloud/docs/tinymce/latest/filter-content/index.md
+- **Icons Available for TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/editor-icon-identifiers/index.md
+- **Initial Configuration**: https://www.tiny.cloud/docs/tinymce/latest/initial-configuration/index.md
+- **Interactive examples of custom dialogs**: https://www.tiny.cloud/docs/tinymce/latest/dialog-examples/index.md
+- **Key editor options for adding TinyMCE to an application**: https://www.tiny.cloud/docs/tinymce/latest/editor-important-options/index.md
+- **Localize TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/localize-your-language/index.md
+- **Menu Items Available for TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/available-menu-items/index.md
+- **Options for customizing the editor’s menus**: https://www.tiny.cloud/docs/tinymce/latest/menus-configuration-options/index.md
+- **Options for customizing the editor’s statusbar**: https://www.tiny.cloud/docs/tinymce/latest/statusbar-configuration-options/index.md
+- **Options for customizing the editor’s toolbars**: https://www.tiny.cloud/docs/tinymce/latest/toolbar-configuration-options/index.md
+- **Options for customizing the editor’s UI mode**: https://www.tiny.cloud/docs/tinymce/latest/ui-mode-configuration-options/index.md
+- **Specify Editor Version & Plugins**: https://www.tiny.cloud/docs/tinymce/latest/editor-plugin-version/index.md
+- **The TinyMCE Content Security Policy guide**: https://www.tiny.cloud/docs/tinymce/latest/tinymce-and-csp/index.md
+- **The TinyMCE Cross-Origin Resource Sharing guide**: https://www.tiny.cloud/docs/tinymce/latest/tinymce-and-cors/index.md
+- **TinyMCE Icon options**: https://www.tiny.cloud/docs/tinymce/latest/editor-icons/index.md
+- **TinyMCE Model options**: https://www.tiny.cloud/docs/tinymce/latest/editor-model/index.md
+- **TinyMCE Skin options**: https://www.tiny.cloud/docs/tinymce/latest/editor-skin/index.md
+- **TinyMCE Theme options**: https://www.tiny.cloud/docs/tinymce/latest/editor-theme/index.md
+- **Toolbar Buttons Available for TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/available-toolbar-buttons/index.md
+- **Understanding editor loads**: https://www.tiny.cloud/docs/tinymce/latest/understanding-editor-loads/index.md
+- **URL handling options**: https://www.tiny.cloud/docs/tinymce/latest/url-handling/index.md
+- **Use multiple TinyMCE instances in a single page**: https://www.tiny.cloud/docs/tinymce/latest/multiple-editors/index.md
+- **Version compatibility reference**: https://www.tiny.cloud/docs/tinymce/latest/plugin-editor-version-compatibility/index.md
+- **Work with plugins to extend TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/work-with-plugins/index.md
 
 
 ### Plugins & Features
 
 #### Core Plugins
-- **Accessibility Checker plugin**: https://www.tiny.cloud/docs/tinymce/latest/a11ychecker/
-- **Accordion plugin**: https://www.tiny.cloud/docs/tinymce/latest/accordion/
-- **Advanced Typography plugin**: https://www.tiny.cloud/docs/tinymce/latest/advanced-typography/
-- **Anchor plugin**: https://www.tiny.cloud/docs/tinymce/latest/anchor/
-- **Autolink plugin**: https://www.tiny.cloud/docs/tinymce/latest/autolink/
-- **Autoresize plugin**: https://www.tiny.cloud/docs/tinymce/latest/autoresize/
-- **Autosave plugin**: https://www.tiny.cloud/docs/tinymce/latest/autosave/
-- **Case Change**: https://www.tiny.cloud/docs/tinymce/latest/casechange/
-- **Character Map plugin**: https://www.tiny.cloud/docs/tinymce/latest/charmap/
-- **Checklist plugin**: https://www.tiny.cloud/docs/tinymce/latest/checklist/
-- **Code plugin**: https://www.tiny.cloud/docs/tinymce/latest/code/
-- **Code Sample plugin**: https://www.tiny.cloud/docs/tinymce/latest/codesample/
-- **Context**: https://www.tiny.cloud/docs/tinymce/latest/context/
-- **Context forms**: https://www.tiny.cloud/docs/tinymce/latest/contextform/
-- **Context menus**: https://www.tiny.cloud/docs/tinymce/latest/contextmenu/
-- **Context toolbar**: https://www.tiny.cloud/docs/tinymce/latest/contexttoolbar/
-- **Directionality plugin**: https://www.tiny.cloud/docs/tinymce/latest/directionality/
-- **Emoticons plugin**: https://www.tiny.cloud/docs/tinymce/latest/emoticons/
-- **Enhanced Code Editor plugin**: https://www.tiny.cloud/docs/tinymce/latest/advcode/
-- **Enhanced Media Embed plugin**: https://www.tiny.cloud/docs/tinymce/latest/introduction-to-mediaembed/
-- **Enhanced Tables plugin**: https://www.tiny.cloud/docs/tinymce/latest/advtable/
-- **Footnotes plugin**: https://www.tiny.cloud/docs/tinymce/latest/footnotes/
-- **Format Painter**: https://www.tiny.cloud/docs/tinymce/latest/formatpainter/
-- **Full Page HTML Plugin**: https://www.tiny.cloud/docs/tinymce/latest/fullpagehtml/
-- **Full Screen plugin**: https://www.tiny.cloud/docs/tinymce/latest/fullscreen/
-- **Handling image uploads**: https://www.tiny.cloud/docs/tinymce/latest/upload-images/
-- **Help plugin**: https://www.tiny.cloud/docs/tinymce/latest/help/
-- **Image and file options**: https://www.tiny.cloud/docs/tinymce/latest/file-image-upload/
-- **Image Editing**: https://www.tiny.cloud/docs/tinymce/latest/editimage/
-- **Image plugin**: https://www.tiny.cloud/docs/tinymce/latest/image/
-- **Import CSS plugin**: https://www.tiny.cloud/docs/tinymce/latest/importcss/
-- **Import from Word plugin**: https://www.tiny.cloud/docs/tinymce/latest/importword/
-- **Insert Date/Time plugin**: https://www.tiny.cloud/docs/tinymce/latest/insertdatetime/
-- **Link Checker plugin**: https://www.tiny.cloud/docs/tinymce/latest/linkchecker/
-- **Link plugin**: https://www.tiny.cloud/docs/tinymce/latest/link/
-- **List Styles plugin**: https://www.tiny.cloud/docs/tinymce/latest/advlist/
-- **Lists plugin**: https://www.tiny.cloud/docs/tinymce/latest/lists/
-- **Markdown plugin**: https://www.tiny.cloud/docs/tinymce/latest/markdown/
-- **Math plugin**: https://www.tiny.cloud/docs/tinymce/latest/math/
-- **Media plugin**: https://www.tiny.cloud/docs/tinymce/latest/media/
-- **Mentions plugin**: https://www.tiny.cloud/docs/tinymce/latest/mentions/
-- **Merge Tags plugin**: https://www.tiny.cloud/docs/tinymce/latest/mergetags/
-- **Nonbreaking Space plugin**: https://www.tiny.cloud/docs/tinymce/latest/nonbreaking/
-- **Page Break plugin**: https://www.tiny.cloud/docs/tinymce/latest/pagebreak/
-- **Page Embed plugin**: https://www.tiny.cloud/docs/tinymce/latest/pageembed/
-- **Permanent Pen Plugin**: https://www.tiny.cloud/docs/tinymce/latest/permanentpen/
-- **Plugins for TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/plugins/
-- **Preview plugin**: https://www.tiny.cloud/docs/tinymce/latest/preview/
-- **Quick Toolbars plugin**: https://www.tiny.cloud/docs/tinymce/latest/quickbars/
-- **Save plugin**: https://www.tiny.cloud/docs/tinymce/latest/save/
-- **Search and Replace plugin**: https://www.tiny.cloud/docs/tinymce/latest/searchreplace/
-- **Table of Contents plugin**: https://www.tiny.cloud/docs/tinymce/latest/tableofcontents/
-- **Table options**: https://www.tiny.cloud/docs/tinymce/latest/table-options/
-- **Table plugin**: https://www.tiny.cloud/docs/tinymce/latest/table/
-- **Templates plugin**: https://www.tiny.cloud/docs/tinymce/latest/advanced-templates/
-- **Visual Blocks plugin**: https://www.tiny.cloud/docs/tinymce/latest/visualblocks/
-- **Visual Characters plugin**: https://www.tiny.cloud/docs/tinymce/latest/visualchars/
-- **Word Count plugin**: https://www.tiny.cloud/docs/tinymce/latest/wordcount/
+- **Accessibility Checker plugin**: https://www.tiny.cloud/docs/tinymce/latest/a11ychecker/index.md
+- **Accordion plugin**: https://www.tiny.cloud/docs/tinymce/latest/accordion/index.md
+- **Advanced Typography plugin**: https://www.tiny.cloud/docs/tinymce/latest/advanced-typography/index.md
+- **Anchor plugin**: https://www.tiny.cloud/docs/tinymce/latest/anchor/index.md
+- **Autolink plugin**: https://www.tiny.cloud/docs/tinymce/latest/autolink/index.md
+- **Autoresize plugin**: https://www.tiny.cloud/docs/tinymce/latest/autoresize/index.md
+- **Autosave plugin**: https://www.tiny.cloud/docs/tinymce/latest/autosave/index.md
+- **Case Change**: https://www.tiny.cloud/docs/tinymce/latest/casechange/index.md
+- **Character Map plugin**: https://www.tiny.cloud/docs/tinymce/latest/charmap/index.md
+- **Checklist plugin**: https://www.tiny.cloud/docs/tinymce/latest/checklist/index.md
+- **Code plugin**: https://www.tiny.cloud/docs/tinymce/latest/code/index.md
+- **Code Sample plugin**: https://www.tiny.cloud/docs/tinymce/latest/codesample/index.md
+- **Context**: https://www.tiny.cloud/docs/tinymce/latest/context/index.md
+- **Context forms**: https://www.tiny.cloud/docs/tinymce/latest/contextform/index.md
+- **Context menus**: https://www.tiny.cloud/docs/tinymce/latest/contextmenu/index.md
+- **Context toolbar**: https://www.tiny.cloud/docs/tinymce/latest/contexttoolbar/index.md
+- **Directionality plugin**: https://www.tiny.cloud/docs/tinymce/latest/directionality/index.md
+- **Emoticons plugin**: https://www.tiny.cloud/docs/tinymce/latest/emoticons/index.md
+- **Enhanced Code Editor plugin**: https://www.tiny.cloud/docs/tinymce/latest/advcode/index.md
+- **Enhanced Media Embed plugin**: https://www.tiny.cloud/docs/tinymce/latest/introduction-to-mediaembed/index.md
+- **Enhanced Tables plugin**: https://www.tiny.cloud/docs/tinymce/latest/advtable/index.md
+- **Footnotes plugin**: https://www.tiny.cloud/docs/tinymce/latest/footnotes/index.md
+- **Format Painter**: https://www.tiny.cloud/docs/tinymce/latest/formatpainter/index.md
+- **Full Page HTML Plugin**: https://www.tiny.cloud/docs/tinymce/latest/fullpagehtml/index.md
+- **Full Screen plugin**: https://www.tiny.cloud/docs/tinymce/latest/fullscreen/index.md
+- **Handling image uploads**: https://www.tiny.cloud/docs/tinymce/latest/upload-images/index.md
+- **Help plugin**: https://www.tiny.cloud/docs/tinymce/latest/help/index.md
+- **Image and file options**: https://www.tiny.cloud/docs/tinymce/latest/file-image-upload/index.md
+- **Image Editing**: https://www.tiny.cloud/docs/tinymce/latest/editimage/index.md
+- **Image plugin**: https://www.tiny.cloud/docs/tinymce/latest/image/index.md
+- **Import CSS plugin**: https://www.tiny.cloud/docs/tinymce/latest/importcss/index.md
+- **Import from Word plugin**: https://www.tiny.cloud/docs/tinymce/latest/importword/index.md
+- **Insert Date/Time plugin**: https://www.tiny.cloud/docs/tinymce/latest/insertdatetime/index.md
+- **Link Checker plugin**: https://www.tiny.cloud/docs/tinymce/latest/linkchecker/index.md
+- **Link plugin**: https://www.tiny.cloud/docs/tinymce/latest/link/index.md
+- **List Styles plugin**: https://www.tiny.cloud/docs/tinymce/latest/advlist/index.md
+- **Lists plugin**: https://www.tiny.cloud/docs/tinymce/latest/lists/index.md
+- **Markdown plugin**: https://www.tiny.cloud/docs/tinymce/latest/markdown/index.md
+- **Math plugin**: https://www.tiny.cloud/docs/tinymce/latest/math/index.md
+- **Media plugin**: https://www.tiny.cloud/docs/tinymce/latest/media/index.md
+- **Mentions plugin**: https://www.tiny.cloud/docs/tinymce/latest/mentions/index.md
+- **Merge Tags plugin**: https://www.tiny.cloud/docs/tinymce/latest/mergetags/index.md
+- **Nonbreaking Space plugin**: https://www.tiny.cloud/docs/tinymce/latest/nonbreaking/index.md
+- **Page Break plugin**: https://www.tiny.cloud/docs/tinymce/latest/pagebreak/index.md
+- **Page Embed plugin**: https://www.tiny.cloud/docs/tinymce/latest/pageembed/index.md
+- **Permanent Pen Plugin**: https://www.tiny.cloud/docs/tinymce/latest/permanentpen/index.md
+- **Plugins for TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/plugins/index.md
+- **Preview plugin**: https://www.tiny.cloud/docs/tinymce/latest/preview/index.md
+- **Quick Toolbars plugin**: https://www.tiny.cloud/docs/tinymce/latest/quickbars/index.md
+- **Save plugin**: https://www.tiny.cloud/docs/tinymce/latest/save/index.md
+- **Search and Replace plugin**: https://www.tiny.cloud/docs/tinymce/latest/searchreplace/index.md
+- **Table of Contents plugin**: https://www.tiny.cloud/docs/tinymce/latest/tableofcontents/index.md
+- **Table options**: https://www.tiny.cloud/docs/tinymce/latest/table-options/index.md
+- **Table plugin**: https://www.tiny.cloud/docs/tinymce/latest/table/index.md
+- **Templates plugin**: https://www.tiny.cloud/docs/tinymce/latest/advanced-templates/index.md
+- **Visual Blocks plugin**: https://www.tiny.cloud/docs/tinymce/latest/visualblocks/index.md
+- **Visual Characters plugin**: https://www.tiny.cloud/docs/tinymce/latest/visualchars/index.md
+- **Word Count plugin**: https://www.tiny.cloud/docs/tinymce/latest/wordcount/index.md
 
 #### Editor Modes
-- **Inline editor options**: https://www.tiny.cloud/docs/tinymce/latest/inline-editor-options/
-- **Setup inline editing mode**: https://www.tiny.cloud/docs/tinymce/latest/use-tinymce-inline/
-- **TinyMCE classic editing mode**: https://www.tiny.cloud/docs/tinymce/latest/use-tinymce-classic/
-- **TinyMCE distraction-free editing mode**: https://www.tiny.cloud/docs/tinymce/latest/use-tinymce-distraction-free/
+- **Inline editor options**: https://www.tiny.cloud/docs/tinymce/latest/inline-editor-options/index.md
+- **Setup inline editing mode**: https://www.tiny.cloud/docs/tinymce/latest/use-tinymce-inline/index.md
+- **TinyMCE classic editing mode**: https://www.tiny.cloud/docs/tinymce/latest/use-tinymce-classic/index.md
+- **TinyMCE distraction-free editing mode**: https://www.tiny.cloud/docs/tinymce/latest/use-tinymce-distraction-free/index.md
 
 #### Spell Checking
-- **Add Hunspell dictionaries to Spell Checker**: https://www.tiny.cloud/docs/tinymce/latest/self-hosting-hunspell/
-- **Adding custom dictionaries**: https://www.tiny.cloud/docs/tinymce/latest/custom-dictionaries-for-tiny-spellchecker/
-- **Deploy the TinyMCE Spelling server-side component using Docker**: https://www.tiny.cloud/docs/tinymce/latest/individual-spelling-container/
-- **Spell Checker plugin**: https://www.tiny.cloud/docs/tinymce/latest/introduction-to-tiny-spellchecker/
-- **Spelling Autocorrect plugin**: https://www.tiny.cloud/docs/tinymce/latest/autocorrect/
-- **Spelling options**: https://www.tiny.cloud/docs/tinymce/latest/spelling/
-- **Spelling service settings**: https://www.tiny.cloud/docs/tinymce/latest/configure-spelling-service/
+- **Add Hunspell dictionaries to Spell Checker**: https://www.tiny.cloud/docs/tinymce/latest/self-hosting-hunspell/index.md
+- **Adding custom dictionaries**: https://www.tiny.cloud/docs/tinymce/latest/custom-dictionaries-for-tiny-spellchecker/index.md
+- **Deploy the TinyMCE Spelling server-side component using Docker**: https://www.tiny.cloud/docs/tinymce/latest/individual-spelling-container/index.md
+- **Spell Checker plugin**: https://www.tiny.cloud/docs/tinymce/latest/introduction-to-tiny-spellchecker/index.md
+- **Spelling Autocorrect plugin**: https://www.tiny.cloud/docs/tinymce/latest/autocorrect/index.md
+- **Spelling options**: https://www.tiny.cloud/docs/tinymce/latest/spelling/index.md
+- **Spelling service settings**: https://www.tiny.cloud/docs/tinymce/latest/configure-spelling-service/index.md
 
 
 ### Premium Features
 
 #### AI Features
-- **AI Assistant plugin**: https://www.tiny.cloud/docs/tinymce/latest/ai/
-- **AI proxy server reference guide**: https://www.tiny.cloud/docs/tinymce/latest/ai-proxy/
-- **Amazon Bedrock integration guide**: https://www.tiny.cloud/docs/tinymce/latest/ai-bedrock/
-- **Azure AI integration guide**: https://www.tiny.cloud/docs/tinymce/latest/ai-azure/
-- **Google Gemini integration guide**: https://www.tiny.cloud/docs/tinymce/latest/ai-gemini/
-- **OpenAI ChatGPT integration guide**: https://www.tiny.cloud/docs/tinymce/latest/ai-openai/
-- **TinyMCE AI API Overview**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-api-overview/
-- **TinyMCE AI API Quick Start**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-api-quick-start/
-- **TinyMCE AI Chat**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-chat/
-- **TinyMCE AI Integration Options**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-integration-options/
-- **TinyMCE AI Introduction**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-introduction/
-- **TinyMCE AI JWT Authentication**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-jwt-authentication-intro/
-- **TinyMCE AI JWT Permissions**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-permissions/
-- **TinyMCE AI Limits**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-limits/
-- **TinyMCE AI Models**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-models/
-- **TinyMCE AI Plugin**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai/
-- **TinyMCE AI Quick Actions**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-actions/
-- **TinyMCE AI Review**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-review/
-- **TinyMCE AI Streaming**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-streaming/
-- **TinyMCE AI with JWT authentication (Node.js) Guide**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-with-jwt-authentication-nodejs/
-- **TinyMCE AI with JWT authentication (PHP) Guide**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-with-jwt-authentication-php/
+- **AI Assistant plugin (Legacy)**: https://www.tiny.cloud/docs/tinymce/latest/ai/index.md
+- **AI proxy server reference guide**: https://www.tiny.cloud/docs/tinymce/latest/ai-proxy/index.md
+- **Amazon Bedrock integration guide**: https://www.tiny.cloud/docs/tinymce/latest/ai-bedrock/index.md
+- **Azure AI integration guide**: https://www.tiny.cloud/docs/tinymce/latest/ai-azure/index.md
+- **Google Gemini integration guide**: https://www.tiny.cloud/docs/tinymce/latest/ai-gemini/index.md
+- **OpenAI ChatGPT integration guide**: https://www.tiny.cloud/docs/tinymce/latest/ai-openai/index.md
+- **TinyMCE AI API Overview**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-api-overview/index.md
+- **TinyMCE AI API Quick Start**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-api-quick-start/index.md
+- **TinyMCE AI Chat**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-chat/index.md
+- **TinyMCE AI Integration Options**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-integration-options/index.md
+- **TinyMCE AI Introduction**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-introduction/index.md
+- **TinyMCE AI JWT Authentication**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-jwt-authentication-intro/index.md
+- **TinyMCE AI JWT Permissions**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-permissions/index.md
+- **TinyMCE AI Limits**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-limits/index.md
+- **TinyMCE AI Models**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-models/index.md
+- **TinyMCE AI Plugin**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai/index.md
+- **TinyMCE AI Quick Actions**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-actions/index.md
+- **TinyMCE AI Review**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-review/index.md
+- **TinyMCE AI Streaming**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-streaming/index.md
+- **TinyMCE AI with JWT authentication (Node.js) Guide**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-with-jwt-authentication-nodejs/index.md
+- **TinyMCE AI with JWT authentication (PHP) Guide**: https://www.tiny.cloud/docs/tinymce/latest/tinymceai-with-jwt-authentication-php/index.md
 
 #### Comments & Collaboration
-- **Commands, Events and APIs for the Comments plugin**: https://www.tiny.cloud/docs/tinymce/latest/comments-commands-events-apis/
-- **Configuring the Comments plugin access option**: https://www.tiny.cloud/docs/tinymce/latest/comments-access-options/
-- **Configuring the Comments plugin in callback mode**: https://www.tiny.cloud/docs/tinymce/latest/comments-callback-mode/
-- **Configuring the Comments plugin in embedded mode**: https://www.tiny.cloud/docs/tinymce/latest/comments-embedded-mode/
-- **Configuring the Comments plugin with the Mentions plugin**: https://www.tiny.cloud/docs/tinymce/latest/comments-with-mentions/
-- **Introduction to Tiny Comments**: https://www.tiny.cloud/docs/tinymce/latest/introduction-to-tiny-comments/
-- **Revision History Plugin**: https://www.tiny.cloud/docs/tinymce/latest/revisionhistory/
-- **Suggested Edits Plugin**: https://www.tiny.cloud/docs/tinymce/latest/suggestededits/
-- **Toolbar buttons and menu items for the Comments plugin**: https://www.tiny.cloud/docs/tinymce/latest/comments-toolbars-menus/
-- **Using the Annotations API**: https://www.tiny.cloud/docs/tinymce/latest/annotations/
-- **Using TinyMCE Comments**: https://www.tiny.cloud/docs/tinymce/latest/comments-using-comments/
+- **Commands, Events and APIs for the Comments plugin**: https://www.tiny.cloud/docs/tinymce/latest/comments-commands-events-apis/index.md
+- **Configuring the Comments plugin access option**: https://www.tiny.cloud/docs/tinymce/latest/comments-access-options/index.md
+- **Configuring the Comments plugin in callback mode**: https://www.tiny.cloud/docs/tinymce/latest/comments-callback-mode/index.md
+- **Configuring the Comments plugin in embedded mode**: https://www.tiny.cloud/docs/tinymce/latest/comments-embedded-mode/index.md
+- **Configuring the Comments plugin with the Mentions plugin**: https://www.tiny.cloud/docs/tinymce/latest/comments-with-mentions/index.md
+- **Introduction to Tiny Comments**: https://www.tiny.cloud/docs/tinymce/latest/introduction-to-tiny-comments/index.md
+- **Revision History Plugin**: https://www.tiny.cloud/docs/tinymce/latest/revisionhistory/index.md
+- **Suggested Edits Plugin**: https://www.tiny.cloud/docs/tinymce/latest/suggestededits/index.md
+- **Toolbar buttons and menu items for the Comments plugin**: https://www.tiny.cloud/docs/tinymce/latest/comments-toolbars-menus/index.md
+- **Using the Annotations API**: https://www.tiny.cloud/docs/tinymce/latest/annotations/index.md
+- **Using TinyMCE Comments**: https://www.tiny.cloud/docs/tinymce/latest/comments-using-comments/index.md
 
 #### Export & Import
-- **Docx to HTML Converter API**: https://www.tiny.cloud/docs/tinymce/latest/docx-to-html-converter-api/
-- **Export to PDF plugin**: https://www.tiny.cloud/docs/tinymce/latest/exportpdf/
-- **Export to PDF with JWT authentication (Node.js) Guide (nodejs)**: https://www.tiny.cloud/docs/tinymce/latest/export-to-pdf-v2-with-jwt-authentication-nodejs/
-- **Export to PDF with JWT authentication (Node.js) Guide (nodejs)**: https://www.tiny.cloud/docs/tinymce/latest/export-to-pdf-with-jwt-authentication-nodejs/
-- **Export to PDF with JWT authentication (PHP) Guide (php)**: https://www.tiny.cloud/docs/tinymce/latest/export-to-pdf-v2-with-jwt-authentication-php/
-- **Export to PDF with JWT authentication (PHP) Guide (php)**: https://www.tiny.cloud/docs/tinymce/latest/export-to-pdf-with-jwt-authentication-php/
-- **Export to Word plugin**: https://www.tiny.cloud/docs/tinymce/latest/exportword/
-- **Export to Word Standalone Service**: https://www.tiny.cloud/docs/tinymce/latest/export-to-word-standalone-service/
-- **Export to Word with JWT authentication (Node.js) Guide**: https://www.tiny.cloud/docs/tinymce/latest/export-to-word-with-jwt-authentication-nodejs/
-- **Export to Word with JWT authentication (PHP) Guide**: https://www.tiny.cloud/docs/tinymce/latest/export-to-word-with-jwt-authentication-php/
-- **HTML to Docx Converter API**: https://www.tiny.cloud/docs/tinymce/latest/html-to-docx-converter-api/
-- **HTML to PDF Converter API (api)**: https://www.tiny.cloud/docs/tinymce/latest/html-to-pdf-converter-api/
-- **HTML to PDF Converter API (v2)**: https://www.tiny.cloud/docs/tinymce/latest/html-to-pdf-converter-api-v2/
-- **Import from Word Standalone Service**: https://www.tiny.cloud/docs/tinymce/latest/import-from-word-standalone-service/
-- **Import from Word with JWT authentication (Node.js) Guide**: https://www.tiny.cloud/docs/tinymce/latest/import-from-word-with-jwt-authentication-nodejs/
-- **Import from Word with JWT authentication (PHP) Guide**: https://www.tiny.cloud/docs/tinymce/latest/import-from-word-with-jwt-authentication-php/
+- **Docx to HTML Converter API**: https://www.tiny.cloud/docs/tinymce/latest/docx-to-html-converter-api/index.md
+- **Export to PDF plugin**: https://www.tiny.cloud/docs/tinymce/latest/exportpdf/index.md
+- **Export to PDF with JWT authentication (Node.js) Guide (nodejs)**: https://www.tiny.cloud/docs/tinymce/latest/export-to-pdf-v2-with-jwt-authentication-nodejs/index.md
+- **Export to PDF with JWT authentication (Node.js) Guide (nodejs)**: https://www.tiny.cloud/docs/tinymce/latest/export-to-pdf-with-jwt-authentication-nodejs/index.md
+- **Export to PDF with JWT authentication (PHP) Guide (php)**: https://www.tiny.cloud/docs/tinymce/latest/export-to-pdf-v2-with-jwt-authentication-php/index.md
+- **Export to PDF with JWT authentication (PHP) Guide (php)**: https://www.tiny.cloud/docs/tinymce/latest/export-to-pdf-with-jwt-authentication-php/index.md
+- **Export to Word plugin**: https://www.tiny.cloud/docs/tinymce/latest/exportword/index.md
+- **Export to Word Standalone Service**: https://www.tiny.cloud/docs/tinymce/latest/export-to-word-standalone-service/index.md
+- **Export to Word with JWT authentication (Node.js) Guide**: https://www.tiny.cloud/docs/tinymce/latest/export-to-word-with-jwt-authentication-nodejs/index.md
+- **Export to Word with JWT authentication (PHP) Guide**: https://www.tiny.cloud/docs/tinymce/latest/export-to-word-with-jwt-authentication-php/index.md
+- **HTML to Docx Converter API**: https://www.tiny.cloud/docs/tinymce/latest/html-to-docx-converter-api/index.md
+- **HTML to PDF Converter API (api)**: https://www.tiny.cloud/docs/tinymce/latest/html-to-pdf-converter-api/index.md
+- **HTML to PDF Converter API (v2)**: https://www.tiny.cloud/docs/tinymce/latest/html-to-pdf-converter-api-v2/index.md
+- **Import from Word Standalone Service**: https://www.tiny.cloud/docs/tinymce/latest/import-from-word-standalone-service/index.md
+- **Import from Word with JWT authentication (Node.js) Guide**: https://www.tiny.cloud/docs/tinymce/latest/import-from-word-with-jwt-authentication-nodejs/index.md
+- **Import from Word with JWT authentication (PHP) Guide**: https://www.tiny.cloud/docs/tinymce/latest/import-from-word-with-jwt-authentication-php/index.md
 
 #### PowerPaste
-- **Commands and Events for the PowerPaste plugin**: https://www.tiny.cloud/docs/tinymce/latest/powerpaste-commands-events-apis/
-- **Introduction to PowerPaste**: https://www.tiny.cloud/docs/tinymce/latest/introduction-to-powerpaste/
-- **Options for the PowerPaste plugin**: https://www.tiny.cloud/docs/tinymce/latest/powerpaste-options/
-- **Supported functionality for the PowerPaste plugin**: https://www.tiny.cloud/docs/tinymce/latest/powerpaste-support/
-- **Troubleshooting the PowerPaste plugin**: https://www.tiny.cloud/docs/tinymce/latest/powerpaste-troubleshooting/
+- **Commands and Events for the PowerPaste plugin**: https://www.tiny.cloud/docs/tinymce/latest/powerpaste-commands-events-apis/index.md
+- **Introduction to PowerPaste**: https://www.tiny.cloud/docs/tinymce/latest/introduction-to-powerpaste/index.md
+- **Options for the PowerPaste plugin**: https://www.tiny.cloud/docs/tinymce/latest/powerpaste-options/index.md
+- **Supported functionality for the PowerPaste plugin**: https://www.tiny.cloud/docs/tinymce/latest/powerpaste-support/index.md
+- **Troubleshooting the PowerPaste plugin**: https://www.tiny.cloud/docs/tinymce/latest/powerpaste-troubleshooting/index.md
 
 #### TinyDrive
-- **.Net Core**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-dotnet/
-- **Configuring the Tiny Drive UI**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-ui-options/
-- **Dropbox and Google Drive integration options**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-dropbox-and-google-drive/
-- **Dropbox integration**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-dropbox-integration/
-- **Getting started**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-getting-started/
-- **Google Drive integration**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-googledrive-integration/
-- **Introduction to the Tiny Drive plugin APIs**: https://www.tiny.cloud/docs/tinymce/latest/introduction-to-tinydrive-apis/
-- **Java Spring**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-java/
-- **Node.js**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-nodejs/
-- **PHP**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-php/
-- **Set up Tiny Drive JWT Authentication**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-jwt-authentication/
-- **Tiny Drive Browse API**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-browse/
-- **Tiny Drive Changelog**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-changelog/
-- **Tiny Drive Introduction**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-introduction/
-- **Tiny Drive Pick API**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-pick/
-- **Tiny Drive plugin setup options**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-setup-options/
-- **Tiny Drive TypeScript interfaces**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-type-interfaces/
-- **Tiny Drive Upload API**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-upload/
-- **Toolbar buttons and menu items for the Tiny Drive plugin**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-toolbars-menus/
+- **.Net Core**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-dotnet/index.md
+- **Configuring the Tiny Drive UI**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-ui-options/index.md
+- **Dropbox and Google Drive integration options**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-dropbox-and-google-drive/index.md
+- **Dropbox integration**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-dropbox-integration/index.md
+- **Getting started**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-getting-started/index.md
+- **Google Drive integration**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-googledrive-integration/index.md
+- **Introduction to the Tiny Drive plugin APIs**: https://www.tiny.cloud/docs/tinymce/latest/introduction-to-tinydrive-apis/index.md
+- **Java Spring**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-java/index.md
+- **Node.js**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-nodejs/index.md
+- **PHP**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-php/index.md
+- **Set up Tiny Drive JWT Authentication**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-jwt-authentication/index.md
+- **Tiny Drive Browse API**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-browse/index.md
+- **Tiny Drive Changelog**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-changelog/index.md
+- **Tiny Drive Introduction**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-introduction/index.md
+- **Tiny Drive Pick API**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-pick/index.md
+- **Tiny Drive plugin setup options**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-setup-options/index.md
+- **Tiny Drive TypeScript interfaces**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-type-interfaces/index.md
+- **Tiny Drive Upload API**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-upload/index.md
+- **Toolbar buttons and menu items for the Tiny Drive plugin**: https://www.tiny.cloud/docs/tinymce/latest/tinydrive-toolbars-menus/index.md
 
 #### Media Optimizer
-- **Media Optimizer**: https://www.tiny.cloud/docs/tinymce/latest/uploadcare/
-- **Media Optimizer (Files and Documents)**: https://www.tiny.cloud/docs/tinymce/latest/uploadcare-documents/
-- **Media Optimizer (Image)**: https://www.tiny.cloud/docs/tinymce/latest/uploadcare-image/
-- **Media Optimizer (Video)**: https://www.tiny.cloud/docs/tinymce/latest/uploadcare-video/
+- **Media Optimizer**: https://www.tiny.cloud/docs/tinymce/latest/uploadcare/index.md
+- **Media Optimizer (Files and Documents)**: https://www.tiny.cloud/docs/tinymce/latest/uploadcare-documents/index.md
+- **Media Optimizer (Image)**: https://www.tiny.cloud/docs/tinymce/latest/uploadcare-image/index.md
+- **Media Optimizer (Video)**: https://www.tiny.cloud/docs/tinymce/latest/uploadcare-video/index.md
 
 #### Services & Infrastructure
-- **Common server-side component settings**: https://www.tiny.cloud/docs/tinymce/latest/configure-common-settings-services/
-- **Configure Enhanced Media Embed Server**: https://www.tiny.cloud/docs/tinymce/latest/mediaembed-server-config/
-- **Creating a private/public key pair for Tiny Cloud**: https://www.tiny.cloud/docs/tinymce/latest/generate-rsa-key-pairs/
-- **Deploy the TinyMCE Export to PDF service server-side component using Docker (individually licensed)**: https://www.tiny.cloud/docs/tinymce/latest/individual-export-to-pdf-on-premises/
-- **Deploy the TinyMCE Hyperlinking server-side component using Docker**: https://www.tiny.cloud/docs/tinymce/latest/individual-hyperlinking-container/
-- **Deploy the TinyMCE Image Proxy service server-side component using Docker**: https://www.tiny.cloud/docs/tinymce/latest/individual-image-proxy-container/
-- **Deploy the TinyMCE Import from Word and Export to Word service server-side component using Docker (individually licensed)**: https://www.tiny.cloud/docs/tinymce/latest/individual-import-from-word-and-export-to-word-on-premises/
-- **Hyperlinking service settings**: https://www.tiny.cloud/docs/tinymce/latest/configure-hyperlink-service/
-- **Image Proxy service settings**: https://www.tiny.cloud/docs/tinymce/latest/configure-imageproxy-service/
-- **Integrate Enhanced Media Embed Server**: https://www.tiny.cloud/docs/tinymce/latest/mediaembed-server-integration/
-- **License key**: https://www.tiny.cloud/docs/tinymce/latest/license-key/
-- **Required configuration for the server-side components**: https://www.tiny.cloud/docs/tinymce/latest/configure-required-services/
-- **Troubleshoot server-side components**: https://www.tiny.cloud/docs/tinymce/latest/troubleshoot-server/
+- **Common server-side component settings**: https://www.tiny.cloud/docs/tinymce/latest/configure-common-settings-services/index.md
+- **Configure Enhanced Media Embed Server**: https://www.tiny.cloud/docs/tinymce/latest/mediaembed-server-config/index.md
+- **Creating a private/public key pair for Tiny Cloud**: https://www.tiny.cloud/docs/tinymce/latest/generate-rsa-key-pairs/index.md
+- **Deploy the TinyMCE Export to PDF service server-side component using Docker (individually licensed)**: https://www.tiny.cloud/docs/tinymce/latest/individual-export-to-pdf-on-premises/index.md
+- **Deploy the TinyMCE Hyperlinking server-side component using Docker**: https://www.tiny.cloud/docs/tinymce/latest/individual-hyperlinking-container/index.md
+- **Deploy the TinyMCE Image Proxy service server-side component using Docker**: https://www.tiny.cloud/docs/tinymce/latest/individual-image-proxy-container/index.md
+- **Deploy the TinyMCE Import from Word and Export to Word service server-side component using Docker (individually licensed)**: https://www.tiny.cloud/docs/tinymce/latest/individual-import-from-word-and-export-to-word-on-premises/index.md
+- **Hyperlinking service settings**: https://www.tiny.cloud/docs/tinymce/latest/configure-hyperlink-service/index.md
+- **Image Proxy service settings**: https://www.tiny.cloud/docs/tinymce/latest/configure-imageproxy-service/index.md
+- **Integrate Enhanced Media Embed Server**: https://www.tiny.cloud/docs/tinymce/latest/mediaembed-server-integration/index.md
+- **License key**: https://www.tiny.cloud/docs/tinymce/latest/license-key/index.md
+- **Required configuration for the server-side components**: https://www.tiny.cloud/docs/tinymce/latest/configure-required-services/index.md
+- **Troubleshoot server-side components**: https://www.tiny.cloud/docs/tinymce/latest/troubleshoot-server/index.md
 
 
 ### Customization & Development
 
 #### Creating Custom Components
-- **Create a plugin for TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/creating-a-plugin/
-- **Create a Skin for TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/creating-a-skin/
-- **Create an icon pack for TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/creating-an-icon-pack/
-- **Create custom notifications**: https://www.tiny.cloud/docs/tinymce/latest/creating-custom-notifications/
-- **Creating custom Basic toolbar buttons**: https://www.tiny.cloud/docs/tinymce/latest/custom-basic-toolbar-button/
-- **Creating custom dialogs**: https://www.tiny.cloud/docs/tinymce/latest/dialog/
-- **Creating custom Group toolbar buttons**: https://www.tiny.cloud/docs/tinymce/latest/custom-group-toolbar-button/
-- **Creating custom menu items**: https://www.tiny.cloud/docs/tinymce/latest/creating-custom-menu-items/
-- **Creating custom Menu toolbar buttons**: https://www.tiny.cloud/docs/tinymce/latest/custom-menu-toolbar-button/
-- **Creating custom Split toolbar buttons**: https://www.tiny.cloud/docs/tinymce/latest/custom-split-toolbar-button/
-- **Creating custom Toggle toolbar buttons**: https://www.tiny.cloud/docs/tinymce/latest/custom-toggle-toolbar-button/
-- **Custom Basic menu items**: https://www.tiny.cloud/docs/tinymce/latest/custom-basic-menu-items/
-- **Custom Icon Pack Demo**: https://www.tiny.cloud/docs/tinymce/latest/custom-icon-pack-demo/
-- **Custom Nested menu items**: https://www.tiny.cloud/docs/tinymce/latest/custom-nested-menu-items/
-- **Custom Toggle menu items**: https://www.tiny.cloud/docs/tinymce/latest/custom-toggle-menu-items/
-- **Custom view**: https://www.tiny.cloud/docs/tinymce/latest/custom-view/
-- **Customizing the editor UI**: https://www.tiny.cloud/docs/tinymce/latest/customize-ui/
-- **Toolbar buttons**: https://www.tiny.cloud/docs/tinymce/latest/custom-toolbarbuttons/
-- **User interface components**: https://www.tiny.cloud/docs/tinymce/latest/ui-components/
+- **Create a plugin for TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/creating-a-plugin/index.md
+- **Create a Skin for TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/creating-a-skin/index.md
+- **Create an icon pack for TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/creating-an-icon-pack/index.md
+- **Create custom notifications**: https://www.tiny.cloud/docs/tinymce/latest/creating-custom-notifications/index.md
+- **Creating custom Basic toolbar buttons**: https://www.tiny.cloud/docs/tinymce/latest/custom-basic-toolbar-button/index.md
+- **Creating custom dialogs**: https://www.tiny.cloud/docs/tinymce/latest/dialog/index.md
+- **Creating custom Group toolbar buttons**: https://www.tiny.cloud/docs/tinymce/latest/custom-group-toolbar-button/index.md
+- **Creating custom menu items**: https://www.tiny.cloud/docs/tinymce/latest/creating-custom-menu-items/index.md
+- **Creating custom Menu toolbar buttons**: https://www.tiny.cloud/docs/tinymce/latest/custom-menu-toolbar-button/index.md
+- **Creating custom Split toolbar buttons**: https://www.tiny.cloud/docs/tinymce/latest/custom-split-toolbar-button/index.md
+- **Creating custom Toggle toolbar buttons**: https://www.tiny.cloud/docs/tinymce/latest/custom-toggle-toolbar-button/index.md
+- **Custom Basic menu items**: https://www.tiny.cloud/docs/tinymce/latest/custom-basic-menu-items/index.md
+- **Custom Icon Pack Demo**: https://www.tiny.cloud/docs/tinymce/latest/custom-icon-pack-demo/index.md
+- **Custom Nested menu items**: https://www.tiny.cloud/docs/tinymce/latest/custom-nested-menu-items/index.md
+- **Custom Toggle menu items**: https://www.tiny.cloud/docs/tinymce/latest/custom-toggle-menu-items/index.md
+- **Custom view**: https://www.tiny.cloud/docs/tinymce/latest/custom-view/index.md
+- **Customizing the editor UI**: https://www.tiny.cloud/docs/tinymce/latest/customize-ui/index.md
+- **Toolbar buttons**: https://www.tiny.cloud/docs/tinymce/latest/custom-toolbarbuttons/index.md
+- **User interface components**: https://www.tiny.cloud/docs/tinymce/latest/ui-components/index.md
 
 #### Bundling & Build Tools
-- **Bundling a .zip version of TinyMCE with CommonJS and Browserify**: https://www.tiny.cloud/docs/tinymce/latest/browserify-cjs-download/
-- **Bundling a .zip version of TinyMCE with CommonJS and Webpack**: https://www.tiny.cloud/docs/tinymce/latest/webpack-cjs-download/
-- **Bundling a .zip version of TinyMCE with ES6 and Rollup.js**: https://www.tiny.cloud/docs/tinymce/latest/rollup-es6-download/
-- **Bundling a .zip version of TinyMCE with ES6 and Webpack**: https://www.tiny.cloud/docs/tinymce/latest/webpack-es6-download/
-- **Bundling an NPM version of TinyMCE with CommonJS and Browserify**: https://www.tiny.cloud/docs/tinymce/latest/browserify-cjs-npm/
-- **Bundling an NPM version of TinyMCE with ES6 and Rollup.js**: https://www.tiny.cloud/docs/tinymce/latest/rollup-es6-npm/
-- **Bundling the User Interface localizations for TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/bundling-localization/
-- **Bundling TinyMCE - Overview**: https://www.tiny.cloud/docs/tinymce/latest/bundling-guide/
-- **Bundling TinyMCE content CSS using module loading**: https://www.tiny.cloud/docs/tinymce/latest/bundling-content-css/
-- **Bundling TinyMCE from NPM using Webpack and CommonJS**: https://www.tiny.cloud/docs/tinymce/latest/webpack-cjs-npm/
-- **Bundling TinyMCE from NPM with ES6 and Vite**: https://www.tiny.cloud/docs/tinymce/latest/vite-es6-npm/
-- **Bundling TinyMCE from NPM with Webpack using ES6 modules**: https://www.tiny.cloud/docs/tinymce/latest/webpack-es6-npm/
-- **Bundling TinyMCE icon packs using module loading**: https://www.tiny.cloud/docs/tinymce/latest/bundling-icons/
-- **Bundling TinyMCE models using module loading**: https://www.tiny.cloud/docs/tinymce/latest/bundling-models/
-- **Bundling TinyMCE plugins using module loading**: https://www.tiny.cloud/docs/tinymce/latest/bundling-plugins/
-- **Bundling TinyMCE skins using module loading**: https://www.tiny.cloud/docs/tinymce/latest/bundling-skins/
-- **Bundling TinyMCE themes using module loading**: https://www.tiny.cloud/docs/tinymce/latest/bundling-themes/
-- **Introduction and initial setup for containerized server-side services from the premium self-hosted bundles**: https://www.tiny.cloud/docs/tinymce/latest/bundle-intro-setup/
-- **Introduction to bundling TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/introduction-to-bundling-tinymce/
+- **Bundling a .zip version of TinyMCE with CommonJS and Browserify**: https://www.tiny.cloud/docs/tinymce/latest/browserify-cjs-download/index.md
+- **Bundling a .zip version of TinyMCE with CommonJS and Webpack**: https://www.tiny.cloud/docs/tinymce/latest/webpack-cjs-download/index.md
+- **Bundling a .zip version of TinyMCE with ES6 and Rollup.js**: https://www.tiny.cloud/docs/tinymce/latest/rollup-es6-download/index.md
+- **Bundling a .zip version of TinyMCE with ES6 and Webpack**: https://www.tiny.cloud/docs/tinymce/latest/webpack-es6-download/index.md
+- **Bundling an NPM version of TinyMCE with CommonJS and Browserify**: https://www.tiny.cloud/docs/tinymce/latest/browserify-cjs-npm/index.md
+- **Bundling an NPM version of TinyMCE with ES6 and Rollup.js**: https://www.tiny.cloud/docs/tinymce/latest/rollup-es6-npm/index.md
+- **Bundling the User Interface localizations for TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/bundling-localization/index.md
+- **Bundling TinyMCE - Overview**: https://www.tiny.cloud/docs/tinymce/latest/bundling-guide/index.md
+- **Bundling TinyMCE content CSS using module loading**: https://www.tiny.cloud/docs/tinymce/latest/bundling-content-css/index.md
+- **Bundling TinyMCE from NPM using Webpack and CommonJS**: https://www.tiny.cloud/docs/tinymce/latest/webpack-cjs-npm/index.md
+- **Bundling TinyMCE from NPM with ES6 and Vite**: https://www.tiny.cloud/docs/tinymce/latest/vite-es6-npm/index.md
+- **Bundling TinyMCE from NPM with Webpack using ES6 modules**: https://www.tiny.cloud/docs/tinymce/latest/webpack-es6-npm/index.md
+- **Bundling TinyMCE icon packs using module loading**: https://www.tiny.cloud/docs/tinymce/latest/bundling-icons/index.md
+- **Bundling TinyMCE models using module loading**: https://www.tiny.cloud/docs/tinymce/latest/bundling-models/index.md
+- **Bundling TinyMCE plugins using module loading**: https://www.tiny.cloud/docs/tinymce/latest/bundling-plugins/index.md
+- **Bundling TinyMCE skins using module loading**: https://www.tiny.cloud/docs/tinymce/latest/bundling-skins/index.md
+- **Bundling TinyMCE themes using module loading**: https://www.tiny.cloud/docs/tinymce/latest/bundling-themes/index.md
+- **Introduction and initial setup for containerized server-side services from the premium self-hosted bundles**: https://www.tiny.cloud/docs/tinymce/latest/bundle-intro-setup/index.md
+- **Introduction to bundling TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/introduction-to-bundling-tinymce/index.md
 
 #### Enhanced Skins & Icons
-- **Enhanced Skins & Icon Packs**: https://www.tiny.cloud/docs/tinymce/latest/enhanced-skins-and-icon-packs/
-- **Using the icon pack template tool**: https://www.tiny.cloud/docs/tinymce/latest/using-the-icon-pack-template/
+- **Enhanced Skins & Icon Packs**: https://www.tiny.cloud/docs/tinymce/latest/enhanced-skins-and-icon-packs/index.md
+- **Using the icon pack template tool**: https://www.tiny.cloud/docs/tinymce/latest/using-the-icon-pack-template/index.md
 
 
 ### API Reference
 
 #### Core APIs
-- **tinymce**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.root/
-- **tinymce.AddOnManager**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.addonmanager/
-- **tinymce.Editor**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.editor/
-- **tinymce.editor.ui.Registry**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.editor.ui.registry/
-- **tinymce.editor.ui.Ui**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.editor.ui.ui/
-- **tinymce.EditorManager**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.editormanager/
-- **tinymce.EditorMode**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.editormode/
-- **tinymce.EditorOptions**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.editoroptions/
-- **tinymce.EditorUpload**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.editorupload/
-- **tinymce.Plugin**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.plugin/
-- **tinymce.Theme**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.theme/
+- **tinymce**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.root/index.md
+- **tinymce.AddOnManager**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.addonmanager/index.md
+- **tinymce.Editor**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.editor/index.md
+- **tinymce.editor.ui.Registry**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.editor.ui.registry/index.md
+- **tinymce.editor.ui.Ui**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.editor.ui.ui/index.md
+- **tinymce.EditorManager**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.editormanager/index.md
+- **tinymce.EditorMode**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.editormode/index.md
+- **tinymce.EditorOptions**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.editoroptions/index.md
+- **tinymce.EditorUpload**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.editorupload/index.md
+- **tinymce.Plugin**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.plugin/index.md
+- **tinymce.Theme**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.theme/index.md
 
 #### UI APIs
-- **tinymce.NotificationManager**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.notificationmanager/
-- **tinymce.Shortcuts**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.shortcuts/
-- **tinymce.WindowManager**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.windowmanager/
+- **tinymce.NotificationManager**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.notificationmanager/index.md
+- **tinymce.Shortcuts**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.shortcuts/index.md
+- **tinymce.WindowManager**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.windowmanager/index.md
 
 #### Utility APIs
-- **tinymce.Annotator**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.annotator/
-- **tinymce.Env**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.env/
-- **tinymce.Event**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.event/
-- **tinymce.FakeClipboard**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.fakeclipboard/
-- **tinymce.Formatter**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.formatter/
-- **tinymce.UndoManager**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.undomanager/
-- **tinymce.UserLookup**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.userlookup/
-- **tinymce.util.Delay**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.util.delay/
-- **tinymce.util.EventDispatcher**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.util.eventdispatcher/
-- **tinymce.util.I18n**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.util.i18n/
-- **tinymce.util.ImageUploader**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.util.imageuploader/
-- **tinymce.util.Observable**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.util.observable/
-- **tinymce.util.Tools**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.util.tools/
-- **tinymce.util.URI**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.util.uri/
+- **tinymce.Annotator**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.annotator/index.md
+- **tinymce.Env**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.env/index.md
+- **tinymce.Event**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.event/index.md
+- **tinymce.FakeClipboard**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.fakeclipboard/index.md
+- **tinymce.Formatter**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.formatter/index.md
+- **tinymce.UndoManager**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.undomanager/index.md
+- **tinymce.UserLookup**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.userlookup/index.md
+- **tinymce.util.Delay**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.util.delay/index.md
+- **tinymce.util.EventDispatcher**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.util.eventdispatcher/index.md
+- **tinymce.util.I18n**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.util.i18n/index.md
+- **tinymce.util.ImageUploader**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.util.imageuploader/index.md
+- **tinymce.util.Observable**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.util.observable/index.md
+- **tinymce.util.Tools**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.util.tools/index.md
+- **tinymce.util.URI**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.util.uri/index.md
 
 #### DOM APIs
-- **tinymce.dom.BookmarkManager**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.dom.bookmarkmanager/
-- **tinymce.dom.DOMUtils**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.dom.domutils/
-- **tinymce.dom.EventUtils**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.dom.eventutils/
-- **tinymce.dom.RangeUtils**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.dom.rangeutils/
-- **tinymce.dom.ScriptLoader**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.dom.scriptloader/
-- **tinymce.dom.Selection**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.dom.selection/
-- **tinymce.dom.Serializer**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.dom.serializer/
-- **tinymce.dom.StyleSheetLoader**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.dom.stylesheetloader/
-- **tinymce.dom.TextSeeker**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.dom.textseeker/
-- **tinymce.dom.TreeWalker**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.dom.treewalker/
+- **tinymce.dom.BookmarkManager**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.dom.bookmarkmanager/index.md
+- **tinymce.dom.DOMUtils**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.dom.domutils/index.md
+- **tinymce.dom.EventUtils**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.dom.eventutils/index.md
+- **tinymce.dom.RangeUtils**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.dom.rangeutils/index.md
+- **tinymce.dom.ScriptLoader**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.dom.scriptloader/index.md
+- **tinymce.dom.Selection**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.dom.selection/index.md
+- **tinymce.dom.Serializer**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.dom.serializer/index.md
+- **tinymce.dom.StyleSheetLoader**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.dom.stylesheetloader/index.md
+- **tinymce.dom.TextSeeker**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.dom.textseeker/index.md
+- **tinymce.dom.TreeWalker**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.dom.treewalker/index.md
 
 #### HTML APIs
-- **tinymce.html.DomParser**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.html.domparser/
-- **tinymce.html.Entities**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.html.entities/
-- **tinymce.html.Node**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.html.node/
-- **tinymce.html.Schema**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.html.schema/
-- **tinymce.html.Serializer**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.html.serializer/
-- **tinymce.html.Styles**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.html.styles/
-- **tinymce.html.Writer**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.html.writer/
+- **tinymce.html.DomParser**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.html.domparser/index.md
+- **tinymce.html.Entities**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.html.entities/index.md
+- **tinymce.html.Node**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.html.node/index.md
+- **tinymce.html.Schema**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.html.schema/index.md
+- **tinymce.html.Serializer**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.html.serializer/index.md
+- **tinymce.html.Styles**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.html.styles/index.md
+- **tinymce.html.Writer**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.html.writer/index.md
 
 #### Geometry APIs
-- **tinymce.geom.Rect**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.geom.rect/
+- **tinymce.geom.Rect**: https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.geom.rect/index.md
 
 
 ### Migration Guides
 
-- **Migrating from Froala to TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/migration-from-froala/
-- **Migrating from TinyMCE 4 to TinyMCE 8**: https://www.tiny.cloud/docs/tinymce/latest/migration-from-4x-to-8x/
-- **Migrating from TinyMCE 5 to TinyMCE 8**: https://www.tiny.cloud/docs/tinymce/latest/migration-from-5x-to-8x/
-- **Migrating from TinyMCE 6 to TinyMCE 8**: https://www.tiny.cloud/docs/tinymce/latest/migration-from-6x-to-8x/
-- **Migrating from TinyMCE 7 to TinyMCE 8**: https://www.tiny.cloud/docs/tinymce/latest/migration-from-7x/
-- **TinyMCE Migration Guides**: https://www.tiny.cloud/docs/tinymce/latest/migration-guides/
-- **Upgrading TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/upgrading/
+- **Migrating from Froala to TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/migration-from-froala/index.md
+- **Migrating from TinyMCE 4 to TinyMCE 8**: https://www.tiny.cloud/docs/tinymce/latest/migration-from-4x-to-8x/index.md
+- **Migrating from TinyMCE 5 to TinyMCE 8**: https://www.tiny.cloud/docs/tinymce/latest/migration-from-5x-to-8x/index.md
+- **Migrating from TinyMCE 6 to TinyMCE 8**: https://www.tiny.cloud/docs/tinymce/latest/migration-from-6x-to-8x/index.md
+- **Migrating from TinyMCE 7 to TinyMCE 8**: https://www.tiny.cloud/docs/tinymce/latest/migration-from-7x/index.md
+- **TinyMCE Migration Guides**: https://www.tiny.cloud/docs/tinymce/latest/migration-guides/index.md
+- **Upgrading TinyMCE**: https://www.tiny.cloud/docs/tinymce/latest/upgrading/index.md
 
 
 ### Examples & Demos
 
-- **Basic example**: https://www.tiny.cloud/docs/tinymce/latest/basic-example/
-- **Borderless skin demo**: https://www.tiny.cloud/docs/tinymce/latest/borderless-demo/
-- **Classic editor example**: https://www.tiny.cloud/docs/tinymce/latest/classic-demo/
-- **Distraction-free editor example**: https://www.tiny.cloud/docs/tinymce/latest/distraction-free-demo/
-- **Fabric skin demo**: https://www.tiny.cloud/docs/tinymce/latest/fabric-demo/
-- **Fluent skin demo**: https://www.tiny.cloud/docs/tinymce/latest/fluent-demo/
-- **Full featured demo: Including Premium Plugins**: https://www.tiny.cloud/docs/tinymce/latest/full-featured-premium-demo/
-- **Full featured demo: Non-Premium Plugins only**: https://www.tiny.cloud/docs/tinymce/latest/full-featured-open-source-demo/
-- **How To Guides**: https://www.tiny.cloud/docs/tinymce/latest/how-to-guides/
-- **Inline editor example**: https://www.tiny.cloud/docs/tinymce/latest/inline-demo/
-- **Jam icons pack demo**: https://www.tiny.cloud/docs/tinymce/latest/jam-demo/
-- **Material Classic skin demo**: https://www.tiny.cloud/docs/tinymce/latest/material-classic-demo/
-- **Material Outline skin demo**: https://www.tiny.cloud/docs/tinymce/latest/material-outline-demo/
-- **Naked skin demo**: https://www.tiny.cloud/docs/tinymce/latest/naked-demo/
-- **Outside skin demo**: https://www.tiny.cloud/docs/tinymce/latest/outside-demo/
-- **Small icons pack demo**: https://www.tiny.cloud/docs/tinymce/latest/small-demo/
-- **Snow skin demo**: https://www.tiny.cloud/docs/tinymce/latest/snow-demo/
-- **TinyMCE 8 examples**: https://www.tiny.cloud/docs/tinymce/latest/examples/
+- **Basic example**: https://www.tiny.cloud/docs/tinymce/latest/basic-example/index.md
+- **Borderless skin demo**: https://www.tiny.cloud/docs/tinymce/latest/borderless-demo/index.md
+- **Classic editor example**: https://www.tiny.cloud/docs/tinymce/latest/classic-demo/index.md
+- **Distraction-free editor example**: https://www.tiny.cloud/docs/tinymce/latest/distraction-free-demo/index.md
+- **Fabric skin demo**: https://www.tiny.cloud/docs/tinymce/latest/fabric-demo/index.md
+- **Fluent skin demo**: https://www.tiny.cloud/docs/tinymce/latest/fluent-demo/index.md
+- **Full featured demo: Including Premium Plugins**: https://www.tiny.cloud/docs/tinymce/latest/full-featured-premium-demo/index.md
+- **Full featured demo: Non-Premium Plugins only**: https://www.tiny.cloud/docs/tinymce/latest/full-featured-open-source-demo/index.md
+- **How To Guides**: https://www.tiny.cloud/docs/tinymce/latest/how-to-guides/index.md
+- **Inline editor example**: https://www.tiny.cloud/docs/tinymce/latest/inline-demo/index.md
+- **Jam icons pack demo**: https://www.tiny.cloud/docs/tinymce/latest/jam-demo/index.md
+- **Material Classic skin demo**: https://www.tiny.cloud/docs/tinymce/latest/material-classic-demo/index.md
+- **Material Outline skin demo**: https://www.tiny.cloud/docs/tinymce/latest/material-outline-demo/index.md
+- **Naked skin demo**: https://www.tiny.cloud/docs/tinymce/latest/naked-demo/index.md
+- **Outside skin demo**: https://www.tiny.cloud/docs/tinymce/latest/outside-demo/index.md
+- **Small icons pack demo**: https://www.tiny.cloud/docs/tinymce/latest/small-demo/index.md
+- **Snow skin demo**: https://www.tiny.cloud/docs/tinymce/latest/snow-demo/index.md
+- **TinyMCE 8 examples**: https://www.tiny.cloud/docs/tinymce/latest/examples/index.md
 
 
 ### Release Information
 
-- **Changelog**: https://www.tiny.cloud/docs/tinymce/latest/changelog/
-- **Release notes for TinyMCE 8**: https://www.tiny.cloud/docs/tinymce/latest/release-notes/
-- **TinyMCE 8.0.0**: https://www.tiny.cloud/docs/tinymce/latest/8.0-release-notes/
-- **TinyMCE 8.0.1**: https://www.tiny.cloud/docs/tinymce/latest/8.0.1-release-notes/
-- **TinyMCE 8.0.2**: https://www.tiny.cloud/docs/tinymce/latest/8.0.2-release-notes/
-- **TinyMCE 8.1**: https://www.tiny.cloud/docs/tinymce/latest/8.1.0-release-notes/
-- **TinyMCE 8.1.1**: https://www.tiny.cloud/docs/tinymce/latest/8.1.1-release-notes/
-- **TinyMCE 8.1.2**: https://www.tiny.cloud/docs/tinymce/latest/8.1.2-release-notes/
-- **TinyMCE 8.2.0**: https://www.tiny.cloud/docs/tinymce/latest/8.2.0-release-notes/
-- **TinyMCE 8.2.1**: https://www.tiny.cloud/docs/tinymce/latest/8.2.1-release-notes/
-- **TinyMCE 8.2.2**: https://www.tiny.cloud/docs/tinymce/latest/8.2.2-release-notes/
-- **TinyMCE 8.3.0**: https://www.tiny.cloud/docs/tinymce/latest/8.3.0-release-notes/
-- **TinyMCE 8.3.1**: https://www.tiny.cloud/docs/tinymce/latest/8.3.1-release-notes/
-- **TinyMCE 8.3.2**: https://www.tiny.cloud/docs/tinymce/latest/8.3.2-release-notes/
-- **TinyMCE 8.4.0**: https://www.tiny.cloud/docs/tinymce/latest/8.4.0-release-notes/
+- **Changelog**: https://www.tiny.cloud/docs/tinymce/latest/changelog/index.md
+- **Release notes for TinyMCE 8**: https://www.tiny.cloud/docs/tinymce/latest/release-notes/index.md
+- **TinyMCE 8.0.0**: https://www.tiny.cloud/docs/tinymce/latest/8.0-release-notes/index.md
+- **TinyMCE 8.0.1**: https://www.tiny.cloud/docs/tinymce/latest/8.0.1-release-notes/index.md
+- **TinyMCE 8.0.2**: https://www.tiny.cloud/docs/tinymce/latest/8.0.2-release-notes/index.md
+- **TinyMCE 8.1**: https://www.tiny.cloud/docs/tinymce/latest/8.1.0-release-notes/index.md
+- **TinyMCE 8.1.1**: https://www.tiny.cloud/docs/tinymce/latest/8.1.1-release-notes/index.md
+- **TinyMCE 8.1.2**: https://www.tiny.cloud/docs/tinymce/latest/8.1.2-release-notes/index.md
+- **TinyMCE 8.2.0**: https://www.tiny.cloud/docs/tinymce/latest/8.2.0-release-notes/index.md
+- **TinyMCE 8.2.1**: https://www.tiny.cloud/docs/tinymce/latest/8.2.1-release-notes/index.md
+- **TinyMCE 8.2.2**: https://www.tiny.cloud/docs/tinymce/latest/8.2.2-release-notes/index.md
+- **TinyMCE 8.3.0**: https://www.tiny.cloud/docs/tinymce/latest/8.3.0-release-notes/index.md
+- **TinyMCE 8.3.1**: https://www.tiny.cloud/docs/tinymce/latest/8.3.1-release-notes/index.md
+- **TinyMCE 8.3.2**: https://www.tiny.cloud/docs/tinymce/latest/8.3.2-release-notes/index.md
+- **TinyMCE 8.4.0**: https://www.tiny.cloud/docs/tinymce/latest/8.4.0-release-notes/index.md
 
 
 ### Accessibility & Security
 
-- **Accessibility options**: https://www.tiny.cloud/docs/tinymce/latest/accessibility/
-- **Accessible navigation guide**: https://www.tiny.cloud/docs/tinymce/latest/tinymce-and-screenreaders/
-- **Custom Keyboard Shortcuts**: https://www.tiny.cloud/docs/tinymce/latest/shortcuts/
-- **Security guide**: https://www.tiny.cloud/docs/tinymce/latest/security/
-- **TinyMCE for Touch-Enabled and Mobile Devices**: https://www.tiny.cloud/docs/tinymce/latest/tinymce-for-mobile/
-- **TinyMCE Keyboard shortcuts**: https://www.tiny.cloud/docs/tinymce/latest/keyboard-shortcuts/
+- **Accessibility options**: https://www.tiny.cloud/docs/tinymce/latest/accessibility/index.md
+- **Accessible navigation guide**: https://www.tiny.cloud/docs/tinymce/latest/tinymce-and-screenreaders/index.md
+- **Custom Keyboard Shortcuts**: https://www.tiny.cloud/docs/tinymce/latest/shortcuts/index.md
+- **Security guide**: https://www.tiny.cloud/docs/tinymce/latest/security/index.md
+- **TinyMCE for Touch-Enabled and Mobile Devices**: https://www.tiny.cloud/docs/tinymce/latest/tinymce-for-mobile/index.md
+- **TinyMCE Keyboard shortcuts**: https://www.tiny.cloud/docs/tinymce/latest/keyboard-shortcuts/index.md
 
 
 ### Support & Resources
 
-- **Premium upgrade promotion**: https://www.tiny.cloud/docs/tinymce/latest/promotions/
-- **Support**: https://www.tiny.cloud/docs/tinymce/latest/support/
+- **Premium upgrade promotion**: https://www.tiny.cloud/docs/tinymce/latest/promotions/index.md
+- **Support**: https://www.tiny.cloud/docs/tinymce/latest/support/index.md
 
 
 ### Legacy & Other
 
-- **Interactive integration example**: https://www.tiny.cloud/docs/tinymce/latest/ie-template-creation/
-- **MoxieManager plugin**: https://www.tiny.cloud/docs/tinymce/latest/moxiemanager/
+- **Interactive integration example**: https://www.tiny.cloud/docs/tinymce/latest/ie-template-creation/index.md
+- **MoxieManager plugin**: https://www.tiny.cloud/docs/tinymce/latest/moxiemanager/index.md
 
 
 ### Other
 
-- **Adding or changing the editor content CSS**: https://www.tiny.cloud/docs/tinymce/latest/add-css-options/
-- **Autocompleter**: https://www.tiny.cloud/docs/tinymce/latest/autocompleter/
-- **Changing user formatting controls**: https://www.tiny.cloud/docs/tinymce/latest/user-formatting-options/
-- **Copy & paste options**: https://www.tiny.cloud/docs/tinymce/latest/copy-and-paste/
-- **Creating custom URL dialogs**: https://www.tiny.cloud/docs/tinymce/latest/urldialog/
-- **Custom sidebar**: https://www.tiny.cloud/docs/tinymce/latest/customsidebar/
-- **Inline CSS plugin**: https://www.tiny.cloud/docs/tinymce/latest/inline-css/
-- **Localization options**: https://www.tiny.cloud/docs/tinymce/latest/ui-localization/
-- **Non-editable content**: https://www.tiny.cloud/docs/tinymce/latest/non-editable-content-options/
-- **TinyMCE 8 Documentation**: https://www.tiny.cloud/docs/tinymce/latest/
-- **User Lookup API**: https://www.tiny.cloud/docs/tinymce/latest/userlookup/
+- **Adding or changing the editor content CSS**: https://www.tiny.cloud/docs/tinymce/latest/add-css-options/index.md
+- **Autocompleter**: https://www.tiny.cloud/docs/tinymce/latest/autocompleter/index.md
+- **Changing user formatting controls**: https://www.tiny.cloud/docs/tinymce/latest/user-formatting-options/index.md
+- **Copy & paste options**: https://www.tiny.cloud/docs/tinymce/latest/copy-and-paste/index.md
+- **Creating custom URL dialogs**: https://www.tiny.cloud/docs/tinymce/latest/urldialog/index.md
+- **Custom sidebar**: https://www.tiny.cloud/docs/tinymce/latest/customsidebar/index.md
+- **Inline CSS plugin**: https://www.tiny.cloud/docs/tinymce/latest/inline-css/index.md
+- **Localization options**: https://www.tiny.cloud/docs/tinymce/latest/ui-localization/index.md
+- **Non-editable content**: https://www.tiny.cloud/docs/tinymce/latest/non-editable-content-options/index.md
+- **TinyMCE 8 Documentation**: https://www.tiny.cloud/docs/tinymce/latest/index.md
+- **User Lookup API**: https://www.tiny.cloud/docs/tinymce/latest/userlookup/index.md
 

--- a/modules/ROOT/attachments/llms.txt
+++ b/modules/ROOT/attachments/llms.txt
@@ -8,15 +8,15 @@ TinyMCE is a powerful, flexible WYSIWYG rich text editor that can be integrated 
 
 ## Getting Started
 
-- [Getting Started](https://www.tiny.cloud/docs/tinymce/latest/getting-started/): Overview and introduction to TinyMCE
-- [Introduction to TinyMCE](https://www.tiny.cloud/docs/tinymce/latest/introduction-to-tinymce/): What is TinyMCE and how to add it to your project
-- [Installation](https://www.tiny.cloud/docs/tinymce/latest/installation/): Installation options and methods
+- [Getting Started](https://www.tiny.cloud/docs/tinymce/latest/getting-started/index.md): Overview and introduction to TinyMCE
+- [Introduction to TinyMCE](https://www.tiny.cloud/docs/tinymce/latest/introduction-to-tinymce/index.md): What is TinyMCE and how to add it to your project
+- [Installation](https://www.tiny.cloud/docs/tinymce/latest/installation/index.md): Installation options and methods
 
 ### Quick Start Guides
 
-- [Cloud Quick Start](https://www.tiny.cloud/docs/tinymce/latest/cloud-quick-start/): Get started with Tiny Cloud CDN (recommended)
-- [NPM Quick Start](https://www.tiny.cloud/docs/tinymce/latest/npm-projects/): Install via npm, yarn, or pnpm
-- [ZIP Quick Start](https://www.tiny.cloud/docs/tinymce/latest/zip-install/): Download and install from ZIP archive
+- [Cloud Quick Start](https://www.tiny.cloud/docs/tinymce/latest/cloud-quick-start/index.md): Get started with Tiny Cloud CDN (recommended)
+- [NPM Quick Start](https://www.tiny.cloud/docs/tinymce/latest/npm-projects/index.md): Install via npm, yarn, or pnpm
+- [ZIP Quick Start](https://www.tiny.cloud/docs/tinymce/latest/zip-install/index.md): Download and install from ZIP archive
 
 ## Integration Guides
 
@@ -76,46 +76,73 @@ function App() {
 
 ## Key Configuration
 
-- [Basic Setup](https://www.tiny.cloud/docs/tinymce/latest/basic-setup/): Essential configuration options
-- [Content Filtering](https://www.tiny.cloud/docs/tinymce/latest/filter-content/): Control HTML output
-- [Localization](https://www.tiny.cloud/docs/tinymce/latest/localize-your-language/): Multi-language support
-- [Spell Checking](https://www.tiny.cloud/docs/tinymce/latest/spell-checking/): Enable spell checking
-- [Cloud Deployment Guide](https://www.tiny.cloud/docs/tinymce/latest/cloud-deployment-guide/): Configure Tiny Cloud
+- [Basic Setup](https://www.tiny.cloud/docs/tinymce/latest/basic-setup/index.md): Essential configuration options
+- [Content Filtering](https://www.tiny.cloud/docs/tinymce/latest/filter-content/index.md): Control HTML output
+- [Localization](https://www.tiny.cloud/docs/tinymce/latest/localize-your-language/index.md): Multi-language support
+- [Spell Checking](https://www.tiny.cloud/docs/tinymce/latest/spell-checking/index.md): Enable spell checking
+- [Cloud Deployment Guide](https://www.tiny.cloud/docs/tinymce/latest/cloud-deployment-guide/index.md): Configure Tiny Cloud
 
 ## Plugins & Features
 
-- [Plugins Overview](https://www.tiny.cloud/docs/tinymce/latest/plugins/): Available plugins and features
-- [Table Plugin](https://www.tiny.cloud/docs/tinymce/latest/table/): Table editing capabilities
-- [Image Plugin](https://www.tiny.cloud/docs/tinymce/latest/image/): Image handling and editing
-- [Link Plugin](https://www.tiny.cloud/docs/tinymce/latest/link/): Link management
+- [Plugins Overview](https://www.tiny.cloud/docs/tinymce/latest/plugins/index.md): Available plugins and features
+- [Table Plugin](https://www.tiny.cloud/docs/tinymce/latest/table/index.md): Table editing capabilities
+- [Image Plugin](https://www.tiny.cloud/docs/tinymce/latest/image/index.md): Image handling and editing
+- [Link Plugin](https://www.tiny.cloud/docs/tinymce/latest/link/index.md): Link management
 
 ## TinyMCE AI (Premium)
 
 TinyMCE AI (`tinymceai` plugin) is the current AI writing assistant for TinyMCE. It provides chat, review, and quick actions powered by multiple LLM providers. The earlier AI Assistant (`ai` plugin) is legacy; new integrations should use TinyMCE AI.
 
-- [TinyMCE AI Introduction](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-introduction/): Overview of TinyMCE AI features and capabilities
-- [Chat](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-chat/): Conversational AI with history and persistent context
-- [Review](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-review/): Content analysis and proofreading
-- [Actions](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-actions/): Fast, stateless AI operations for specific tasks
-- [AI Models](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-models/): Supported AI models and configuration
-- [Plugin Configuration](https://www.tiny.cloud/docs/tinymce/latest/tinymceai/): `tinymceai` plugin options and setup
-- [Integration Options](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-integration-options/): Cloud and self-hosted integration paths
-- [API Overview](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-api-overview/): TinyMCE AI API for use inside and outside the editor
-- [API Quick Start](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-api-quick-start/): Get started with the TinyMCE AI API
-- [Streaming](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-streaming/): Streaming responses from the AI API
-- [JWT Authentication](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-jwt-authentication-intro/): Authentication setup for TinyMCE AI
-- [Limits](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-limits/): Rate limits and usage constraints
-- [AI Assistant (legacy)](https://www.tiny.cloud/docs/tinymce/latest/ai/): Earlier `ai` plugin — use TinyMCE AI for new projects
+- [TinyMCE AI Introduction](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-introduction/index.md): Overview of TinyMCE AI features and capabilities
+- [Chat](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-chat/index.md): Conversational AI with history and persistent context
+- [Review](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-review/index.md): Content analysis and proofreading
+- [Actions](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-actions/index.md): Fast, stateless AI operations for specific tasks
+- [AI Models](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-models/index.md): Supported AI models and configuration
+- [Plugin Configuration](https://www.tiny.cloud/docs/tinymce/latest/tinymceai/index.md): `tinymceai` plugin options and setup
+- [Integration Options](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-integration-options/index.md): Cloud and self-hosted integration paths
+- [API Overview](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-api-overview/index.md): TinyMCE AI API for use inside and outside the editor
+- [API Quick Start](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-api-quick-start/index.md): Get started with the TinyMCE AI API
+- [Streaming](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-streaming/index.md): Streaming responses from the AI API
+- [JWT Authentication](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-jwt-authentication-intro/index.md): Authentication setup for TinyMCE AI
+- [Limits](https://www.tiny.cloud/docs/tinymce/latest/tinymceai-limits/index.md): Rate limits and usage constraints
+- [AI Assistant (legacy)](https://www.tiny.cloud/docs/tinymce/latest/ai/index.md): Earlier `ai` plugin — use TinyMCE AI for new projects
 
 ## API Reference
 
-- [Editor API](https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.editor/): Core editor API
-- [Plugin API](https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.plugin/): Plugin development API
+- [Editor API](https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.editor/index.md): Core editor API
+- [Plugin API](https://www.tiny.cloud/docs/tinymce/latest/apis/tinymce.plugin/index.md): Plugin development API
 
 ## Migration & Upgrading
 
-- [Upgrading TinyMCE](https://www.tiny.cloud/docs/tinymce/latest/upgrading/): Upgrade guide
-- [Migration from 7.x](https://www.tiny.cloud/docs/tinymce/latest/migration-from-7x/): Migrate from TinyMCE 7
+- [Upgrading TinyMCE](https://www.tiny.cloud/docs/tinymce/latest/upgrading/index.md): Upgrade guide
+- [Migration from 7.x](https://www.tiny.cloud/docs/tinymce/latest/migration-from-7x/index.md): Migrate from TinyMCE 7
+
+## AI-Assisted Development with MCP
+
+For up-to-date TinyMCE documentation directly in AI coding tools, set up the Context7 MCP server. TinyMCE docs are indexed at [context7.com/tinymce/tinymce-docs](https://context7.com/tinymce/tinymce-docs).
+
+### Cursor
+
+Add to `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"]
+    }
+  }
+}
+```
+
+### Claude Code
+
+```bash
+claude mcp add context7 -- npx -y @upstash/context7-mcp
+```
+
+Add "use context7" to any prompt for live TinyMCE documentation lookups.
 
 ## Complete Documentation
 


### PR DESCRIPTION
## Summary

- Add `toMarkdownEndpoints()` to `generate-llm-files.js` so the next regeneration outputs `index.md` Markdown endpoint URLs instead of trailing-slash HTML URLs.
- Add "AI-Assisted Development with MCP" section to `llms.txt` with Context7 MCP setup instructions for Cursor and Claude Code.

## Tickets

- DOC-3471 — Update llms.txt URLs to Markdown endpoints
- DOC-3476 — Context7 MCP setup instructions in llms.txt
- Tasks: DOC-3477, DOC-3478, DOC-3484

## How it works

The `toMarkdownEndpoints()` function post-processes the generated output, converting any `https://www.tiny.cloud/docs/tinymce/.../<page>/` URL to `.../<page>/index.md`. It only affects doc page URLs (CDN, file references, and non-doc URLs are untouched).

No changes to the build pipeline or workflows on `main` are needed.

## Validation

- Context7 MCP section added with correct setup instructions
- `llms.txt` URLs remain as trailing-slash in source (transformed at generation time)
- `llms-full.txt` unchanged from `tinymce/8`

## Test plan

- Regenerate LLM files (`yarn generate-llm-files-from-url`) and verify all doc URLs end in `index.md`
- Verify Context7 MCP setup instructions are accurate (test in Cursor)
- Spot-check that CDN URLs and `llms-full.txt` reference link are untouched