### PR TITLE
DOC-3526: Integrators can now add custom AI reviews using the tinymceai_reviews option

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -39,6 +39,21 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following addition.
+
+==== Integrators can now add custom AI reviews using the `+tinymceai_reviews+` option
+// #TINY-14200
+
+Previously, the Review sidebar supported only a fixed set of built-in reviews, selected by ID through the `+tinymceai_reviews+` option. There was no supported way for integrators to add named reviews, parameterized prompts, or menus that mixed built-in and custom reviews. Integrators had to rely on generic flows, such as Custom review, instead of dedicated review actions in the Review sidebar.
+
+In {productname} {release-version}, the `+tinymceai_reviews+` option also accepts integrator-defined review objects alongside the existing built-in string IDs. Integrators can define `+simple+`, `+list+`, and `+input+` review types, each with a custom name, description, and prompt. For the full schema and examples, see the xref:tinymceai.adoc#tinymceai_reviews[`+tinymceai_reviews+`] option.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 
 [[improvements]]
 == Improvements

--- a/modules/ROOT/pages/tinymceai-models.adoc
+++ b/modules/ROOT/pages/tinymceai-models.adoc
@@ -34,6 +34,12 @@ The following is a detailed list of available models with their capabilities:
 |Yes
 |`'auto'` (also `'agent-1'`, learn more about xref:tinymceai-models.adoc#model-compatibility-versions[compatibility versions])
 
+|**GPT-5.5**
+|OpenAI's flagship model for advanced reasoning, creativity, and complex tasks
+|Yes
+|Yes
+|`'gpt-5.5'`
+
 |**GPT-5.4**
 |OpenAI's flagship model for advanced reasoning, creativity, and complex tasks
 |Yes
@@ -70,11 +76,29 @@ The following is a detailed list of available models with their capabilities:
 |Yes
 |`'gpt-5-mini'`
 
+|**GPT-5.4 Mini**
+|A lighter variant of GPT-5.4 that balances speed and cost while maintaining solid accuracy
+|Yes
+|Yes
+|`'gpt-5.4-mini'`
+
 |**GPT-4.1 Mini**
 |A lighter variant of GPT-4.1 that balances speed and cost while maintaining solid accuracy
 |Yes
 |No
 |`'gpt-4.1-mini'`
+
+|**Claude Opus 4.8**
+|Anthropic's most capable model for extended reasoning and complex tasks
+|Yes
+|Yes
+|`'claude-opus-4-8'`
+
+|**Claude Opus 4.7**
+|Anthropic's most capable model for extended reasoning and complex tasks
+|Yes
+|Yes
+|`'claude-opus-4-7'`
 
 |**Claude 4.6 Sonnet**
 |Advanced model with improved creativity, reliability, and reasoning
@@ -111,6 +135,12 @@ The following is a detailed list of available models with their capabilities:
 |Yes
 |Yes
 |`'gemini-3-flash'`
+
+|**Gemini 3.5 Flash**
+|Lightweight Gemini model for fast, cost-efficient interactions
+|Yes
+|Yes
+|`'gemini-3-5-flash'`
 |===
 
 [[limitations]]

--- a/modules/ROOT/partials/configuration/tinymceai_options.adoc
+++ b/modules/ROOT/partials/configuration/tinymceai_options.adoc
@@ -516,9 +516,9 @@ These options configure the AI Review sidebar, which provides content quality an
 [[tinymceai_reviews]]
 === `+tinymceai_reviews+`
 
-Array of review command IDs that define which review types appear in the Review sidebar and their order. Only the listed reviews are available to users.
+Array that defines which reviews appear in the Review sidebar and their order. Only the listed reviews are available to users. Each item is either a built-in review command ID (a string) or an xref:#integrator-defined-reviews[integrator-defined review] (an object).
 
-*Type:* `+Array+` of `+String+`
+*Type:* `+Array+` of `+String+` or `+Object+`
 
 *Valid values:*
 
@@ -561,5 +561,99 @@ tinymce.init({
     return fetch('/api/token').then(r => r.json());
   }
 });
