### PR TITLE
TINYDOC-3526: The custom review textarea showed a scrollbar when it was empty.

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -39,6 +39,21 @@ The following premium plugin updates were released alongside {productname} {rele
 
 // For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following bug fix.
+
+==== The custom review textarea showed a scrollbar when it was empty.
+// #TINYMCE-14409
+
+Previously, the text area in the Custom review section of the **TinyMCE AI** Review sidebar showed a scrollbar even when it was empty. The placeholder text could scroll and the corners of the text area appeared cut off, which made the control look broken.
+
+In {productname} {release-version}, the Custom review text area uses a larger default height, so the placeholder fits without a scrollbar and the text area renders correctly when empty.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 
 [[improvements]]
 == Improvements


### PR DESCRIPTION
**Ticket:** TINYDOC-3526 (TINYMCE-14409)

**Site:** [Staging](https://pr-4232.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#the-custom-review-textarea-showed-a-scrollbar-when-it-was-empty)

**Changes:**
* Added release note entry for TINYMCE-14409 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Accompanying Premium plugin changes → TinyMCE AI): the Custom review text area no longer shows a scrollbar when empty.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.