### PR TITLE
DOC-3526: Removed the 300-item limit on the emoticons dialog All tab

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -50,6 +50,13 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // CCFR here.
 
+=== Removed the 300-item limit on the emoticons dialog All tab
+// #TINY-7552
+
+Previously, the emoticons dialog limited the **All** tab to 300 items. This limit was a workaround, because rendering all of the available emoticons (over 1,200) caused performance issues and a laggy experience.
+
+In {productname} {release-version}, the render performance of the emoticons dialog has been optimized and the 300-item limit on the **All** tab has been removed. All available emoticons are now displayed.
+
 
 [[additions]]
 == Additions


### PR DESCRIPTION
**Ticket:** DOC-3526

**Site:** [Staging](https://pr-4191.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#removed-the-300-item-limit-on-the-emoticons-dialog-all-tab)

**Changes:**
* Added release note entry for TINY-7552 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Improvements section): Removed the 300-item limit on the emoticons dialog All tab.

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.