### PR TITLE
TINYDOC-3528: The misspelled word highlight disappeared when pressing Enter to create a new line

### DIFF
--- a/modules/ROOT/pages/8.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.8.0-release-notes.adoc
@@ -71,6 +71,21 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Spell Checker
+
+The {productname} {release-version} release includes an accompanying release of the **Spell Checker** premium plugin.
+
+**Spell Checker** includes the following fix.
+
+==== The misspelled word highlight disappeared when pressing Enter to create a new line
+// #TINYMCE-12934
+
+Previously, deleting the last letter of a misspelled word with the *Backspace* key and then pressing *Enter* to start a new line removed the red highlight from the word, even though the word remained misspelled. The Spell Checker plugin did not re-check the affected line after the new block was created, so the word appeared as though it were spelled correctly.
+
+In {productname} {release-version}, the Spell Checker plugin re-checks both the new line and the previous line after a new block is created. Words that remain misspelled keep their highlighting.
+
+For information on the **Spell Checker** plugin, see: xref:introduction-to-tiny-spellchecker.adoc[Spell Checker].
+
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement


### PR DESCRIPTION
**Ticket:** TINYDOC-3528 (TINYMCE-12934)

**Site:** [Staging](https://pr-4266.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.8.0-release-notes/#the-misspelled-word-highlight-disappeared-when-pressing-enter-to-create-a-new-line)

**Changes:**
* Added a release note entry for TINYMCE-12934 to `modules/ROOT/pages/8.8.0-release-notes.adoc` (Accompanying Premium plugin changes → Spell Checker): The misspelled word highlight disappeared when pressing Enter to create a new line.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.
