### PR TITLE
DOC-3518: Add inline mode limitation banner to TinyMCE AI plugin docs page

### DIFF
--- a/modules/ROOT/pages/tinymceai.adoc
+++ b/modules/ROOT/pages/tinymceai.adoc
@@ -11,6 +11,8 @@
 
 include::partial$misc/admon-premium-plugin.adoc[]
 
+include::partial$misc/admon-inline-not-supported.adoc[]
+
 The {pluginname} plugin integrates AI-assisted authoring with rich-text editing. Users can interact through Actions, Reviews, or Conversations that can use relevant context from multiple sources.
 
 [[interactive-example]]


### PR DESCRIPTION
**Ticket:** DOC-3518

**Site:** [Staging branch](https://pr-4162.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/tinymceai/)

**Changes:**
* Added the inline mode limitation banner (`partial$misc/admon-inline-not-supported.adoc`) to `modules/ROOT/pages/tinymceai.adoc`, after the premium plugin admonition. The TinyMCE AI plugin's Chat and Review features render as sidebars, which are not available in inline editor mode, so the banner informs readers the feature is supported in classic mode only.

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: `hotfix/8/DOC-3518`
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.

> Note: Quick Actions uses an inline toolbar rather than a sidebar. Please confirm the shared "classic mode only" wording is appropriate, or whether a tinymceai-specific banner variant is preferred.