+----
+
+[[integrator-defined-reviews]]
+==== Integrator-defined reviews
+
+In addition to the built-in review command IDs, the `+tinymceai_reviews+` option accepts integrator-defined review objects. These objects can be interleaved with the built-in string IDs, allowing integrators to add named reviews to the Review sidebar.
+
+Each integrator-defined review object has a `+type+` of `+'simple'+`, `+'list'+`, or `+'input'+`, and shares the following properties:
+
+* `+type+`: The review type. One of `+'simple'+`, `+'list'+`, or `+'input'+`.
+* `+id+`: A unique identifier for the review. It must not reuse a built-in review command ID.
+* `+name+`: The review name shown in the Review sidebar.
+* `+description+`: A short description shown beneath the name.
+* `+prompt+`: The prompt sent to the model when the review runs.
+* `+model+` (optional): The model used for the review. The value must be a model ID that the configured AI service exposes (see xref:tinymceai-models.adoc[AI Models]). When omitted, the editor default model set by xref:tinymceai.adoc#tinymceai_default_model[`+tinymceai_default_model+`] is used.
+
+A `+list+` review adds an `+options+` array, and an `+input+` review adds an optional `+inputPlaceholder+`:
+
+* `+options+` (`+list+` only): An array of `+{ label, value }+` objects. The selected `+value+` is substituted into the prompt wherever `+{value}+` appears.
+* `+inputPlaceholder+` (`+input+`, optional): Placeholder text for the input field. {productname} substitutes the text entered by the end user into the prompt wherever `+{input}+` appears.
+
+If an integrator-defined review is invalid, for example, if it reuses a built-in review command ID or does not match the expected schema, {productname} falls back to the default reviews list in the Review sidebar.
+
+NOTE: The `+model+` ID used in the following examples (`+agent-1+`) selects the recommended automatic model. The available model IDs depend on the configured AI service. See xref:tinymceai-models.adoc[AI Models] for the supported models and how to confirm which are available in an environment.
+
+.Simple integrator-defined review
+[source,js]
+----
+tinymceai_reviews: [
+  {
+    type: 'simple',
+    id: 'integrator-simple-review',
+    name: 'Simple Integrator Review',
+    description: 'This is a simple integrator review',
+    prompt: 'Review this document',
+    model: 'agent-1'
+  }
+]
+----
+
+.List integrator-defined review
+[source,js]
+----
+tinymceai_reviews: [
+  {
+    type: 'list',
+    id: 'integrator-list-review',
+    name: 'Translate Document',
+    description: 'Translate the document to a selected language.',
+    prompt: 'Translate this document to {value}',
+    model: 'agent-1',
+    options: [
+      { label: 'English', value: 'english' },
+      { label: 'Swedish', value: 'swedish' }
+    ]
+  }
+]
+----
+
+.Input integrator-defined review
+[source,js]
+----
+tinymceai_reviews: [
+  {
+    type: 'input',
+    id: 'integrator-input-review',
+    name: 'Custom Instruction',
+    description: 'Apply a custom instruction.',
+    prompt: 'Apply the following instruction {input}',
+    model: 'agent-1',
+    inputPlaceholder: 'Enter an instruction here...'
+  }
+]
+----
+
+.Built-in and integrator-defined reviews combined
+[source,js]
+----
+tinymceai_reviews: [
+  // Built-in reviews
+  'ai-reviews-proofread',
+  'ai-reviews-improve-clarity',
+  'ai-reviews-change-tone',
+  'ai-reviews-custom',
+  // Integrator-defined review
+  {
+    type: 'simple',
+    id: 'integrator-simple-review',
+    name: 'Simple Integrator Review',
+    description: 'This is a simple integrator review',
+    prompt: 'Review this document',
+    model: 'agent-1'
+  }
+]
 ----
 


### PR DESCRIPTION
**Ticket:** DOC-3526 (TINY-14200)

**Site:** [Staging](https://pr-4194.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#integrators-can-now-add-custom-ai-reviews-using-the-tinymceai_reviews-option)

**Changes:**
* Add an 8.7.0 release note for integrator-defined AI reviews via the `tinymceai_reviews` option.
* Expand the `tinymceai_reviews` option documentation with the integrator-defined review schema, the `simple`, `list`, and `input` types, and examples.
* Refresh the AI Models supported models table with the latest models returned by the models API (GPT-5.5, GPT-5.4 Mini, Claude Opus 4.8, Claude Opus 4.7, Gemini 3.5 Flash).

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: `feature/8.7.0/DOC-3526_TINY-14200`
- [x] Files have been included where required (if applicable).
- [x] Files added for **New product features** include a `release note` entry.
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.