### PR TITLE
DOC-3526: Block formats can now be applied when a non-editable inline element is selected

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -92,7 +92,9 @@ The following premium plugin updates were released alongside {productname} {rele
 === Block formats can now be applied when a non-editable inline element is selected
 // #TINY-13333
 
-Previously, selecting an inline `+contenteditable="false"+` element, such as an iframe wrapped by the Media plugin, and applying a block-level format (such as a custom class or heading style) failed silently and had no effect. {productname} now applies block formats to the nearest editable parent block in this case, including adding classes and styles and changing block tags.
+Previously, selecting an inline `+contenteditable="false"+` element, such as an iframe wrapped by the Media plugin, and applying a block-level format, such as a custom class or heading style, failed silently and had no effect.
+
+In {productname} {release-version}, block formats are applied to the nearest editable parent block in this case, including adding classes and styles and changing block tags.
 
 // === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1

--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -89,6 +89,11 @@ The following premium plugin updates were released alongside {productname} {rele
 
 {productname} {release-version} also includes the following bug fix<es>:
 
+=== Block formats can now be applied when a non-editable inline element is selected
+// #TINY-13333
+
+Previously, selecting an inline `+contenteditable="false"+` element, such as an iframe wrapped by the Media plugin, and applying a block-level format (such as a custom class or heading style) failed silently and had no effect. {productname} now applies block formats to the nearest editable parent block in this case, including adding classes and styles and changing block tags.
+
 // === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1
 


### PR DESCRIPTION
**Ticket:** DOC-3526 (TINY-13333)

**Site:** [Staging](https://pr-4209.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#block-formats-can-now-be-applied-when-a-non-editable-inline-element-is-selected)

**Changes:**
* Add an 8.7.0 bug fix release note: block-level formats now apply to the nearest editable parent block when an inline `contenteditable="false"` element is selected.

### **Pre-checks:**

- [x] Branch is correctly prefixed: `feature/8.7.0/DOC-3526_TINY-13333`
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

### **Review:**

- [x] Documentation Team Lead has reviewed.