### PR TITLE
DOC-3526: TinyMCE AI image edits now target the correct image

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -28,6 +28,19 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following fix.
+
+==== Image edits now target the correct image in content with multiple images
+// #TINY-14454
+
+Previously, images sent to the model were not uniquely identified, so a prompt referencing a specific image could mistake one image for another and apply changes, such as alt text updates, to the wrong image. **TinyMCE AI** now tags each `+img+` element with a `+data-id+` attribute when content is sent to the model and removes the attribute before the response is inserted. Image edits now apply to the intended image, even when the content contains multiple images.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 // === <Premium plugin name 1> <Premium plugin name 1 version>
 
 // The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.

--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -37,7 +37,7 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== Image edits now target the correct image in content with multiple images
 // #TINY-14454
 
-Previously, images sent to the model were not uniquely identified, so a prompt referencing a specific image could mistake one image for another and apply changes, such as alt text updates, to the wrong image. **TinyMCE AI** now tags each `+img+` element with a `+data-id+` attribute when content is sent to the model and removes the attribute before the response is inserted. Image edits now apply to the intended image, even when the content contains multiple images.
+Previously, images sent to the model were not uniquely identified, so a prompt referencing a specific image could mistake one image for another and apply changes, such as alt text updates, to the wrong image. **TinyMCE AI** now uniquely tags each `+img+` elements so they are less likely to be mistaken. Image edits now apply to the intended image, even when the content contains multiple images.
 
 For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
 


### PR DESCRIPTION
**Ticket:** DOC-3526 (TINY-14454)

**Site:** [Staging](https://pr-4196.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#image-edits-now-target-the-correct-image-in-content-with-multiple-images)

**Changes:**
* Add an 8.7.0 TinyMCE AI bug fix release note: images are now tagged with a `data-id` attribute when sent to the model so edits target the correct image when content contains multiple images.

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: `feature/8.7.0/DOC-3526_TINY-14454`
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.