### PR TITLE
DOC-3526: The AI preview did not match the editor content structure, causing style rendering differences

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -39,6 +39,21 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following fix.
+
+==== The AI preview did not match the editor content structure, causing style rendering differences
+// #TINY-14328
+
+Previously, the AI suggestions preview rendered content inside a wrapper element within the preview iframe body, rather than directly into the iframe body as the editor does. Because the preview and editor had different structures, injected styles could render differently. Absolutely positioned elements and body-level CSS rules did not always apply the same way, which could cause glitches such as misaligned table headers and footers.
+
+In {productname} {release-version}, the preview inserts content directly into the iframe body so that its structure mirrors the editor. Injected styles now produce the same visual result in both, and the preview renders consistently with the editor.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 
 [[improvements]]
 == Improvements


### PR DESCRIPTION
**Ticket:** DOC-3526

**Site:** [Staging](https://pr-4190.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#the-ai-preview-did-not-match-the-editor-content-structure-causing-style-rendering-differences)

**Changes:**
* Added release note entry for TINY-14328 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Accompanying Premium plugin changes - TinyMCE AI): The AI preview did not match the editor content structure, causing style rendering differences.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.