### PR TITLE
DOC-3501 - Update OSS support cutoff from TinyMCE 6 to TinyMCE 7

### DIFF
--- a/modules/ROOT/partials/misc/supported-versions.adoc
+++ b/modules/ROOT/partials/misc/supported-versions.adoc
@@ -31,7 +31,7 @@ Bug fixes and new features are always released in the latest version of {product
 === Security updates:
 
 * Security updates are released in the latest minor version of each major version of {productname} that is still under active premium or LTS support ({productname} {productmajorversion}, {productname} 7 and {productname} 5 LTS).
-* Security updates for the free open source edition of {productname} are issued only for around six months after the new major version is available. Security support for the free open source version of {productname} 6 ended on October 31, 2024.
+* Security updates for the free open source edition of {productname} are issued only for around six months after the new major version is available. Security support for the free open source version of {productname} 7 ended on November 11, 2025.
 * For customers with a commercial license, security support for {productname} 6 ended on June 06^th^, 2025.
 * {productname} 5 (both open source and commercial versions) is no longer receiving security updates. However, it is possible to extend security support for {productname} 5 by purchasing a dedicated LTS (Long Term Support) agreement. If you are interested in purchasing a {productname} 5 LTS license, please link:https://www.tiny.cloud/contact/[contact us].
 


### PR DESCRIPTION
**Ticket:** DOC-3501

**Site:** [Staging branch](https://pr-4139.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/8/support/#supported-tinymce-versions)

**Changes:**
* Updated `supported-versions.adoc` to reflect TinyMCE 7 as the final OSS-supported version, with security support ending November 11, 2025 (previously referenced TinyMCE 6 / October 31, 2024).
* Line about commercial TinyMCE 6 support ending June 2025 is unchanged per product guidance.

### **Pre-checks:**

- [x] Branch is correctly prefixed:
- [x] Build passes without console errors, warnings, or issues.

### **Review:**

- [x] Documentation Team Lead has reviewed.