### PR TITLE
DOC-3526: TinyMCE AI prompts that unwrap nested list items now preserve content

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -28,6 +28,19 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following fix.
+
+==== Prompts that unwrap nested list items now preserve content
+// #TINY-14488
+
+Previously, when the model unwrapped nested blocks into top-level blocks, such as converting `+<li>+` items into `+<p>+` paragraphs, it reused the original element IDs. The diffing logic treated the reused IDs as updates to the nested elements, so some prompts intermittently removed the content instead of unwrapping it. A reused ID is now treated as an existing block only when it points to a top-level element; otherwise it is processed as a new element. Edits that unwrap nested elements now apply reliably and preserve content.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 // === <Premium plugin name 1> <Premium plugin name 1 version>
 
 // The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.


### PR DESCRIPTION
**Ticket:** DOC-3526 (TINY-14488)

**Site:** [Staging](https://pr-4198.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#prompts-that-unwrap-nested-list-items-now-preserve-content)

**Changes:**
* Add an 8.7.0 TinyMCE AI bug fix release note: a reused element ID is now treated as an existing block only when it points to a top-level element, so prompts that unwrap nested list items preserve their content.

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: `feature/8.7.0/DOC-3526_TINY-14488`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable). _Not applicable._
- [x] Files have been included where required (if applicable).
- [x] Files removed have been deleted, not just excluded from the build (if applicable). _Not applicable._
- [x] Files added for **New product features** include a `release note` entry. _Not applicable (bug fix)._
- [x] Major or minor version changes have updated the `supported-versions.adoc` table. _Not applicable._
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.