### PR TITLE
DOC-3506 - Add firewall whitelist instructions to AI and Doc Converters documentation

### DIFF
--- a/modules/ROOT/pages/editor-and-features.adoc
+++ b/modules/ROOT/pages/editor-and-features.adoc
@@ -60,7 +60,7 @@ If the network has a firewall or forward proxy that controls access to the inter
 
 * All URLs where the editor is deployed.
 * All URLs where the plugins are deployed.
-* `+*.tiny.cloud+` — covers all {cloudname} services, including the image proxy, link checker, spell checker, AI, and document converters.
+* `+*.tiny.cloud+` — covers all {cloudname} services, including the image proxy, link checker, spell checker, AI API, and document converters.
 
 Ensure the `+tiny-api-key+` and `+tinymce-api-key+` headers are retained while requesting the above URLs.
 

--- a/modules/ROOT/pages/editor-and-features.adoc
+++ b/modules/ROOT/pages/editor-and-features.adoc
@@ -56,15 +56,15 @@ include::partial$misc/admon-cloud-configured-options.adoc[]
 
 === Step 4: Forward proxy configuration
 
-Ensure that the following URLs are accessible via this proxy if the network has a forward proxy that controls access to the internet.
+If the network has a forward proxy that controls access to the internet, ensure that the following URLs are accessible:
 
 * All URLs where the editor is deployed.
 * All URLs where the plugins are deployed.
-* +https://imageproxy.tiny.cloud+
-* +https://hyperlinking.tiny.cloud+
-* +https://spelling.tiny.cloud+
+* `+*.tiny.cloud+` — covers all {cloudname} services, including the image proxy, link checker, spell checker, AI, and document converters.
 
-Ensure the `+tiny-api-key+` and `+tinymce-api-key+` headers are retained while requesting the list of above URLs.
+Ensure the `+tiny-api-key+` and `+tinymce-api-key+` headers are retained while requesting the above URLs.
+
+For the full list of {cloudname} service domains and required headers, see xref:tinymce-and-csp.adoc#firewall-and-proxy-allowlisting[Firewall and proxy allowlisting].
 
 === Step 5: Specifying a translation
 

--- a/modules/ROOT/pages/editor-and-features.adoc
+++ b/modules/ROOT/pages/editor-and-features.adoc
@@ -54,9 +54,9 @@ include::partial$misc/premium-plugin-list.adoc[]
 
 include::partial$misc/admon-cloud-configured-options.adoc[]
 
-=== Step 4: Forward proxy configuration
+=== Step 4: Forward proxy and firewall configuration
 
-If the network has a forward proxy that controls access to the internet, ensure that the following URLs are accessible:
+If the network has a firewall or forward proxy that controls access to the internet, ensure that the following URLs are accessible:
 
 * All URLs where the editor is deployed.
 * All URLs where the plugins are deployed.

--- a/modules/ROOT/pages/exportpdf.adoc
+++ b/modules/ROOT/pages/exportpdf.adoc
@@ -55,6 +55,7 @@ For more infomation on the exportpdf_token_provider option, see xref:exportpdf.a
 
 include::partial$misc/admon-jwt-authentication-requirements.adoc[]
 
+include::partial$misc/admon-cloud-firewall.adoc[]
 
 == Basic setup using the self-hosted service
 

--- a/modules/ROOT/pages/exportword.adoc
+++ b/modules/ROOT/pages/exportword.adoc
@@ -11,8 +11,6 @@
 
 include::partial$misc/admon-export-word-paid-addon-pricing.adoc[]
 
-include::partial$misc/admon-cloud-firewall.adoc[]
-
 The export to Microsoft Word feature collects the HTML generated with the `tinymce.editor.getContent()` method and combines it with the default editor content styles along with the styles provided in the plugin configuration. The combined content and styles are then processed by the included server-side converter service, which can be either self-hosted or cloud-based. Following this processing, a Word file is generated, which is subsequently returned to the user's browser, enabling them to save it in the Word format onto their disk or drive.
 
 == Interactive example
@@ -56,6 +54,7 @@ For more infomation on the exportword_token_provider option, see xref:exportword
 
 include::partial$misc/admon-jwt-authentication-requirements.adoc[]
 
+include::partial$misc/admon-cloud-firewall.adoc[]
 
 == Basic setup using the self-hosted service
 

