### PR TITLE
TINYDOC-3550 - Clarify on-premises AI quick-start provider configuration

### DIFF
--- a/modules/ROOT/pages/tinymceai-on-premises-getting-started.adoc
+++ b/modules/ROOT/pages/tinymceai-on-premises-getting-started.adoc
@@ -181,7 +181,7 @@ Use the matching network name in `--network` below. First, load the `.env` file:
 set -a && source .env && set +a
 ----
 
-Then start the AI service container:
+Then start the AI service container. The `docker run` command maps the friendly `.env` names onto the service's own environment variables — for example, `AI_LICENCE_KEY` is passed to the container as `LICENSE_KEY`, and `MANAGEMENT_SECRET` as `ENVIRONMENTS_MANAGEMENT_SECRET_KEY`:
 
 [source,bash]
 ----
@@ -202,6 +202,13 @@ docker run --init -d -p 8000:8000 \
   -e ENABLE_METRIC_LOGS='true' \
   registry.containers.tiny.cloud/ai-service-tiny:latest
 ----
+
+[IMPORTANT]
+====
+This launch command configures a single OpenAI provider, through the `PROVIDERS` value and `$OPENAI_API_KEY`. The AI service only receives the environment variables explicitly passed in the `docker run` command, so adding `PROVIDERS`, `MODELS`, or other provider settings to the `.env` file alone has no effect.
+
+To use any other provider — `openai-compatible` (for example Databricks, Ollama, or vLLM), Azure, Amazon Bedrock, or Google Vertex — edit the `docker run` command directly: replace the `PROVIDERS` value and add a `MODELS` array. The `MODELS` variable is required for every provider except direct OpenAI, Anthropic, and Google, which have built-in model routing. See xref:tinymceai-on-premises-providers.adoc[LLM providers] for the full `PROVIDERS` and `MODELS` configuration.
+====
 
 NOTE: The AI service contacts `license.containers.tiny.cloud` on startup to validate the license key. Ensure this endpoint is reachable from the container. No customer data is sent during this check.
 


### PR DESCRIPTION
**Ticket:** TINYDOC-3550

**Site:** [Staging branch](https://pr-4253.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/tinymceai-on-premises-getting-started/#launch-the-ai-service)

**Changes:**
* Added an `IMPORTANT` admonition after the "Launch the AI service" `docker run` block clarifying that the quick-start command configures a single OpenAI provider, and that adding `PROVIDERS`, `MODELS`, or other provider settings to the `.env` file alone has no effect (only variables passed in `docker run` reach the service).
* Documented that any other provider — `openai-compatible` (Databricks, Ollama, vLLM), Azure, Amazon Bedrock, or Google Vertex — requires editing the `docker run` command to replace `PROVIDERS` and add a `MODELS` array, and that `MODELS` is required for every provider except direct OpenAI, Anthropic, and Google. Cross-referenced the LLM providers page.
* Clarified at the launch step that the `docker run` command maps the friendly `.env` names onto the service's own environment variables (for example `AI_LICENCE_KEY` → `LICENSE_KEY`, `MANAGEMENT_SECRET` → `ENVIRONMENTS_MANAGEMENT_SECRET_KEY`).

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: `hotfix/8/TINYDOC-3550`
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable). — not applicable (no new pages)
- [x] Files have been included where required (if applicable). — not applicable
- [x] Files removed have been deleted, not just excluded from the build (if applicable). — not applicable
- [x] Files added for **New product features** include a `release note` entry. — not applicable (clarification to existing page)
- [x] Major or minor version changes have updated the `supported-versions.adoc` table. — not applicable
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
