### PR TITLE
TINYDOC-3526: Deleting a newline within a list item would delete the list item.

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -94,6 +94,13 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // CCFR here.
 
+=== Deleting a newline within a list item would delete the list item.
+// #TINYMCE-13292
+
+Previously, pressing `Backspace` to delete a newline (`<br>`) inside an otherwise empty list item removed the entire list item instead of only the newline. The issue affected lists created with `Shift + Enter`, including nested lists, and deleted content without warning.
+
+In {productname} {release-version}, `Backspace` removes only the newline and leaves the empty list item in place.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
**Ticket:** TINYDOC-3526 (TINYMCE-13292)

**Site:** [Staging](https://pr-4221.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#deleting-a-newline-within-a-list-item-would-delete-the-list-item)

**Changes:**
* Added release note entry for TINYMCE-13292 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Bug fixes section): Deleting a newline within a list item would delete the list item.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.