--- a/modules/ROOT/pages/exportword.adoc
+++ b/modules/ROOT/pages/exportword.adoc
@@ -11,6 +11,8 @@
 
 include::partial$misc/admon-export-word-paid-addon-pricing.adoc[]
 
+include::partial$misc/admon-cloud-firewall.adoc[]
+
 The export to Microsoft Word feature collects the HTML generated with the `tinymce.editor.getContent()` method and combines it with the default editor content styles along with the styles provided in the plugin configuration. The combined content and styles are then processed by the included server-side converter service, which can be either self-hosted or cloud-based. Following this processing, a Word file is generated, which is subsequently returned to the user's browser, enabling them to save it in the Word format onto their disk or drive.
 
 == Interactive example

--- a/modules/ROOT/pages/features-only.adoc
+++ b/modules/ROOT/pages/features-only.adoc
@@ -55,9 +55,9 @@ The following is a complete example, where:
 <html>
 ----
 
-== Step 3: Forward proxy configuration
+== Step 3: Forward proxy and firewall configuration
 
-If the network has a forward proxy that controls access to the internet, ensure that the following URLs are accessible:
+If the network has a firewall or forward proxy that controls access to the internet, ensure that the following URLs are accessible:
 
 * All URLs where the editor is deployed.
 * All URLs where the plugins are deployed.

--- a/modules/ROOT/pages/features-only.adoc
+++ b/modules/ROOT/pages/features-only.adoc
@@ -61,7 +61,7 @@ If the network has a firewall or forward proxy that controls access to the inter
 
 * All URLs where the editor is deployed.
 * All URLs where the plugins are deployed.
-* `+*.tiny.cloud+` — covers all {cloudname} services, including the image proxy, link checker, spell checker, AI, and document converters.
+* `+*.tiny.cloud+` — covers all {cloudname} services, including the image proxy, link checker, spell checker, AI API, and document converters.
 
 Ensure the `+tiny-api-key+` and `+tinymce-api-key+` headers are retained while requesting the above URLs.
 

--- a/modules/ROOT/pages/features-only.adoc
+++ b/modules/ROOT/pages/features-only.adoc
@@ -57,12 +57,12 @@ The following is a complete example, where:
 
 == Step 3: Forward proxy configuration
 
-Ensure that the following URLs are accessible via this proxy if the network has a forward proxy that controls access to the internet.
+If the network has a forward proxy that controls access to the internet, ensure that the following URLs are accessible:
 
 * All URLs where the editor is deployed.
 * All URLs where the plugins are deployed.
-* +https://imageproxy.tiny.cloud+
-* +https://hyperlinking.tiny.cloud+
-* +https://spelling.tiny.cloud+
+* `+*.tiny.cloud+` — covers all {cloudname} services, including the image proxy, link checker, spell checker, AI, and document converters.
 
-Ensure the `+tiny-api-key+` and `+tinymce-api-key+` headers are retained while requesting the list of above URLs.
+Ensure the `+tiny-api-key+` and `+tinymce-api-key+` headers are retained while requesting the above URLs.
+
+For the full list of {cloudname} service domains and required headers, see xref:tinymce-and-csp.adoc#firewall-and-proxy-allowlisting[Firewall and proxy allowlisting].

--- a/modules/ROOT/pages/importword.adoc
+++ b/modules/ROOT/pages/importword.adoc
@@ -13,6 +13,8 @@ include::partial$misc/admon-import-word-paid-addon-pricing.adoc[]
 
 The {pluginname} plugin lets you import `.docx` (Word document) or `.dotx` (Word template) files into the editor. The process preserves formatting and rich media.
 
+include::partial$misc/admon-cloud-firewall.adoc[]
+
 == Interactive example
 
 liveDemo::importword[]

--- a/modules/ROOT/pages/importword.adoc
+++ b/modules/ROOT/pages/importword.adoc
@@ -13,8 +13,6 @@ include::partial$misc/admon-import-word-paid-addon-pricing.adoc[]
 
 The {pluginname} plugin lets you import `.docx` (Word document) or `.dotx` (Word template) files into the editor. The process preserves formatting and rich media.
 
-include::partial$misc/admon-cloud-firewall.adoc[]
-
 == Interactive example
 
 liveDemo::importword[]
@@ -49,6 +47,7 @@ For more infomation on the importword_token_provider option, see xref:importword
 
 include::partial$misc/admon-jwt-authentication-requirements.adoc[]
 
