### PR TITLE
TINYDOC-3526: The diff overlay was misaligned when users had `position: relative` on their body element in custom content_style

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -28,6 +28,21 @@ include::partial$misc/admon-releasenotes-for-stable.adoc[]
 
 The following premium plugin updates were released alongside {productname} {release-version}.
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following fix.
+
+==== The diff overlay could be misaligned when the body element used `+position: relative+` in a custom `+content_style+`
+// #TINYMCE-14327
+
+Previously, previewing a quick action such as Translate showed a misaligned diff overlay when the editor body element used `+position: relative+` in a custom `+content_style+`. The overlay used the body element as its containing block instead of the viewport, but the positioning logic still used the viewport. As a result, the highlight cutouts appeared offset from the translated text. Print-style layouts and document templates that positioned the body element could make the preview difficult to use.
+
+In {productname} {release-version}, the diff overlay renders independently of the editor content styles. The overlay aligns with the translated text regardless of custom body positioning, and the cutouts highlight the active translated content as expected.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 // === <Premium plugin name 1> <Premium plugin name 1 version>
 
 // The {productname} {release-version} release includes an accompanying release of the **<Premium plugin name 1>** premium plugin.


### PR DESCRIPTION
**Ticket:** TINYDOC-3526 (TINYMCE-14327)

**Site:** [Staging](https://pr-4237.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#the-diff-overlay-could-be-misaligned-when-the-body-element-used-position-relative-in-a-custom-content_style)

**Changes:**
* Added release note entry for TINYMCE-14327 to `modules/ROOT/pages/8.7.0-release-notes.adoc` (Accompanying Premium plugin changes -> TinyMCE AI): The diff overlay was misaligned when users had `position: relative` on their body element in custom content_style.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.