### PR TITLE
DOC-3526: White space in user prompts was not rendered correctly in the AI Chat history

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -39,6 +39,21 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following fix.
+
+==== White space in user prompts was not rendered correctly in the AI Chat history
+// #TINY-14448
+
+Previously, user prompts shown in the AI Chat history collapsed consecutive spaces and line breaks. A multi-line prompt was displayed as a single run-on line, so the message in the chat thread did not match what was typed.
+
+In {productname} {release-version}, user prompts in the AI Chat history preserve their original line breaks and spacing, while long lines still wrap within the message. Prompts now display as they were typed.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 
 [[improvements]]
 == Improvements


### PR DESCRIPTION
**Ticket:** DOC-3526

**Site:** [Staging](https://pr-4187.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#white-space-in-user-prompts-was-not-rendered-correctly-in-the-ai-chat-history)

**Changes:**
* Added release note entry for TINY-14448 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Accompanying Premium plugin changes - TinyMCE AI): White space in user prompts was not rendered correctly in the AI Chat history.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.