### PR TITLE
DOC-3520: Downgrade Node to 22 LTS in preview workflow (tinymce/7 port)

### DIFF
--- a/.github/workflows/preview_create.yml
+++ b/.github/workflows/preview_create.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/setup-node@v5
       with:
         cache: 'yarn'
-        node-version: 24
+        node-version: 22
 
     - name: Install dependencies
       run: yarn install


### PR DESCRIPTION
## Summary

* Port of #4157 to the `tinymce/7` branch.
* Node 24.16.0 (shipped in runner image 20260525.161.1) causes isomorphic-git's HTTP transport to silently fail, resulting in Antora producing zero output. This makes the "Rename site folder to docs" step fail (`mv ./build/site ./build/docs`) because no build output exists.
* Node 22 LTS is unaffected. This pins `node-version: 22` in the preview workflow, matching the fix already applied to `main` and `tinymce/8`.

## Test plan

* The "Update Docs Preview" workflow on this PR builds the site successfully and produces `./build/site`.

Ref: DOC-3520