### PR TITLE
DOC-3520: Fix CI workflows for Node 24 runner migration

### DIFF
--- a/.github/workflows/deploy_docs_v2.yml
+++ b/.github/workflows/deploy_docs_v2.yml
@@ -65,7 +65,7 @@ jobs:
         mv ./build/docs/sitemap.xml ./build/docs/antora-sitemap.xml
 
     - name: configure aws credentials
-      uses: aws-actions/configure-aws-credentials@v5.0.0
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: 'arn:aws:iam::${{ env.ACCT }}:role/${{ env.TARGET }}-tinymce-docs-update'
         role-session-name: tinymce-docs-${{ env.TARGET }}-release

--- a/.github/workflows/preview_create.yml
+++ b/.github/workflows/preview_create.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/setup-node@v5
       with:
         cache: 'yarn'
-        node-version: 24
+        node-version: 22
 
     - name: Install dependencies
       run: yarn install
@@ -55,7 +55,7 @@ jobs:
         mv ./build/docs/sitemap.xml ./build/docs/antora-sitemap.xml
 
     - name: configure aws credentials
-      uses: aws-actions/configure-aws-credentials@v5.0.0
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: arn:aws:iam::327995277200:role/staging-tinymce-docs-update
         role-session-name: tinymce-docs-update

--- a/.github/workflows/preview_delete.yml
+++ b/.github/workflows/preview_delete.yml
@@ -33,7 +33,7 @@ jobs:
         node-version: 24
 
     - name: configure aws credentials
-      uses: aws-actions/configure-aws-credentials@v5.0.0
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: arn:aws:iam::327995277200:role/staging-tinymce-docs-update
         role-session-name: tinymce-docs-delete


### PR DESCRIPTION
## Summary
- Upgrade `configure-aws-credentials` from v5 to v6 in `deploy_docs_v2.yml`, `preview_create.yml`, and `preview_delete.yml` to fix OIDC hangs on GitHub Actions Node 24 runners
- Pin `preview_create.yml` build steps to Node 22 LTS on `main` (matching tinymce/5–8) to avoid Antora silent failures with Node 24

## Context
Deploy Tiny Docs v2 on `main` was hanging at the AWS credentials step because v5 targets Node 20 and GitHub now forces those actions onto Node 24 runners.

## Test plan
- [x] Merge and re-run Deploy Tiny Docs v2 workflow on `main`
- [x] Confirm OIDC step completes and S3 upload succeeds
- [x] Open a test PR against `main` and confirm preview_create passes