### PR TITLE
TINYDOC-3528: Updated the bundled DOMPurify dependency to the latest version

### DIFF
--- a/modules/ROOT/pages/8.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.8.0-release-notes.adoc
@@ -116,6 +116,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Updated the bundled DOMPurify dependency to the latest version
+// #TINYMCE-14556
+
+Previously, {productname} bundled an older version of the DOMPurify sanitization library. Although {productname} was not affected by the published DOMPurify advisories, because they relate to DOMPurify options that {productname} does not use, the outdated version could be flagged by automated security scanners.
+
+In {productname} {release-version}, DOMPurify has been updated to the latest version. This resolves the scanner warnings without changing {productname}'s sanitization behavior.
+
 
 [[additions]]
 == Additions


### PR DESCRIPTION
**Ticket:** TINYDOC-3528 (TINYMCE-14556)

**Site:** [Staging](https://pr-4264.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.8.0-release-notes/#updated-the-bundled-dompurify-dependency-to-the-latest-version)

**Changes:**
* Added a release note entry for TINYMCE-14556 to `modules/ROOT/pages/8.8.0-release-notes.adoc` (Improvements section): Updated the bundled DOMPurify dependency to the latest version.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.
