### PR TITLE
Docs: TINYDOC-3544 - Remove blank Export to Word Standalone Service page

### DIFF
--- a/modules/ROOT/attachments/llms-full.txt
+++ b/modules/ROOT/attachments/llms-full.txt
@@ -470,7 +470,6 @@ This section provides a complete list of all 411 documentation pages available i
 - **Export to PDF with JWT authentication (PHP) Guide (php)**: https://www.tiny.cloud/docs/tinymce/latest/export-to-pdf-v2-with-jwt-authentication-php/index.md
 - **Export to PDF with JWT authentication (PHP) Guide (php)**: https://www.tiny.cloud/docs/tinymce/latest/export-to-pdf-with-jwt-authentication-php/index.md
 - **Export to Word plugin**: https://www.tiny.cloud/docs/tinymce/latest/exportword/index.md
-- **Export to Word Standalone Service**: https://www.tiny.cloud/docs/tinymce/latest/export-to-word-standalone-service/index.md
 - **Export to Word with JWT authentication (Node.js) Guide**: https://www.tiny.cloud/docs/tinymce/latest/export-to-word-with-jwt-authentication-nodejs/index.md
 - **Export to Word with JWT authentication (PHP) Guide**: https://www.tiny.cloud/docs/tinymce/latest/export-to-word-with-jwt-authentication-php/index.md
 - **HTML to Docx Converter API**: https://www.tiny.cloud/docs/tinymce/latest/html-to-docx-converter-api/index.md

--- a/modules/ROOT/pages/export-to-word-standalone-service.adoc
+++ b/modules/ROOT/pages/export-to-word-standalone-service.adoc
@@ -1,5 +1,0 @@
-= Export to Word Standalone Service
-:navtitle: Export to Word Standalone Service
-:description: The Export to Word service feature, provides the ability to generate a .docx Word files directly without the need for an editor.
-:description_short: Generate a Word file directly from standalone application.
-:keywords: service, exportword, export to Word


### PR DESCRIPTION
## Summary

- Removes `modules/ROOT/pages/export-to-word-standalone-service.adoc`, which contained only AsciiDoc front matter (title, navtitle, description, keywords) and no body content, so it rendered as a blank page at `/docs/tinymce/latest/export-to-word-standalone-service/`.
- Removes the corresponding stale entry from the generated `llms-full.txt` index.

The page is not required. It had no inbound nav entries or xref references, so removing it does not affect any other page.

## Reference

- TINYDOC-3544

## Test plan

- [x] Confirmed the source file contained only front matter (no body).
- [x] Repo-wide search shows no nav or xref references to the page (only the generated `llms-full.txt` line, now removed).
- [x] Antora build (`antora-playbook-local.yml`) completes successfully with no errors related to the removed page.