### PR TITLE
DOC-3503: Update jQuery integration example to jQuery 4 (tinymce/7 port)

### DIFF
--- a/modules/ROOT/partials/integrations/jquery-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/jquery-quick-start.adoc
@@ -174,8 +174,8 @@ ifeval::["{productSource}" == "cloud"]
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script
-      src="https://code.jquery.com/jquery-3.6.0.min.js"
-      integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4="
+      src="https://code.jquery.com/jquery-4.0.0.min.js"
+      integrity="sha256-OaVG6prZf4v69dPg6PhVattBXkcOWQB62pdZ3ORyrao="
       crossorigin="anonymous"
     ></script>
     <script


### PR DESCRIPTION
## Summary

* Port of #4161 to the `tinymce/7` branch.
* Update the jQuery integration quick start Cloud example to load jQuery 4.0.0 (with the official SRI `integrity` hash) instead of jQuery 3.6.0.
* Reflects the release of `@tinymce/tinymce-jquery` v2.3, which adds support for jQuery v4 (parent epic INT-3426).
* The `{jquery_url}` attribute already targets `@tinymce/tinymce-jquery@2`, which resolves to the latest 2.x release (2.3), so no change was required there.

## Test plan

* `yarn antora ./antora-playbook-local.yml` builds with no errors or new warnings for the jQuery pages.
* Confirm the rendered jQuery Cloud page shows the jQuery 4.0.0 script tag with the correct integrity hash.

Ref: DOC-3503