### PR TITLE
DOC-3516 - Add service license key documentation and clarify difference from TinyMCE keys

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -495,5 +495,6 @@
 ** xref:changelog.adoc[Changelog]
 * xref:invalid-api-key.adoc[Invalid API key]
 * xref:license-key.adoc[License key]
+* xref:service-license-keys.adoc[Service license keys]
 * xref:support.adoc[Support]
 * xref:usage-based-billing.adoc[Usage-Based Billing]

--- a/modules/ROOT/pages/bundle-intro-setup.adoc
+++ b/modules/ROOT/pages/bundle-intro-setup.adoc
@@ -20,6 +20,10 @@ The following sections assist with containerizing the {productname} services for
 ** Using a Unix-like operating system, such as Linux or macOS.
 ** Using Windows and has access to unix command line tools using link:https://gitforwindows.org/[Git for Windows^], link:https://www.cygwin.com/[Cygwin^], or the link:https://docs.microsoft.com/en-us/windows/wsl/install-win10[Windows Subsystem for Linux^].
 
+=== Service license keys
+
+Some on-premises services require a service license key in addition to the Docker registry access token. Service license keys are separate from {productname} editor license keys. See xref:service-license-keys.adoc[Service license keys] for details on which services require them and how to configure them.
+
 === Next steps
 
 Proceed to setting up and deploying the containerized services for:

--- a/modules/ROOT/pages/license-key.adoc
+++ b/modules/ROOT/pages/license-key.adoc
@@ -6,6 +6,11 @@
 == Overview
 {productname} 8 uses an enhanced license key system to ensure compliance with {productname} licensing terms.
 
+[NOTE]
+====
+This page covers **{productname} editor license keys** only. For information about license keys used with on-premises Docker-based services (such as TinyMCE AI, Export to PDF, and Import from Word / Export to Word), see xref:service-license-keys.adoc[Service license keys].
+====
+
 [IMPORTANT]
 ====
 {productname} is licensed under the GNU General Public License Version 2 or later. A configuration option called `+'license_key'+` introduced in {productname} 7 requires developers to make a conscious decision to use {productname} with the GPLv2+ license or with a commercial license.

--- a/modules/ROOT/pages/service-license-keys.adoc
+++ b/modules/ROOT/pages/service-license-keys.adoc
@@ -33,10 +33,19 @@ Other containerized services such as Spell Checker, Enhanced Media Embed, and Im
 [[how-service-license-keys-work]]
 == How service license keys work
 
-Service license keys are used in two contexts when deploying on-premises services:
+Deploying a {companyname} on-premises service can involve two separate credentials. These are different values and cannot be substituted for one another:
 
-. **Docker registry authentication** -- an access token (provided separately by {companyname}) is used with `+docker login+` to pull service images from the {companyname} Docker registry.
-. **Container runtime licensing** -- the service license key is passed to the Docker container as the `+LICENSE_KEY+` environment variable to enable the service at runtime. Without a valid service license key, the container will not start.
+. **Docker registry access token** -- used with `+docker login+` to authenticate with the {companyname} Docker registry and pull the service image. *All* {companyname} on-premises services require an access token to pull images. An access token is not a service license key.
+. **Service license key** -- passed to the running Docker container as the `+LICENSE_KEY+` environment variable to enable the service at runtime. *Only* the services listed in <<services-requiring-a-service-license-key>> require a service license key. Without a valid service license key, those containers will not start.
+
+[TIP]
+====
+Three separate credentials can be involved when running {companyname} on-premises services. Do not confuse them:
+
+* **{productname} editor license key** -- configures the license mode for the {productname} editor (GPL or commercial). See xref:license-key.adoc[License key].
+* **Docker registry access token** -- authenticates with the {companyname} Docker registry to pull service images. Required by all on-premises services.
+* **Service license key** -- enables a licensed on-premises service at runtime. Required by some services only.
+====
 
 [[obtaining-a-service-license-key]]
 === Obtaining a service license key
