### PR TITLE
DOC-3497 - Fix self-referencing canonical URLs via page-aliases on v8

### DIFF
--- a/modules/ROOT/pages/advanced-templates.adoc
+++ b/modules/ROOT/pages/advanced-templates.adoc
@@ -1,5 +1,6 @@
 = Templates plugin
 :navtitle: Template
+:page-aliases: template.adoc
 :description: Create and edit complex templates in {productname} for use with {productname}.
 :description_short: Create templates.
 :keywords: plugin, template, templates, advtemplate.

--- a/modules/ROOT/pages/bootstrap-cloud.adoc
+++ b/modules/ROOT/pages/bootstrap-cloud.adoc
@@ -1,5 +1,6 @@
 = Using {productname} from the Tiny Cloud CDN with the Bootstrap framework
 :navtitle: Bootstrap
+:page-aliases: bootstrap.adoc
 :description: A guide on integrating TinyMCE from the Tiny Cloud into the Bootstrap framework.
 :keywords: integration, integrate, bootstrap
 :productSource: cloud

--- a/modules/ROOT/pages/cloud-quick-start.adoc
+++ b/modules/ROOT/pages/cloud-quick-start.adoc
@@ -1,5 +1,6 @@
 = Quick start: {productname} from {cloudname}
 :navtitle: Quick start: Cloud
+:page-aliases: quick-start.adoc
 :description_short: Setup a basic {productname} {productmajorversion} editor using the {cloudname}.
 :description: Get an instance of {productname} {productmajorversion} up and running using the {cloudname}. Initialize the editor on a textarea element using its ID with tinymce.init and the selector option.
 :keywords: tinymce, script, textarea, selector, id, #mytextarea, tinymce.init, initialize, quick start

--- a/modules/ROOT/pages/copy-and-paste.adoc
+++ b/modules/ROOT/pages/copy-and-paste.adoc
@@ -1,5 +1,6 @@
 = Copy & paste options
 :navtitle: Copy and paste options
+:page-aliases: paste.adoc
 :description: TinyMCE copy and paste
 
 == {productname} PowerPaste plugin

--- a/modules/ROOT/pages/django-cloud.adoc
+++ b/modules/ROOT/pages/django-cloud.adoc
@@ -1,5 +1,6 @@
 = Using {productname} from the Tiny Cloud CDN with the Django framework
 :navtitle: Django
+:page-aliases: django.adoc
 :description: A guide on integrating TinyMCE from the Tiny Cloud into the Django framework.
 :keywords: integration, integrate, Django, django, django-tinymce, python
 :productSource: cloud

--- a/modules/ROOT/pages/exportpdf.adoc
+++ b/modules/ROOT/pages/exportpdf.adoc
@@ -1,6 +1,7 @@
 = {pluginname} plugin
 :plugincode: exportpdf
 :pluginname: Export to PDF
+:page-aliases: export.adoc
 :pluginfilename: export-to-pdf
 :navtitle: Export to PDF
 :description: The {pluginname} feature provides the ability to generate a PDF file directly from the editor.

--- a/modules/ROOT/pages/laravel-tiny-cloud.adoc
+++ b/modules/ROOT/pages/laravel-tiny-cloud.adoc
@@ -1,5 +1,6 @@
 = Using TinyMCE from the Tiny Cloud CDN with the Laravel framework
 :navtitle: Laravel
+:page-aliases: laravel.adoc
 :description: A guide on integrating TinyMCE from the Tiny Cloud into the Laravel framework.
 :keywords: integration, integrate, laravel, php, composer
 :productSource: cloud

--- a/modules/ROOT/pages/non-editable-content-options.adoc
+++ b/modules/ROOT/pages/non-editable-content-options.adoc
@@ -1,5 +1,6 @@
 = Non-editable content
 :navtitle: Non-editable content
+:page-aliases: noneditable.adoc
 :description: Options for creating non-editable content.
 :keywords: noneditable, non-editable, editable, multi-root, multiroot
 

--- a/modules/ROOT/pages/rails-cloud.adoc
+++ b/modules/ROOT/pages/rails-cloud.adoc
@@ -1,5 +1,6 @@
 = Using TinyMCE from the Tiny Cloud CDN with Ruby on Rails
 :navtitle: Ruby on Rails
+:page-aliases: rails.adoc
 :description: A guide on integrating TinyMCE from the Tiny Cloud into Ruby on Rails.
 :keywords: integration, integrate, ruby, rails
 :productSource: cloud

--- a/modules/ROOT/pages/react-cloud.adoc
+++ b/modules/ROOT/pages/react-cloud.adoc
@@ -1,5 +1,6 @@
 = Using TinyMCE from Tiny Cloud in React
 :navtitle: React
