### PR TITLE
TinyMCE 7.9.3 security release notes

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -417,6 +417,9 @@
 ** xref:tinymce-and-cors.adoc[Cross-Origin Resource Sharing (CORS)]
 * Release information
 ** xref:release-notes.adoc[Release notes for {productname}]
+*** {productname} 7.9.3
+**** xref:7.9.3-release-notes.adoc#overview[Overview]
+**** xref:7.9.3-release-notes.adoc#security-fixes[Security fixes]
 *** {productname} 7.9.2
 **** xref:7.9.2-release-notes.adoc#overview[Overview]
 **** xref:7.9.2-release-notes.adoc#additions[Additions]

--- a/modules/ROOT/pages/7.1-release-notes.adoc
+++ b/modules/ROOT/pages/7.1-release-notes.adoc
@@ -384,9 +384,21 @@ In {productname} {release-version}, the Full Screen plugin has been modified to 
 == Security fixes
 
 
-{productname} {release-version} includes one fix for the following security issue:
+{productname} {release-version} includes fixes for the following security issues:
 
-The following server-side component has been updated to include dependency updates addressing the following security issues. 
+=== Fixed stored XSS vulnerability using sanitization bypass through nested SVGs
+
+A cross-site scripting (XSS) vulnerability was identified in {productname} 6.8.x through 7.0.x caused by improper SVG namespace scope handling in the sanitizer. A crafted payload using nested elements could bypass attribute sanitization and execute arbitrary JavaScript. {productname} {release-version} resolves this issue through a rewrite of the affected sanitizer code.
+
+CVE: _pending_
+
+GHSA: https://github.com/tinymce/tinymce/security/advisories/GHSA-mh5m-5hw4-5c69[GitHub Advisories].
+
+NOTE: Tiny Technologies would like to thank https://maple3142.net[maple3142] of DEVCORE for discovering this vulnerability.
+
+=== Updated server-side component dependencies
+
+The following server-side component has been updated to include dependency updates addressing the following security issues.
 
 * https://nvd.nist.gov/vuln/detail/CVE-2024-29025[CVE-2024-29025]
 

--- a/modules/ROOT/pages/7.9.3-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.3-release-notes.adoc
@@ -1,0 +1,55 @@
+= {productname} {release-version}
+:release-version: 7.9.3
+:navtitle: {productname} {release-version}
+:description: Release notes for {productname} {release-version}
+:keywords: releasenotes, new, changes, bugfixes
+:page-toclevels: 1
+
+include::partial$misc/admon-releasenotes-for-stable.adoc[]
+
+
+[[overview]]
+== Overview
+
+{productname} {release-version} was released for {enterpriseversion} and {cloudname} on <weekday>, <month> <DD>^<st|nd|rd|th>^, <YYYY>. These release notes provide an overview of the changes for {productname} {release-version}, including:
+
+* xref:security-fixes[Security fixes]
+
+
+[[security-fixes]]
+== Security fixes
+
+{productname} {release-version} includes fixes for the following security issues:
+
+=== Fixed stored XSS vulnerability using media plugin `data-mce-object` injection
+// #TINY-14357
+
+A stored cross-site scripting (XSS) vulnerability was identified in the media plugin. Malicious scripts could be injected through crafted `data-mce-object` and `data-mce-p-*` attributes, which were executed when content was rendered. {productname} {release-version} ensures that content with `data-mce-object` and `data-mce-p-*` attributes is properly sanitized when the media plugin is in use.
+
+CVE: _pending_
+
+GHSA: https://github.com/tinymce/tinymce/security/advisories/GHSA-vg35-5wq7-3x7w[GitHub Advisories].
+
+// Credits: _pending_
+
+=== Fixed stored XSS vulnerability through `mce:protected` comments
+// #TINY-14353
+
+A stored cross-site scripting (XSS) vulnerability was identified through forged `mce:protected` comments. Attackers could bypass sanitization and inject scripts that executed when content was restored. This issue affected configurations using the `protect` option. {productname} {release-version} validates decoded `mce:protected` content against configured `protect` regex rules before restoring.
+
+CVE: _pending_
+
+GHSA: https://github.com/tinymce/tinymce/security/advisories/GHSA-v98h-vmpc-fpqv[GitHub Advisories].
+
+// Credits: _pending_
+
+=== Fixed stored XSS vulnerability through `data-mce-` prefixed `src`, `href`, `style` attributes
+// #TINY-14333
+
+A stored cross-site scripting (XSS) vulnerability was identified through unsanitized `data-mce-href`, `data-mce-src`, and `data-mce-style` attributes. Malicious values in these attributes could override safe attributes during serialization, bypassing validation. {productname} {release-version} strips unsafe `data-mce-*` attributes during parsing.
+
+CVE: _pending_
+
+GHSA: https://github.com/tinymce/tinymce/security/advisories/GHSA-q742-qvgc-gc2f[GitHub Advisories].
+
+// Credits: _pending_

