### PR TITLE
DOC-3535 - Standardize on-premises registry login and support references

### DIFF
--- a/modules/ROOT/pages/tinymceai-on-premises-getting-started.adoc
+++ b/modules/ROOT/pages/tinymceai-on-premises-getting-started.adoc
@@ -48,18 +48,18 @@ For Docker:
 
 [source,bash]
 ----
-docker login -u tiny https://registry.containers.tiny.cloud
-# Docker prompts for the password; this avoids leaking it in shell history.
+docker login -u tiny -p [access-token] registry.containers.tiny.cloud
 ----
 
 For Podman:
 
 [source,bash]
 ----
-podman login -u tiny registry.containers.tiny.cloud
+podman login -u tiny -p [access-token] registry.containers.tiny.cloud
 ----
 
-All accounts authenticate with the username `tiny`. When prompted, enter the access token supplied by the Tiny account representative. If credentials have not been received, contact `support@tiny.cloud`.
+[NOTE]
+All accounts authenticate with the username `tiny`. Replace `[access-token]` with the access token supplied by the Tiny account representative. If credentials have not been received, contact link:{supporturl}/[{supportname}].
 
 === Pull the AI service image
 

--- a/modules/ROOT/pages/tinymceai-on-premises-production.adoc
+++ b/modules/ROOT/pages/tinymceai-on-premises-production.adoc
@@ -105,7 +105,7 @@ The AI service works with Podman as an alternative to Docker. In Podman, contain
 
 [source,bash]
 ----
-podman login -u '<registry-username>' registry.containers.tiny.cloud
+podman login -u tiny -p [access-token] registry.containers.tiny.cloud
 
 podman pull registry.containers.tiny.cloud/ai-service-tiny:latest
 
@@ -147,7 +147,7 @@ kubectl create namespace tinymce-ai
 kubectl create secret docker-registry tiny-registry \
   --namespace tinymce-ai \
   --docker-server=registry.containers.tiny.cloud \
-  --docker-username=<registry-username> \
+  --docker-username=tiny \
   --docker-password='<registry-access-token>'
 ----
 

--- a/modules/ROOT/pages/tinymceai-on-premises-troubleshooting.adoc
+++ b/modules/ROOT/pages/tinymceai-on-premises-troubleshooting.adoc
@@ -5,7 +5,7 @@
 :keywords: AI, on-premises, troubleshooting, errors, debugging, diagnostics, JWT, container, LLM
 :pluginname: TinyMCE AI
 
-Match the symptom to the fix below. If the symptom does not fit any section, escalate to `support@tiny.cloud` with the output of `docker logs ai-service --tail 200` and a redacted copy of the `PROVIDERS` value.
+Match the symptom to the fix below. If the symptom does not fit any section, escalate to link:{supporturl}/[{supportname}] with the output of `docker logs ai-service --tail 200` and a redacted copy of the `PROVIDERS` value.
 
 == Quick triage
 
@@ -19,7 +19,7 @@ Work through this list to identify the symptom area:
 . *Slow, timing out, or failing under load?* See <<performance>>.
 . *Scaling, upgrades, or deployment questions?* See xref:tinymceai-on-premises-production.adoc[Production deployment].
 
-If none of the above match, see <<diagnostic-recipes>> and then escalate to `support@tiny.cloud`.
+If none of the above match, see <<diagnostic-recipes>> and then escalate to link:{supporturl}/[{supportname}].
 
 
 [[container-startup-failures]]


### PR DESCRIPTION
**Ticket:** DOC-3535

**Site:** [Staging branch](https://pr-4218.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/8/tinymceai-on-premises-getting-started/#authenticate-with-the-container-registry)

**Changes:**
* Aligned all on-premises container registry login examples with the published pattern used across the service pages (Export to PDF, Spelling, Hyperlinking, Image Proxy, Import/Export Word).
* `tinymceai-on-premises-production.adoc` — replaced the remaining `<registry-username>` placeholders with the username `tiny` in the Podman login and the `kubectl create secret docker-registry` example.
* `tinymceai-on-premises-getting-started.adoc` and `tinymceai-on-premises-production.adoc` — use `docker login -u tiny -p [access-token] registry.containers.tiny.cloud` (and the Podman equivalent) consistently, and refer to the credential as an access token.
* `tinymceai-on-premises-getting-started.adoc` and `tinymceai-on-premises-troubleshooting.adoc` — replaced the hardcoded `support@tiny.cloud` email with the standard `link:{supporturl}/[{supportname}]` reference.

Background: follow-up to DOC-3530, which fixed only the getting-started page. This brings the rest of the on-premises pages in line so the registry username (`tiny`) and access-token terminology are consistent everywhere.

Prepared for documentation team review.