+:page-aliases: react.adoc
 :description: A guide on integrating TinyMCE from the Tiny Cloud into React.
 :keywords: integration, integrate, react, reactjs, vite, tinymce-react, tinymce
 :productSource: cloud

--- a/modules/ROOT/pages/spelling.adoc
+++ b/modules/ROOT/pages/spelling.adoc
@@ -1,5 +1,6 @@
 = Spelling options
 :navtitle: Spelling options
+:page-aliases: spellchecker.adoc
 :description: TinyMCE spell checking
 
 include::partial$misc/spell-checker.adoc[]

--- a/modules/ROOT/pages/svelte-cloud.adoc
+++ b/modules/ROOT/pages/svelte-cloud.adoc
@@ -1,5 +1,6 @@
 = Using TinyMCE from the Tiny Cloud CDN with the Svelte framework
 :navtitle: Svelte
+:page-aliases: svelte.adoc
 :description: A guide on integrating TinyMCE from the Tiny Cloud into the Svelte framework.
 :keywords: integration, integrate, svelte, sveltejs, tinymce-svelte
 :productSource: cloud

--- a/modules/ROOT/pages/vue-cloud.adoc
+++ b/modules/ROOT/pages/vue-cloud.adoc
@@ -1,5 +1,6 @@
 = Using TinyMCE from Tiny Cloud in Vue.js
 :navtitle: Vue.js
+:page-aliases: vue.adoc
 :description: A guide on integrating TinyMCE from the Tiny Cloud into a Vue.js application.
 :keywords: integration, integrate, vue, vuejs, tinymce-vue
 :productSource: cloud

--- a/modules/ROOT/pages/webcomponent-cloud.adoc
+++ b/modules/ROOT/pages/webcomponent-cloud.adoc
@@ -1,5 +1,6 @@
 = Using TinyMCE from the Tiny Cloud CDN with the Web Component
 :navtitle: Web Component
+:page-aliases: webcomponent.adoc
 :description: A guide on integrating TinyMCE from the Tiny Cloud into the Web Component.
 :keywords: integration, integrate, web-component
 :productSource: cloud


### PR DESCRIPTION
## Ticket

DOC-3497 / TINY-14151

## Site

Inspect this page
- [latest/react-cloud](https://pr-4126.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/react-cloud/)
Notice it points to `<link rel="canonical" href="https://www.tiny.cloud/docs/tinymce/latest/react-cloud/">` which is expected.
then inspect this [5/react](https://pr-4126.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/5/react/) notice it now points to `<link rel="canonical" href="https://www.tiny.cloud/docs/tinymce/latest/react-cloud/">` and not `<link rel="canonical" href="https://www.tiny.cloud/docs/tinymce/5/react/">`

## Changes

Adds `:page-aliases:` to 14 pages on the `tinymce/8` branch to claim the old page IDs from v5/v6. This allows Antora to resolve the correct canonical URL for older versions that were renamed or restructured in v6+.

Without these aliases, Antora cannot match the old page IDs to their v8 equivalents and falls back to self-referencing canonicals — causing Google to treat legacy pages as authoritative.

**Framework integrations (8 pages):**
- `react-cloud.adoc` claims `react.adoc`
- `vue-cloud.adoc` claims `vue.adoc`
- `svelte-cloud.adoc` claims `svelte.adoc`
- `webcomponent-cloud.adoc` claims `webcomponent.adoc`
- `rails-cloud.adoc` claims `rails.adoc`
- `django-cloud.adoc` claims `django.adoc`
- `bootstrap-cloud.adoc` claims `bootstrap.adoc`
- `laravel-tiny-cloud.adoc` claims `laravel.adoc`

**Plugin/feature pages (6 pages):**
- `copy-and-paste.adoc` claims `paste.adoc`
- `cloud-quick-start.adoc` claims `quick-start.adoc`
- `spelling.adoc` claims `spellchecker.adoc`
- `non-editable-content-options.adoc` claims `noneditable.adoc`
- `advanced-templates.adoc` claims `template.adoc`
- `exportpdf.adoc` claims `export.adoc`

Each change is a single `:page-aliases:` line addition; no content changes.

**Note:** The canonical fix requires a full multi-version build (v5 + v6 + v8) to verify — single-branch staging previews will show self-referencing canonicals regardless. Verify on production after merge by checking the `<link rel="canonical">` tag on e.g. `/docs/tinymce/5/react/`.

**Replaces:** #4118 (v5) and #4119 (v6) — the `page-aliases` approach on v8 fixes canonicals for all older versions from a single branch.

**Ref:** [Antora canonical URL docs](https://docs.antora.org/antora/latest/playbook/site-url/#canonical-url)