--- a/modules/ROOT/pages/7.9.3-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.3-release-notes.adoc
@@ -11,7 +11,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 [[overview]]
 == Overview
 
-{productname} {release-version} was released for {enterpriseversion} and {cloudname} on Tuesday, May 20^th^, 2026. These release notes provide an overview of the changes for {productname} {release-version}, including:
+{productname} {release-version} was released for {enterpriseversion} and {cloudname} on Wednesday, May 20^th^, 2026. These release notes provide an overview of the changes for {productname} {release-version}, including:
 
 * xref:security-fixes[Security fixes]
 

--- a/modules/ROOT/pages/7.9.3-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.3-release-notes.adoc
@@ -30,7 +30,7 @@ CVE: _pending_
 
 GHSA: https://github.com/tinymce/tinymce/security/advisories/GHSA-vg35-5wq7-3x7w[GitHub Advisories].
 
-// Credits: _pending_
+NOTE: Tiny Technologies would like to thank https://github.com/UncleJ4ck[Aymane MAZGUITI] and https://github.com/ange-primiterra[Ange Primiterra] for discovering this vulnerability.
 
 === Fixed stored XSS vulnerability through `mce:protected` comments
 // #TINY-14353
@@ -41,7 +41,7 @@ CVE: _pending_
 
 GHSA: https://github.com/tinymce/tinymce/security/advisories/GHSA-v98h-vmpc-fpqv[GitHub Advisories].
 
-// Credits: _pending_
+NOTE: Tiny Technologies would like to thank https://github.com/he1d3n[Ivan Babenko (he1d3n)] for discovering this vulnerability.
 
 === Fixed stored XSS vulnerability through `data-mce-` prefixed `src`, `href`, `style` attributes
 // #TINY-14333
@@ -52,4 +52,4 @@ CVE: _pending_
 
 GHSA: https://github.com/tinymce/tinymce/security/advisories/GHSA-q742-qvgc-gc2f[GitHub Advisories].
 
-// Credits: _pending_
+// Credits: Tadi Kadango (https://github.com/mtrill47) — pending permission to attribute

--- a/modules/ROOT/pages/7.9.3-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.3-release-notes.adoc
@@ -52,4 +52,4 @@ CVE: _pending_
 
 GHSA: https://github.com/tinymce/tinymce/security/advisories/GHSA-q742-qvgc-gc2f[GitHub Advisories].
 
-// Credits: Tadi Kadango (https://github.com/mtrill47) — pending permission to attribute
+// Credits: Tadi Kadango (https://github.com/mtrill47) and Ivan Babenko (https://github.com/he1d3n) — pending permission to attribute

--- a/modules/ROOT/pages/7.9.3-release-notes.adoc
+++ b/modules/ROOT/pages/7.9.3-release-notes.adoc
@@ -11,7 +11,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 [[overview]]
 == Overview
 
-{productname} {release-version} was released for {enterpriseversion} and {cloudname} on <weekday>, <month> <DD>^<st|nd|rd|th>^, <YYYY>. These release notes provide an overview of the changes for {productname} {release-version}, including:
+{productname} {release-version} was released for {enterpriseversion} and {cloudname} on Tuesday, May 20^th^, 2026. These release notes provide an overview of the changes for {productname} {release-version}, including:
 
 * xref:security-fixes[Security fixes]
 

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -4,7 +4,7 @@
 
 NOTE: This is the {productname} Community version changelog. For information about the latest {cloudname} or {enterpriseversion} Release, see: xref:release-notes.adoc[{productname} Release Notes].
 
