### PR TITLE
DOC-3521: Clarify license keys in AI on-premises credentials table

### DIFF
--- a/modules/ROOT/pages/tinymceai-on-premises.adoc
+++ b/modules/ROOT/pages/tinymceai-on-premises.adoc
@@ -99,15 +99,15 @@ Two license keys are involved in an on-premises deployment. They are distinct, c
 |Service license key (`LICENSE_KEY`)
 |AI service container (environment variable)
 |Activates the on-premises AI service at runtime. A long string provisioned through the {companyname} customer portal.
-|Yes — the service refuses to start without it.
+|Yes — required to run the service.
 
 |{productname} editor license key (`license_key`)
 |`tinymce.init({ license_key: 'T8LK:...' })`
 |Configures the license mode for the {productname} editor and activates premium {productname} features.
-|Yes — required to run the {productname} editor.
+|Yes — required for the premium {productname} AI features.
 |===
 
-NOTE: The service license key (`LICENSE_KEY`) and the {productname} editor license key (`license_key`) are different credentials from different sources, and they are not interchangeable. For more information, see xref:service-license-keys.adoc[Service license keys] and xref:license-key.adoc[License key].
+NOTE: The service license key (`LICENSE_KEY`) and the {productname} editor license key (`license_key`) are not interchangeable. For more information, see xref:service-license-keys.adoc[Service license keys] and xref:license-key.adoc[License key].
 
 == Prerequisites
 

--- a/modules/ROOT/pages/tinymceai-on-premises.adoc
+++ b/modules/ROOT/pages/tinymceai-on-premises.adoc
@@ -97,12 +97,12 @@ Two license keys are involved in an on-premises deployment. They are distinct, c
 |Credential |Where it lives |What it does |Required?
 
 |Service license key (`LICENSE_KEY`)
-|AI service container (environment variable)
+|Passed to the AI service container as an environment variable (for example, in the `docker run` command or Compose file)
 |Activates the on-premises AI service at runtime. A long string provisioned through the {companyname} customer portal.
 |Yes — required to run the service.
 
 |{productname} editor license key (`license_key`)
-|`tinymce.init({ license_key: 'T8LK:...' })`
+|Added to the editor configuration: `tinymce.init({ license_key: 'T8LK:...' })`
 |Configures the license mode for the {productname} editor and activates premium {productname} features.
 |Yes — required for the premium {productname} AI features.
 |===

--- a/modules/ROOT/pages/tinymceai-on-premises.adoc
+++ b/modules/ROOT/pages/tinymceai-on-premises.adoc
@@ -90,29 +90,24 @@ The shared secret (API Secret) exists only in the application back end (token en
 
 == Credentials
 
-Three credentials are involved in an on-premises deployment. They are distinct and serve different purposes.
+Two license keys are involved in an on-premises deployment. They are distinct, come from different sources, and serve different purposes.
 
 [cols="1,1,2,1",options="header"]
 |===
 |Credential |Where it lives |What it does |Required?
 
-|`LICENSE_KEY`
+|Service license key (`LICENSE_KEY`)
 |AI service container (environment variable)
-|Activates the AI service. A long string provided by the Tiny account representative.
+|Activates the on-premises AI service at runtime. A long string provisioned through the {companyname} customer portal.
 |Yes — the service refuses to start without it.
 
-|`TINYMCE_API_KEY`
-|Editor page (CDN script URL) or build configuration
-|Authenticates against `cdn.tiny.cloud` when loading {productname} from the CDN. This is the short string from the tiny.cloud dashboard.
-|Only when loading {productname} from the CDN. Omit for self-hosted editor bundles.
-
-|`license_key` (init option)
+|{productname} editor license key (`license_key`)
 |`tinymce.init({ license_key: 'T8LK:...' })`
-|Activates premium {productname} features when using a self-hosted editor bundle (not the CDN).
-|Only for self-hosted editor deployments. Provided by the Tiny account representative.
+|Configures the license mode for the {productname} editor and activates premium {productname} features.
+|Yes — required to run the {productname} editor.
 |===
 
-NOTE: `LICENSE_KEY` (the AI service license) and `TINYMCE_API_KEY` / `license_key` (the editor license) are different credentials from different sources. They are not interchangeable.
+NOTE: The service license key (`LICENSE_KEY`) and the {productname} editor license key (`license_key`) are different credentials from different sources, and they are not interchangeable. For more information, see xref:service-license-keys.adoc[Service license keys] and xref:license-key.adoc[License key].
 
 == Prerequisites
 


### PR DESCRIPTION
**Ticket:** DOC-3521

**Site:** [Staging branch](https://pr-4160.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/8/)

Staging links for each changed page:

- **TinyMCE AI on-premises** — Credentials table: [Credentials](https://pr-4160.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/8/tinymceai-on-premises/#credentials)

**Changes:**

* Removes the `TINYMCE_API_KEY` row and all API key / `cdn.tiny.cloud` references from the Credentials table, since loading the editor from the CDN does not apply to an on-premises deployment.
* Reduces the table from three credentials to two and updates the introductory sentence accordingly.
* Clarifies the distinction between the **service license key** (`LICENSE_KEY`) and the **TinyMCE editor license key** (`license_key`), aligning terminology with the `Service license keys` and `License key` pages.
* Updates the explanatory note and adds cross-references to `service-license-keys.adoc` and `license-key.adoc`.

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: `hotfix/8/DOC-3521`
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
