### PR TITLE
TINYDOC-3526: It is now possible to have the kind of `export` in getContent's events and nodeFilter.

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -39,6 +39,34 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Export to PDF
+
+The {productname} {release-version} release includes an accompanying release of the **Export to PDF** premium plugin.
+
+**Export to PDF** includes the following addition.
+
+[[exportpdf-getcontent-export-property]]
+==== It is now possible to have the kind of `export` in getContent's events and nodeFilter.
+// #TINYMCE-14323
+
+The **Export to PDF** plugin now calls `tinymce.editor.getContent()` with an `export` property set to `pdf`. {productname} passes this property to the `GetContent` event and to serializer node filters, so an integrator can apply content filtering that targets a PDF export without affecting regular content retrieval.
+
+For information on filtering content during an export, see: xref:exportpdf.adoc#export-specific-content-filtering[Export-specific content filtering]. For information on the **Export to PDF** plugin, see: xref:exportpdf.adoc[Export to PDF].
+
+=== Export to Word
+
+The {productname} {release-version} release includes an accompanying release of the **Export to Word** premium plugin.
+
+**Export to Word** includes the following addition.
+
+[[exportword-getcontent-export-property]]
+==== It is now possible to have the kind of `export` in getContent's events and nodeFilter.
+// #TINYMCE-14323
+
+The **Export to Word** plugin now calls `tinymce.editor.getContent()` with an `export` property set to `word`. {productname} passes this property to the `GetContent` event and to serializer node filters, so an integrator can apply content filtering that targets a Word export without affecting regular content retrieval.
+
+For information on filtering content during an export, see: xref:exportword.adoc#export-specific-content-filtering[Export-specific content filtering]. For information on the **Export to Word** plugin, see: xref:exportword.adoc[Export to Word].
+
 
 [[improvements]]
 == Improvements

--- a/modules/ROOT/pages/exportpdf.adoc
+++ b/modules/ROOT/pages/exportpdf.adoc
@@ -81,6 +81,33 @@ The `exportpdf_service_url` option automatically appends `/v2/convert/html-pdf` 
 
 include::partial$misc/pagebreak-export-note.adoc[]
 
+[[export-specific-content-filtering]]
+== Export-specific content filtering
+
+When the {pluginname} plugin generates content for export, it calls the `tinymce.editor.getContent()` method with an `export` property set to `pdf`. {productname} passes this `export` property to the xref:events.adoc#editor-core-events[`+GetContent+` event] and to serializer node filters. As a result, an integrator can apply content filtering that targets a {pluginname} export without affecting regular `tinymce.editor.getContent()` calls.
+
+The following example shows how to remove `footer` elements from the content only during a {pluginname} export:
+
+[source,js]
+----
+editor.serializer.addNodeFilter('footer', (nodes, name, args) => {
+  if (args.export === 'pdf') {
+    nodes.forEach((node) => node.remove());
+  }
+});
+----
+
+The `GetContent` event also receives the `export` property:
+
+[source,js]
+----
+editor.on('GetContent', (e) => {
+  if (e.export === 'pdf') {
+    e.content = removeFooterFromHtml(e.content);
+  }
+});
+----
+
 == Options
 
 The following configuration options affect the behavior of the {pluginname} plugin.

--- a/modules/ROOT/pages/exportpdf.adoc
+++ b/modules/ROOT/pages/exportpdf.adoc
@@ -1,6 +1,7 @@
 = {pluginname} plugin
 :plugincode: exportpdf
 :pluginname: Export to PDF
+:export-type: pdf
 :page-aliases: export.adoc
 :pluginfilename: export-to-pdf
 :navtitle: Export to PDF
@@ -81,32 +82,7 @@ The `exportpdf_service_url` option automatically appends `/v2/convert/html-pdf` 
 
 include::partial$misc/pagebreak-export-note.adoc[]
 
-[[export-specific-content-filtering]]
-== Export-specific content filtering
-
-When the {pluginname} plugin generates content for export, it calls the `tinymce.editor.getContent()` method with an `export` property set to `pdf`. {productname} passes this `export` property to the xref:events.adoc#editor-core-events[`+GetContent+` event] and to serializer node filters. As a result, an integrator can apply content filtering that targets a {pluginname} export without affecting regular `tinymce.editor.getContent()` calls.
-
-The following example shows how to remove `footer` elements from the content only during a {pluginname} export:
-
-[source,js]
-----
-editor.serializer.addNodeFilter('footer', (nodes, name, args) => {
-  if (args.export === 'pdf') {
-    nodes.forEach((node) => node.remove());
-  }
-});
-----
-
-The `GetContent` event also receives the `export` property:
-
-[source,js]
-----
-editor.on('GetContent', (e) => {
-  if (e.export === 'pdf') {
-    e.content = removeFooterFromHtml(e.content);
-  }
-});
-----
+include::partial$misc/export-specific-content-filtering.adoc[]
 
 == Options
 

