### PR TITLE
TinyMCE 8.5.1 security release notes

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -408,7 +408,9 @@
 ** xref:tinymce-and-cors.adoc[Cross-Origin Resource Sharing (CORS)]
 * Release information
 ** xref:release-notes.adoc[Release notes for {productname}]
-// Remove un-used-for-this-particular-release entries.
+*** {productname} 8.5.1
+**** xref:8.5.1-release-notes.adoc#overview[Overview]
+**** xref:8.5.1-release-notes.adoc#security-fixes[Security fixes]
 *** {productname} 8.5.0
 **** xref:8.5.0-release-notes.adoc#overview[Overview]
 **** xref:8.5.0-release-notes.adoc#accompanying-premium-plugin-changes[Accompanying Premium Plugin changes]

--- a/modules/ROOT/pages/8.5.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.5.1-release-notes.adoc
@@ -11,7 +11,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 [[overview]]
 == Overview
 
-{productname} {release-version} was released for {enterpriseversion} and {cloudname} on Tuesday, May 20^th^, 2026. These release notes provide an overview of the changes for {productname} {release-version}, including:
+{productname} {release-version} was released for {enterpriseversion} and {cloudname} on Wednesday, May 20^th^, 2026. These release notes provide an overview of the changes for {productname} {release-version}, including:
 
 * xref:security-fixes[Security fixes]
 

--- a/modules/ROOT/pages/8.5.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.5.1-release-notes.adoc
@@ -30,7 +30,7 @@ CVE: _pending_
 
 GHSA: https://github.com/tinymce/tinymce/security/advisories/GHSA-vg35-5wq7-3x7w[GitHub Advisories].
 
-// Credits: _pending_
+NOTE: Tiny Technologies would like to thank https://github.com/UncleJ4ck[Aymane MAZGUITI] and https://github.com/ange-primiterra[Ange Primiterra] for discovering this vulnerability.
 
 === Fixed stored XSS vulnerability through `mce:protected` comments
 // #TINY-14353
@@ -41,7 +41,7 @@ CVE: _pending_
 
 GHSA: https://github.com/tinymce/tinymce/security/advisories/GHSA-v98h-vmpc-fpqv[GitHub Advisories].
 
-// Credits: _pending_
+NOTE: Tiny Technologies would like to thank https://github.com/he1d3n[Ivan Babenko (he1d3n)] for discovering this vulnerability.
 
 === Fixed stored XSS vulnerability through `data-mce-` prefixed `src`, `href`, `style` attributes
 // #TINY-14333
@@ -52,4 +52,4 @@ CVE: _pending_
 
 GHSA: https://github.com/tinymce/tinymce/security/advisories/GHSA-q742-qvgc-gc2f[GitHub Advisories].
 
-// Credits: _pending_
+// Credits: Tadi Kadango (https://github.com/mtrill47) — pending permission to attribute

--- a/modules/ROOT/pages/8.5.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.5.1-release-notes.adoc
@@ -1,0 +1,55 @@
+= {productname} {release-version}
+:release-version: 8.5.1
+:navtitle: {productname} {release-version}
+:description: Release notes for {productname} {release-version}
+:keywords: releasenotes, new, changes, bugfixes
+:page-toclevels: 1
+
+include::partial$misc/admon-releasenotes-for-stable.adoc[]
+
+
+[[overview]]
+== Overview
+
+{productname} {release-version} was released for {enterpriseversion} and {cloudname} on <weekday>, <month> <DD>^<st|nd|rd|th>^, <YYYY>. These release notes provide an overview of the changes for {productname} {release-version}, including:
+
+* xref:security-fixes[Security fixes]
+
+
+[[security-fixes]]
+== Security fixes
+
+{productname} {release-version} includes fixes for the following security issues:
+
+=== Fixed stored XSS vulnerability using media plugin `data-mce-object` injection
+// #TINY-14357
+
+A stored cross-site scripting (XSS) vulnerability was identified in the media plugin. Malicious scripts could be injected through crafted `data-mce-object` and `data-mce-p-*` attributes, which were executed when content was rendered. {productname} {release-version} ensures that content with `data-mce-object` and `data-mce-p-*` attributes is properly sanitized when the media plugin is in use.
+
+CVE: _pending_
+
+GHSA: https://github.com/tinymce/tinymce/security/advisories/GHSA-vg35-5wq7-3x7w[GitHub Advisories].
+
+// Credits: _pending_
+
+=== Fixed stored XSS vulnerability through `mce:protected` comments
+// #TINY-14353
+
+A stored cross-site scripting (XSS) vulnerability was identified through forged `mce:protected` comments. Attackers could bypass sanitization and inject scripts that executed when content was restored. This issue affected configurations using the `protect` option. {productname} {release-version} validates decoded `mce:protected` content against configured `protect` regex rules before restoring.
+
+CVE: _pending_
+
+GHSA: https://github.com/tinymce/tinymce/security/advisories/GHSA-v98h-vmpc-fpqv[GitHub Advisories].
+
+// Credits: _pending_
+
+=== Fixed stored XSS vulnerability through `data-mce-` prefixed `src`, `href`, `style` attributes
+// #TINY-14333
+
+A stored cross-site scripting (XSS) vulnerability was identified through unsanitized `data-mce-href`, `data-mce-src`, and `data-mce-style` attributes. Malicious values in these attributes could override safe attributes during serialization, bypassing validation. {productname} {release-version} strips unsafe `data-mce-*` attributes during parsing.
+
+CVE: _pending_
+
+GHSA: https://github.com/tinymce/tinymce/security/advisories/GHSA-q742-qvgc-gc2f[GitHub Advisories].
+
+// Credits: _pending_

