### PR TITLE
TINYDOC-3531 - Document expand and split format parameters for content formatting

### DIFF
--- a/modules/ROOT/partials/configuration/formats.adoc
+++ b/modules/ROOT/partials/configuration/formats.adoc
@@ -358,7 +358,7 @@ tinymce.init({
 [[expand]]
 ==== `+expand+`
 
-Controls whether the selection is expanded to include the entire matching element before a format is applied or removed. This applies to `+selector+` formats that are not also `+inline+` formats. When enabled, if the selection only partially covers a matching element, the range is expanded to cover the whole element. Setting `+expand+` to `+false+` restricts the operation to the current selection.
+Controls whether the selection is expanded to the enclosing matching selector element before a format is applied or removed. This applies to `+selector+` formats that are not also `+inline+` formats. When enabled, if the selection only partially covers a matching element, the range is expanded to cover the whole element. Setting `+expand+` to `+false+` restricts the operation to the current selection.
 
 *Type:* `+Boolean+`
 

--- a/modules/ROOT/partials/configuration/formats.adoc
+++ b/modules/ROOT/partials/configuration/formats.adoc
@@ -362,7 +362,7 @@ Controls whether the selection is expanded to include the entire matching elemen
 
 *Type:* `+Boolean+`
 
-*Default value:* `+true+` for `+selector+` formats
+*Default value:* `+true+` for `+selector+` formats that are not also `+inline+` formats
 
 *Possible values:* `+true+`, `+false+`
 

--- a/modules/ROOT/partials/configuration/formats.adoc
+++ b/modules/ROOT/partials/configuration/formats.adoc
@@ -321,7 +321,7 @@ So if the selection is from _a_ to _b_ in this html contents `+<h1><b>[a</b></h1
 
 *Type:* `+Boolean+`
 
-+Default value:* `+false+`
+*Default value:* `+false+`
 
 *Possible values:* `+true+`, `+false+`
 
@@ -350,6 +350,58 @@ tinymce.init({
       },
       { selector: 'span', attributes: ['style', 'class'], remove: 'empty', split: true, expand: false, deep: true },
       { selector: '*', attributes: ['style', 'class'], split: false, expand: false, deep: true }
+    ]
+  }
+});
+----
+
+[[expand]]
+==== `+expand+`
+
+Controls whether the selection is expanded to include the entire matching element before a format is applied or removed. This applies to `+selector+` formats that are not also `+inline+` formats. When enabled, if the selection only partially covers a matching element, the range is expanded to cover the whole element. Setting `+expand+` to `+false+` restricts the operation to the current selection.
+
+*Type:* `+Boolean+`
+
+*Default value:* `+true+` for `+selector+` formats
+
+*Possible values:* `+true+`, `+false+`
+
+===== Example: using `+expand+`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  formats: {
+    removeformat: [
+      // Restrict removal to the current selection instead of expanding to the whole matching element
+      { selector: 'h1,h2,h3,h4,h5,h6', remove: 'all', expand: false, deep: true }
+    ]
+  }
+});
+----
+
+[[split]]
+==== `+split+`
+
+Used when removing a format. Controls whether the element wrapping the selection is split at the selection boundaries so that the format is removed only from the selected text. When set to `+false+`, the wrapping element is not split, so the format is not removed from a partial selection.
+
+*Type:* `+Boolean+`
+
+*Default value:* `+true+` for `+inline+` formats and non-`+selector+` formats; `+false+` for `+selector+` (block) formats.
+
+*Possible values:* `+true+`, `+false+`
+
+===== Example: using `+split+`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  formats: {
+    removeformat: [
+      // Remove the format without splitting the wrapping element at the selection boundaries
+      { selector: 'span', attributes: ['style', 'class'], remove: 'empty', split: false, deep: true }
     ]
   }
 });


### PR DESCRIPTION
**Ticket:** TINYDOC-3531

**Site:** [Staging branch](https://pr-4260.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/content-formatting/#format-parameters)

**Changes:**
* Documented the `expand` format parameter in `modules/ROOT/partials/configuration/formats.adoc` (Format parameters section): description, type, default (`true` for selector formats), possible values, and an example. `expand` controls whether the range is expanded to cover the whole matching selector element before a format is applied or removed; `expand: false` restricts the operation to the current selection.
* Documented the `split` format parameter: description, type, default (`true` for inline/non-selector formats, `false` for selector/block formats), possible values, and an example. `split` controls whether the wrapping element is split at the selection boundaries when a format is removed.
* Both parameters were already used in the existing `block_expand`, `deep`, and `removeformat` examples on this page but were undefined; they are now listed alongside the other format object properties.
* Fixed a pre-existing malformed AsciiDoc marker in the adjacent `block_expand` entry (`+Default value:*` -> `*Default value:*`) so its default value renders in bold like every other parameter.

All parameter descriptions and defaults were validated against the TinyMCE core formatter source.

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: `hotfix/8/TINYDOC-3531`

- [x] Files have been included where required (partial included by `content-formatting.adoc`).

- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
