### PR TITLE
TINYDOC-3526: The plugin no longer shows a console warning when `tinymceai_default_model` is not provided.

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -39,6 +39,21 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following bug fix.
+
+==== The plugin no longer shows a console warning when `tinymceai_default_model` is not provided.
+// #TINYMCE-14223
+
+Previously, the **TinyMCE AI** plugin logged a console warning when the xref:tinymceai.adoc#tinymceai_default_model[`+tinymceai_default_model+`] option was not set, even though omitting the option is valid. The warning suggested a misconfiguration and caused confusion.
+
+In {productname} {release-version}, the **TinyMCE AI** plugin no longer logs a console warning when the `tinymceai_default_model` option is not provided.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 
 [[improvements]]
 == Improvements


### PR DESCRIPTION
**Ticket:** TINYDOC-3526 (TINYMCE-14223)

**Site:** [Staging](https://pr-4231.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#the-plugin-no-longer-shows-a-console-warning-when-tinymceai_default_model-is-not-provided)

**Changes:**
* Added release note entry for TINYMCE-14223 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Accompanying Premium plugin changes → TinyMCE AI): the plugin no longer shows a console warning when `tinymceai_default_model` is not provided.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.