### PR TITLE
DOC-3526: An error could be reported when aborting and starting a new conversation

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -39,6 +39,21 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following fix.
+
+==== An error could be reported when aborting and starting a new conversation
+// #TINY-14381
+
+Previously, aborting a streamed AI response and starting a new conversation could report an error. Aborting the response triggered a document delete operation that sometimes failed.
+
+In {productname} {release-version}, the document is no longer deleted when an AI request is aborted. Aborting a response and starting a new conversation no longer reports this error.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 
 [[improvements]]
 == Improvements


### PR DESCRIPTION
**Ticket:** DOC-3526

**Site:** [Staging](https://pr-4174.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#an-error-could-be-reported-when-aborting-and-starting-a-new-conversation)

**Changes:**
* Added release note entry for TINY-14381 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Accompanying Premium plugin changes - TinyMCE AI): An error could be reported when aborting and starting a new conversation.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.