### PR TITLE
DOC-3526: Block formatting now targets the correct element across a table cell selection

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -89,6 +89,11 @@ The following premium plugin updates were released alongside {productname} {rele
 
 {productname} {release-version} also includes the following bug fix<es>:
 
+=== Block formatting now targets the correct element across a table cell selection
+// #TINY-14385
+
+Previously, when multiple table cells were selected, the check for whether a block could be renamed did not inspect nested elements. For example, with a blockquote containing a heading, applying a new heading format changed the blockquote instead of the heading. {productname} now inspects nested elements, so block formatting is applied to the correct element.
+
 // === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1
 

--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -92,7 +92,9 @@ The following premium plugin updates were released alongside {productname} {rele
 === Block formatting now targets the correct element across a table cell selection
 // #TINY-14385
 
-Previously, when multiple table cells were selected, the check for whether a block could be renamed did not inspect nested elements. For example, with a blockquote containing a heading, applying a new heading format changed the blockquote instead of the heading. {productname} now inspects nested elements, so block formatting is applied to the correct element.
+Previously, when multiple table cells were selected, the check for whether a block could be renamed did not inspect nested elements. For example, with a blockquote containing a heading, applying a new heading format changed the blockquote instead of the heading.
+
+In {productname} {release-version}, the check inspects nested elements, so block formatting is applied to the correct element.
 
 // === <TINY-vwxyz 1 changelog entry>
 // #TINY-vwxyz1


### PR DESCRIPTION
**Ticket:** DOC-3526 (TINY-14385)

**Site:** [Staging](https://pr-4213.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#block-formatting-now-targets-the-correct-element-across-a-table-cell-selection)

**Changes:**
* Add an 8.7.0 bug fix release note: block formatting now inspects nested elements across a table cell selection and applies to the correct element.

### **Pre-checks:**

- [x] Branch is correctly prefixed: `feature/8.7.0/DOC-3526_TINY-14385`
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

### **Review:**

- [x] Documentation Team Lead has reviewed.