### PR TITLE
DOC-3512: Fix formatting for code blocks in .NET installation instructions

### DIFF
--- a/modules/ROOT/partials/install/basic-quickstart-base.adoc
+++ b/modules/ROOT/partials/install/basic-quickstart-base.adoc
@@ -91,14 +91,14 @@ To add {productname} to a .NET project, run the following on a command line:
 
 * Using the NuGet package manager console, run the following:
 +
-[source,sh]
+[source,sh,subs="attributes+"]
 ----
 Install-Package {productname}
 ----
 
 * Using the `+dotnet+` CLI, run the following:
 +
-[source,sh]
+[source,sh,subs="attributes+"]
 ----
 dotnet add package {productname}
 ----


### PR DESCRIPTION
Ticket: DOC-3512

Port of #4147 to the `tinymce/7` branch.

Site: tinymce/7 branch

## Changes

* Added `subs="attributes+"` to the NuGet `.NET` install code blocks in `modules/ROOT/partials/install/basic-quickstart-base.adoc` so `{productname}` is substituted in the rendered output (previously displayed as the literal `{productname}` placeholder).

This mirrors the v8 fix in #4147, addressing the v7 instance noted in that PR's review.

## Pre-checks

* Branch prefixed with `hotfix/<version>/`.
* `modules/ROOT/nav.adoc` update not applicable.
* No release note entry required (formatting fix).