### PR TITLE
TINYDOC-3546 - Document Hunspell bundle download location (tinymce/7)

### DIFF
--- a/modules/ROOT/pages/self-hosting-hunspell.adoc
+++ b/modules/ROOT/pages/self-hosting-hunspell.adoc
@@ -13,7 +13,7 @@ To add Hunspell dictionaries to a self-hosted {productname}:
 
 == Downloadable Hunspell Bundles
 
-{companyname} provides two downloadable bundles of Hunspell dictionaries.
+{companyname} provides two downloadable bundles of Hunspell dictionaries. Download the bundles from link:{accountpageurl}/downloads/[{accountpage} > Downloads].
 
 `+hunspell-dictionaries-approved.zip+`:: Does *not* contain dictionaries licensed under:
 


### PR DESCRIPTION
**Ticket:** TINYDOC-3546

**Site:** [Staging branch](https://pr-4245.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/7/self-hosting-hunspell#downloadable-hunspell-bundles)

**Changes:**
* Backport to `tinymce/7`: updated `modules/ROOT/pages/self-hosting-hunspell.adoc` to note that Hunspell dictionary bundles are available from [Tiny Account > Downloads](https://www.tiny.cloud/my-account/downloads/).
* Bundle filenames remain listed as plain text; no direct zip URLs are published in the docs.

**Related:** https://github.com/tinymce/tinymce-docs/pull/4241 (tinymce/8)

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: `hotfix/7/TINYDOC-3546`
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.