+include::partial$misc/admon-cloud-firewall.adoc[]
 
 == Basic setup using the self-hosted service
 

--- a/modules/ROOT/pages/tinymce-and-csp.adoc
+++ b/modules/ROOT/pages/tinymce-and-csp.adoc
@@ -23,6 +23,7 @@ This single entry covers all cloud-hosted services, including but not limited to
 * xref:tinymceai.adoc[TinyMCE AI] (`+tinymceai.api.tiny.cloud+`)
 * xref:importword.adoc[Import from Word] (`+importdocx.api.tiny.cloud+`)
 * xref:exportword.adoc[Export to Word] (`+exportdocx.api.tiny.cloud+`)
+* xref:exportpdf.adoc[Export to PDF] (`+exportpdf.api.tiny.cloud+`)
 * Image proxy (`+imageproxy.tiny.cloud+`)
 * Link checking (`+hyperlinking.tiny.cloud+`)
 * Spell checking (`+spelling.tiny.cloud+`)

--- a/modules/ROOT/pages/tinymce-and-csp.adoc
+++ b/modules/ROOT/pages/tinymce-and-csp.adoc
@@ -8,7 +8,7 @@ include::partial$misc/general-csp.adoc[]
 [[firewall-and-proxy-allowlisting]]
 == Firewall and proxy allowlisting
 
-Organizations operating behind a firewall or forward proxy that restricts outbound internet access must allowlist {cloudname} domains for cloud-hosted {productname} features to function.
+Organizations operating behind a firewall or forward proxy that restricts outbound internet access must allowlist {cloudname} domains. {productname} cloud-hosted features require the browser to make outbound HTTPS requests to these domains; no inbound access from {cloudname} is required.
 
 [[required-domains]]
 === Required domains

--- a/modules/ROOT/pages/tinymce-and-csp.adoc
+++ b/modules/ROOT/pages/tinymce-and-csp.adoc
@@ -1,9 +1,43 @@
-= The TinyMCE Content Security Policy guide
+= {productname} Content Security Policy and allowed domains
 :navtitle: Content Security Policies (CSP)
-:description: Information and options related to using TinyMCE with a Content Security Policy (CSP)
-:keywords: security, csp
+:description: Content Security Policy directives, firewall allowlisting, and proxy configuration for {productname} and {cloudname} services
+:keywords: security, csp, firewall, allowlist, proxy, whitelist
 
 include::partial$misc/general-csp.adoc[]
+
+[[firewall-and-proxy-allowlisting]]
+== Firewall and proxy allowlisting
+
+Organizations operating behind a firewall or forward proxy that restricts outbound internet access must allowlist {cloudname} domains for cloud-hosted {productname} features to function.
+
+[[required-domains]]
+=== Required domains
+
+Allowlist the following wildcard domain to cover all {cloudname} services:
+
+`+*.tiny.cloud+`
+
+This single entry covers all cloud-hosted services, including but not limited to:
+
+* Editor loading and plugin delivery (`+cdn.tiny.cloud+`)
+* xref:tinymceai.adoc[TinyMCE AI] (`+tinymceai.api.tiny.cloud+`)
+* xref:importword.adoc[Import from Word] (`+importdocx.api.tiny.cloud+`)
+* xref:exportword.adoc[Export to Word] (`+exportdocx.api.tiny.cloud+`)
+* Image proxy (`+imageproxy.tiny.cloud+`)
+* Link checking (`+hyperlinking.tiny.cloud+`)
+* Spell checking (`+spelling.tiny.cloud+`)
+
+NOTE: Self-hosted deployments that do not connect to any {cloudname} services do not require this allowlisting. For self-hosted services such as on-premises document converters or AI, allowlist the domain where the self-hosted service is running instead.
+
+[[required-http-headers]]
+=== Required HTTP headers
+
+Ensure the proxy retains (does not strip) the following HTTP headers on requests to `+*.tiny.cloud+` domains:
+
+* `+tiny-api-key+`
+* `+tinymce-api-key+`
+
+These headers are required for API key validation and service authentication.
 
 == Content Security Policy related options
 

--- a/modules/ROOT/pages/tinymceai.adoc
+++ b/modules/ROOT/pages/tinymceai.adoc
@@ -13,8 +13,6 @@ include::partial$misc/admon-premium-plugin.adoc[]
 
 The {pluginname} plugin integrates AI-assisted authoring with rich-text editing. Users can interact through Actions, Reviews, or Conversations that can use relevant context from multiple sources.
 
