### PR TITLE
DOC-3511: Add CVE IDs and missing credit to 8.5.1 release notes

### DIFF
--- a/modules/ROOT/pages/8.5.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.5.1-release-notes.adoc
@@ -26,7 +26,7 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 A stored cross-site scripting (XSS) vulnerability was identified in the media plugin. Malicious scripts could be injected through crafted `data-mce-object` and `data-mce-p-*` attributes, which were executed when content was rendered. {productname} {release-version} ensures that content with `data-mce-object` and `data-mce-p-*` attributes is properly sanitized when the media plugin is in use.
 
-CVE: _pending_
+CVE: https://nvd.nist.gov/vuln/detail/CVE-2026-47761[CVE-2026-47761]
 
 GHSA: https://github.com/tinymce/tinymce/security/advisories/GHSA-vg35-5wq7-3x7w[GitHub Advisories].
 
@@ -37,7 +37,7 @@ NOTE: Tiny Technologies would like to thank https://github.com/UncleJ4ck[Aymane 
 
 A stored cross-site scripting (XSS) vulnerability was identified through forged `mce:protected` comments. Attackers could bypass sanitization and inject scripts that executed when content was restored. This issue affected configurations using the `protect` option. {productname} {release-version} validates decoded `mce:protected` content against configured `protect` regex rules before restoring.
 
-CVE: _pending_
+CVE: https://nvd.nist.gov/vuln/detail/CVE-2026-47762[CVE-2026-47762]
 
 GHSA: https://github.com/tinymce/tinymce/security/advisories/GHSA-v98h-vmpc-fpqv[GitHub Advisories].
 
@@ -48,8 +48,8 @@ NOTE: Tiny Technologies would like to thank https://github.com/he1d3n[Ivan Baben
 
 A stored cross-site scripting (XSS) vulnerability was identified through unsanitized `data-mce-href`, `data-mce-src`, and `data-mce-style` attributes. Malicious values in these attributes could override safe attributes during serialization, bypassing validation. {productname} {release-version} strips unsafe `data-mce-*` attributes during parsing.
 
-CVE: _pending_
+CVE: https://nvd.nist.gov/vuln/detail/CVE-2026-47759[CVE-2026-47759]
 
 GHSA: https://github.com/tinymce/tinymce/security/advisories/GHSA-q742-qvgc-gc2f[GitHub Advisories].
 
-// Credits: Tadi Kadango (https://github.com/mtrill47) and Ivan Babenko (https://github.com/he1d3n) — pending permission to attribute
+NOTE: Tiny Technologies would like to thank https://github.com/mtrill47[Tadi Kadango] (https://tadiwakadango.com/[website]) and https://github.com/he1d3n[Ivan Babenko (he1d3n)] for discovering this vulnerability.


### PR DESCRIPTION
## Summary

- Replace `CVE: _pending_` placeholders with assigned CVE IDs
- Add missing thank you note for Tadi Kadango and Ivan Babenko on GHSA-q742-qvgc-gc2f

## CVE IDs

| Advisory | CVE |
|---|---|
| GHSA-vg35-5wq7-3x7w (media plugin) | CVE-2026-47761 |
| GHSA-v98h-vmpc-fpqv (mce:protected) | CVE-2026-47762 |
| GHSA-q742-qvgc-gc2f (data-mce- attributes) | CVE-2026-47759 |

## Test plan

- [x] Verify CVE links resolve to NVD
- [x] Verify credit note renders on 8.5.1 release notes page