### PR TITLE
TINYDOC-3541 - Add redirects for migration-from-6x and powerpaste 404s

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -2878,6 +2878,14 @@
     "redirect": "/docs/tinymce/latest/math/"
   },
   {
+    "location": "/docs/tinymce/latest/migration-from-6x/",
+    "redirect": "/docs/tinymce/latest/migration-from-6x-to-8x/"
+  },
+  {
+    "location": "/docs/tinymce/latest/powerpaste/",
+    "redirect": "/docs/tinymce/latest/introduction-to-powerpaste/"
+  },
+  {
     "location": "/docs/tinymce/latest/premium-full-featured/",
     "redirect": "/docs/tinymce/latest/full-featured-premium-demo/"
   },


### PR DESCRIPTION
Ticket: TINYDOC-3541

Site: [Staging branch](https://pr-4235.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/migration-from-6x/)

Changes:
* Added two redirect entries to `redirects.json` to fix 404s reported in TDX-1483:
  * `/docs/tinymce/latest/migration-from-6x/` -> `/docs/tinymce/latest/migration-from-6x-to-8x/`
  * `/docs/tinymce/latest/powerpaste/` -> `/docs/tinymce/latest/introduction-to-powerpaste/`
* Entries placed alphabetically in the `/docs/tinymce/latest/` block.

Note: `redirects.json` exists only on `main` (docs redirects were moved out of the archived `tiny.cloud-infrastructure` repo), so this PR targets `main` rather than `tinymce/8`.

Pre-checks:
- [x] Branch prefixed with `hotfix/8/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`.
- [x] Included a `release note` entry for any `New product features`.
- [x] If this is a minor release, updated `productminorversion` in `antora.yml` and added new supported versions entry in `modules/ROOT/partials/misc/supported-versions.adoc`.

Review:
- [x] Documentation Team Lead has reviewed