### PR TITLE
TINYDOC-3526: Tooltips were clipped when the editor was hosted in a shadow DOM and its parent element had `overflow:scroll`.

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -94,6 +94,13 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // CCFR here.
 
+=== Tooltips were clipped when the editor was hosted in a shadow DOM and its parent element had `overflow:scroll`.
+// #TINYMCE-14384
+
+Previously, when {productname} ran in a shadow DOM, such as a web component, and a parent element of the host used `overflow: scroll`, that element clipped a tooltip that extended past the host element boundary. The clipped tooltip could become unreadable.
+
+{productname} {release-version} restricts tooltip positioning to the bounds of the host element. A tooltip now repositions to stay within the host element and remains visible when {productname} runs in a shadow DOM.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
**Ticket:** TINYDOC-3526 (TINYMCE-14384)

**Site:** [Staging](https://pr-4226.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#tooltips-were-clipped-when-the-editor-was-hosted-in-a-shadow-dom-and-its-parent-element-had-overflowscroll)

**Changes:**
* Added release note entry for TINYMCE-14384 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Bug fixes section): tooltips were clipped when the editor ran in a shadow DOM with a scrolling ancestor.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.