### PR TITLE
DOC-3526: Context toolbar with position 'line' was not repositioning to the opposite side when overflowing the viewport

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -94,6 +94,13 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // CCFR here.
 
+=== Context toolbar with position 'line' was not repositioning to the opposite side when overflowing the viewport
+// #TINY-14376
+
+Previously, a context toolbar configured with `position: 'line'`, such as a quickbar, was not repositioned when it overflowed the edge of the viewport. Under these conditions the toolbar could be cut off, which prevented users from clicking its buttons.
+
+In {productname} {release-version}, a context toolbar that uses `position: 'line'` now flips to the opposite side when there is not enough space. The toolbar remains fully visible and usable in constrained layouts.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
**Ticket:** DOC-3526

**Site:** [Staging](https://pr-4180.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#context-toolbar-with-position-line-was-not-repositioning-to-the-opposite-side-when-overflowing-the-viewport)

**Changes:**
* Added release note entry for TINY-14376 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Bug fixes section): Context toolbar with position 'line' was not repositioning to the opposite side when overflowing the viewport.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.