### PR TITLE
TINYDOC-3528: The cursor could be placed at the start of a list item instead of the clicked position

### DIFF
--- a/modules/ROOT/pages/8.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.8.0-release-notes.adoc
@@ -163,9 +163,9 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === The cursor could be placed at the start of a list item instead of the clicked position
 // #TINYMCE-14490
 
-Previously, in Chromium-based browsers such as Chrome and Edge, clicking to the right of a line inside certain list items could place the cursor at the start of the item rather than at the clicked position. This edge case affected list items that contained a nested list, along with any list items created from them, making it difficult to position the cursor accurately. This behavior originates from a known link:https://issues.chromium.org/issues/40767343[Chromium browser issue].
+Previously, in Chromium-based browsers such as Chrome and Edge, clicking within a list item after the end of its text — for example, in the empty space to the right of the line — could place the cursor at the start of the item instead of at the end of the line. Clicking directly within a list item's text was not affected. This behavior originates from a known link:https://issues.chromium.org/issues/40767343[Chromium browser issue].
 
-In {productname} {release-version}, {productname} detects this browser behavior and corrects the cursor position. Clicking within these list items now places the cursor at the clicked position.
+In {productname} {release-version}, {productname} detects this browser behavior and corrects the cursor position. Clicking within these list items now places the cursor at the expected position.
 
 
 [[security-fixes]]

--- a/modules/ROOT/pages/8.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.8.0-release-notes.adoc
@@ -160,6 +160,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== The cursor could be placed at the start of a list item instead of the clicked position
+// #TINYMCE-14490
+
+Previously, in Chromium-based browsers such as Chrome and Edge, clicking to the right of a line inside certain list items could place the cursor at the start of the item rather than at the clicked position. This edge case affected list items that contained a nested list, along with any list items created from them, making it difficult to position the cursor accurately.
+
+In {productname} {release-version}, {productname} detects this browser behavior and corrects the cursor position. Clicking within these list items now places the cursor at the clicked position.
+
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/pages/8.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.8.0-release-notes.adoc
@@ -163,7 +163,7 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 === The cursor could be placed at the start of a list item instead of the clicked position
 // #TINYMCE-14490
 
-Previously, in Chromium-based browsers such as Chrome and Edge, clicking to the right of a line inside certain list items could place the cursor at the start of the item rather than at the clicked position. This edge case affected list items that contained a nested list, along with any list items created from them, making it difficult to position the cursor accurately.
+Previously, in Chromium-based browsers such as Chrome and Edge, clicking to the right of a line inside certain list items could place the cursor at the start of the item rather than at the clicked position. This edge case affected list items that contained a nested list, along with any list items created from them, making it difficult to position the cursor accurately. This behavior originates from a known link:https://issues.chromium.org/issues/40767343[Chromium browser issue].
 
 In {productname} {release-version}, {productname} detects this browser behavior and corrects the cursor position. Clicking within these list items now places the cursor at the clicked position.
 


### PR DESCRIPTION
**Ticket:** TINYDOC-3528 (TINYMCE-14490)

**Site:** [Staging](https://pr-4269.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.8.0-release-notes/#the-cursor-could-be-placed-at-the-start-of-a-list-item-instead-of-the-clicked-position)

**Changes:**
* Added a release note entry for TINYMCE-14490 to `modules/ROOT/pages/8.8.0-release-notes.adoc` (Bug fixes section): The cursor could be placed at the start of a list item instead of the clicked position.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.
