### PR TITLE
Docs: DOC-3530 - Update registry login username to tiny on AI on-premises page

### DIFF
--- a/modules/ROOT/pages/tinymceai-on-premises-getting-started.adoc
+++ b/modules/ROOT/pages/tinymceai-on-premises-getting-started.adoc
@@ -48,7 +48,7 @@ For Docker:
 
 [source,bash]
 ----
-docker login -u '<registry-username>' https://registry.containers.tiny.cloud
+docker login -u tiny https://registry.containers.tiny.cloud
 # Docker prompts for the password; this avoids leaking it in shell history.
 ----
 
@@ -56,10 +56,10 @@ For Podman:
 
 [source,bash]
 ----
-podman login -u '<registry-username>' registry.containers.tiny.cloud
+podman login -u tiny registry.containers.tiny.cloud
 ----
 
-Replace `<registry-username>` with the username supplied by the Tiny account representative. If credentials have not been received, contact `support@tiny.cloud`.
+All accounts authenticate with the username `tiny`. When prompted, enter the access token supplied by the Tiny account representative. If credentials have not been received, contact `support@tiny.cloud`.
 
 === Pull the AI service image
 


### PR DESCRIPTION
## Summary

- Replace the `<registry-username>` placeholder with the actual username `tiny` in the Docker and Podman login commands on the AI on-premises getting started page.
- Update the surrounding guidance to clarify that all accounts authenticate with the username `tiny` and that the access token is supplied by the Tiny account representative.

The registry at `registry.containers.tiny.cloud` does not use per-customer usernames; all accounts log in as `tiny`. This brings the AI on-premises page in line with the other on-premises installation pages (export to PDF, spelling service, etc.) which already use `docker login -u tiny`.

## Affected page

- `modules/ROOT/pages/tinymceai-on-premises-getting-started.adoc` — Authenticate with the container registry

## Test plan

- [x] `yarn build` completes successfully
- [x] Verify the rendered "Authenticate with the container registry" section shows `docker login -u tiny` and `podman login -u tiny`