### PR TITLE
DOC-3526: Review mode keyboard navigation now matches the Chat sidebar

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -28,6 +28,19 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following improvement.
+
+==== Review mode keyboard navigation now matches the Chat sidebar
+// #TINY-14275
+
+Keyboard navigation in review mode now matches the Chat sidebar. A `+Ctrl+Alt+S+` shortcut opens and focuses the Review sidebar, `+Tab+` and `+Shift+Tab+` move through the suggestion cards and their buttons, and `+Esc+` moves focus instead of rejecting pending changes. Review suggestions are now fully keyboard-navigable, with no accidental loss of pending changes.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 // === <Premium plugin name 1> <Premium plugin name 1 version>
 
 // The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.

--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -37,7 +37,9 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== Review mode keyboard navigation now matches the Chat sidebar
 // #TINY-14275
 
-Keyboard navigation in review mode now matches the Chat sidebar. A `+Ctrl+Alt+S+` shortcut opens and focuses the Review sidebar, `+Tab+` and `+Shift+Tab+` move through the suggestion cards and their buttons, and `+Esc+` moves focus instead of rejecting pending changes. Review suggestions are now fully keyboard-navigable, with no accidental loss of pending changes.
+Previously, keyboard navigation in the Review sidebar did not match the Chat sidebar, so keyboard-only workflows behaved inconsistently when switching between the two sidebars. Pressing `+Esc+` could also reject all pending suggestions instead of moving focus, which meant keyboard users could discard suggestions unintentionally.
+
+In {productname} {release-version}, keyboard navigation in the Review sidebar matches the Chat sidebar. The `+Ctrl+Alt+S+` shortcut opens and focuses the Review sidebar. `+Tab+` and `+Shift+Tab+` move through the suggestion cards and the buttons on each card. `+Esc+` now moves focus instead of rejecting pending suggestions. Keyboard-only users can navigate and apply suggestions without a mouse.
 
 For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
 


### PR DESCRIPTION
**Ticket:** DOC-3526 (TINY-14275)

**Site:** [Staging](https://pr-4212.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#review-mode-keyboard-navigation-now-matches-the-chat-sidebar)

**Changes:**
* Add an 8.7.0 TinyMCE AI improvement release note: review-mode keyboard navigation now matches the Chat sidebar, including a Ctrl+Alt+S shortcut, Tab/Shift+Tab navigation through suggestion cards, and Esc moving focus instead of rejecting pending changes.

### **Pre-checks:**

- [x] Branch is correctly prefixed: `feature/8.7.0/DOC-3526_TINY-14275`
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

### **Review:**

- [x] Documentation Team Lead has reviewed.