### PR TITLE
TINYDOC-3526: Highlighted suggestions in Chat and Actions preview mode no longer appear selected when clicked, since no follow up action is available on them.

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -39,6 +39,21 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following improvement.
+
+==== Highlighted suggestions in Chat and Actions preview mode no longer appear selected when clicked, since no follow up action is available on them.
+// #TINYMCE-14310
+
+Previously, clicking a highlighted suggestion in preview mode in TinyMCE AI Chat and TinyMCE AI Quick Actions showed a selected state, even though preview mode offers no action for highlighted suggestions. The selected state made the suggestions appear interactive and led users to expect a follow-up action that preview mode does not provide.
+
+In {productname} {release-version}, highlighted suggestions in preview mode in TinyMCE AI Chat and TinyMCE AI Quick Actions do not respond to clicks and no longer show a selected state. The highlights remain visible for reference, so preview mode presents a read-only view of the final text.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 
 [[improvements]]
 == Improvements


### PR DESCRIPTION
**Ticket:** TINYDOC-3526 (TINYMCE-14310)

**Site:** [Staging](https://pr-4222.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#highlighted-suggestions-in-chat-and-actions-preview-mode-no-longer-appear-selected-when-clicked-since-no-follow-up-action-is-available-on-them)

**Changes:**
* Added release note entry for TINYMCE-14310 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Accompanying Premium plugin changes → TinyMCE AI): Highlighted suggestions in Chat and Actions preview mode no longer appear selected when clicked.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.