### PR TITLE
Fix markdown generation crash on LLM special tokens

### DIFF
--- a/scripts/generate-markdown.mjs
+++ b/scripts/generate-markdown.mjs
@@ -226,7 +226,7 @@ const convertPage = async (htmlPath) => {
 
   const title = extractTitle(dom.window.document);
   const markdown = toMarkdown(articleEl, dom);
-  const tokens = encode(markdown).length;
+  const tokens = encode(markdown, { allowedSpecial: 'all' }).length;
   const content = buildFrontmatter(title, tokens) + markdown + '\n';
   const mdPath = htmlPath.replace(/\.html$/, '.md');
 


### PR DESCRIPTION
## Summary

- The `gpt-tokenizer` `encode()` call in `scripts/generate-markdown.mjs` throws when it encounters LLM special tokens (`<|im_start|>`, `<|im_end|>`) that appear in documentation code examples (specifically the Ollama Modelfile template in the on-premises providers page).
- Passes `{ allowedSpecial: 'all' }` to treat these as regular content rather than disallowed control tokens.

## Context

This is blocking the deploy workflow after the DOC-3498 on-premises docs merge to `tinymce/8`.

## Test plan

- [x] Verified locally that `encode(content, { allowedSpecial: 'all' })` handles the problematic tokens without error
- [x] Deploy workflow succeeds after merge