--- a/modules/ROOT/pages/8.5.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.5.1-release-notes.adoc
@@ -52,4 +52,4 @@ CVE: _pending_
 
 GHSA: https://github.com/tinymce/tinymce/security/advisories/GHSA-q742-qvgc-gc2f[GitHub Advisories].
 
-// Credits: Tadi Kadango (https://github.com/mtrill47) — pending permission to attribute
+// Credits: Tadi Kadango (https://github.com/mtrill47) and Ivan Babenko (https://github.com/he1d3n) — pending permission to attribute

--- a/modules/ROOT/pages/8.5.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.5.1-release-notes.adoc
@@ -11,7 +11,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 [[overview]]
 == Overview
 
-{productname} {release-version} was released for {enterpriseversion} and {cloudname} on <weekday>, <month> <DD>^<st|nd|rd|th>^, <YYYY>. These release notes provide an overview of the changes for {productname} {release-version}, including:
+{productname} {release-version} was released for {enterpriseversion} and {cloudname} on Tuesday, May 20^th^, 2026. These release notes provide an overview of the changes for {productname} {release-version}, including:
 
 * xref:security-fixes[Security fixes]
 

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -4,6 +4,17 @@
 
 NOTE: This is the {productname} Community version changelog. For information about the latest {cloudname} or {enterpriseversion} Release, see: xref:release-notes.adoc[{productname} Release Notes].
 
+== xref:8.5.1-release-notes.adoc[8.5.1 - YYYY-MM-DD]
+
+=== Security
+
+* Fixed stored XSS vulnerability using media plugin `data-mce-object` injection.
+// #TINY-14357
+* Fixed stored XSS vulnerability through `mce:protected` comments.
+// #TINY-14353
+* Fixed stored XSS vulnerability through `data-mce-` prefixed `src`, `href`, `style` attributes.
+// #TINY-14333
+
 == xref:8.5.0-release-notes.adoc[8.5.0 - 2026-04-29]
 
 ### Added

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -4,7 +4,7 @@
 
 NOTE: This is the {productname} Community version changelog. For information about the latest {cloudname} or {enterpriseversion} Release, see: xref:release-notes.adoc[{productname} Release Notes].
 
-== xref:8.5.1-release-notes.adoc[8.5.1 - YYYY-MM-DD]
+== xref:8.5.1-release-notes.adoc[8.5.1 - 2026-05-20]
 
 === Security
 

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -10,6 +10,12 @@ This section lists the releases for {productname} {productmajorversion} and the 
 |===
 a|
 [.lead]
+xref:8.5.1-release-notes.adoc#overview[{productname} 8.5.1]
+
+Release notes for {productname} 8.5.1
+
+a|
+[.lead]
 xref:8.5.0-release-notes.adoc#overview[{productname} 8.5.0]
 
 Release notes for {productname} 8.5.0
@@ -92,5 +98,5 @@ xref:8.0-release-notes.adoc#overview[{productname} 8.0.0]
 Release notes for {productname} 8.0.0
 
 // Uncomment the dummy cell when the number of cells in the table is odd to ensure the table renders correctly.
-// a|
+a|
 |===


### PR DESCRIPTION
## Summary

[Release notes](https://pr-4143.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.5.1-release-notes/)
[Changelog](https://pr-4143.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/changelog/#8-5-1-2026-05-20)

- Add `8.5.1-release-notes.adoc` with security fixes for TINY-14357, TINY-14353, TINY-14333
- Update `nav.adoc` with 8.5.1 entry (Overview + Security fixes)
- Update `release-notes.adoc` table with 8.5.1 cell
- Update `changelog.adoc` with 8.5.1 security section
- Release date: Wednesday, May 20th, 2026

## Security advisories covered

- [GHSA-vg35-5wq7-3x7w](https://github.com/tinymce/tinymce/security/advisories/GHSA-vg35-5wq7-3x7w) — Media plugin `data-mce-object` injection
- [GHSA-v98h-vmpc-fpqv](https://github.com/tinymce/tinymce/security/advisories/GHSA-v98h-vmpc-fpqv) — `mce:protected` comments bypass
- [GHSA-q742-qvgc-gc2f](https://github.com/tinymce/tinymce/security/advisories/GHSA-q742-qvgc-gc2f) — `data-mce-` prefixed attribute override

## Test plan

- [x] Verify release notes page renders correctly in preview
- [x] Verify nav links resolve
- [x] Verify changelog entry format matches conventions