--- a/modules/ROOT/pages/exportword.adoc
+++ b/modules/ROOT/pages/exportword.adoc
@@ -80,6 +80,33 @@ The `exportword_service_url` option automatically appends `/v2/convert/html-docx
 
 include::partial$misc/pagebreak-export-note.adoc[]
 
+[[export-specific-content-filtering]]
+== Export-specific content filtering
+
+When the {pluginname} plugin generates content for export, it calls the `tinymce.editor.getContent()` method with an `export` property set to `word`. {productname} passes this `export` property to the xref:events.adoc#editor-core-events[`+GetContent+` event] and to serializer node filters. As a result, an integrator can apply content filtering that targets a {pluginname} export without affecting regular `tinymce.editor.getContent()` calls.
+
+The following example shows how to remove `footer` elements from the content only during a {pluginname} export:
+
+[source,js]
+----
+editor.serializer.addNodeFilter('footer', (nodes, name, args) => {
+  if (args.export === 'word') {
+    nodes.forEach((node) => node.remove());
+  }
+});
+----
+
+The `GetContent` event also receives the `export` property:
+
+[source,js]
+----
+editor.on('GetContent', (e) => {
+  if (e.export === 'word') {
+    e.content = removeFooterFromHtml(e.content);
+  }
+});
+----
+
 == Options
 
 The following configuration options affect the behavior of the {pluginname} plugin.

--- a/modules/ROOT/pages/exportword.adoc
+++ b/modules/ROOT/pages/exportword.adoc
@@ -1,6 +1,7 @@
 = {pluginname} plugin
 :plugincode: exportword
 :pluginname: Export to Word
+:export-type: word
 :pluginfilename: export-to-word
 :navtitle: {pluginname}
 :description: The {pluginname} feature lets you generate a .docx (Microsoft Word document) file directly from the editor.
@@ -80,32 +81,7 @@ The `exportword_service_url` option automatically appends `/v2/convert/html-docx
 
 include::partial$misc/pagebreak-export-note.adoc[]
 
-[[export-specific-content-filtering]]
-== Export-specific content filtering
-
-When the {pluginname} plugin generates content for export, it calls the `tinymce.editor.getContent()` method with an `export` property set to `word`. {productname} passes this `export` property to the xref:events.adoc#editor-core-events[`+GetContent+` event] and to serializer node filters. As a result, an integrator can apply content filtering that targets a {pluginname} export without affecting regular `tinymce.editor.getContent()` calls.
-
-The following example shows how to remove `footer` elements from the content only during a {pluginname} export:
-
-[source,js]
-----
-editor.serializer.addNodeFilter('footer', (nodes, name, args) => {
-  if (args.export === 'word') {
-    nodes.forEach((node) => node.remove());
-  }
-});
-----
-
-The `GetContent` event also receives the `export` property:
-
-[source,js]
-----
-editor.on('GetContent', (e) => {
-  if (e.export === 'word') {
-    e.content = removeFooterFromHtml(e.content);
-  }
-});
-----
+include::partial$misc/export-specific-content-filtering.adoc[]
 
 == Options
 

--- a/modules/ROOT/partials/misc/export-specific-content-filtering.adoc
+++ b/modules/ROOT/partials/misc/export-specific-content-filtering.adoc
@@ -1,0 +1,26 @@
+[[export-specific-content-filtering]]
+== Export-specific content filtering
+
+To generate content for export, the {pluginname} plugin calls the `tinymce.editor.getContent()` method with an `export` property set to `{export-type}`. {productname} adds this `export` property to the data for the xref:events.adoc#editor-core-events[`+GetContent+` event] and for serializer node filters. A serializer node filter or a `GetContent` event handler can read the `export` property to filter content during a {pluginname} export only, without changing the result of a standard `tinymce.editor.getContent()` call.
+
+The following serializer node filter removes `footer` elements during a {pluginname} export:
+
+[source,js,subs="+attributes"]
+----
+editor.serializer.addNodeFilter('footer', (nodes, name, args) => {
+  if (args.export === '{export-type}') {
+    nodes.forEach((node) => node.remove());
+  }
+});
+----
+
+A `GetContent` event handler can read the same `export` property:
+
+[source,js,subs="+attributes"]
+----
+editor.on('GetContent', (e) => {
+  if (e.export === '{export-type}') {
+    e.content = removeFooterFromHtml(e.content);
+  }
+});
+----


### PR DESCRIPTION
**Ticket:** TINYDOC-3526 (TINYMCE-14323)

**Site:** [Staging](https://pr-4224.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#exportpdf-getcontent-export-property)

**Changes:**
* Added release note entries for TINYMCE-14323 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Accompanying Premium plugin changes → Export to PDF and Export to Word): the `export` property is now available on the `GetContent` event and serializer node filters during an export.
* Added an **Export-specific content filtering** section to `modules/ROOT/pages/exportpdf.adoc` documenting the `export` property (Additions gate reference docs).
* Added an **Export-specific content filtering** section to `modules/ROOT/pages/exportword.adoc` documenting the `export` property (Additions gate reference docs).

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] Files added for **New product features** include a `release note` entry.
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.