### PR TITLE
DOC-3513: Fix broken external links (v6)

### DIFF
--- a/modules/ROOT/examples/live-demos/advcode/index.html
+++ b/modules/ROOT/examples/live-demos/advcode/index.html
@@ -31,7 +31,7 @@
             <li>Increase and decrease display font size.</li>
             <li>Full-screen mode.</li>
           </ul>
-          <p>For the Advanced Code Editor to offer a full-screen mode requires the <a href="https://tiny.cloud/docs/tinymce/6/fullscreen">Full screen</a> plugin and requires the Advanced Code Editor to be running in <a href="https://tiny.cloud/docs/tinymce/6/advcode/#advcode_inline">inline mode</a>.</p>
+          <p>For the Advanced Code Editor to offer a full-screen mode requires the <a href="https://www.tiny.cloud/docs/tinymce/6/fullscreen">Full screen</a> plugin and requires the Advanced Code Editor to be running in <a href="https://www.tiny.cloud/docs/tinymce/6/advcode/#advcode_inline">inline mode</a>.</p>
           <p>To open the Advanced Code Editor dialog:</p>
           <ul>
             <li>On the menu bar, open <strong>View</strong> &gt; <strong>Source code</strong>.</li>

--- a/modules/ROOT/examples/live-demos/advtemplate-insertionpoint/index.html
+++ b/modules/ROOT/examples/live-demos/advtemplate-insertionpoint/index.html
@@ -33,7 +33,7 @@
 
 <h4>Working with Merge Tags</h4>
 
-<p>The second pre-defined template in this demonstration — the <em>Letter outline</em> template — shows the <code>{{prefix}}mce-cursor{{suffix}}</code> string working in conjunction with the <a href="https://tiny.cloud/docs/tinymce/6/mergetags/">Merge Tags</a> Premium plugin.</p>
+<p>The second pre-defined template in this demonstration — the <em>Letter outline</em> template — shows the <code>{{prefix}}mce-cursor{{suffix}}</code> string working in conjunction with the <a href="https://www.tiny.cloud/docs/tinymce/6/mergetags/">Merge Tags</a> Premium plugin.</p>
 
 <p>The fixed string that is the Insertion Point Marker uses the same delimiting characters as are used by default by the Merge Tags plugin.</p>
 

--- a/modules/ROOT/examples/live-demos/editor-dfree/index.html
+++ b/modules/ROOT/examples/live-demos/editor-dfree/index.html
@@ -4,7 +4,7 @@
   </h2>
   <br/>
   <div class="dfree-body mce-content-body" contenteditable="true" style="position: relative;" spellcheck="false">
-    <p><img src="https://tiny.cloud/images/medium-pic.jpg" style="display: block; margin-left: auto; margin-right: auto; width: 100%;"></p>
+    <p><img src="https://www.tiny.cloud/images/medium-pic.jpg" style="display: block; margin-left: auto; margin-right: auto; width: 100%;"></p>
     <br/>
     <h2>The world’s first rich text editor in the cloud</h2>
 

--- a/modules/ROOT/examples/live-demos/footnotes/index.html
+++ b/modules/ROOT/examples/live-demos/footnotes/index.html
@@ -16,7 +16,7 @@
         <li id="footnotes_entry_46102500311662090427490"><a class="mce-footnotes-backlink" href="#footnote_46102500311662090427490">^&nbsp;</a><span class="mce-footnotes-note">If there is a highlighted selection when a footnote is added, the new footnote is added to the end of the highlighted selection.&nbsp;</span></li>
         <li id="footnotes_entry_795387001171662097474091"><a class="mce-footnotes-backlink" href="#footnote_795387001171662097474091">^&nbsp;</a><span class="mce-footnotes-note">Scrolling the document to the end, if necessary.</span></li>
         <li id="footnotes_entry_83105724181662097486697"><a class="mce-footnotes-backlink" href="#footnote_83105724181662097486697">^&nbsp;</a><span class="mce-footnotes-note">The footnotes section contains every footnote entry.</span></li>
