### PR TITLE
DOC-3520: Upgrade configure-aws-credentials to v6

### DIFF
--- a/.github/workflows/preview_create.yml
+++ b/.github/workflows/preview_create.yml
@@ -52,7 +52,7 @@ jobs:
         mv ./build/docs/sitemap.xml ./build/docs/antora-sitemap.xml
 
     - name: configure aws credentials
-      uses: aws-actions/configure-aws-credentials@v5.0.0
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: arn:aws:iam::327995277200:role/staging-tinymce-docs-update
         role-session-name: tinymce-docs-update

--- a/.github/workflows/preview_delete.yml
+++ b/.github/workflows/preview_delete.yml
@@ -33,7 +33,7 @@ jobs:
         node-version: 24
 
     - name: configure aws credentials
-      uses: aws-actions/configure-aws-credentials@v5.0.0
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: arn:aws:iam::327995277200:role/staging-tinymce-docs-update
         role-session-name: tinymce-docs-delete


### PR DESCRIPTION
## Summary
- Upgrade `configure-aws-credentials` from v5 to v6 in preview workflows on `tinymce/7`

## Context
GitHub Actions now forces Node 20-targeting actions onto Node 24 runners, causing `configure-aws-credentials@v5` to hang at OIDC role assumption. v6 natively supports Node 24.

## Test plan
- [x] Open or update a PR against `tinymce/7` and confirm preview_create and preview_delete complete