### PR TITLE
TINYDOC-3526: Suggested Edits API should not be tied to the existence of the suggested edits toolbar button

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -39,6 +39,21 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Suggested Edits
+
+The {productname} {release-version} release includes an accompanying release of the **Suggested Edits** premium plugin.
+
+**Suggested Edits** includes the following fix.
+
+==== Suggested Edits API should not be tied to the existence of the suggested edits toolbar button
+// #TINYMCE-13256
+
+Previously, the `SuggestedEditsHasChangesUpdate` event only fired alongside other editor events, such as typing, selecting, or focusing. Completing a review did not fire the event on its own, so the value returned by the `hasChanges` API could become outdated. An integration that used the API through a custom button, rather than the built-in `suggestededits` toolbar button, did not receive an update when a review finished.
+
+In {productname} {release-version}, the `SuggestedEditsHasChangesUpdate` event fires whenever the value returned by the `hasChanges` API changes, including when a review completes. The `hasChanges` API no longer depends on the presence of the `suggestededits` toolbar button, so a custom integration stays in sync with the document state.
+
+For information on the **Suggested Edits** plugin, see: xref:suggestededits.adoc[Suggested Edits].
+
 
 [[improvements]]
 == Improvements

--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -50,7 +50,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 Previously, the `SuggestedEditsHasChangesUpdate` event only fired alongside other editor events, such as typing, selecting, or focusing. Completing a review did not fire the event on its own, so the value returned by the `hasChanges` API could become outdated. As a result, any integration that relied upon the API would not receive an update when a review finished.
 
-In {productname} {release-version}, the `SuggestedEditsHasChangesUpdate` event fires whenever the value returned by the `hasChanges` API changes, including when a review completes. The `hasChanges` API no longer depends on the presence of the `suggestededits` toolbar button, so a custom integration stays in sync with the document state.
+In {productname} {release-version}, the `SuggestedEditsHasChangesUpdate` event fires whenever the value within the `hasChanges` API changes, including when a review completes.
 
 For information on the **Suggested Edits** plugin, see: xref:suggestededits.adoc[Suggested Edits].
 

--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -48,7 +48,7 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== Suggested Edits API should not be tied to the existence of the suggested edits toolbar button
 // #TINYMCE-13256
 
-Previously, the `SuggestedEditsHasChangesUpdate` event only fired alongside other editor events, such as typing, selecting, or focusing. Completing a review did not fire the event on its own, so the value returned by the `hasChanges` API could become outdated. An integration that used the API through a custom button, rather than the built-in `suggestededits` toolbar button, did not receive an update when a review finished.
+Previously, the `SuggestedEditsHasChangesUpdate` event only fired alongside other editor events, such as typing, selecting, or focusing. Completing a review did not fire the event on its own, so the value returned by the `hasChanges` API could become outdated. As a result, any integration that relied upon the API would not receive an update when a review finished.
 
 In {productname} {release-version}, the `SuggestedEditsHasChangesUpdate` event fires whenever the value returned by the `hasChanges` API changes, including when a review completes. The `hasChanges` API no longer depends on the presence of the `suggestededits` toolbar button, so a custom integration stays in sync with the document state.
 


### PR DESCRIPTION
**Ticket:** TINYDOC-3526 (TINYMCE-13256)

**Site:** [Staging](https://pr-4225.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#suggested-edits-api-should-not-be-tied-to-the-existence-of-the-suggested-edits-toolbar-button)

**Changes:**
* Added release note entry for TINYMCE-13256 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Accompanying Premium plugin changes → Suggested Edits): the `SuggestedEditsHasChangesUpdate` event now fires whenever the `hasChanges` API value changes, including on review completion.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.