### PR TITLE
Ignore local-only workspace configuration directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,15 @@ build/
 
 # Antora tmp files
 _site/
+
+# Cursor setup (local only, do not push)
+.cursor/
+AGENTS.md
+.cursorignore
+
+# Claude setup (local only, do not push)
+.claude/
+.claudeignore
+
+# .mcp.json
+.mcp.json

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,6 @@ AGENTS.md
 # Claude setup (local only, do not push)
 .claude/
 .claudeignore
-
+CLAUDE.md
 # .mcp.json
 .mcp.json

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,4 @@ AGENTS.md
 .claude/
 .claudeignore
 CLAUDE.md
-# .mcp.json
 .mcp.json


### PR DESCRIPTION
Adds ignore rules so per-developer, local-only workspace configuration is never committed to this branch.

These directories/files hold machine-local tooling state and must not be pushed:

- `.cursor/` (+ `AGENTS.md`, `.cursorignore`)
- `.claude/` (+ `.claudeignore`)
- `.mcp.json`

Nothing of this kind is currently tracked on this branch — this is a preventive guard against accidental commits (for example via `git add -A`). No content or build files are affected.