### PR TITLE
TINYDOC-3528: Clicking anchor links with special characters could throw a querySelectorAll error

### DIFF
--- a/modules/ROOT/pages/8.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.8.0-release-notes.adoc
@@ -163,9 +163,9 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === Clicking anchor links with special characters could throw a `+querySelectorAll+` error
 // #TINYMCE-8784
 
-Previously, clicking an anchor link whose href contained special characters such as semicolons, common in Google Web Toolkit (GWT) place tokens like `+#!placetoken;param1=value1+`, threw a `+querySelectorAll+` syntax error. This occurred both in read-only mode and when using the Link plugin *Open link* feature through the toolbar button, the context menu, and the Alt+Enter keyboard shortcut, leaving a console error and preventing navigation to the target bookmark.
+Previously, clicking an anchor link whose href contained special characters, such as the semicolons common in Google Web Toolkit (GWT) place tokens like `+#!placetoken;param1=value1;param2=value2+`, threw a `+querySelectorAll+` syntax error: `+Uncaught SyntaxError: Failed to execute 'querySelectorAll' on 'Document': '...' is not a valid selector+`. This occurred both in read-only mode and when using the Link plugin *Open link* feature through the toolbar button, the context menu, and the Alt+Enter keyboard shortcut. The error appeared in the console and prevented navigation to the target bookmark.
 
-In {productname} {release-version}, anchor href values are escaped with `+CSS.escape+` before they are used as selectors. Clicking anchor links with special characters no longer throws an error, and the editor scrolls to the target bookmark as expected.
+In {productname} {release-version}, anchor href values are escaped with `+CSS.escape+` before they are used as `+querySelectorAll+` selectors, so all ASCII special characters in an href are handled. Clicking anchor links with special characters no longer throws an error, and the editor scrolls to the target bookmark across different URL fragment formats.
 
 
 [[security-fixes]]

--- a/modules/ROOT/pages/8.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.8.0-release-notes.adoc
@@ -160,6 +160,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Clicking anchor links with special characters could throw a `+querySelectorAll+` error
+// #TINYMCE-8784
+
+Previously, clicking an anchor link whose href contained special characters such as semicolons, common in Google Web Toolkit (GWT) place tokens like `+#!placetoken;param1=value1+`, threw a `+querySelectorAll+` syntax error. This occurred both in read-only mode and when using the Link plugin *Open link* feature through the toolbar button, the context menu, and the Alt+Enter keyboard shortcut, leaving a console error and preventing navigation to the target bookmark.
+
+In {productname} {release-version}, anchor href values are escaped with `+CSS.escape+` before they are used as selectors. Clicking anchor links with special characters no longer throws an error, and the editor scrolls to the target bookmark as expected.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
**Ticket:** TINYDOC-3528 (TINYMCE-8784)

**Site:** [Staging](https://pr-4268.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.8.0-release-notes/#clicking-anchor-links-with-special-characters-could-throw-a-queryselectorall-error)

**Changes:**
* Added a release note entry for TINYMCE-8784 to `modules/ROOT/pages/8.8.0-release-notes.adoc` (Bug fixes section): Clicking anchor links with special characters could throw a `querySelectorAll` error.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.
