### PR TITLE
Ignore local-only workspace configuration directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,4 @@ AGENTS.md
 .claude/
 .claudeignore
 CLAUDE.md
-# .mcp.json
 .mcp.json

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,15 @@ vendor
 
 # Antora tmp files
 _site/
+
+# Cursor setup (local only, do not push)
+.cursor/
+AGENTS.md
+.cursorignore
+
+# Claude setup (local only, do not push)
+.claude/
+.claudeignore
+
+# .mcp.json
+.mcp.json

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,6 @@ AGENTS.md
 # Claude setup (local only, do not push)
 .claude/
 .claudeignore
-
+CLAUDE.md
 # .mcp.json
 .mcp.json


### PR DESCRIPTION
Adds ignore rules so per-developer, local-only workspace configuration is never committed to this branch.

These directories/files hold machine-local tooling state and must not be pushed:

- `.cursor/` (+ `AGENTS.md`, `.cursorignore`)
- `.claude/` (+ `.claudeignore`)
- `.mcp.json`

Nothing of this kind is currently tracked on this branch — this is a preventive guard against accidental commits (for example via `git add -A`). No content or build files are affected.