### PR TITLE
DOC-3520: Downgrade Node to 22 LTS in preview workflow (tinymce/5 port)

### DIFF
--- a/.github/workflows/preview_create.yml
+++ b/.github/workflows/preview_create.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/setup-node@v5
       with:
         cache: 'yarn'
-        node-version: 24
+        node-version: 22
 
     - name: Install dependencies
       run: yarn install


### PR DESCRIPTION
## Summary

* Port of #4157 / #4164 to the `tinymce/5` branch.
* Node 24.16.0 (shipped in runner image 20260525.161.1) causes isomorphic-git's HTTP transport to silently fail, resulting in Antora producing zero output. This makes the "Rename site folder to docs" step fail (`mv ./build/site ./build/docs`) because no build output exists.
* Node 22 LTS is unaffected. This pins `node-version: 22` in the preview workflow, matching the fix already applied to `main`, `tinymce/8`, and `tinymce/7`.

## Why

The `Preview Create/Update` workflow runs on `pull_request` events using the base branch's workflow file. Because `tinymce/5` still pinned Node 24, every PR targeting this branch (for example #4200) fails the "Update Docs Preview" check. Porting the fix here unblocks those PRs.

## Test plan

* The "Update Docs Preview" workflow on this PR builds the site successfully and produces `./build/site`.

Ref: DOC-3520