### PR TITLE
TINYDOC-3554 - Fix Angular cloud docs: remove license key/self-hosted content

### DIFF
--- a/modules/ROOT/partials/integrations/angular-quick-start.adoc
+++ b/modules/ROOT/partials/integrations/angular-quick-start.adoc
@@ -55,7 +55,6 @@ import { EditorComponent } from '@tinymce/tinymce-angular';
   <h1>{productname} {productmajorversion} Angular Demo</h1>
   <editor
     [init]="init"
-    licenseKey="gpl"
     apiKey="no-api-key"
   />
   `
@@ -101,7 +100,9 @@ ifeval::["{productSource}" == "zip"]
 . Unzip the content of the `+tinymce/js+` folder from the link:{download-enterprise}[{productname} zip] into the `+src+` folder.
 endif::[]
 
+ifeval::["{productSource}" != "cloud"]
 include::partial$integrations/angular-load-tinymce-independently.adoc[]
+endif::[]
 
 . Run the Angular a development server
 +


### PR DESCRIPTION
**Ticket:** TINYDOC-3554

**Site:** [Staging branch](https://pr-4274.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/angular-cloud/)

**Changes:**

Fixes the Angular cloud quick-start so that, like the React and Vue cloud pages, {productname} loads exclusively via the API key.

* Removed `licenseKey="gpl"` from the cloud-gated (`ifeval::["{productSource}" == "cloud"]`) component sample in `modules/ROOT/partials/integrations/angular-quick-start.adoc`. The cloud sample now uses `apiKey="no-api-key"` only.
* Gated the self-hosted loading include (`angular-load-tinymce-independently.adoc`) behind `ifeval::["{productSource}" != "cloud"]`, so the self-hosted setup steps (`TINYMCE_SCRIPT_SRC` lazy-loading, `angular.json` assets, `base_url`/`suffix`) no longer leak onto the cloud page.

The partial is shared by the cloud, package-manager, and zip Angular pages; both changes are scoped to the cloud variant. The `angular-pm` and `angular-zip` pages are unaffected — verified in the local build that both still render `licenseKey="gpl"` and the full self-hosted setup.

Note on other versions: the `tinymce/5`, `tinymce/6`, and `tinymce/7` Angular partials were checked and do not contain this defect (no `licenseKey` in the cloud sample; self-hosted content already correctly gated), so no backport is required.

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: `hotfix/8/TINYDOC-3554`
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
