### PR TITLE
DOC-3520: Downgrade Node to 22 LTS in deploy workflow

### DIFF
--- a/.github/workflows/deploy_docs_v2.yml
+++ b/.github/workflows/deploy_docs_v2.yml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/setup-node@v5
       with:
         cache: 'yarn'
-        node-version: 24
+        node-version: 22
 
     - name: Install dependencies
       run: yarn install

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "liquidjs": ">=10.25.7"
   },
   "devDependencies": {
-    "@antora/cli": "3.1.10",
-    "@antora/site-generator-default": "3.1.10",
+    "@antora/cli": "^3.1.10",
+    "@antora/site-generator-default": "^3.1.10",
     "@tinymce/antora-extension-livedemos": "^0.1.0",
     "@tinymce/moxiedoc": "^0.3.0",
     "dom-to-semantic-markdown": "^1.5.0",


### PR DESCRIPTION
## Summary

- Node 24.16.0 (shipped in GitHub Actions runner image `20260525.161.1`) causes `isomorphic-git`'s HTTP transport to silently fail, resulting in Antora producing zero output with no error.
- Downgrades `node-version` from `24` to `22` (LTS) in `deploy_docs_v2.yml`.
- Reverts the unnecessary Antora version pin from #4155 (root cause was Node, not Antora version).

## Context

- JIRA: DOC-3520
- Antora issue: https://gitlab.com/antora/antora/-/issues/1215
- Companion PR for tinymce/8: #4157

## Test plan

- [x] Preview build passes with Node 22 (verified on PR #4156)
- [x] Trigger deploy after merge to confirm production works