-include::partial$misc/admon-cloud-firewall.adoc[]
-
 [[interactive-example]]
 == Interactive example
 
@@ -28,6 +26,8 @@ To set up the {pluginname} plugin in {productname}:
 * add `{plugincode}` to the `plugins` option in the editor configuration;
 * configure the `tinymceai_token_provider` option to provide authentication tokens (must return `+{ token: string }+`). During a {cloudname} trial, the xref:tinymceai-jwt-authentication-intro.adoc#trial-demo-identity-service[demo identity service] can supply JWTs so a custom token endpoint is not required;
 * when the `toolbar` option is omitted or left at the default, the Silver theme toolbar already includes the AI toolbar buttons once the plugin is enabled: `+tinymceai-chat+` image:icons-premium/ai-assistant.svg[Chat icon,24px], `+tinymceai-quickactions+` image:icons/ai-prompt.svg[Quick Actions icon,24px], and `+tinymceai-review+` image:icons-premium/ai-review.svg[Review icon,24px]. When a custom `toolbar` string is set, add those button ids to the string explicitly.
+
+include::partial$misc/admon-cloud-firewall.adoc[]
 
 [[minimal-setup]]
 === Minimal setup

--- a/modules/ROOT/pages/tinymceai.adoc
+++ b/modules/ROOT/pages/tinymceai.adoc
@@ -13,6 +13,8 @@ include::partial$misc/admon-premium-plugin.adoc[]
 
 The {pluginname} plugin integrates AI-assisted authoring with rich-text editing. Users can interact through Actions, Reviews, or Conversations that can use relevant context from multiple sources.
 
+include::partial$misc/admon-cloud-firewall.adoc[]
+
 [[interactive-example]]
 == Interactive example
 

--- a/modules/ROOT/partials/misc/admon-cloud-firewall.adoc
+++ b/modules/ROOT/partials/misc/admon-cloud-firewall.adoc
@@ -1,0 +1,1 @@
+NOTE: When using the cloud-hosted service behind a firewall or forward proxy, ensure `+*.tiny.cloud+` is allowlisted and that required HTTP headers are not stripped. See xref:tinymce-and-csp.adoc#firewall-and-proxy-allowlisting[Firewall and proxy allowlisting] for details.


### PR DESCRIPTION
**Ticket:** DOC-3506

**Site:**

* [CSP page — Firewall and proxy allowlisting (new section)](https://pr-4141.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/tinymce-and-csp/#firewall-and-proxy-allowlisting)
* [TinyMCE AI plugin — Basic setup](https://pr-4141.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/tinymceai/#basic-setup)
* [Import from Word plugin — Cloud setup](https://pr-4141.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/importword/#basic-setup-using-the-tiny-cloud-service)
* [Export to Word plugin — Cloud setup](https://pr-4141.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/exportword/#basic-setup-using-the-tiny-cloud-service)
* [Export to PDF plugin — Cloud setup](https://pr-4141.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/exportpdf/#basic-setup-using-the-tiny-cloud-service)
* [Cloud deployment of editor & plugins — Forward proxy](https://pr-4141.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/editor-and-features/#step-4-forward-proxy-configuration)
* [Cloud deployment of plugins only — Forward proxy](https://pr-4141.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/features-only/#step-3-forward-proxy-configuration)

**Changes:**

* Added a new "Firewall and proxy allowlisting" section to the CSP page (`tinymce-and-csp.adoc`) as a single source of truth, documenting the `*.tiny.cloud` wildcard domain, individual service subdomains, and required HTTP headers (`tiny-api-key`, `tinymce-api-key`).
* Created a reusable admonition partial (`admon-cloud-firewall.adoc`) for cross-referencing the firewall guidance from plugin pages.
* Added the firewall admonition to the TinyMCE AI (`tinymceai.adoc`), Import from Word (`importword.adoc`), Export to Word (`exportword.adoc`), and Export to PDF (`exportpdf.adoc`) plugin pages, inside their cloud setup sections.
* Updated the forward proxy configuration sections in `editor-and-features.adoc` and `features-only.adoc` to use the `*.tiny.cloud` wildcard domain instead of listing only three specific service URLs, and added a cross-reference to the CSP page.

### **Pre-checks:**

- [x] Branch is correctly prefixed:
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

### **Review:**

- [x] Documentation Team Lead has reviewed.