### PR TITLE
DOC-3536: Add minimum TinyMCE version banner to TinyMCE AI Introduction

### DIFF
--- a/modules/ROOT/pages/tinymceai-introduction.adoc
+++ b/modules/ROOT/pages/tinymceai-introduction.adoc
@@ -9,10 +9,7 @@
 
 Integrate real-time AI writing assistance into your application with TinyMCE AI, with ready-to-go editor features available via the TinyMCE plugin, and custom functionality available via the API -- even outside the editor. Speed up content creation and enhance editorial workflows across a wide range of use cases, from productivity boosts and proof-reading to content quality and consistency. All with your choice of LLM -- including your own.
 
-[NOTE]
-====
-{pluginname} requires {productname} 8.4 or later.
-====
+include::partial$misc/admon-tinymceai-min-version.adoc[]
 
 [[demo]]
 == Demo

--- a/modules/ROOT/pages/tinymceai-introduction.adoc
+++ b/modules/ROOT/pages/tinymceai-introduction.adoc
@@ -9,6 +9,11 @@
 
 Integrate real-time AI writing assistance into your application with TinyMCE AI, with ready-to-go editor features available via the TinyMCE plugin, and custom functionality available via the API -- even outside the editor. Speed up content creation and enhance editorial workflows across a wide range of use cases, from productivity boosts and proof-reading to content quality and consistency. All with your choice of LLM -- including your own.
 
+[IMPORTANT]
+====
+{pluginname} requires {productname} 8.4 or later.
+====
+
 [[demo]]
 == Demo
 

--- a/modules/ROOT/pages/tinymceai-introduction.adoc
+++ b/modules/ROOT/pages/tinymceai-introduction.adoc
@@ -9,7 +9,7 @@
 
 Integrate real-time AI writing assistance into your application with TinyMCE AI, with ready-to-go editor features available via the TinyMCE plugin, and custom functionality available via the API -- even outside the editor. Speed up content creation and enhance editorial workflows across a wide range of use cases, from productivity boosts and proof-reading to content quality and consistency. All with your choice of LLM -- including your own.
 
-[IMPORTANT]
+[NOTE]
 ====
 {pluginname} requires {productname} 8.4 or later.
 ====

--- a/modules/ROOT/pages/tinymceai.adoc
+++ b/modules/ROOT/pages/tinymceai.adoc
@@ -14,6 +14,8 @@ include::partial$misc/admon-inline-not-supported.adoc[]
 
 The {pluginname} plugin integrates AI-assisted authoring with rich-text editing. Users can interact through Actions, Reviews, or Conversations that can use relevant context from multiple sources.
 
+include::partial$misc/admon-tinymceai-min-version.adoc[]
+
 [[interactive-example]]
 == Interactive example
 

--- a/modules/ROOT/partials/misc/admon-tinymceai-min-version.adoc
+++ b/modules/ROOT/partials/misc/admon-tinymceai-min-version.adoc
@@ -1,0 +1,1 @@
+NOTE: The {pluginname} plugin requires {productname} 8.4 or later.


### PR DESCRIPTION
**Ticket:** DOC-3536

**Site:**
* [AI Introduction](https://pr-4220.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/tinymceai-introduction/)
* [AI Plugin reference](https://pr-4220.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/tinymceai/)

**Changes:**
* `modules/ROOT/partials/misc/admon-tinymceai-min-version.adoc` — new shared NOTE partial: "The TinyMCE AI plugin requires TinyMCE 8.4 or later."
* `modules/ROOT/pages/tinymceai-introduction.adoc` — include the partial below the intro paragraph.
* `modules/ROOT/pages/tinymceai.adoc` — include the partial below the intro paragraph on the plugin reference page.

The minimum version is scoped to the plugin, since the AI API works outside the editor and has no TinyMCE version requirement. Minimum supported version (8.4, not 8.0) confirmed by engineering (Fredrik Danielsson).

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: `hotfix/8/DOC-3536`
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.