-        <li id="footnotes_entry_6878577521662090521962"><a class="mce-footnotes-backlink" href="#footnote_6878577521662090521962">^&nbsp;</a><span class="mce-footnotes-note">See <a href="https://tiny.cloud/docs/tinymce/6/plugins/">Premium plugins</a> for details.</span></li>
+        <li id="footnotes_entry_6878577521662090521962"><a class="mce-footnotes-backlink" href="#footnote_6878577521662090521962">^&nbsp;</a><span class="mce-footnotes-note">See <a href="https://www.tiny.cloud/docs/tinymce/6/plugins/">Premium plugins</a> for details.</span></li>
       </ol>
     </div>
   </textarea>

--- a/modules/ROOT/examples/live-demos/linkchecker/index.html
+++ b/modules/ROOT/examples/live-demos/linkchecker/index.html
@@ -15,7 +15,7 @@
 <p>Note each of them is:
 
 <ol>
-<li>turned into a clickable link by the <a href="https://tiny.cloud/docs/tinymce/6/autolink">Autolink</a> plugin; and then, after a short delay,
+<li>turned into a clickable link by the <a href="https://www.tiny.cloud/docs/tinymce/6/autolink">Autolink</a> plugin; and then, after a short delay,
 <li>highlighted in red by the <strong>Link Checker</strong> plugin.</li>
 </ol>
 
@@ -36,7 +36,7 @@
 <p>Note each of them is:</p>
 
 <ol>
-<li>turned into a clickable link by the <a href="https://tiny.cloud/docs/tinymce/6/autolink">Autolink</a> plugin; and then
+<li>turned into a clickable link by the <a href="https://www.tiny.cloud/docs/tinymce/6/autolink">Autolink</a> plugin; and then
 <li><strong>not</strong> highlighted in red by the <strong>Link Checker</strong> plugin.</li>
 </ol>
 

--- a/modules/ROOT/pages/6.0-release-notes-premium-changes.adoc
+++ b/modules/ROOT/pages/6.0-release-notes-premium-changes.adoc
@@ -24,29 +24,29 @@ No Premium Plugins released with {productname} 6.0 are backwards compatible with
 
 | `formatpainter_blacklisted_formats` | `formatpainter_ignored_formats`  | Option                              | 
 
-| `imagetools`                        | `editimage`                      | Plugin                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `imagetools`                        | `editimage`                      | Plugin                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-| `imagetools_toolbar`                | `editimage_toolbar`              | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `imagetools_toolbar`                | `editimage_toolbar`              | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-| `imagetools_proxy`                  | `editimage_proxy`                | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `imagetools_proxy`                  | `editimage_proxy`                | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-| `imagetools_cors_hosts`             | `editimage_cors_hosts`           | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `imagetools_cors_hosts`             | `editimage_cors_hosts`           | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-| `imagetools_credentials_hosts`      | `editimage_credentials_hosts`    | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `imagetools_credentials_hosts`      | `editimage_credentials_hosts`    | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-| `imagetools_fetch_image`            | `editimage_fetch_image`          | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `imagetools_fetch_image`            | `editimage_fetch_image`          | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-| `images_upload_timeout`             | `editimage_upload_timeout`       | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `images_upload_timeout`             | `editimage_upload_timeout`       | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-| `toc`                               | `tableofcontents`                | Plugin, Menu item, and Toolbar item | This presents in both the menu item and the toolbar’s tooltip text. NB: _Table of Contents_ is now a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `toc`                               | `tableofcontents`                | Plugin, Menu item, and Toolbar item | This presents in both the menu item and the toolbar’s tooltip text. NB: _Table of Contents_ is now a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-| `tocupdate`                         | `tableofcontentsupdate`          | Toolbar item                        | This presents in the toolbar’s tooltip text. NB: _Table of Contents_ is now a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `tocupdate`                         | `tableofcontentsupdate`          | Toolbar item                        | This presents in the toolbar’s tooltip text. NB: _Table of Contents_ is now a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-| `toc_class`                         | `tableofcontents_class`          | Option                              | NB: _Table of Contents_ is now a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `toc_class`                         | `tableofcontents_class`          | Option                              | NB: _Table of Contents_ is now a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-| `toc_depth`                         | `tableofcontents_depth`          | Option                              | NB: _Table of Contents_ is now a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `toc_depth`                         | `tableofcontents_depth`          | Option                              | NB: _Table of Contents_ is now a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-| `toc_header`                        | `tableofcontents_header`         | Option                              | NB: _Table of Contents_ is now a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `toc_header`                        | `tableofcontents_header`         | Option                              | NB: _Table of Contents_ is now a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 |===
 
 [[hindi-malay-and-vietnamese-translations-added-to-premium-plugins]]