-== xref:7.9.3-release-notes.adoc[7.9.3 - YYYY-MM-DD]
+== xref:7.9.3-release-notes.adoc[7.9.3 - 2026-05-20]
 
 === Security
 

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -4,6 +4,17 @@
 
 NOTE: This is the {productname} Community version changelog. For information about the latest {cloudname} or {enterpriseversion} Release, see: xref:release-notes.adoc[{productname} Release Notes].
 
+== xref:7.9.3-release-notes.adoc[7.9.3 - YYYY-MM-DD]
+
+=== Security
+
+* Fixed stored XSS vulnerability using media plugin `data-mce-object` injection.
+// #TINY-14357
+* Fixed stored XSS vulnerability through `mce:protected` comments.
+// #TINY-14353
+* Fixed stored XSS vulnerability through `data-mce-` prefixed `src`, `href`, `style` attributes.
+// #TINY-14333
+
 == xref:7.9.2-release-notes.adoc[7.9.2 - 2026-02-11]
 
 === Deprecated

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -454,6 +454,10 @@ NOTE: This is the {productname} Community version changelog. For information abo
 * The "Open Link" context menu action was not enabled for links on images.
 // #TINY-10391
 
+=== Security
+
+* Fixed stored XSS vulnerability using sanitization bypass through nested SVGs.
+
 == xref:7.0.1-release-notes.adoc[7.0.1 - 2024-04-10]
 
 === Fixed

--- a/modules/ROOT/pages/release-notes.adoc
+++ b/modules/ROOT/pages/release-notes.adoc
@@ -11,6 +11,12 @@ This section lists the releases for {productname} 7 and the changes made in each
 
 a|
 [.lead]
+xref:7.9.3-release-notes.adoc#overview[{productname} 7.9.3]
+
+Release notes for {productname} 7.9.3
+
+a|
+[.lead]
 xref:7.9.2-release-notes.adoc#overview[{productname} 7.9.2]
 
 Release notes for {productname} 7.9.2


### PR DESCRIPTION
## Summary

[Release notes](https://pr-4144.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/7/7.9.3-release-notes/)
[Changelog](https://pr-4144.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/7/changelog/#7-9-3-2026-05-20)

- Add `7.9.3-release-notes.adoc` with security fixes for TINY-14357, TINY-14353, TINY-14333
- Update `nav.adoc` with 7.9.3 entry (Overview + Security fixes)
- Update `release-notes.adoc` table with 7.9.3 cell
- Update `changelog.adoc` with 7.9.3 security section
- Add missing GHSA-mh5m-5hw4-5c69 (nested SVG XSS) entry to 7.1 release notes and changelog
- Release date: Wednesday, May 20th, 2026

## Security advisories covered

### 7.9.3
- [GHSA-vg35-5wq7-3x7w](https://github.com/tinymce/tinymce/security/advisories/GHSA-vg35-5wq7-3x7w) — Media plugin `data-mce-object` injection
- [GHSA-v98h-vmpc-fpqv](https://github.com/tinymce/tinymce/security/advisories/GHSA-v98h-vmpc-fpqv) — `mce:protected` comments bypass
- [GHSA-q742-qvgc-gc2f](https://github.com/tinymce/tinymce/security/advisories/GHSA-q742-qvgc-gc2f) — `data-mce-` prefixed attribute override

### 7.1 (retroactive)
- [GHSA-mh5m-5hw4-5c69](https://github.com/tinymce/tinymce/security/advisories/GHSA-mh5m-5hw4-5c69) — Nested SVG sanitization bypass (patched in 7.1.0, advisory published today)

## Test plan

- [x] Verify 7.9.3 release notes page renders correctly in preview
- [x] Verify 7.1 release notes security section updated correctly
- [x] Verify nav links resolve
- [x] Verify changelog entries format matches conventions