### PR TITLE
TINYDOC-3544 - Remove blank Export to Word Standalone Service page (7.x)

### DIFF
--- a/modules/ROOT/pages/export-to-word-standalone-service.adoc
+++ b/modules/ROOT/pages/export-to-word-standalone-service.adoc
@@ -1,5 +1,0 @@
-= Export to Word Standalone Service
-:navtitle: Export to Word Standalone Service
-:description: The Export to Word service feature, provides the ability to generate a .docx Word files directly without the need for an editor.
-:description_short: Generate a Word file directly from standalone application.
-:keywords: service, exportword, export to Word


### PR DESCRIPTION
## Summary

- Removes `modules/ROOT/pages/export-to-word-standalone-service.adoc` on the `tinymce/7` branch. The page contained only AsciiDoc front matter (title, navtitle, description, keywords) with no body content, so it rendered as a blank page.

This mirrors the `tinymce/8` removal (#4238). The page is not required and has no inbound nav entries or xref references on this branch.

## Reference

- TINYDOC-3544

## Test plan

- [x] Confirmed the source file contained only front matter (no body).
- [x] Repo-wide search shows no nav or xref references to the page on `tinymce/7`.
- [x] Antora build (`antora-playbook-local.yml`) completes successfully with no errors related to the removed page.