### PR TITLE
DOC-3526: New tinymceai_reviews_change_tone_menu option to control the Change Tone review menu

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -28,6 +28,19 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following addition.
+
+==== New `tinymceai_reviews_change_tone_menu` option to control the Change Tone review menu
+// #TINY-14274
+
+{productname} {release-version} adds the `+tinymceai_reviews_change_tone_menu+` option for **TinyMCE AI**, which controls the tone options shown in the Change Tone review menu. Only preset tone IDs are supported, the configured order is reflected in the menu, and duplicate values are removed. An invalid configuration falls back to the default tones, and an empty array (`+[]+`) hides the Change Tone review.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 // === <Premium plugin name 1> <Premium plugin name 1 version>
 
 // The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.

--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -37,7 +37,7 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== New `tinymceai_reviews_change_tone_menu` option to control the Change Tone review menu
 // #TINY-14274
 
-{productname} {release-version} adds the `+tinymceai_reviews_change_tone_menu+` option for **TinyMCE AI**, which controls the tone options shown in the Change Tone review menu. Only preset tone IDs are supported, the configured order is reflected in the menu, and duplicate values are removed. An invalid configuration falls back to the default tones, and an empty array (`+[]+`) hides the Change Tone review.
+{productname} {release-version} adds the `+tinymceai_reviews_change_tone_menu+` option for **TinyMCE AI**, which controls the tone options shown in the Change Tone review and their order. Only preset tone IDs are supported, the configured order is reflected in the menu, and duplicate values are removed. An invalid configuration falls back to the default tones. For the full list of tone IDs and behavior, see the xref:tinymceai.adoc#tinymceai_reviews_change_tone_menu[`+tinymceai_reviews_change_tone_menu+`] option.
 
 For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
 

--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -37,7 +37,7 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== New `tinymceai_reviews_change_tone_menu` option to control the Change Tone review menu
 // #TINY-14274
 
-{productname} {release-version} adds the `+tinymceai_reviews_change_tone_menu+` option for **TinyMCE AI**, which controls the tone options shown in the Change Tone review and their order. Only preset tone IDs are supported, the configured order is reflected in the menu, and duplicate values are removed. An invalid configuration falls back to the default tones. For the full list of tone IDs and behavior, see the xref:tinymceai.adoc#tinymceai_reviews_change_tone_menu[`+tinymceai_reviews_change_tone_menu+`] option.
+{productname} {release-version} adds the `+tinymceai_reviews_change_tone_menu+` option for **TinyMCE AI**. This option controls which tone options appear in the Change Tone review and their order. Only preset tone IDs are supported. Duplicate IDs are removed, and the menu displays tones in the configured order. If the option includes an invalid tone ID, the configuration is rejected and the default tones are used. For valid tone IDs and option details, see xref:tinymceai.adoc#tinymceai_reviews_change_tone_menu[`+tinymceai_reviews_change_tone_menu+`].
 
 For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
 

