### PR TITLE
DOC-3401: TinyMCE 8.6.0 Release Documentation and Community Changelog.

### DIFF
--- a/modules/ROOT/pages/8.6.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.6.0-release-notes.adoc
@@ -13,8 +13,6 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 {productname} {release-version} was released for {enterpriseversion} and {cloudname} on Tuesday, June 30^th^, 2026. These release notes provide an overview of the changes for {productname} {release-version}, including:
 
-// Remove sections and section boilerplates as necessary.
-// Pluralise as necessary or remove the placeholder plural marker.
 * xref:new-premium-plugin<s>[New Premium plugin<s>]
 * xref:new-open-source-plugin<s>[New Open Source plugin<s>]
 * xref:accompanying-premium-plugin-changes[Accompanying Premium plugin changes]
@@ -35,11 +33,11 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following new Premium plugin was released alongside {productname} {release-version}.
 
-=== <Premium plugin name>
+// === <Premium plugin name>
 
-The new Premium plugin, **<Premium plugin name>** // description here.
+// The new Premium plugin, **<Premium plugin name>** // description here.
 
-For information on the **<Premium plugin name>** plugin, see xref:<plugincode>.adoc[<Premium plugin name>].
+// For information on the **<Premium plugin name>** plugin, see xref:<plugincode>.adoc[<Premium plugin name>].
 
 
 [[new-open-source-plugin]]
@@ -47,11 +45,11 @@ For information on the **<Premium plugin name>** plugin, see xref:<plugincode>.a
 
 The following new Open Source plugin was released alongside {productname} {release-version}.
 
-=== <Open source plugin name>
+// === <Open source plugin name>
 
-The new open source plugin, **<Open source plugin name>** // description here.
+// The new open source plugin, **<Open source plugin name>** // description here.
 
-For information on the **<Open source plugin name>** plugin, see xref:<plugincode>.adoc[<Open source plugin name>].
+// For information on the **<Open source plugin name>** plugin, see xref:<plugincode>.adoc[<Open source plugin name>].
 
 
 [[accompanying-premium-plugin-changes]]
@@ -59,17 +57,17 @@ For information on the **<Open source plugin name>** plugin, see xref:<plugincod
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
-=== <Premium plugin name 1> <Premium plugin name 1 version>
+// === <Premium plugin name 1> <Premium plugin name 1 version>
 
-The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
+// The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.
 
-**<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
+// **<Premium plugin name 1>** <Premium plugin name 1 version> includes the following <fixes, changes, improvements>.
 
-==== <Premium plugin name 1 change 1>
+// ==== <Premium plugin name 1 change 1>
 
 // CCFR here.
 
-For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
+// For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
@@ -77,9 +75,9 @@ For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode
 
 The following Premium plugin has been announced as reaching its end-of-life:
 
-=== <Premium plugin name eol>
+// === <Premium plugin name eol>
 
-{productname}'s xref:<plugincode>.adoc[<Premium plugin name eol>] plugin will be deactivated on <month> <DD>, <YYYY>, and is no longer available for purchase.
+// {productname}'s xref:<plugincode>.adoc[<Premium plugin name eol>] plugin will be deactivated on <month> <DD>, <YYYY>, and is no longer available for purchase.
 
 
 [[accompanying-open-source-plugin-end-of-life-announcement]]
@@ -87,9 +85,9 @@ The following Premium plugin has been announced as reaching its end-of-life:
 
 The following open source plugin has been announced as reaching its end-of-life:
 
-=== <Open source plugin name eol>
+// === <Open source plugin name eol>
 
-{productname}'s xref:<plugincode>.adoc[<Open source plugin name eol>] plugin will be deactivated on <month> <DD>, <YYYY>, and is no longer available for purchase.
+// {productname}'s xref:<plugincode>.adoc[<Open source plugin name eol>] plugin will be deactivated on <month> <DD>, <YYYY>, and is no longer available for purchase.
 
 
 [[accompanying-enhanced-skins-and-icon-packs-changes]]
@@ -111,7 +109,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following improvement<s>:
 
-=== <TINY-vwxyz 1 changelog entry>
+// === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1
 
 // CCFR here.
@@ -122,7 +120,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following addition<s>:
 
-=== <TINY-vwxyz 1 changelog entry>
+// === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1
 
 // CCFR here.
@@ -133,7 +131,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following change<s>:
 
-=== <TINY-vwxyz 1 changelog entry>
+// === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1
 
 // CCFR here.
@@ -144,7 +142,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following removal<s>:
 
-=== <TINY-vwxyz 1 changelog entry>
+// === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1
 
 // CCFR here.
@@ -155,7 +153,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} also includes the following bug fix<es>:
 
-=== <TINY-vwxyz 1 changelog entry>
+// === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1
 
 // CCFR here.
@@ -166,7 +164,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} includes <a fix | fixes for the following security issue<s>:
 
-=== <TINY-vwxyz 1 changelog entry>
+// === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1
 
 // CCFR here.
@@ -177,8 +175,8 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 {productname} {release-version} includes the following deprecation<s>:
 
-=== The `<plugin>` configuration property, `<name>`, has been deprecated
-
+// === The `<plugin>` configuration property, `<name>`, has been deprecated
+// #TINY-vwxyz1
 // placeholder here.
 
 
@@ -189,7 +187,7 @@ This section describes issues that users of {productname} {release-version} may 
 
 There <is one | are <number> known issue<s> in {productname} {release-version}.
 
-=== <TINY-vwxyz 1 changelog entry>
+// === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1
 
 // CCFR here.


### PR DESCRIPTION
Ticket: DOC-3401

Site: [Staging branch](https://pr-4136.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/)

Changes:
* TinyMCE 8.6.0 Release Documentation and Community Changelog.
* All things 8.6.0

Pre-checks:
- [ ] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [ ] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [ ] Included a `release note` entry for any `New product features`.
- [ ] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.
- [ ] `api-version` bump to `8.6.0`

Review:
- [ ] Documentation Team Lead has reviewed