### PR TITLE
DOC-3526: The editor resize handle now uses browser pointer events for more reliable behavior across different integration environments

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -50,6 +50,13 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // CCFR here.
 
+=== The editor resize handle now uses browser pointer events for more reliable behavior across different integration environments
+// #TINY-14241
+
+Previously, the editor resize handle relied on an overlay element to capture pointer movement, which required raising the editor's stacking order. In some integrations this caused the editor to appear on top of the floating sidebar used by the TinyMCE AI plugin while the editor was being resized.
+
+In {productname} {release-version}, the resize handle uses modern browser pointer events instead. This removes the need for the overlay element and the raised stacking order, providing more reliable resizing across different integration environments and resolving the overlap with the floating sidebar.
+
 
 [[additions]]
 == Additions

--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -53,7 +53,7 @@ The following premium plugin updates were released alongside {productname} {rele
 === The editor resize handle now uses browser pointer events for more reliable behavior across different integration environments
 // #TINY-14241
 
-Previously, the editor resize handle relied on an overlay element to capture pointer movement, which required raising the editor's stacking order. In some integrations this caused the editor to appear on top of the floating sidebar used by the TinyMCE AI plugin while the editor was being resized.
+Previously, the editor resize handle relied on an overlay element to capture pointer movement, which required raising the editor's stacking order. This caused the editor to appear on top of the floating sidebar used by the TinyMCE AI plugin while the editor was being resized.
 
 In {productname} {release-version}, the resize handle uses modern browser pointer events instead. This removes the need for the overlay element and the raised stacking order, providing more reliable resizing across different integration environments and resolving the overlap with the floating sidebar.
 


### PR DESCRIPTION
**Ticket:** DOC-3526

**Site:** [Staging](https://pr-4178.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#the-editor-resize-handle-now-uses-browser-pointer-events-for-more-reliable-behavior-across-different-integration-environments)

**Changes:**
* Added release note entry for TINY-14241 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Improvements section): The editor resize handle now uses browser pointer events for more reliable behavior across different integration environments.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.