### PR TITLE
TINYDOC-3526: Iframes inserted with the pageembed plugin could not be aligned using the align left, center, and right toolbar buttons.

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -48,9 +48,9 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== Iframes inserted with the pageembed plugin could not be aligned using the align left, center, and right toolbar buttons.
 // #TINYMCE-14458
 
-Previously, the align left, center, and right toolbar buttons could not align an iframe inserted with the Page Embed plugin. The Page Embed plugin wraps the iframe in a `tiny-pageembed` container that the default alignment format rules did not recognize, so selecting the iframe and choosing align left, center, or right on the toolbar had no effect. By contrast, an iframe inserted with the Media plugin uses a wrapper that the alignment rules already recognized.
+Previously, the align left, center, and right toolbar buttons had no effect on an iframe inserted with the Page Embed plugin. Selecting the embedded iframe and choosing an alignment did not change its position.
 
-In {productname} {release-version}, the alignment format rules recognize the `tiny-pageembed` container. The align left, center, and right toolbar buttons now apply alignment to a selected Page Embed iframe, matching the behavior of iframes inserted with the Media plugin.
+In {productname} {release-version}, the align left, center, and right toolbar buttons align an iframe inserted with the Page Embed plugin.
 
 For information on the **Page Embed** plugin, see: xref:pageembed.adoc[Page Embed].
 

--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -39,6 +39,21 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Page Embed
+
+The {productname} {release-version} release includes an accompanying release of the **Page Embed** premium plugin.
+
+**Page Embed** includes the following fix.
+
+==== Iframes inserted with the pageembed plugin could not be aligned using the align left, center, and right toolbar buttons.
+// #TINYMCE-14458
+
+Previously, the align left, center, and right toolbar buttons could not align an iframe inserted with the Page Embed plugin. The Page Embed plugin wraps the iframe in a `tiny-pageembed` container that the default alignment format rules did not recognize, so selecting the iframe and choosing align left, center, or right on the toolbar had no effect. By contrast, an iframe inserted with the Media plugin uses a wrapper that the alignment rules already recognized.
+
+In {productname} {release-version}, the alignment format rules recognize the `tiny-pageembed` container. The align left, center, and right toolbar buttons now apply alignment to a selected Page Embed iframe, matching the behavior of iframes inserted with the Media plugin.
+
+For information on the **Page Embed** plugin, see: xref:pageembed.adoc[Page Embed].
+
 
 [[improvements]]
 == Improvements


### PR DESCRIPTION
**Ticket:** TINYDOC-3526 (TINYMCE-14458)

**Site:** [Staging](https://pr-4223.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#iframes-inserted-with-the-pageembed-plugin-could-not-be-aligned-using-the-align-left-center-and-right-toolbar-buttons)

**Changes:**
* Added release note entry for TINYMCE-14458 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Accompanying Premium plugin changes → Page Embed): Iframes inserted with the Page Embed plugin could not be aligned using the align toolbar buttons.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.