### PR TITLE
DOC-3526: The TinyMCE AI plugin now adds an `ai` property to the `SetContent` and `BeforeSetContent` event payloads

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -28,6 +28,21 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following improvement.
+
+==== The TinyMCE AI plugin now adds an `ai` property to the `SetContent` and `BeforeSetContent` event payloads
+// #TINYMCE-14302
+
+Previously, the **TinyMCE AI** plugin set content into the editor without marking it as AI-generated. Integrations that listen to the `+BeforeSetContent+` and `+SetContent+` events had no reliable way to distinguish this content from content set by other sources, and could not apply origin-specific processing, tracking, or analytics.
+
+In {productname} {release-version}, the **TinyMCE AI** plugin adds an `+ai+` property to the `+BeforeSetContent+` and `+SetContent+` event payloads when it sets content. Event handlers can check this property to detect **TinyMCE AI**-generated content and respond based on its origin.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 // === <Premium plugin name 1> <Premium plugin name 1 version>
 
 // The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.


### PR DESCRIPTION
### **Ticket:**

DOC-3526 (TINYMCE-14302)

### **Site:**

[Staging](https://pr-4215.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#the-tinymce-ai-plugin-now-adds-an-ai-property-to-the-setcontent-and-beforesetcontent-event-payloads)

### **Changes:**

Added a release note entry for TINYMCE-14302 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Accompanying Premium plugin changes → TinyMCE AI): the **TinyMCE AI** plugin now adds an `ai` property to the `SetContent` and `BeforeSetContent` event payloads when it sets content, allowing integrations to detect AI-generated content.

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.