### PR TITLE
DOC-3526: Tooltips are now shown for the Chat sidebar buttons

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -28,6 +28,19 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following improvement.
+
+==== Tooltips are now shown for the Chat sidebar buttons
+// #TINY-14507
+
+The buttons in the Chat sidebar now display tooltips, making their actions easier to identify.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 // === <Premium plugin name 1> <Premium plugin name 1 version>
 
 // The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.


### PR DESCRIPTION
**Ticket:** DOC-3526 (TINY-14507)

**Site:** [Staging](https://pr-4205.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#tooltips-are-now-shown-for-the-chat-sidebar-buttons)

**Changes:**
* Add an 8.7.0 TinyMCE AI improvement release note: the buttons in the Chat sidebar now display tooltips.

> Note: drafted from the ticket description; the ticket Documentation section was not filled in, and the ticket is currently In Progress.

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: `feature/8.7.0/DOC-3526_TINY-14507`
- [ ] `modules/ROOT/nav.adoc` has been updated (if applicable). _Not applicable._
- [x] Files have been included where required (if applicable).
- [ ] Files removed have been deleted, not just excluded from the build (if applicable). _Not applicable._
- [ ] Files added for **New product features** include a `release note` entry. _Not applicable (improvement)._
- [ ] Major or minor version changes have updated the `supported-versions.adoc` table. _Not applicable._
- [ ] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [ ] Documentation Team Lead has reviewed.