@@ -46,7 +55,9 @@ Service license keys are provisioned through the link:{accountpageurl}[{companyn
 [[using-service-specific-environment-variables]]
 === Using service-specific environment variables
 
-When running multiple on-premises services, use service-specific environment variable names to store each service license key. This prevents collisions when consolidating services into a single `+.env+` file or Docker Compose project.
+When running multiple on-premises services and storing their environment variables in a shared location, use service-specific environment variable names for each service license key. This prevents collisions when consolidating services into a single `+.env+` file or Docker Compose project.
+
+Each Docker container expects the `+LICENSE_KEY+` environment variable internally. The service-specific variable names (such as `+AI_LICENSE_KEY+`, `+PDF_LICENSE_KEY+`, and `+DOCX_LICENSE_KEY+`) are host-side conventions that map to `+LICENSE_KEY+` when launching the container. These names are the conventions used in the documentation for each service rather than a fixed requirement.
 
 [cols="1,1,1", options="header"]
 |===
@@ -65,15 +76,13 @@ When running multiple on-premises services, use service-specific environment var
 | `+-e LICENSE_KEY="$DOCX_LICENSE_KEY"+`
 |===
 
-Each Docker container expects the `+LICENSE_KEY+` environment variable internally. The service-specific variable names (such as `+AI_LICENSE_KEY+`, `+PDF_LICENSE_KEY+`, and `+DOCX_LICENSE_KEY+`) are host-side conventions that map to `+LICENSE_KEY+` when launching the container.
-
-For example, in a `+.env+` file used with Docker Compose:
+Each service license key is a distinct value. For example, in a `+.env+` file used with Docker Compose:
 
 [source,env]
 ----
-AI_LICENSE_KEY=[your license key]
-PDF_LICENSE_KEY=[your license key]
-DOCX_LICENSE_KEY=[your license key]
+AI_LICENSE_KEY=[your AI license key]
+PDF_LICENSE_KEY=[your PDF converter license key]
+DOCX_LICENSE_KEY=[your DOCX converter license key]
 ----
 
 [[deployment-guides]]

--- a/modules/ROOT/pages/service-license-keys.adoc
+++ b/modules/ROOT/pages/service-license-keys.adoc
@@ -1,0 +1,88 @@
+= Service license keys
+:navtitle: Service license keys
+:description: Service license keys for on-premises Docker-based services, including TinyMCE AI, Export to PDF, Import from Word, and Export to Word.
+:keywords: service license key, on-premises, Docker, license, docker login, registry, TinyMCE AI
+
+[[overview]]
+== Overview
+
+Service license keys authenticate and enable {companyname} on-premises services that run as Docker containers. These keys are separate from {productname} editor license keys.
+
+[IMPORTANT]
+====
+Service license keys and {productname} editor license keys serve different purposes:
+
+* **{productname} editor license keys** configure the license mode for the {productname} editor (GPL or commercial). See xref:license-key.adoc[License key] for details.
+* **Service license keys** authenticate on-premises Docker-based services such as TinyMCE AI, Export to PDF, and the Import from Word / Export to Word converters. They are provisioned separately and managed through the link:{accountpageurl}[{companyname} customer portal].
+====
+
+[[services-requiring-a-service-license-key]]
+== Services requiring a service license key
+
+The following on-premises services require a service license key:
+
+* **xref:tinymceai-on-premises.adoc[TinyMCE AI]** -- the on-premises AI service.
+* **xref:individual-export-to-pdf-on-premises.adoc[Export to PDF]** -- the PDF converter service.
+* **xref:individual-import-from-word-and-export-to-word-on-premises.adoc[Import from Word and Export to Word]** -- the DOCX converter service.
+
+[NOTE]
+====
+Other containerized services such as Spell Checker, Enhanced Media Embed, and Image Proxy do not currently require service license keys. These services use access tokens for Docker registry authentication only.
+====
+
+[[how-service-license-keys-work]]
+== How service license keys work
+
+Service license keys are used in two contexts when deploying on-premises services:
+
+. **Docker registry authentication** -- an access token (provided separately by {companyname}) is used with `+docker login+` to pull service images from the {companyname} Docker registry.
+. **Container runtime licensing** -- the service license key is passed to the Docker container as the `+LICENSE_KEY+` environment variable to enable the service at runtime. Without a valid service license key, the container will not start.
+
+[[obtaining-a-service-license-key]]
+=== Obtaining a service license key
+
+Service license keys are provisioned through the link:{accountpageurl}[{companyname} customer portal]. link:https://www.tiny.cloud/contact/[Contact {companyname}] to request a trial or to discuss service licensing.
+
+[[using-service-specific-environment-variables]]
+=== Using service-specific environment variables
+
+When running multiple on-premises services, use service-specific environment variable names to store each service license key. This prevents collisions when consolidating services into a single `+.env+` file or Docker Compose project.
+
+[cols="1,1,1", options="header"]
+|===
+| Service | Environment variable name | Docker container mapping
+
+| TinyMCE AI
+| `+AI_LICENSE_KEY+`
+| `+-e LICENSE_KEY="$AI_LICENSE_KEY"+`
+
+| Export to PDF
+| `+PDF_LICENSE_KEY+`
+| `+-e LICENSE_KEY="$PDF_LICENSE_KEY"+`
+
+| Import from Word / Export to Word
+| `+DOCX_LICENSE_KEY+`
+| `+-e LICENSE_KEY="$DOCX_LICENSE_KEY"+`
+|===
+
+Each Docker container expects the `+LICENSE_KEY+` environment variable internally. The service-specific variable names (such as `+AI_LICENSE_KEY+`, `+PDF_LICENSE_KEY+`, and `+DOCX_LICENSE_KEY+`) are host-side conventions that map to `+LICENSE_KEY+` when launching the container.
+
+For example, in a `+.env+` file used with Docker Compose:
+
+[source,env]
+----
+AI_LICENSE_KEY=[your license key]
+PDF_LICENSE_KEY=[your license key]
+DOCX_LICENSE_KEY=[your license key]
+----
+
+[[deployment-guides]]
+== Deployment guides
+
+See the deployment guides for each service for complete setup instructions:
+
+* xref:tinymceai-on-premises-getting-started.adoc[Getting started with TinyMCE AI on-premises]
+* xref:individual-export-to-pdf-on-premises.adoc[Deploy the Export to PDF service using Docker]
+* xref:individual-import-from-word-and-export-to-word-on-premises.adoc[Deploy the Import from Word and Export to Word service using Docker]
+
+For an overview of containerized server-side services, see xref:bundle-intro-setup.adoc[Introduction and initial setup for containerized server-side services].

--- a/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-fonts.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-fonts.adoc
@@ -47,7 +47,7 @@ Launch the Docker container on Unix-like operating system example:
 
 [source, bash, subs="attributes+"]
 ----
-docker run --init -v ~/your_fonts_dir:/usr/share/fonts/your_fonts_dir -p 8080:8080 -e LICENSE_KEY=[your_license_key] {dockerimageexporttopdf}:[version]
+docker run --init -v ~/your_fonts_dir:/usr/share/fonts/your_fonts_dir -p 8080:8080 -e LICENSE_KEY="$PDF_LICENSE_KEY" {dockerimageexporttopdf}:[version]
 ----
 
 [[use-windows-fonts-in-pdf-converter]]
@@ -61,5 +61,5 @@ Launch the Docker container on Windows operating system example:
 
 [source, bash, subs="attributes+"]
 ----
-docker run -v C:\Windows\Fonts:C:\Windows\Fonts -p 8080:8080 --env LICENSE_KEY=[your_license_key] {dockerimageexporttopdfwindows}:[version]
+docker run -v C:\Windows\Fonts:C:\Windows\Fonts -p 8080:8080 --env LICENSE_KEY="$PDF_LICENSE_KEY" {dockerimageexporttopdfwindows}:[version]
 ----

--- a/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-installation.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-installation.adoc
@@ -2,8 +2,8 @@
 == Installation
 
 [NOTE]
-A valid license key is needed in order to install {pluginname} On-Premises.
-link:https://www.tiny.cloud/contact/[Contact us] for a trial license key.
+A valid service license key is required to run the {pluginname} on-premises service. This is separate from the {productname} editor license key. See xref:service-license-keys.adoc[Service license keys] for details.
+link:https://www.tiny.cloud/contact/[Contact us] for a trial service license key.
 
 === Supported technologies
 
@@ -46,14 +46,16 @@ Launch the Docker container:
 
 [source, sh, subs="attributes+"]
 ----
-docker run --init -p 8080:8080 -e LICENSE_KEY=[your_license_key] {dockerimageexporttopdf}:[version]
+docker run --init -p 8080:8080 -e LICENSE_KEY="$PDF_LICENSE_KEY" {dockerimageexporttopdf}:[version]
 ----
+
+Replace `+$PDF_LICENSE_KEY+` with the service license key, or set `+PDF_LICENSE_KEY+` as an environment variable. See xref:service-license-keys.adoc#using-service-specific-environment-variables[Using service-specific environment variables] for details.
 
 If using authorization provide the SECRET_KEY:
 
 [source, sh, subs="attributes+"]
 ----
-docker run --init -p 8080:8080 -e LICENSE_KEY=[your_license_key] -e SECRET_KEY=[your_secret_key] {dockerimageexporttopdf}:[version]
+docker run --init -p 8080:8080 -e LICENSE_KEY="$PDF_LICENSE_KEY" -e SECRET_KEY=[your_secret_key] {dockerimageexporttopdf}:[version]
 ----
 
 Read more about using authorization in the xref:individual-export-to-pdf-on-premises.adoc#authorization[authorization] section.
@@ -73,7 +75,7 @@ services:
     restart: always
     init: true
     environment:
-      LICENSE_KEY: "license_key"
+      LICENSE_KEY: "$\{PDF_LICENSE_KEY}"
       # Secret Key is optional
       SECRET_KEY: "secret_key"
       # Custom request origin is optional
@@ -91,7 +93,7 @@ docker compose up
 
 [NOTE]
 ====
-* Without a correct `LICENSE_KEY` the application will not start.
+* Without a correct `+LICENSE_KEY+` the application will not start. Set `+PDF_LICENSE_KEY+` in the `+.env+` file or shell environment with a valid service license key.
 ** If the license is invalid, a wrong license key error will display in the logs and the application will not run.
 * It is advisable to override the SECRET_KEY variable using a unique and hard to guess string for security reasons.
 * If the specific infrastructure has strict CORS enabled, then use the `CUSTOM_REQUEST_ORIGIN` variable to set the origin of requests made by the converter. The default value is `https://pdf-internal`.

--- a/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-installation.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-installation.adoc
@@ -2,8 +2,14 @@
 == Installation
 
 [NOTE]
-A valid service license key is required to run the {pluginname} on-premises service. This is separate from the {productname} editor license key. See xref:service-license-keys.adoc[Service license keys] for details.
-link:https://www.tiny.cloud/contact/[Contact us] for a trial service license key.
+====
+Running the {pluginname} on-premises service requires two separate credentials:
+
+* A *Docker registry access token* to authenticate with the {companyname} Docker registry and pull the service image.
+* A *service license key* to enable the service at runtime. This is separate from the {productname} editor license key.
+
+See xref:service-license-keys.adoc[Service license keys] for details. link:https://www.tiny.cloud/contact/[Contact us] for a trial service license key.
+====
 
 === Supported technologies
 

--- a/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-overview.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/export-to-pdf/export-to-pdf-overview.adoc
@@ -8,8 +8,8 @@ The On-Premises version of the {pluginname} Converter is an application that can
 To use {productname} 8.4.0 or newer with the Export to PDF plugin, the on-premises Docker image must support the v2 API (`/v2/convert/html-pdf`). Use the latest image or a v2-compatible version. See the link:https://registry.containers.tiny.cloud/api/changelogs/pdf-converter-tiny[changelog^] for version details.
 ====
 
-A valid license key is required in order to install {pluginname} Converter On-Premises. You will also need an access token to access the {companyname} Cloud Docker registry and pull the Docker image. 
+A valid service license key is required to run the {pluginname} Converter on-premises service. This key is separate from the {productname} editor license key. An access token is also required to access the {companyname} Cloud Docker registry and pull the Docker image. See xref:service-license-keys.adoc[Service license keys] for more information.
 
-To get started, link:https://www.tiny.cloud/contact/[Contact Tiny Support] for a trial license key and Docker access token. 
+To get started, link:https://www.tiny.cloud/contact/[Contact Tiny Support] for a trial service license key and Docker access token. 
 
 The only requirement to run {pluginname} On-Premises is a container runtime or orchestration tool e.g. Docker, Kubernetes, Podman. 

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
@@ -2,8 +2,8 @@
 == Installation
 
 [NOTE]
-A valid license key is needed in order to install {pluginname} On-Premises.
-link:https://www.tiny.cloud/contact/[Contact us] for a trial license key.
+A valid service license key is required to run the {pluginname} on-premises service. This is separate from the {productname} editor license key. See xref:service-license-keys.adoc[Service license keys] for details.
+link:https://www.tiny.cloud/contact/[Contact us] for a trial service license key.
 
 === Supported technologies
 
@@ -46,14 +46,16 @@ Launch the Docker container:
 
 [source, sh, subs="attributes+"]
 ----
-docker run --init -p 8080:8080 -e LICENSE_KEY=[your_license_key] {dockerimageimportfromwordexporttoword}:[version]
+docker run --init -p 8080:8080 -e LICENSE_KEY="$DOCX_LICENSE_KEY" {dockerimageimportfromwordexporttoword}:[version]
 ----
+
+Replace `+$DOCX_LICENSE_KEY+` with the service license key, or set `+DOCX_LICENSE_KEY+` as an environment variable. See xref:service-license-keys.adoc#using-service-specific-environment-variables[Using service-specific environment variables] for details.
 
 If using authorization provide the SECRET_KEY:
 
 [source, sh, subs="attributes+"]
 ----
-docker run --init -p 8080:8080 -e LICENSE_KEY=[your_license_key] -e SECRET_KEY=[your_secret_key] {dockerimageimportfromwordexporttoword}:[version]
+docker run --init -p 8080:8080 -e LICENSE_KEY="$DOCX_LICENSE_KEY" -e SECRET_KEY=[your_secret_key] {dockerimageimportfromwordexporttoword}:[version]
 ----
 
 Read more about using authorization in the xref:individual-import-from-word-and-export-to-word-on-premises.adoc#authorization[authorization] section.
@@ -73,7 +75,7 @@ services:
     restart: always
     init: true
     environment:
-      LICENSE_KEY: "license_key"
+      LICENSE_KEY: "$\{DOCX_LICENSE_KEY}"
       # Secret Key is optional
       SECRET_KEY: "secret_key"
 ----
@@ -89,9 +91,9 @@ docker compose up
 
 [NOTE]
 ====
-* Without a correct `LICENSE_KEY` the application will not start.
+* Without a correct `+LICENSE_KEY+` the application will not start. Set `+DOCX_LICENSE_KEY+` in the `+.env+` file or shell environment with a valid service license key.
 ** If the license is invalid, a wrong license key error will display in the logs and the application will not run.
-* It is advisable to override the `SECRET_KEY` variable using a unique and hard to guess string for security reasons.
+* It is advisable to override the `+SECRET_KEY+` variable using a unique and hard to guess string for security reasons.
 ====
 
 === Next steps

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-installation-on-premises.adoc
@@ -2,8 +2,14 @@
 == Installation
 
 [NOTE]
-A valid service license key is required to run the {pluginname} on-premises service. This is separate from the {productname} editor license key. See xref:service-license-keys.adoc[Service license keys] for details.
-link:https://www.tiny.cloud/contact/[Contact us] for a trial service license key.
+====
+Running the {pluginname} on-premises service requires two separate credentials:
+
+* A *Docker registry access token* to authenticate with the {companyname} Docker registry and pull the service image.
+* A *service license key* to enable the service at runtime. This is separate from the {productname} editor license key.
+
+See xref:service-license-keys.adoc[Service license keys] for details. link:https://www.tiny.cloud/contact/[Contact us] for a trial service license key.
+====
 
 === Supported technologies
 
@@ -15,7 +21,7 @@ Refer to the xref:individual-import-from-word-and-export-to-word-on-premises.ado
 
 === Setting up the application using a Docker container
 
-. The username and password credentials supplied by Tiny are utilized for logging into the Docker registry and retrieving the Docker image.
+. Log into the Docker registry and retrieve the Docker image using the provided access token.
 . Containerize the application using `docker` or `docker-compose`.
 . Use a demo page to verify if the application works properly.
 

--- a/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-overview-on-premises.adoc
+++ b/modules/ROOT/partials/individually-licensed-components/import-from-word-and-export-to-word/import-from-word-and-export-to-word-overview-on-premises.adoc
@@ -3,9 +3,9 @@
 
 {pluginname} is a set of two converter services that allow for both exporting a structured HTML content (e.g. created with {productname} WYSIWYG editor) into a `.docx` Microsoft Word file and for importing content from `.docx` and `.dotx` files and converting it into a styled HTML document.
 
-A valid license key is needed in order to install {pluginname} On-Premises. You will also need an access token to access the Tiny Cloud Docker registry and pull the Docker image. 
+A valid service license key is required to run the {pluginname} on-premises service. This key is separate from the {productname} editor license key. An access token is also required to access the {companyname} Cloud Docker registry and pull the Docker image. See xref:service-license-keys.adoc[Service license keys] for more information.
 
-To get started, link:https://www.tiny.cloud/contact/[Contact Tiny Support] for a trial license key and Docker access token.
+To get started, link:https://www.tiny.cloud/contact/[Contact Tiny Support] for a trial service license key and Docker access token.
 
 The documentation in this section refers to a simplified version of the {pluginname} On-Premises which was designed to be easy to set up and maintain (while preserving all the features). It also lowers the running costs by reducing the number of servers required to run the whole application to the minimum.
 


### PR DESCRIPTION
## Ticket

DOC-3516

## Site

Staging base: https://pr-4153.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/

Staging links for each changed page:

- **Service license keys** (new): [Service license keys](https://pr-4153.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/service-license-keys/)
- **License key**: [License key](https://pr-4153.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/license-key/)
- **Introduction and initial setup for containerized server-side services** (new "Service license keys" subsection): [Service license keys subsection](https://pr-4153.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/bundle-intro-setup/#service-license-keys)
- **Export to PDF (on-premises)** — overview, installation, and fonts updates: [Export to PDF](https://pr-4153.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/individual-export-to-pdf-on-premises/)
  - [Overview](https://pr-4153.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/individual-export-to-pdf-on-premises/#overview)
  - [Installation](https://pr-4153.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/individual-export-to-pdf-on-premises/#installation)
  - [Fonts](https://pr-4153.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/individual-export-to-pdf-on-premises/#fonts)
- **Import from Word and Export to Word (on-premises)** — overview and installation updates: [Import from Word and Export to Word](https://pr-4153.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/individual-import-from-word-and-export-to-word-on-premises/)
  - [Overview](https://pr-4153.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/individual-import-from-word-and-export-to-word-on-premises/#overview)
  - [Installation](https://pr-4153.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/individual-import-from-word-and-export-to-word-on-premises/#installation)

> Note: \`nav.adoc\` adds the "Service license keys" navigation entry (visible in the left-hand nav on any page above). The \`tinymceai-on-premises\` xrefs resolve once #4142 merges.

## Changes

- **New page: \`service-license-keys.adoc\`** — overview of service license keys, which services require them, how they differ from editor license keys and Docker registry access tokens, service-specific environment variable naming convention with table and \`.env\` example
- **\`license-key.adoc\`** — added NOTE clarifying this page covers editor license keys only, with cross-reference to the new service license keys page
- **\`bundle-intro-setup.adoc\`** — added "Service license keys" subsection with cross-reference to the new page
- **\`export-to-pdf-overview.adoc\`** — clarified "service license key" distinction from editor key, added cross-reference
- **\`export-to-pdf-installation.adoc\`** — updated docker run and docker-compose examples to use \`PDF_LICENSE_KEY\` service-specific environment variable pattern; expanded install note to cover both the Docker registry access token and the service license key
- **\`export-to-pdf-fonts.adoc\`** — updated font-related docker run commands to use \`PDF_LICENSE_KEY\`
- **\`import-from-word-and-export-to-word-overview-on-premises.adoc\`** — clarified "service license key" distinction, added cross-reference
- **\`import-from-word-and-export-to-word-installation-on-premises.adoc\`** — updated docker run and docker-compose examples to use \`DOCX_LICENSE_KEY\` service-specific environment variable pattern; expanded install note to cover both the access token and the service license key
- **\`nav.adoc\`** — added \`service-license-keys.adoc\` entry after "License key"

## Notes

- This PR includes xrefs to \`tinymceai-on-premises.adoc\` and \`tinymceai-on-premises-getting-started.adoc\` which will resolve after DOC-3498 / PR #4142 merges. Ship this PR after #4142.
- Open questions from the ticket (confirm before merging): whether one service license key covers all services, and service key format specifics.