### PR TITLE
TINYDOC-3528: The TinyMCE AI chat sidebar now shows only one tooltip at a time

### DIFF
--- a/modules/ROOT/pages/8.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.8.0-release-notes.adoc
@@ -116,6 +116,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== The {productname} AI chat sidebar now shows only one tooltip at a time
+// #TINYMCE-14507
+
+Previously, each button in the {productname} AI chat sidebar managed its tooltip independently, with no coordination between them. Opening one tooltip did not close a tooltip that was already visible, so more than one tooltip could remain on screen at the same time.
+
+In {productname} {release-version}, opening a tooltip in the {productname} AI chat sidebar closes any other open tooltip, so the chat sidebar shows only one tooltip at a time. This keeps the interface clear and consistent.
+
 
 [[additions]]
 == Additions


### PR DESCRIPTION
### **Ticket:**

TINYDOC-3528 (TINYMCE-14507)

### **Site:**

[Staging](https://pr-4272.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.8.0-release-notes/#the-tinymce-ai-chat-sidebar-now-shows-only-one-tooltip-at-a-time)

### **Changes:**

Added release note entry for TINYMCE-14507 to `modules/ROOT/pages/8.8.0-release-notes.adoc` (Improvements section): The TinyMCE AI chat sidebar now shows only one tooltip at a time.

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.
