### PR TITLE
DOC-3526: Review sidebar no longer shows No improvements found after a review is applied

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -28,6 +28,19 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following fix.
+
+==== The Review sidebar no longer shows "No improvements found" after a review is applied
+// #TINY-14198
+
+Previously, hiding the Review sidebar and applying or skipping suggestions with the preview footer buttons did not reset the review state. Reopening the sidebar showed "No improvements found" instead of the available review options, requiring the editor to be reloaded. The review state now resets correctly, so the sidebar can be hidden and reopened to run new reviews.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 // === <Premium plugin name 1> <Premium plugin name 1 version>
 
 // The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.

--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -37,7 +37,9 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== The Review sidebar no longer shows "No improvements found" after a review is applied
 // #TINY-14198
 
-Previously, hiding the Review sidebar and applying or skipping suggestions with the preview footer buttons did not reset the review state. Reopening the sidebar showed "No improvements found" instead of the available review options, requiring the editor to be reloaded. The review state now resets correctly, so the sidebar can be hidden and reopened to run new reviews.
+Previously, if the Review sidebar was hidden while the model was still responding and the resulting suggestions were then applied or skipped from the Preview footer, the review state was not reset. Reopening the Review sidebar showed "Review complete — no improvements found" instead of the review list, even though the review had finished. The only way to recover the review options was to reload the editor.
+
+In {productname} {release-version}, the review state now resets correctly after suggestions are applied or skipped from the Preview footer while the sidebar is hidden. Reopening the Review sidebar shows the review list again, so further reviews can be run without reloading the editor.
 
 For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
 


### PR DESCRIPTION
**Ticket:** DOC-3526 (TINY-14198)

**Site:** [Staging](https://pr-4210.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#the-review-sidebar-no-longer-shows-no-improvements-found-after-a-review-is-applied)

**Changes:**
* Add an 8.7.0 TinyMCE AI bug fix release note: the review state now resets correctly so the Review sidebar no longer shows "No improvements found" after applying or skipping suggestions with the sidebar hidden.

### **Pre-checks:**

- [x] Branch is correctly prefixed: `feature/8.7.0/DOC-3526_TINY-14198`
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

### **Review:**

- [x] Documentation Team Lead has reviewed.