### PR TITLE
DOC-3526: Tooltips no longer get cut off when the editor is in a web component

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -89,6 +89,11 @@ The following premium plugin updates were released alongside {productname} {rele
 
 {productname} {release-version} also includes the following bug fix<es>:
 
+=== Tooltips no longer get cut off when the editor is in a web component
+// #TINY-14384
+
+Previously, tooltips could be cut off when the editor was embedded in a web component, because they were clipped at the bounds of the component. Tooltips now reposition to remain within the editor container.
+
 // === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1
 


### PR DESCRIPTION
**Ticket:** DOC-3526 (TINY-14384)

**Site:** [Staging](https://pr-4207.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#tooltips-no-longer-get-cut-off-when-the-editor-is-in-a-web-component)

**Changes:**
* Add an 8.7.0 bug fix release note: tooltips now reposition to remain within the editor container when the editor is embedded in a web component.

> Note: drafted from the ticket description; the ticket Documentation section was not filled in, the implementation approach was still exploratory, and the ticket is currently In Progress. Wording should be confirmed against the final fix.

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: `feature/8.7.0/DOC-3526_TINY-14384`
- [ ] `modules/ROOT/nav.adoc` has been updated (if applicable). _Not applicable._
- [x] Files have been included where required (if applicable).
- [ ] Files removed have been deleted, not just excluded from the build (if applicable). _Not applicable._
- [ ] Files added for **New product features** include a `release note` entry. _Not applicable (bug fix)._
- [ ] Major or minor version changes have updated the `supported-versions.adoc` table. _Not applicable._
- [ ] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [ ] Documentation Team Lead has reviewed.