### PR TITLE
DOC-3526: Chat can now update an empty document

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -39,7 +39,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 Previously, Chat did not update an empty document when generating content. Chat displayed the generated content only in the Chat sidebar, because the AI service could not apply edits when the document had no content.
 
-In {productname} {release-version}, Chat handles an empty document the same way as the Review sidebar. When the editor is empty, Chat now inserts the generated content directly into the document instead of displaying it only in the Chat sidebar.
+In {productname} {release-version}, AI Chat can now handle updating an empty document. When the editor is empty, the generated content is now directly inserted into the document rather than only being displayed in the sidebar.
 
 For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
 

--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -37,9 +37,9 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== Chat can now update an empty document
 // #TINY-14393
 
-Previously, submitting a Chat prompt with empty editor content updated only the chat response and not the document.
+Previously, Chat did not update an empty document when generating content. Chat displayed the generated content only in the Chat sidebar, because the AI service could not apply edits when the document had no content.
 
-In {productname} {release-version}, the editor sends an empty paragraph to the model when the content is empty, so changes are applied directly to the document.
+In {productname} {release-version}, Chat handles an empty document the same way as the Review sidebar. When the editor is empty, Chat now inserts the generated content directly into the document instead of displaying it only in the Chat sidebar.
 
 For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
 

--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -28,6 +28,19 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following fix.
+
+==== Chat can now update an empty document
+// #TINY-14393
+
+Previously, submitting a Chat prompt with empty editor content updated only the chat response and not the document. The editor now sends an empty paragraph to the model when the content is empty, so changes are applied directly to the document.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 // === <Premium plugin name 1> <Premium plugin name 1 version>
 
 // The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.

--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -37,7 +37,9 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== Chat can now update an empty document
 // #TINY-14393
 
-Previously, submitting a Chat prompt with empty editor content updated only the chat response and not the document. The editor now sends an empty paragraph to the model when the content is empty, so changes are applied directly to the document.
+Previously, submitting a Chat prompt with empty editor content updated only the chat response and not the document.
+
+In {productname} {release-version}, the editor sends an empty paragraph to the model when the content is empty, so changes are applied directly to the document.
 
 For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
 


### PR DESCRIPTION
**Ticket:** DOC-3526 (TINY-14393) TINYMCE-14393

**Site:** [Staging](https://pr-4214.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#chat-can-now-update-an-empty-document)

**Changes:**
* Add an 8.7.0 TinyMCE AI bug fix release note: the editor now sends an empty paragraph to the model when the content is empty, so Chat prompts can apply changes directly to an empty document.

### **Pre-checks:**

- [x] Branch is correctly prefixed: `feature/8.7.0/DOC-3526_TINY-14393`
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

### **Review:**

- [x] Documentation Team Lead has reviewed.