### PR TITLE
DOC-3526: Indentation is now applied to all selected table cells

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -92,7 +92,9 @@ The following premium plugin updates were released alongside {productname} {rele
 === Indentation is now applied to all selected table cells
 // #TINY-14370
 
-Previously, applying indentation with multiple table cells selected affected only the cell where the pointer was released, because the action used the browser's native selection rather than the editor's cell selection. {productname} now applies indentation to every cell in the selection.
+Previously, applying indentation with multiple table cells selected affected only the cell where the pointer was released. The action used the browser's native selection rather than the editor's cell selection, so the remaining selected cells were left unchanged.
+
+In {productname} {release-version}, indentation is applied to every cell in the selection.
 
 // === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1

--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -89,6 +89,11 @@ The following premium plugin updates were released alongside {productname} {rele
 
 {productname} {release-version} also includes the following bug fix<es>:
 
+=== Indentation is now applied to all selected table cells
+// #TINY-14370
+
+Previously, applying indentation with multiple table cells selected affected only the cell where the pointer was released, because the action used the browser's native selection rather than the editor's cell selection. {productname} now applies indentation to every cell in the selection.
+
 // === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1
 


### PR DESCRIPTION
**Ticket:** DOC-3526 (TINY-14370)

**Site:** [Staging](https://pr-4195.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#indentation-is-now-applied-to-all-selected-table-cells)

**Changes:**
* Add an 8.7.0 bug fix release note: indentation now applies to all selected table cells instead of only the cell where the pointer is released.

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: `feature/8.7.0/DOC-3526_TINY-14370`
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.