### PR TITLE
TINYDOC-3528: Clicking the reply button triggered an editor blur event

### DIFF
--- a/modules/ROOT/pages/8.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.8.0-release-notes.adoc
@@ -71,6 +71,21 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Comments
+
+The {productname} {release-version} release includes an accompanying release of the **Comments** premium plugin.
+
+**Comments** includes the following fix.
+
+==== Clicking the reply button triggered an editor blur event
+// #TINYMCE-12236
+
+Previously, selecting the reply button on a comment could cause the editor to fire a `+blur+` event, even though focus remained within the editor. Expanding the replies re-rendered the comment and moved focus, which the editor interpreted as focus leaving the editor. Applications that rely on the `+blur+` event to detect when editing has finished could behave incorrectly.
+
+In {productname} {release-version}, the Comments plugin preserves editor focus when expanding replies. The editor no longer fires an unexpected `+blur+` event when the reply button is selected.
+
+For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Comments].
+
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement

--- a/modules/ROOT/pages/8.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.8.0-release-notes.adoc
@@ -80,7 +80,7 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== Clicking the reply button triggered an editor blur event
 // #TINYMCE-12236
 
-Previously, selecting the reply button on a comment thread, such as *1 reply*, could cause the editor to fire a `+blur+` event, even though focus remained within the editor. Expanding the replies re-rendered the comment and moved focus to the editor content, which the editor interpreted as focus leaving the editor. Applications that rely on the `+blur+` event to detect when editing has finished could behave incorrectly.
+Previously, selecting the reply button on a comment thread, such as *1 reply*, could cause the editor to fire a `+blur+` event, even though the user was still working within the editor. Expanding the replies re-rendered the comment, and because the focused element was removed during the re-render, focus fell back to the document body instead of remaining within the editor. The editor interpreted this loss of focus as the user leaving the editor entirely. Applications that rely on the `+blur+` event to detect when editing has finished could behave incorrectly.
 
 In {productname} {release-version}, the Comments plugin preserves editor focus when expanding replies. The editor no longer fires an unexpected `+blur+` event when the reply button is selected.
 

--- a/modules/ROOT/pages/8.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.8.0-release-notes.adoc
@@ -80,7 +80,7 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== Clicking the reply button triggered an editor blur event
 // #TINYMCE-12236
 
-Previously, selecting the reply count button on a comment thread, such as *1 reply*, could cause the editor to fire a `+blur+` event, even though focus remained within the editor. Expanding the replies re-rendered the comment and moved focus to the editor content, which the editor interpreted as focus leaving the editor. Applications that rely on the `+blur+` event to detect when editing has finished could behave incorrectly.
+Previously, selecting the reply button on a comment thread, such as *1 reply*, could cause the editor to fire a `+blur+` event, even though focus remained within the editor. Expanding the replies re-rendered the comment and moved focus to the editor content, which the editor interpreted as focus leaving the editor. Applications that rely on the `+blur+` event to detect when editing has finished could behave incorrectly.
 
 In {productname} {release-version}, the Comments plugin preserves editor focus when expanding replies. The editor no longer fires an unexpected `+blur+` event when the reply button is selected.
 

--- a/modules/ROOT/pages/8.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.8.0-release-notes.adoc
@@ -80,7 +80,7 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== Clicking the reply button triggered an editor blur event
 // #TINYMCE-12236
 
-Previously, selecting the reply button on a comment could cause the editor to fire a `+blur+` event, even though focus remained within the editor. Expanding the replies re-rendered the comment and moved focus, which the editor interpreted as focus leaving the editor. Applications that rely on the `+blur+` event to detect when editing has finished could behave incorrectly.
+Previously, selecting the reply count button on a comment thread, such as *1 reply*, could cause the editor to fire a `+blur+` event, even though focus remained within the editor. Expanding the replies re-rendered the comment and moved focus to the editor content, which the editor interpreted as focus leaving the editor. Applications that rely on the `+blur+` event to detect when editing has finished could behave incorrectly.
 
 In {productname} {release-version}, the Comments plugin preserves editor focus when expanding replies. The editor no longer fires an unexpected `+blur+` event when the reply button is selected.
 


### PR DESCRIPTION
**Ticket:** TINYDOC-3528 (TINYMCE-12236)

**Site:** [Staging](https://pr-4271.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.8.0-release-notes/#clicking-the-reply-button-triggered-an-editor-blur-event)

**Changes:**
* Added a release note entry for TINYMCE-12236 to `modules/ROOT/pages/8.8.0-release-notes.adoc` (Accompanying Premium plugin changes → Comments): Clicking the reply button triggered an editor blur event.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.
