### PR TITLE
DOC-2614: Wrong information in docs around iframe_aria_text

### DIFF
--- a/modules/ROOT/partials/configuration/iframe_aria_text.adoc
+++ b/modules/ROOT/partials/configuration/iframe_aria_text.adoc
@@ -1,17 +1,16 @@
 [[iframe_aria_text]]
 == `+iframe_aria_text+`
 
-This option is used to update the `+aria-label+` applied to the editor content inside the {product name} `+iframe+`.
+This option sets the accessible name for the editable content area inside the {productname} `+iframe+`. The value is read by screen readers to help users identify the editor.
 
-The value is set as an `aria-label` on the `<body>` element inside the {product name} iframe document. For example:
+On most browsers, the value is applied as an `+aria-label+` on the `+<body>+` element inside the iframe document. For example:
 
 [source,html]
 ----
 <body aria-label="Rich Text Area. Press ALT-0 for help."></body>
 ----
 
-Note:
-The iframe `+title+` attribute is not modified by this option and remains a fixed value ("Rich Text Area").
+This option only applies to {productname} classic (iframe) mode and has no effect on xref:inline-editor-options.adoc#inline[`+inline+` editors].
 
 *Type:* `+String+`
 

--- a/modules/ROOT/partials/configuration/iframe_aria_text.adoc
+++ b/modules/ROOT/partials/configuration/iframe_aria_text.adoc
@@ -1,14 +1,17 @@
 [[iframe_aria_text]]
 == `+iframe_aria_text+`
 
-This option is used to customize the `+title+` attribute on the {productname} `+iframe+` element. For example:
+This option is used to update the `+aria-label+` applied to the editor content inside the {product name} `+iframe+`.
+
+The value is set as an `aria-label` on the `<body>` element inside the {product name} iframe document. For example:
 
 [source,html]
 ----
-<iframe title="Rich Text Area. Press ALT-0 for help."></iframe>
+<body aria-label="Rich Text Area. Press ALT-0 for help."></body>
 ----
 
-The `+title+` attribute is read by screen-readers to help users identify the editor. This option only applies to {productname} classic (iframe) mode and has no effect on xref:inline-editor-options.adoc#inline[`+inline+` editors].
+Note:
+The iframe `+title+` attribute is not modified by this option and remains a fixed value ("Rich Text Area").
 
 *Type:* `+String+`
 


### PR DESCRIPTION
Ticket: TINYDOC-2614

Site: [Staging branch](https://pr-<PR#>.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/<version>/)

Changes:
* replaced the prev. example 
* altered the intro desc. to shift the focus from title to body
* kept the final note at the bottom the same. unsure if this needs to be changed. 

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.
- [x] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed