### PR TITLE
DOC-3526: CSS custom property names and color values in the style attribute were lowercased when parsed

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -94,6 +94,13 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // CCFR here.
 
+=== CSS custom property names and color values in the style attribute were lowercased when parsed
+// #TINY-11524
+
+Previously, the {productname} style parser converted CSS custom property names and color values in the `style` attribute to lowercase. Values that relied on their original casing, such as CSS custom properties referenced with mixed-case names, could be altered, which in some cases changed how the content was rendered.
+
+In {productname} {release-version}, the style parser retains the original case of CSS custom property names and color values in the `style` attribute. Styles that depend on case are now preserved as authored.
+
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -97,9 +97,9 @@ The following premium plugin updates were released alongside {productname} {rele
 === CSS custom property names and color values in the style attribute were lowercased when parsed
 // #TINY-11524
 
-Previously, the {productname} style parser converted CSS custom property names and color values in the `style` attribute to lowercase. Values that relied on their original casing, such as CSS custom properties referenced with mixed-case names, could be altered, which in some cases changed how the content was rendered.
+Previously, the {productname} style parser lowercased CSS custom property names (such as `--MyColor`) and `color` and `background-color` values when reading the `style` attribute. This altered case-sensitive values, including CSS custom properties, template placeholders such as `{{FooBar}}`, and hex colors such as `#AABBCC`, so the affected styling sometimes did not render as authored.
 
-In {productname} {release-version}, the style parser retains the original case of CSS custom property names and color values in the `style` attribute. Styles that depend on case are now preserved as authored.
+In {productname} {release-version}, the style parser preserves the original case of CSS custom property names and `color` and `background-color` values. Standard property names are still lowercased, and other processing, such as RGB-to-hex conversion, shorthand merging, and security filtering, is unchanged. Case-sensitive colors and custom properties now stay exactly as authored.
 
 
 [[security-fixes]]


### PR DESCRIPTION
**Ticket:** DOC-3526

**Site:** [Staging](https://pr-4186.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#css-custom-property-names-and-color-values-in-the-style-attribute-were-lowercased-when-parsed)

**Changes:**
* Added release note entry for TINY-11524 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Bug fixes section): CSS custom property names and color values in the style attribute were lowercased when parsed.
* Entry aligned with the updated JIRA Documentation section (custom property names and `color`/`background-color` values retain case; standard property names are still lowercased).

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.