### PR TITLE
TINYDOC-3552 - Fix missing closing code fence in tinymceai_reviews_change_tone_menu example

### DIFF
--- a/modules/ROOT/partials/configuration/tinymceai_options.adoc
+++ b/modules/ROOT/partials/configuration/tinymceai_options.adoc
@@ -659,6 +659,7 @@ tinymce.init({
     return fetch('/api/token').then(r => r.json());
   }
 });
+----
 
 [[integrator-defined-reviews]]
 ==== Integrator-defined reviews


### PR DESCRIPTION
**Ticket:** TINYDOC-3552

**Site:** [Staging branch](https://pr-4259.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/tinymceai/#tinymceai_reviews_change_tone_menu)

**Changes:**
* Added the missing closing `----` AsciiDoc code fence after the `tinymceai_reviews_change_tone_menu` example in `modules/ROOT/partials/configuration/tinymceai_options.adoc`. The unterminated block caused formatting to bleed into the following "Integrator-defined reviews" section on the rendered page.
* Verified all remaining code blocks on the affected page are terminated correctly.

### **Pre-checks:**

- [x] Branch is correctly prefixed: `hotfix/8/TINYDOC-3552`
- [x] Build passes without console errors, warnings, or issues.

### **Review:**

- [x] Documentation Team Lead has reviewed.
