### PR TITLE
DOC-3507: TinyMCE 8.6.0 Documentation.

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -409,6 +409,22 @@
 * Release information
 ** xref:release-notes.adoc[Release notes for {productname}]
 // Remove un-used-for-this-particular-release entries.
+*** {productname} 8.6.0
+**** xref:8.6.0-release-notes.adoc#overview[Overview]
+**** xref:8.6.0-release-notes.adoc#new-premium-plugin<s>[New Premium Plugin<s>]
+**** xref:8.6.0-release-notes.adoc#new-open-source-plugin<s>[New Open Source Plugin<s>]
+**** xref:8.6.0-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]
+**** xref:8.6.0-release-notes.adoc#accompanying-premium-plugin-end-of-life-announcement[Accompanying Premium Plugin end-of-life announcement]
+**** xref:8.6.0-release-notes.adoc#accompanying-open-source-plugin-end-of-life-announcement[Accompanying Open Source Plugin end-of-life announcement]
+**** xref:8.6.0-release-notes.adoc#accompanying-enhanced-skins-and-icon-packs-changes[Accompanying Enhanced Skins & Icon Packs changes]
+**** xref:8.6.0-release-notes.adoc#improvements[Improvements]
+**** xref:8.6.0-release-notes.adoc#additions[Additions]
+**** xref:8.6.0-release-notes.adoc#changes[Changes]
+**** xref:8.6.0-release-notes.adoc#removed[Removed]
+**** xref:8.6.0-release-notes.adoc#bug-fixes[Bug fixes]
+**** xref:8.6.0-release-notes.adoc#security-fixes[Security fixes]
+**** xref:8.6.0-release-notes.adoc#deprecated[Deprecated]
+**** xref:8.6.0-release-notes.adoc#known-issues[Known issues]
 *** {productname} 8.5.0
 **** xref:8.5.0-release-notes.adoc#overview[Overview]
 **** xref:8.5.0-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]

