### PR TITLE
DOC-3504: Add redirect from /docs/tinymce/5/react-cloud/ to /docs/tinymce/5/react/

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -2313,6 +2313,10 @@
     "redirect": "/docs/tinymce/5/"
   },
   {
+    "location": "/docs/tinymce/5/react-cloud/",
+    "redirect": "/docs/tinymce/5/react/"
+  },
+  {
     "location": "/docs/tinymce/5/integrations/react/",
     "redirect": "/docs/tinymce/5/"
   },


### PR DESCRIPTION
Ticket: DOC-3504
## Summary

- Adds a redirect entry in `redirects.json` so visitors hitting the invalid URL `/docs/tinymce/5/react-cloud/` are sent to the correct path `/docs/tinymce/5/react/`.
- The `react-cloud` page slug only exists from TinyMCE 7+ onwards; version 5 used `react` as the page name.
