### PR TITLE
DOC-3526: TinyMCE AI now continues an earlier conversation when reopened

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -28,6 +28,19 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following fix.
+
+==== Switching back to an earlier conversation now continues that conversation
+// #TINY-14487
+
+Previously, a regression prevented earlier conversations from loading correctly in the Chat sidebar. After starting a new chat, returning to an earlier conversation and sending a prompt began a disconnected exchange instead of continuing the original thread. Switching to an existing conversation now restores its conversation ID, so later prompts continue the selected conversation.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 // === <Premium plugin name 1> <Premium plugin name 1 version>
 
 // The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.


### PR DESCRIPTION
**Ticket:** DOC-3526 (TINY-14487)

**Site:** [Staging](https://pr-4197.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#switching-back-to-an-earlier-conversation-now-continues-that-conversation)

**Changes:**
* Add an 8.7.0 TinyMCE AI bug fix release note: switching back to an earlier conversation in the Chat sidebar now restores its conversation ID so prompts continue that conversation.

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: `feature/8.7.0/DOC-3526_TINY-14487`
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.