### PR TITLE
DOC-3526: Bulk action buttons when reviewing AI suggestions now reflect the current progress

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -39,6 +39,21 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following improvement.
+
+==== Bulk action buttons when reviewing AI suggestions now reflect the current progress
+// #TINY-14228
+
+Previously, when reviewing AI suggestions, the bulk action buttons always showed **Skip remaining** and **Apply remaining**, even before any suggestion had been applied or skipped. This was confusing because no decisions had been made yet.
+
+In {productname} {release-version}, the bulk action buttons reflect the current progress. They show **Skip all** and **Apply all** before the first decision, then switch to **Skip remaining** and **Apply remaining** after at least one suggestion has been applied or skipped. This behavior is consistent across the Chat and Quick Actions flows.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 
 [[improvements]]
 == Improvements


### PR DESCRIPTION
**Ticket:** DOC-3526

**Site:** [Staging](https://pr-4189.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#bulk-action-buttons-when-reviewing-ai-suggestions-now-reflect-the-current-progress)

**Changes:**
* Added release note entry for TINY-14228 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Accompanying Premium plugin changes - TinyMCE AI): Bulk action buttons when reviewing AI suggestions now reflect the current progress.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.