### PR TITLE
Pin Antora to 3.1.10 to fix deploy regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "liquidjs": ">=10.25.7"
   },
   "devDependencies": {
-    "@antora/cli": "^3.1.10",
-    "@antora/site-generator-default": "^3.1.10",
+    "@antora/cli": "3.1.10",
+    "@antora/site-generator-default": "3.1.10",
     "@tinymce/antora-extension-livedemos": "^0.1.0",
     "@tinymce/moxiedoc": "^0.3.0",
     "dom-to-semantic-markdown": "^1.5.0",


### PR DESCRIPTION
## Summary

- Antora 3.1.15 was published on May 26 and introduces a regression where remote content fetching silently produces zero output.
- The `^3.1.10` range in `package.json` allows yarn to resolve to 3.1.15 on fresh installs (CI), breaking the deploy workflow.
- Pins `@antora/cli` and `@antora/site-generator-default` to exact version `3.1.10`.

## Context

Deploy workflow has been failing since May 28 with `find: 'build/site': No such file or directory` because Antora completes in ~8 seconds without generating any pages.

## Test plan

- [x] Deploy workflow succeeds after merge
- [x] Local build with pinned 3.1.10 produces full site (1545 pages)