### PR TITLE
DOC-3526: Alignment buttons now work on iframes inserted with Page Embed

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -28,6 +28,19 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
+=== Page Embed
+
+The {productname} {release-version} release includes an accompanying release of the **Page Embed** premium plugin.
+
+**Page Embed** includes the following fix.
+
+==== Alignment buttons now work on iframes inserted with Page Embed
+// #TINY-14458
+
+Previously, the alignment toolbar buttons had no effect on iframes inserted with the **Page Embed** plugin, because the alignment formats did not recognize the Page Embed wrapper element. {productname} now applies left, center, and right alignment to Page Embed iframes.
+
+For information on the **Page Embed** plugin, see: xref:pageembed.adoc[Page Embed].
+
 // === <Premium plugin name 1> <Premium plugin name 1 version>
 
 // The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.


### PR DESCRIPTION
**Ticket:** DOC-3526 (TINY-14458)

**Site:** [Staging](https://pr-4204.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#alignment-buttons-now-work-on-iframes-inserted-with-page-embed)

**Changes:**
* Add an 8.7.0 Page Embed bug fix release note: the alignment toolbar buttons now apply to iframes inserted with the Page Embed plugin.

> Note: drafted from the ticket description; the ticket Documentation section was not filled in, and the ticket is currently In Progress.

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: `feature/8.7.0/DOC-3526_TINY-14458`
- [ ] `modules/ROOT/nav.adoc` has been updated (if applicable). _Not applicable._
- [x] Files have been included where required (if applicable).
- [ ] Files removed have been deleted, not just excluded from the build (if applicable). _Not applicable._
- [ ] Files added for **New product features** include a `release note` entry. _Not applicable (bug fix)._
- [ ] Major or minor version changes have updated the `supported-versions.adoc` table. _Not applicable._
- [ ] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [ ] Documentation Team Lead has reviewed.