### PR TITLE
TINYDOC-3526: Dragging and dropping or copying and pasting an image didn't add `width` and `height` to the tag.

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -94,6 +94,13 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // CCFR here.
 
+=== Dragging and dropping or copying and pasting an image didn't add `width` and `height` to the tag.
+// #TINYMCE-14411
+
+Previously, {productname} inserted an `img` tag without `width` and `height` attributes when a user dragged and dropped or copied and pasted an image into the editor. The inserted `img` tag lacked the dimension attributes that the image dialog adds.
+
+In {productname} {release-version}, the editor reads the dimensions of a dropped or pasted image and adds the `width` and `height` attributes to the `img` tag. A dropped or pasted image now includes the same `width` and `height` attributes that the image dialog adds.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
**Ticket:** TINYDOC-3526 (TINYMCE-14411)

**Site:** [Staging](https://pr-4227.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#dragging-and-dropping-or-copying-and-pasting-an-image-didnt-add-width-and-height-to-the-tag)

**Changes:**
* Added release note entry for TINYMCE-14411 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Bug fixes section): dropped or pasted images now receive `width` and `height` attributes.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.