### PR TITLE
DOC-3526: New tinymce.dom.AriaAnnouncer API for screen reader announcements

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -56,6 +56,17 @@ The following premium plugin updates were released alongside {productname} {rele
 
 {productname} {release-version} also includes the following addition<s>:
 
+=== New `tinymce.dom.AriaAnnouncer` API for screen reader announcements
+// #TINY-12791
+
+{productname} {release-version} adds the `+tinymce.dom.AriaAnnouncer+` API for sending messages to screen readers through an `+aria-live+` region without shifting focus. The `+announce+` method accepts a message and an optional `+{ assertive }+` setting. Integrators can use it to announce formatting changes, for example by listening to the `+FormatApply+` and `+FormatRemove+` events.
+
+[source,js]
+----
+tinymce.dom.AriaAnnouncer.announce('Bold on');
+tinymce.dom.AriaAnnouncer.announce('Error occurred', { assertive: true });
+----
+
 // === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1
 


### PR DESCRIPTION
**Ticket:** DOC-3526 (TINY-12791)

**Site:** [Staging](https://pr-4208.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#new-tinymce-dom-ariaannouncer-api-for-screen-reader-announcements)

**Changes:**
* Add an 8.7.0 addition release note for the new `tinymce.dom.AriaAnnouncer` API, which sends messages to screen readers via an `aria-live` region without shifting focus.

### **Pre-checks:**

- [x] Branch is correctly prefixed: `feature/8.7.0/DOC-3526_TINY-12791`
- [x] Files have been included where required (if applicable).
- [x] Files added for **New product features** include a `release note` entry.
- [x] Build passes without console errors, warnings, or issues.

### **Review:**

- [x] Documentation Team Lead has reviewed.