### PR TITLE
TINYDOC-3528: Opening table properties on a nested table could edit the wrong table

### DIFF
--- a/modules/ROOT/pages/8.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.8.0-release-notes.adoc
@@ -160,6 +160,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Opening table properties on a nested table could edit the wrong table
+// #TINYMCE-13767
+
+Previously, when a table was nested inside another table, opening the table properties dialog for the outer table could display and edit the properties of the inner table instead. In Chrome and Edge, right-clicking near the left edge of a cell and selecting *Table properties* resolved to the nested table, so the settings shown did not match the selected table. This made nested tables confusing and error prone to edit.
+
+In {productname} {release-version}, the table properties dialog determines the target table by starting from the selected cell and finding the table that directly contains it. The dialog now reliably targets the table currently being edited, and property changes apply to the intended table.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
**Ticket:** TINYDOC-3528 (TINYMCE-13767)

**Site:** [Staging](https://pr-4263.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.8.0-release-notes/#opening-table-properties-on-a-nested-table-could-edit-the-wrong-table)

**Changes:**
* Added a release note entry for TINYMCE-13767 to `modules/ROOT/pages/8.8.0-release-notes.adoc` (Bug fixes section): Opening table properties on a nested table could edit the wrong table.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.
