### PR TITLE
DOC-3526: Some tooltips now appear only when the content is too long to display

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -39,6 +39,21 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following improvement.
+
+==== Some tooltips now appear only when the content is too long to display
+// #TINY-14072
+
+Previously, some tooltips in the TinyMCE AI interface were shown whenever their trigger condition was met, even when the content was already fully visible. This added unnecessary visual clutter.
+
+In {productname} {release-version}, these tooltips appear only when the content is truncated because it is too long to display in full. This reduces unnecessary tooltips and keeps the interface less cluttered.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 
 [[improvements]]
 == Improvements


### PR DESCRIPTION
**Ticket:** DOC-3526

**Site:** [Staging](https://pr-4188.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#some-tooltips-now-appear-only-when-the-content-is-too-long-to-display)

**Changes:**
* Added release note entry for TINY-14072 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Accompanying Premium plugin changes - TinyMCE AI): Some tooltips now appear only when the content is too long to display.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.