### PR TITLE
TINYDOC-3548 - Update legacy AI Assistant demo proxy tokens (openai_proxy_token)

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -15,7 +15,7 @@ asciidoc:
     webcomponent_url: https://cdn.jsdelivr.net/npm/@tinymce/tinymce-webcomponent@2/dist/tinymce-webcomponent.min.js
     jquery_url: https://cdn.jsdelivr.net/npm/@tinymce/tinymce-jquery@2/dist/tinymce-jquery.min.js
     openai_proxy_url: https://openai.ai-demo-proxy.tiny.cloud/v1/chat/completions
-    openai_proxy_token: eyJhbGciOiJFUzM4NCJ9.eyJhdWQiOlsiaHR0cHM6Ly9vcGVuYWkuYWktZGVtby1wcm94eS50aW55LmNsb3VkLyJdLCJleHAiOjE3ODI4NjQwMDAsImh0dHBzOi8vb3BlbmFpLmFpLWRlbW8tcHJveHkudGlueS5jbG91ZC9yb2xlIjoicHVibGljLWRlbW8iLCJpc3MiOiJodHRwczovL2FpLWRlbW8tcHJveHkudGlueS5jbG91ZC8iLCJqdGkiOiIxZWY3NjJiNi1mZDYyLTQ3ZWQtOGRkNS0yOGRmMzBkZDU4YmMiLCJzdWIiOiJhaS1hc3Npc3RhbnQtZGVtbyJ9.WC8GIY19MgZneDVZoA-Ttt9E7gNkD0Yl-pcM_5c2RT3RdV_zE0i4bPOGBJpg_g6wu_4ki2ery6_JZtk2Q9gXEBHH7fIu7hXDFS8uIV9qe8MyxEqqRncGFVDjSTldVXGS
+    openai_proxy_token: eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiaHR0cHM6Ly9vcGVuYWkuYWktZGVtby1wcm94eS50aW55LmNsb3VkLyJdLCJpc3MiOiJodHRwczovL2FpLWRlbW8tcHJveHkudGlueS5jbG91ZC8iLCJzdWIiOiJhaS1hc3Npc3RhbnQtZGVtbyIsImlhdCI6MTc4Mjc4MTk0OSwiZXhwIjoxODExODA4MDAwLCJqdGkiOiIyYTAxZjJmYy04MWRjLTQxOWUtYmI5My05OGY5MWYxZDJiOWIiLCJodHRwczovL29wZW5haS5haS1kZW1vLXByb3h5LnRpbnkuY2xvdWQvcm9sZSI6InB1YmxpYy1kZW1vIn0.VzRNbv8LtLKEJE-du_m7lSwoJDa0qpwPiZYcVZwl17ThBIbaWtYB_FNC8tsAg0ozM0s1QVUL9z63kFf3Ki9G6qDF6oERrzbU0TI9yiUeNMeFELzZhPaGE_VhM4PEtkXl
     default_meta_keywords: tinymce, documentation, docs, plugins, customizable skins, configuration, examples, html, php, java, javascript, image editor, inline editor, distraction-free editor, classic editor, wysiwyg
     # product variables
     productname: TinyMCE


### PR DESCRIPTION
**Ticket:** TINYDOC-3548

**Site:** [Staging branch](https://pr-4244.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/6/ai/)

**Changes:**
* Port of #4242: updated `openai_proxy_token` in `antora.yml` with the new production JWT (exp 2027-06-01) for the AI Assistant (Legacy) live demo on the `tinymce/6` branch.

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: `hotfix/6/TINYDOC-3548`
- [x] Build passes without console errors, warnings, or issues. — Same one-line token change as #4242.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.