--- a/modules/ROOT/pages/8.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.6.0-release-notes.adoc
@@ -1,0 +1,195 @@
+= {productname} {release-version}
+:release-version: 8.6.0
+:navtitle: {productname} {release-version}
+:description: Release notes for {productname} {release-version}
+:keywords: releasenotes, new, changes, bugfixes
+:page-toclevels: 1
+
+include::partial$misc/admon-releasenotes-for-stable.adoc[]
+
+
+[[overview]]
+== Overview
+
+{productname} {release-version} was released for {enterpriseversion} and {cloudname} on Tuesday, June 30^th^, 2026. These release notes provide an overview of the changes for {productname} {release-version}, including:
+
+// Remove sections and section boilerplates as necessary.
+// Pluralise as necessary or remove the placeholder plural marker.
+* xref:new-premium-plugin<s>[New Premium plugin<s>]
+* xref:new-open-source-plugin<s>[New Open Source plugin<s>]
+* xref:accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
+* xref:accompanying-premium-plugin-end-of-life-announcement[Accompanying Premium plugin end-of-life announcement]
+* xref:accompanying-open-source-plugin-end-of-life-announcement[Accompanying open source plugin end-of-life-announcement]
+* xref:accompanying-enhanced-skins-and-icon-packs-changes[Accompanying Enhanced Skins & Icon Packs changes]
+* xref:improvements[Improvements]
+* xref:additions[Additions]
+* xref:changes[Changes]
+* xref:bug-fixes[Bug fixes]
+* xref:security-fixes[Security fixes]
+* xref:deprecated[Deprecated]
+* xref:known-issues[Known issues]
+
+
+[[new-premium-plugin<s>]]
+== New Premium plugin<s>
+
+The following new Premium plugin was released alongside {productname} {release-version}.
+
+=== <Premium plugin name>
+
+The new Premium plugin, **<Premium plugin name>** // description here.
+
+For information on the **<Premium plugin name>** plugin, see xref:<plugincode>.adoc[<Premium plugin name>].
+
+
+[[new-open-source-plugin]]
+== New Open Source plugin
+
+The following new Open Source plugin was released alongside {productname} {release-version}.
+
+=== <Open source plugin name>
+
+The new open source plugin, **<Open source plugin name>** // description here.
+
+For information on the **<Open source plugin name>** plugin, see xref:<plugincode>.adoc[<Open source plugin name>].
+
+
+[[accompanying-premium-plugin-changes]]
+== Accompanying Premium plugin changes
+
+The following premium plugin updates were released alongside {productname} {release-version}.
+
+=== <Premium plugin name 1> <Premium plugin name 1 version>
+
+The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+
+**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+
+==== <Premium plugin name 1 change 1>
+
+// CCFR here.
+
+For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+
+
+[[accompanying-premium-plugin-end-of-life-announcement]]
+== Accompanying Premium plugin end-of-life announcement
+
+The following Premium plugin has been announced as reaching its end-of-life:
+
+=== <Premium plugin name eol>
+
+{productname}'s xref:<plugincode>.adoc[<Premium plugin name eol>] plugin will be deactivated on <month> <DD>, <YYYY>, and is no longer available for purchase.
+
+
+[[accompanying-open-source-plugin-end-of-life-announcement]]
+== Accompanying open source plugin end-of-life announcement
+
+The following open source plugin has been announced as reaching its end-of-life:
+
+=== <Open source plugin name eol>
+
+{productname}'s xref:<plugincode>.adoc[<Open source plugin name eol>] plugin will be deactivated on <month> <DD>, <YYYY>, and is no longer available for purchase.
+
+
+[[accompanying-enhanced-skins-and-icon-packs-changes]]
+== Accompanying Enhanced Skins & Icon Packs changes
+
+The {productname} {release-version} release includes an accompanying release of the **Enhanced Skins & Icon Packs**.
+
+=== Enhanced Skins & Icon Packs
+
+The **Enhanced Skins & Icon Packs** release includes the following updates:
+
+The **Enhanced Skins & Icon Packs** were rebuilt to pull in the changes also incorporated into the default {productname} {release-version} skin, Oxide.
+
+For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-and-icon-packs.adoc[Enhanced Skins & Icon Packs].
+
+
+[[improvements]]
+== Improvements
+
+{productname} {release-version} also includes the following improvement<s>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[additions]]
+== Additions
+
+{productname} {release-version} also includes the following addition<s>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[changes]]
+== Changes
+
+{productname} {release-version} also includes the following change<s>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[removed]]
+== Removed
+
+{productname} {release-version} also includes the following removal<s>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[bug-fixes]]
+== Bug fixes
+
+{productname} {release-version} also includes the following bug fix<es>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[security-fixes]]
+== Security fixes
+
+{productname} {release-version} includes <a fix | fixes for the following security issue<s>:
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.
+
+
+[[deprecated]]
+== Deprecated
+
+{productname} {release-version} includes the following deprecation<s>:
+
+=== The `<plugin>` configuration property, `<name>`, has been deprecated
+
+// placeholder here.
+
+
+[[known-issues]]
+== Known issues
+
+This section describes issues that users of {productname} {release-version} may encounter and possible workarounds for these issues.
+
+There <is one | are <number> known issue<s> in {productname} {release-version}.
+
+=== <TINY-vwxyz 1 changelog entry>
+// #TINY-vwxyz1
+
+// CCFR here.

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -4,6 +4,10 @@
 
 NOTE: This is the {productname} Community version changelog. For information about the latest {cloudname} or {enterpriseversion} Release, see: xref:release-notes.adoc[{productname} Release Notes].
 
+== xref:8.6.0-release-notes.adoc[8.6.0 - 2026-06-30]
+
+//TODO
+
 == xref:8.5.0-release-notes.adoc[8.5.0 - 2026-04-29]
 
 ### Added

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -10,6 +10,12 @@ This section lists the releases for {productname} {productmajorversion} and the 
 |===
 a|
 [.lead]
+xref:8.6.0-release-notes.adoc#overview[{productname} 8.6.0]
+
+Release notes for {productname} 8.6.0
+
+a|
+[.lead]
 xref:8.5.0-release-notes.adoc#overview[{productname} 8.5.0]
 
 Release notes for {productname} 8.5.0
@@ -92,5 +98,5 @@ xref:8.0-release-notes.adoc#overview[{productname} 8.0.0]
 Release notes for {productname} 8.0.0
 
 // Uncomment the dummy cell when the number of cells in the table is odd to ensure the table renders correctly.
-// a|
+a|
 |===

--- a/modules/ROOT/partials/misc/supported-versions.adoc
+++ b/modules/ROOT/partials/misc/supported-versions.adoc
@@ -6,6 +6,7 @@ Supported versions of {productname}:
 [cols="^,^,^",options="header"]
 |===
 |Version |Release Date |End of Premium Support
+|8.6 |2026-06-30 |2027-12-30
 |8.5 |2026-04-29 |2027-10-29
 |8.4 |2026-03-31 |2027-09-30
 |8.3 |2025-12-10 |2027-06-10


### PR DESCRIPTION
Ticket: DOC-3507

Site: [Staging branch](https://pr-4135.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* TinyMCE 8.6.0 Documentation

Pre-checks:
- [ ] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [ ] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [ ] Included a `release note` entry for any `New product features`.
- [ ] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [ ] Documentation Team Lead has reviewed