### PR TITLE
TINYDOC-3528: The TinyMCE AI plugin now ignores non-string values returned by tinymceai_tool_data_callback

### DIFF
--- a/modules/ROOT/pages/8.8.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.8.0-release-notes.adoc
@@ -71,6 +71,21 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following fix.
+
+==== The TinyMCE AI plugin now ignores non-string values returned by `tinymceai_tool_data_callback`
+// #TINYMCE-14525
+
+Previously, the xref:tinymceai.adoc#tinymceai_tool_data_callback[`+tinymceai_tool_data_callback+`] callback could return a value that was not a string, such as a number. The **TinyMCE AI** plugin then displayed that value directly in the Chat sidebar status message, even though the option documents a return type of `+string | undefined+`. As a result, the status message shown while a Model Context Protocol (MCP) tool ran did not make sense.
+
+In {productname} {release-version}, the **TinyMCE AI** plugin validates the value returned by the callback. When the callback returns a value that is not a string, the plugin ignores that value, treats the result as `+undefined+`, and shows the default status message instead.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement


### PR DESCRIPTION
### **Ticket:**

TINYDOC-3528 (TINYMCE-14525)

### **Site:**

[Staging](https://pr-4273.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.8.0-release-notes/#the-tinymce-ai-plugin-now-ignores-non-string-values-returned-by-tinymceai_tool_data_callback)

### **Changes:**

Added release note entry for TINYMCE-14525 to `modules/ROOT/pages/8.8.0-release-notes.adoc` (Accompanying Premium plugin changes → TinyMCE AI): The TinyMCE AI plugin now ignores non-string values returned by `tinymceai_tool_data_callback`.

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.
