### PR TITLE
DOC-3526: Using the undo keyboard shortcut did not restore editor selection correctly

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -94,6 +94,13 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // CCFR here.
 
+=== Using the undo keyboard shortcut did not restore editor selection correctly
+// #TINY-14255
+
+Previously, pressing the undo keyboard shortcut (Ctrl+Z, or Cmd+Z on macOS) after deleting a selection could leave the cursor in the wrong position. An earlier change registered an extra undo step whenever Ctrl or Cmd was pressed, so the step was recorded before the deleted content was restored.
+
+In {productname} {release-version}, the undo step is registered only when Ctrl or Cmd is pressed together with Backspace or Delete. Undoing the deletion of a selection now restores both the content and the original selection correctly.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
**Ticket:** DOC-3526

**Site:** [Staging](https://pr-4170.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#using-the-undo-keyboard-shortcut-did-not-restore-editor-selection-correctly)

**Changes:**
* Added release note entry for TINY-14255 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Bug fixes section): Using the undo keyboard shortcut did not restore editor selection correctly.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.