### PR TITLE
DOC-3526: The fullpage header and footer were not included when getting HTML content with inline CSS

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -39,6 +39,21 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Inline CSS
+
+The {productname} {release-version} release includes an accompanying release of the **Inline CSS** premium plugin.
+
+**Inline CSS** includes the following fix.
+
+==== The fullpage header and footer were not included when getting HTML content with inline CSS
+// #TINY-14410
+
+Previously, the **Inline CSS** plugin's `getContent` API did not return a complete HTML document when the **Full Page HTML** plugin was enabled. The surrounding document header and footer were omitted, which made the output unsuitable for use cases such as generating email-ready documents.
+
+In {productname} {release-version}, the **Inline CSS** plugin detects when the **Full Page HTML** plugin is enabled and includes the document header and footer in its output. The `getContent` API now returns a full HTML document as expected.
+
+For information on the **Inline CSS** plugin, see: xref:inline-css.adoc[Inline CSS].
+
 
 [[improvements]]
 == Improvements


### PR DESCRIPTION
**Ticket:** DOC-3526

**Site:** [Staging](https://pr-4175.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#the-fullpage-header-and-footer-were-not-included-when-getting-html-content-with-inline-css)

**Changes:**
* Added release note entry for TINY-14410 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Accompanying Premium plugin changes - Inline CSS): The fullpage header and footer were not included when getting HTML content with inline CSS.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.