@@ -135,11 +135,11 @@ The following changes were made to the xref:editimage.adoc[Enhanced Image Editin
 
 As noted in the xref:6.0-release-notes-core-changes.adoc#removed-or-deprecated-plugins-imagetools[_{productname} 6.0 Release Notes_], the `imagetools` plugin is no longer included as part of the Free editor.
 
-_Image Tools_ is now _Enhanced Image Editing_, a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+_Image Tools_ is now _Enhanced Image Editing_, a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
 The `imagetools_proxy` option has been renamed to `editimage_proxy`. However, when setting up xref:introduction-to-premium-selfhosted-services.adoc[Tiny services] the recommended configuration is now `editimage_proxy_service_url` and will be used in favour of `editimage_proxy` if both are set.
 
-Users of the Free version of {productname} 5.x who rely on the removed `imagetools` plugin should not upgrade to {productname} 6.0 without a https://tiny.cloud/pricing/[subscription plan] that provides access to https://tiny.cloud/tinymce/features/#productivity[_Enhanced Image Editing_].
+Users of the Free version of {productname} 5.x who rely on the removed `imagetools` plugin should not upgrade to {productname} 6.0 without a https://www.tiny.cloud/pricing/[subscription plan] that provides access to https://www.tiny.cloud/tinymce/features/#productivity[_Enhanced Image Editing_].
 
 
 === Enhanced Media Embed
@@ -154,7 +154,7 @@ This value was previously deprecated and, with this release, support for `false`
 
 The following improvement was made to the xref:export.adoc[Export] plugin:
 
-A new `export_image_proxy_service_url` option is available for use with the proxy service provided by https://tiny.cloud/docs/enterprise/server/[Tiny services].
+A new `export_image_proxy_service_url` option is available for use with the proxy service provided by https://www.tiny.cloud/docs/enterprise/server/[Tiny services].
 
 
 === Format Painter
@@ -275,9 +275,9 @@ The following changes were made to the xref:tableofcontents.adoc[Table of Conten
 
 As noted in the xref:6.0-release-notes-core-changes.adoc#new-and-improved-plugins-table-of-contents[_{productname} 6.0 Release Notes_], the `toc` plugin is no longer part of the Core editor.
 
-Table of Contents has been updated and is now a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+Table of Contents has been updated and is now a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-Users of the Free version of {productname} 5.x who rely on the, now deprecated and removed, `toc` plugin, should not upgrade to {productname} 6.0 without a https://tiny.cloud/pricing/[subscription plan] that provides access to Premium plugins such as https://tiny.cloud/tinymce/features/#productivity[_Table of Contents_].
+Users of the Free version of {productname} 5.x who rely on the, now deprecated and removed, `toc` plugin, should not upgrade to {productname} 6.0 without a https://www.tiny.cloud/pricing/[subscription plan] that provides access to Premium plugins such as https://www.tiny.cloud/tinymce/features/#productivity[_Table of Contents_].
 
 The new Premium `tableofcontents` plugin also changes the names of several elements.
 

--- a/modules/ROOT/pages/6.1-release-notes.adoc
+++ b/modules/ROOT/pages/6.1-release-notes.adoc
@@ -460,7 +460,7 @@ For information on using premium skins and icon packs, see: xref:enhanced-skins-
 
 Setting `window.opener` to `null` set the browser to load the target resource without granting the target resource access to the document that opened it.
 
-With this release, all {productname} help dialog links out to https://tiny.cloud[tiny.cloud] include the `rel="noopener"` attribute and value.
+With this release, all {productname} help dialog links out to https://www.tiny.cloud[tiny.cloud] include the `rel="noopener"` attribute and value.
 
 This provides basic protection against attacks that mis-use the `window.opener` default.
 

--- a/modules/ROOT/pages/6.7-release-notes.adoc
+++ b/modules/ROOT/pages/6.7-release-notes.adoc
@@ -815,9 +815,9 @@ Note the duplicated material in the post-drag editor state example.
 === Using the Media plugin unexpectedly changed `<script>` tags in the editor body to `<image>` tags
 // TINY-10007
 
-As part of the {productname} 5.10 release, the `https://tiny.cloud/docs/plugins/opensource/media/#media_scripts)[media_scripts]` option was deprecated. And, as of the {productname} 6.0 release, this option was removed.
+As part of the {productname} 5.10 release, the `https://www.tiny.cloud/docs/plugins/opensource/media/#media_scripts)[media_scripts]` option was deprecated. And, as of the {productname} 6.0 release, this option was removed.
 
-When the setting was available, it was used to allow some script tags, with specified source URLs, to have some of their properties edited in the https://tiny.cloud/docs/plugins/opensource/media/[*Media*] plugin’s dialog.
+When the setting was available, it was used to allow some script tags, with specified source URLs, to have some of their properties edited in the https://www.tiny.cloud/docs/plugins/opensource/media/[*Media*] plugin’s dialog.
 
 And, while the `media_scripts` option was removed, the logic that allowed the plugin to edit properties in some script tags was not.
 

--- a/modules/ROOT/pages/browserify-cjs-download.adoc
+++ b/modules/ROOT/pages/browserify-cjs-download.adoc
@@ -5,7 +5,7 @@
 :keywords: browserify, commonjs, cjs, zip, modules, tinymce
 :installtype: pass:n[a `+.zip+`]
 :bundler: https://browserify.org/[Browserify]
-:syntax: http://www.commonjs.org/specs/modules/1.0/[CommonJS syntax]
+:syntax: https://en.wikipedia.org/wiki/CommonJS[CommonJS syntax]
 
 include::partial$module-loading/bundling-procedure-intro.adoc[]
 

--- a/modules/ROOT/pages/browserify-cjs-npm.adoc
+++ b/modules/ROOT/pages/browserify-cjs-npm.adoc
@@ -5,7 +5,7 @@
 :keywords: browserify, commonjs, cjs, npm, modules, tinymce
 :installtype: an npm
 :bundler: https://browserify.org/[Browserify]
-:syntax: http://www.commonjs.org/specs/modules/1.0/[CommonJS syntax]
+:syntax: https://en.wikipedia.org/wiki/CommonJS[CommonJS syntax]
 
 include::partial$module-loading/bundling-procedure-intro.adoc[]
 

--- a/modules/ROOT/pages/mediaembed-server-integration.adoc
+++ b/modules/ROOT/pages/mediaembed-server-integration.adoc
@@ -2,7 +2,7 @@
 :description: Using the Enhanced Media Embed server with non-public content such as a corporate CMS.
 :keywords: enterprise, pricing, video, youtube, vimeo, mp3, mp4, mov, movie, clip, film, link, linkchecking, linkchecker, mediaembed, media
 
-Websites like https://developers.facebook.com/docs/plugins/oembed-endpoints[Facebook] and https://www.instagram.com/developer/embedding/[Instagram] expose an http://oembed.com/[oEmbed] endpoint for developers to utilize. The https://iframely.com/[Iframely] service creates embeds from websites on the public Internet. For content on private networks, such as a corporate CMS, this document outlines how to enrich the content or build an API that the Enhanced Media Embed server can utilize to create rich hyperlinks. We'll also provide some information about the Enhanced Media Embed server's summary cards.
+Websites like Facebook and https://developers.facebook.com/docs/instagram-platform/oembed[Instagram] expose an https://oembed.com/[oEmbed] endpoint for developers to utilize. The https://iframely.com/[Iframely] service creates embeds from websites on the public Internet. For content on private networks, such as a corporate CMS, this document outlines how to enrich the content or build an API that the Enhanced Media Embed server can utilize to create rich hyperlinks. We'll also provide some information about the Enhanced Media Embed server's summary cards.
 
 There are three options for enhancing the embeds created for private content by the Enhanced Media Embed server:
 

--- a/modules/ROOT/pages/migration-from-5x.adoc
+++ b/modules/ROOT/pages/migration-from-5x.adoc
@@ -279,7 +279,7 @@ Three plugins have been empty stub plugins since {productname} 5.0, and were rem
 . `contextmenu`
 . `textcolor`
 
-NOTE: The https://tiny.cloud/tinymce/features/#productivity[Premium plugin], xref:introduction-to-tiny-spellchecker.adoc[Spell Checker Pro], which offers equivalent functionality and more, is available.
+NOTE: The https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin], xref:introduction-to-tiny-spellchecker.adoc[Spell Checker Pro], which offers equivalent functionality and more, is available.
 
 NOTE: No Premium Plugins released with {productname} 6.0 are backwards compatible with earlier versions of {productname}.
 
@@ -287,11 +287,11 @@ NOTE: No Premium Plugins released with {productname} 6.0 are backwards compatibl
 
 As noted in the xref:6.0-release-notes-core-changes.adoc#removed-or-deprecated-plugins-imagetools[_{productname} 6.0 Release Notes_], the `imagetools` plugin is no longer included as part of the Free editor.
 
-_Image Tools_ is now _Enhanced Image Editing_, a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+_Image Tools_ is now _Enhanced Image Editing_, a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
 The `imagetools_proxy` option has been renamed to `editimage_proxy`. However, when setting up xref:introduction-to-premium-selfhosted-services.adoc[Tiny services] the recommended configuration is now `editimage_proxy_service_url` and will be used in favour of `editimage_proxy` if both are set.
 
-Users of the Free version of {productname} 5.x who rely on the removed `imagetools` plugin should not upgrade to {productname} 6.0 without a https://tiny.cloud/pricing/[subscription plan] that provides access to xref:editimage.adoc[Enhanced Image Editing].
+Users of the Free version of {productname} 5.x who rely on the removed `imagetools` plugin should not upgrade to {productname} 6.0 without a https://www.tiny.cloud/pricing/[subscription plan] that provides access to xref:editimage.adoc[Enhanced Image Editing].
 
 NOTE: No Premium Plugins released with {productname} 6.0 are backwards compatible with earlier versions of {productname}.
 
@@ -374,9 +374,9 @@ In iframe (classic editor) mode, {productname} copies the `tabindex` attribute f
 
 As noted in the xref:6.0-release-notes-core-changes.adoc#new-and-improved-plugins-table-of-contents[_{productname} 6.0 Release Notes_], the `toc` plugin is no longer part of the Free editor.
 
-Table of Contents has been updated and is now a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+Table of Contents has been updated and is now a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-Users of the Free version of {productname} 5.x who rely on the, now deprecated and removed, `toc` plugin, should not upgrade to {productname} 6.0 without a https://tiny.cloud/pricing/[subscription plan] that provides access to Premium plugins such as xref:tableofcontents.adoc[Table of Contents].
+Users of the Free version of {productname} 5.x who rely on the, now deprecated and removed, `toc` plugin, should not upgrade to {productname} 6.0 without a https://www.tiny.cloud/pricing/[subscription plan] that provides access to Premium plugins such as xref:tableofcontents.adoc[Table of Contents].
 
 The new Premium `tableofcontents` plugin also changes the names of several elements.
 

--- a/modules/ROOT/pages/moxiemanager.adoc
+++ b/modules/ROOT/pages/moxiemanager.adoc
@@ -13,4 +13,4 @@ MoxieManager is a paid addition to {productname}. It is included in link:{pricin
 
 Full documentation on MoxieManager, including how to http://www.moxiemanager.com/documentation/index.php/TinyMCE_Integration[integrate with {productname}], can be http://www.moxiemanager.com/documentation/[found] on the MoxieManager website.
 
-Documentation is archived for the deprecated http://archive.tinymce.com/wiki.php/MCImageManager[MCImageManager] and http://archive.tinymce.com/wiki.php/MCFileManager[MCFileManager].
+Documentation was previously available for the deprecated MCImageManager and MCFileManager (no longer accessible online).

--- a/modules/ROOT/pages/tinydrive-googledrive-integration.adoc
+++ b/modules/ROOT/pages/tinydrive-googledrive-integration.adoc
@@ -89,7 +89,7 @@ The following other options can be performed to the selected file :
 * Choose *Download* to download the selected file/files.
 * Choose *Delete* to remove the selected file/files from the Google Drive.
 
-Read more about these options https://gsuite.google.com/learning-center/products/drive/get-started/#!/[here].
+Read more about these options in the https://support.google.com/a/users/answer/9300017[Google Drive cheat sheet].
 
 == Interactive example
 

--- a/modules/ROOT/pages/troubleshoot-server.adoc
+++ b/modules/ROOT/pages/troubleshoot-server.adoc
@@ -124,9 +124,9 @@ Use your distribution package manager to install curl. See your distribution doc
 
 Download and install the curl package based on your environment:
 
-x64: http://curl.haxx.se/dlwiz/?type=bin&os=Win64&flav=MinGW64
+x64: https://curl.se/windows/
 
-x86: http://curl.haxx.se/dlwiz/?type=bin&os=Win32&flav=-&ver=2000%2FXP and select either of the curl version: 7.39.0 - SSL enabled SSH enabled packages
+x86: https://curl.se/windows/
 
 Once downloaded:
 

--- a/modules/ROOT/pages/webpack-cjs-download.adoc
+++ b/modules/ROOT/pages/webpack-cjs-download.adoc
@@ -5,7 +5,7 @@
 :keywords: webpack, commonjs, cjs, zip, modules, tinymce
 :installtype: pass:n[a `+.zip+`]
 :bundler: https://webpack.js.org/[Webpack]
-:syntax: http://www.commonjs.org/specs/modules/1.0/[CommonJS syntax]
+:syntax: https://en.wikipedia.org/wiki/CommonJS[CommonJS syntax]
 
 include::partial$module-loading/bundling-procedure-intro.adoc[]
 

--- a/modules/ROOT/pages/webpack-cjs-npm.adoc
+++ b/modules/ROOT/pages/webpack-cjs-npm.adoc
@@ -5,7 +5,7 @@
 :keywords: webpack, commonjs, cjs, npm, modules, tinymce
 :installtype: an npm
 :bundler: https://webpack.js.org/[Webpack]
-:syntax: http://www.commonjs.org/specs/modules/1.0/[CommonJS syntax]
+:syntax: https://en.wikipedia.org/wiki/CommonJS[CommonJS syntax]
 
 include::partial$module-loading/bundling-procedure-intro.adoc[]
 

--- a/modules/ROOT/partials/misc/admon-ai-pricing.adoc
+++ b/modules/ROOT/partials/misc/admon-ai-pricing.adoc
@@ -1,1 +1,1 @@
-NOTE: This plugin is only available as a link:{aipricingurl}/[paid add-on] to link:{pricingpage}/[a TinyMCE subscription].
+NOTE: This plugin is only available as a link:{aipricingurl}[paid add-on] to link:{pricingpage}[a TinyMCE subscription].

--- a/modules/ROOT/partials/release-notes/6.0-release-notes-plugins.adoc
+++ b/modules/ROOT/partials/release-notes/6.0-release-notes-plugins.adoc
@@ -98,7 +98,7 @@ As of {productname} 6.0, `autoresize_on_init` has been removed from the `autores
 [[changed-plugins-media]]
 === Media
 
-In {productname} 5.x, the `media` plugin used https://tiny.cloud/docs/api/tinymce.html/tinymce.html.saxparser/[`SaxParser`] to validate elements for parsing.
+In {productname} 5.x, the `media` plugin used https://www.tiny.cloud/docs/api/tinymce.html/tinymce.html.saxparser/[`SaxParser`] to validate elements for parsing.
 
 As of {productname} 6.0, `SaxParser` is no longer used. Another {productname} public API — `DomParser` — is used instead.
 

--- a/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
+++ b/modules/ROOT/partials/release-notes/6.0-release-notes-summary.adoc
@@ -32,7 +32,7 @@ NOTE: In particular, this means {productname} 6.0 does not support Microsoft Int
 * Vietnamese (vi)
 --
 +
-These packs are available to all https://tiny.cloud/get-tiny/[Cloud subscribers] and all https://tiny.cloud/pricing/[Premium plan subscribers].
+These packs are available to all https://www.tiny.cloud/get-tiny/[Cloud subscribers] and all https://www.tiny.cloud/pricing/[Premium plan subscribers].
 
 // end::core-changes[]
 
@@ -56,19 +56,19 @@ This section also includes four tables that set out the:
 
 | `formatselect`                      | `blocks`                         | Toolbar item                        | No behavioral changes.
 
-| `imagetools`                        | `editimage`                      | Plugin                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `imagetools`                        | `editimage`                      | Plugin                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-| `imagetools_toolbar`                | `editimage_toolbar`              | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `imagetools_toolbar`                | `editimage_toolbar`              | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-| `imagetools_proxy`                  | `editimage_proxy`                | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `imagetools_proxy`                  | `editimage_proxy`                | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-| `imagetools_cors_hosts`             | `editimage_cors_hosts`           | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `imagetools_cors_hosts`             | `editimage_cors_hosts`           | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-| `imagetools_credentials_hosts`      | `editimage_credentials_hosts`    | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `imagetools_credentials_hosts`      | `editimage_credentials_hosts`    | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-| `imagetools_fetch_image`            | `editimage_fetch_image`          | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `imagetools_fetch_image`            | `editimage_fetch_image`          | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-| `images_upload_timeout`             | `editimage_upload_timeout`       | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `images_upload_timeout`             | `editimage_upload_timeout`       | Option                              | NB: _Image Tools_ is now _Enhanced Image Editing_, a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
 | `fire()`                            | `dispatch()`                     | API                                 | `fire()` in `tinymce.Editor`, `tinymce.dom.EventUtils`, `tinymce.dom.DOMUtils`, `tinymce.util.Observable` and `tinymce.util.EventDispatcher` has been renamed to `dispatch()`. `fire` has been aliased to `dispatch` but has also been marked as _deprecated_.
 
@@ -116,15 +116,15 @@ This section also includes four tables that set out the:
 
 | `tinymce.Env.os.isOSX`              | `tinymce.Env.os.isMacOS`         | API                                 | Updated so the API now uses the current name of Apple’s desktop operating system when checking to see if a device’s OS is, in fact, macOS.
 
-| `toc`                               | `tableofcontents`                | Plugin, Menu item, and Toolbar item | This presents in both the menu item and the toolbar’s tooltip text. NB: _Table of Contents_ is now a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `toc`                               | `tableofcontents`                | Plugin, Menu item, and Toolbar item | This presents in both the menu item and the toolbar’s tooltip text. NB: _Table of Contents_ is now a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-| `tocupdate`                         | `tableofcontentsupdate`          | Toolbar item                        | This presents in the toolbar’s tooltip text. NB: _Table of Contents_ is now a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `tocupdate`                         | `tableofcontentsupdate`          | Toolbar item                        | This presents in the toolbar’s tooltip text. NB: _Table of Contents_ is now a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-| `toc_class`                         | `tableofcontents_class`          | Option                              | NB: _Table of Contents_ is now a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `toc_class`                         | `tableofcontents_class`          | Option                              | NB: _Table of Contents_ is now a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-| `toc_depth`                         | `tableofcontents_depth`          | Option                              | NB: _Table of Contents_ is now a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `toc_depth`                         | `tableofcontents_depth`          | Option                              | NB: _Table of Contents_ is now a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 
-| `toc_header`                        | `tableofcontents_header`         | Option                              | NB: _Table of Contents_ is now a https://tiny.cloud/tinymce/features/#productivity[Premium plugin].
+| `toc_header`                        | `tableofcontents_header`         | Option                              | NB: _Table of Contents_ is now a https://www.tiny.cloud/tinymce/features/#productivity[Premium plugin].
 |===
 
 - *Commands* are what is passed via the `editor.execCommand()` API.


### PR DESCRIPTION
## Summary

- Fixes broken external links on the v6 docs branch (same audit as v8/v7 PRs)
- Replaces dead URLs with verified working alternatives

## Changes

| Original broken URL | Replacement |
|---|---|
| `commonjs.org/specs/modules/1.0/` | `en.wikipedia.org/wiki/CommonJS` |
| `curl.haxx.se/dlwiz/...` | `curl.se/windows/` |
| `developers.facebook.com/docs/plugins/oembed-endpoints` | Plain text (page removed by Meta) |
| `instagram.com/developer/embedding/` | `developers.facebook.com/docs/instagram-platform/oembed` |
| `archive.tinymce.com/wiki.php/...` | Plain text (archive offline) |
| `gsuite.google.com/learning-center/...` | `support.google.com/a/users/answer/9300017` |

## Test plan

- [x] All replacement URLs verified accessible (HTTP 200)
- [x] Docs build passes
- [x] No new broken links introduced