### PR TITLE
DOC-3526: AI Chat state was lost if the sidebar was closed before the model started responding

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -39,6 +39,21 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following fix.
+
+==== AI state was lost if the AI chat was closed before the AI started responding to a prompt
+// #TINY-14222
+
+Previously, the AI conversation state could be lost if the AI sidebar was closed before the AI began responding to a prompt. The plugin recorded which sidebar started the response only after the response began, so closing the sidebar beforehand left no record, and reopening it reset the conversation.
+
+In {productname} {release-version}, the sidebar is recorded as soon as the prompt is sent. Toggling the sidebar before the AI responds no longer resets the conversation state.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 
 [[improvements]]
 == Improvements

--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -45,12 +45,12 @@ The {productname} {release-version} release includes an accompanying release of 
 
 **TinyMCE AI** includes the following fix.
 
-==== AI state was lost if the AI chat was closed before the AI started responding to a prompt
+==== AI Chat state was lost if the sidebar was closed before the model started responding
 // #TINY-14222
 
-Previously, the AI conversation state could be lost if the AI sidebar was closed before the AI began responding to a prompt. The plugin recorded which sidebar started the response only after the response began, so closing the sidebar beforehand left no record, and reopening it reset the conversation.
+Previously, the state of an AI Chat conversation could be lost if the Chat sidebar was closed before the model began responding to a prompt. The plugin recorded which sidebar started a response only once the response began, so closing the sidebar beforehand left no record. Reopening the sidebar then reset the conversation and any pending preview.
 
-In {productname} {release-version}, the sidebar is recorded as soon as the prompt is sent. Toggling the sidebar before the AI responds no longer resets the conversation state.
+In {productname} {release-version}, the sidebar is recorded as soon as the prompt is sent. Closing and reopening the Chat sidebar before the response is ready no longer resets the conversation.
 
 For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
 


### PR DESCRIPTION
**Ticket:** DOC-3526

**Site:** [Staging](https://pr-4172.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#ai-chat-state-was-lost-if-the-sidebar-was-closed-before-the-model-started-responding)

**Changes:**
* Added release note entry for TINY-14222 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Accompanying Premium plugin changes - TinyMCE AI): AI Chat state was lost if the sidebar was closed before the model started responding.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.