### PR TITLE
DOC-3526: Context sources can now be removed while they are still loading

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -39,6 +39,21 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following improvement.
+
+==== Context sources can now be removed while they are still loading
+// #TINYMCE-13876
+
+Previously, a user could not remove a context source from a TinyMCE AI conversation while the file was still uploading. A user who added a large file, such as an image or PDF, had to wait for the upload to the AI service to finish before removing it. The plugin provided no way to cancel a request that was already in progress.
+
+In {productname} {release-version}, the remove button on a context source now cancels an in-progress upload immediately. A user can remove a context source while it is still loading, without waiting for the request to complete.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 
 [[improvements]]
 == Improvements


### PR DESCRIPTION
### **Ticket:**

DOC-3526 (TINYMCE-13876)

### **Site:**

[Staging](https://pr-4219.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#context-sources-can-now-be-removed-while-they-are-still-loading)

### **Changes:**

Added release note entry for TINYMCE-13876 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Accompanying Premium plugin changes section, TinyMCE AI plugin): Context sources can now be removed while they are still loading.

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.