### PR TITLE
DOC-3520: Downgrade Node to 22 LTS in preview workflow

### DIFF
--- a/.github/workflows/preview_create.yml
+++ b/.github/workflows/preview_create.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/setup-node@v5
       with:
         cache: 'yarn'
-        node-version: 24
+        node-version: 22
 
     - name: Install dependencies
       run: yarn install


### PR DESCRIPTION
## Summary

- Node 24.16.0 (shipped in GitHub Actions runner image `20260525.161.1`) causes `isomorphic-git`'s HTTP transport to silently fail, resulting in Antora producing zero output with no error.
- Downgrades `node-version` from `24` to `22` (LTS) in `preview_create.yml`.

## Context

- JIRA: DOC-3520
- Antora issue: https://gitlab.com/antora/antora/-/issues/1215
- Confirmed via CI diagnostics: Antora 3.1.10 is installed correctly, `--log-level=all --stacktrace` produces zero output on Node 24.16.0, but works fine on Node 22.

## Test plan

- [x] Preview build passes with Node 22 (verified on PR #4156 during debugging)
- [x] This PR's preview check passes