### PR TITLE
DOC-3509 - Add missing Custom Reviews entry to 8.5.0 release notes

### DIFF
--- a/modules/ROOT/pages/8.5.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.5.0-release-notes.adoc
@@ -125,6 +125,15 @@ The {productname} {release-version} release includes an accompanying release of 
 
 **TinyMCE AI** includes the following fixes, improvements, and additions.
 
+==== Custom reviews with user-defined prompts and model selection
+// #TINY-14171
+
+Previously, the Review sidebar only offered a fixed set of built-in review types such as Proofread, Improve clarity, and Adjust tone and style. There was no way for users to define their own review criteria or select a specific AI model for a review pass.
+
+In {productname} {release-version}, the Review sidebar includes a new **Custom review** category. A natural-language prompt can be entered and, when xref:tinymceai.adoc#tinymceai_allow_model_selection[`+tinymceai_allow_model_selection+`] permits it, an AI model can be selected. The review runs the same streaming suggestion and apply flow as built-in reviews. Custom reviews can range from checking for specific words or phrases to applying a full company style guide. To hide Custom review from the Review sidebar, omit `+'ai-reviews-custom'+` from xref:tinymceai.adoc#tinymceai_reviews[`+tinymceai_reviews+`].
+
+For information on Custom reviews, see: xref:tinymceai-review.adoc#custom-review-choose-review[Custom review].
+
 ==== A long list of fetched sources could overflow the submenu in the AI chat without a way to scroll
 // #TINY-14064
 


### PR DESCRIPTION
## Ticket

[DOC-3509](https://ephocks.atlassian.net/browse/DOC-3509)

## Site

[Staging](https://pr-4138.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.5.0-release-notes/#custom-reviews-with-user-defined-prompts-and-model-selection)

## Changes

- Added a release note entry for the Custom Reviews feature (TINY-14171) under the TinyMCE AI section of the 8.5.0 release notes
- The entry describes the new Custom review category in the Review sidebar, including user-defined prompts and model selection
- Includes cross-references to the existing Custom review documentation and relevant configuration options (`tinymceai_reviews`, `tinymceai_allow_model_selection`)

The Custom Reviews feature was shipped in 8.5.0 and is already documented on the TinyMCE AI Review page, but the release notes entry was missing.

[DOC-3509]: https://ephocks.atlassian.net/browse/DOC-3509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