### PR TITLE
TINYDOC-3528: Double tooltips appeared on tags in the prompt context in Safari

### DIFF
--- a/modules/ROOT/pages/8.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.8.0-release-notes.adoc
@@ -71,6 +71,21 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following fix.
+
+==== Double tooltips appeared on tags in the prompt context in Safari
+// #TINYMCE-14485
+
+Previously, in Safari, hovering over the context source tags in the AI Chat prompt could display duplicated tooltips, and a tooltip could appear even when the tag text was not truncated. The tags were missing the attribute that prevents tooltip duplication in Safari.
+
+In {productname} {release-version}, the context source tags include the attribute that resolves Safari tooltip duplication. Each tag now shows a single tooltip, and only when its text is truncated.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai-introduction.adoc[TinyMCE AI].
+
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement


### PR DESCRIPTION
**Ticket:** TINYDOC-3528 (TINYMCE-14485)

**Site:** [Staging](https://pr-4270.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.8.0-release-notes/#double-tooltips-appeared-on-tags-in-the-prompt-context-in-safari)

**Changes:**
* Added a release note entry for TINYMCE-14485 to `modules/ROOT/pages/8.8.0-release-notes.adoc` (Accompanying Premium plugin changes → TinyMCE AI): Double tooltips appeared on tags in the prompt context in Safari.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.