--- a/modules/ROOT/partials/configuration/tinymceai_options.adoc
+++ b/modules/ROOT/partials/configuration/tinymceai_options.adoc
@@ -566,7 +566,7 @@ tinymce.init({
 [[tinymceai_reviews_change_tone_menu]]
 === `+tinymceai_reviews_change_tone_menu+`
 
-Array of tone control IDs that define which tone options appear in the Change Tone review, and their order. Only the listed tones are available to users.
+Array of tone IDs that define which tone options appear in the Change Tone review and their order. Only the listed tones appear in the menu.
 
 This option applies only when `+'ai-reviews-change-tone'+` is included in the xref:tinymceai.adoc#tinymceai_reviews[`+tinymceai_reviews+`] option.
 
@@ -580,7 +580,7 @@ This option applies only when `+'ai-reviews-change-tone'+` is included in the xr
 * `+'ai-reviews-tone-confident'+`: Confident tone
 * `+'ai-reviews-tone-professional'+`: Professional tone
 
-Duplicate IDs are removed, and the configured order is reflected in the menu. If the option contains any value that is not a valid tone ID, the configuration is rejected and the default tones are used. An empty array (`+[]+`) is accepted but logs a console warning. To remove the Change Tone review entirely, omit `+'ai-reviews-change-tone'+` from the xref:tinymceai.adoc#tinymceai_reviews[`+tinymceai_reviews+`] option.
+Duplicate IDs are removed, and the menu displays tones in the configured order. If the option includes an invalid tone ID, the configuration is rejected and the default tones are used. An empty array (`+[]+`) is accepted, but {productname} logs a console warning. To remove the Change Tone review entirely, omit `+'ai-reviews-change-tone'+` from the xref:tinymceai.adoc#tinymceai_reviews[`+tinymceai_reviews+`] option.
 
 *Default value:*
 [source,js]

--- a/modules/ROOT/partials/configuration/tinymceai_options.adoc
+++ b/modules/ROOT/partials/configuration/tinymceai_options.adoc
@@ -563,3 +563,52 @@ tinymce.init({
 });
 ----
 
+[[tinymceai_reviews_change_tone_menu]]
+=== `+tinymceai_reviews_change_tone_menu+`
+
+Array of tone control IDs that define which tone options appear in the Change Tone review, and their order. Only the listed tones are available to users.
+
+This option applies only when `+'ai-reviews-change-tone'+` is included in the xref:tinymceai.adoc#tinymceai_reviews[`+tinymceai_reviews+`] option.
+
+*Type:* `+Array+` of `+String+`
+
+*Valid values:*
+
+* `+'ai-reviews-tone-casual'+`: Casual tone
+* `+'ai-reviews-tone-direct'+`: Direct tone
+* `+'ai-reviews-tone-friendly'+`: Friendly tone
+* `+'ai-reviews-tone-confident'+`: Confident tone
+* `+'ai-reviews-tone-professional'+`: Professional tone
+
+Duplicate IDs are removed, and the configured order is reflected in the menu. If the option contains any value that is not a valid tone ID, the configuration is rejected and the default tones are used. An empty array (`+[]+`) is accepted but logs a console warning. To remove the Change Tone review entirely, omit `+'ai-reviews-change-tone'+` from the xref:tinymceai.adoc#tinymceai_reviews[`+tinymceai_reviews+`] option.
+
+*Default value:*
+[source,js]
+----
+[
+  'ai-reviews-tone-casual',
+  'ai-reviews-tone-direct',
+  'ai-reviews-tone-friendly',
+  'ai-reviews-tone-confident',
+  'ai-reviews-tone-professional'
+]
+----
+
+.Example
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',
+  plugins: 'tinymceai',
+  toolbar: 'tinymceai-chat tinymceai-quickactions tinymceai-review',
+  tinymceai_reviews_change_tone_menu: [
+    'ai-reviews-tone-professional',
+    'ai-reviews-tone-friendly'
+  ],
+  // Required for authentication
+  tinymceai_token_provider: () => {
+    return fetch('/api/token').then(r => r.json());
+  }
+});
+----
+


### PR DESCRIPTION
**Ticket:** DOC-3526 (TINY-14274)

**Site:** [Staging](https://pr-4211.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#new-tinymceai_reviews_change_tone_menu-option-to-control-the-change-tone-review-menu)

**Changes:**
* Document the new `tinymceai_reviews_change_tone_menu` configuration option in the **TinyMCE AI** options reference (`modules/ROOT/partials/configuration/tinymceai_options.adoc`), including type, valid tone IDs, default value, validation behavior, and an example.
* Add an 8.7.0 TinyMCE AI addition release note for the option and cross-reference the option documentation.

### **Pre-checks:**

- [x] Branch is correctly prefixed: `feature/8.7.0/DOC-3526_TINY-14274`
- [x] Files have been included where required (if applicable).
- [x] Files added for **New product features** include a `release note` entry.
- [x] Build passes without console errors, warnings, or issues.

### **Review:**

- [x] Documentation Team Lead has reviewed.