### PR TITLE
TINYDOC-3524 - Fix empty table rows and add ignored-words persistence and custom-dictionary guidance in Spell Checker docs

### DIFF
--- a/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
+++ b/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
@@ -36,6 +36,8 @@ To enable the {productname} Enterprise Spellchecking plugin, add `+tinymcespellc
 
 For information on installing the server-side component for spell checking, please see the xref:individual-spelling-container.adoc[Deploy the {productname} spelling service server-side component using Docker].
 
+NOTE: Custom dictionaries, which add words that are recognized as correctly spelled across a deployment, are available only with a xref:individual-spelling-container.adoc[self-hosted spelling service]. They cannot be configured on {cloudname}. For details, see xref:custom-dictionaries-for-tiny-spellchecker.adoc[Adding custom dictionaries].
+
 === Example: TinyMCE Self-hosted Installation
 
 [source,js]

--- a/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
+++ b/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
@@ -36,7 +36,7 @@ To enable the {productname} Enterprise Spellchecking plugin, add `+tinymcespellc
 
 For information on installing the server-side component for spell checking, please see the xref:individual-spelling-container.adoc[Deploy the {productname} spelling service server-side component using Docker].
 
-TIP: A self-hosted spelling service also unlocks custom dictionaries, letting you add organization-specific terms — such as product names, trademarks, and technical vocabulary — that the spell checker treats as correctly spelled. This capability is not available on {cloudname}. For details, see xref:custom-dictionaries-for-tiny-spellchecker.adoc[Adding custom dictionaries].
+NOTE: Custom dictionaries are supported only with a self-hosted spelling service. They allow additional terms, such as product names or technical vocabulary, to be treated as correctly spelled. Custom dictionaries are not available on {cloudname}. For details, see xref:custom-dictionaries-for-tiny-spellchecker.adoc[Adding custom dictionaries].
 
 === Example: TinyMCE Self-hosted Installation
 

--- a/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
+++ b/modules/ROOT/pages/introduction-to-tiny-spellchecker.adoc
@@ -36,7 +36,7 @@ To enable the {productname} Enterprise Spellchecking plugin, add `+tinymcespellc
 
 For information on installing the server-side component for spell checking, please see the xref:individual-spelling-container.adoc[Deploy the {productname} spelling service server-side component using Docker].
 
-NOTE: Custom dictionaries, which add words that are recognized as correctly spelled across a deployment, are available only with a xref:individual-spelling-container.adoc[self-hosted spelling service]. They cannot be configured on {cloudname}. For details, see xref:custom-dictionaries-for-tiny-spellchecker.adoc[Adding custom dictionaries].
+TIP: A self-hosted spelling service also unlocks custom dictionaries, letting you add organization-specific terms — such as product names, trademarks, and technical vocabulary — that the spell checker treats as correctly spelled. This capability is not available on {cloudname}. For details, see xref:custom-dictionaries-for-tiny-spellchecker.adoc[Adding custom dictionaries].
 
 === Example: TinyMCE Self-hosted Installation
 

--- a/modules/ROOT/partials/commands/tinymcespellchecker-cmds.adoc
+++ b/modules/ROOT/partials/commands/tinymcespellchecker-cmds.adoc
@@ -5,7 +5,6 @@
 |mceSpellcheckDisable |Turns spellchecking off.
 |mceSpellcheckDialog |Opens the spellchecking dialog.
 |mceSpellcheckDialogClose |Closes the spellchecking dialog.
-2+|
 |mceSpellcheckUpdate |Checks the editor content for new misspellings, highlights them, and offers spelling suggestions.
 |===
 

--- a/modules/ROOT/partials/configuration/spellchecker_ignore_list.adoc
+++ b/modules/ROOT/partials/configuration/spellchecker_ignore_list.adoc
@@ -7,6 +7,11 @@ NOTE: Languages specified as keys in the `+spellchecker_ignore_list+` object mus
 
 *Type:* `+Array+` or `+Object+`
 
+[[persisting-ignored-words]]
+=== Persisting ignored words
+
+Words ignored during an editing session — through the *Ignore* or *Ignore All* menu items, or the `+addIgnoredWords+` API — apply only to the current session and are not retained after the editor is reloaded. To persist ignored words across sessions, store them in the host application (for example, when handling the `+SpellcheckerIgnore+` and `+SpellcheckerIgnoreAll+` events) and reapply them through the `+spellchecker_ignore_list+` option each time the editor is initialized.
+
 === Example: using `+spellchecker_ignore_list+` to ignore words in all languages
 
 [source,js]

--- a/modules/ROOT/partials/events/tinymcespellchecker-events.adoc
+++ b/modules/ROOT/partials/events/tinymcespellchecker-events.adoc
@@ -9,6 +9,5 @@ The following events are provided by the xref:introduction-to-tiny-spellchecker.
 |SpellcheckStart |N/A |Fired when spellchecking is enabled.
 |SpellcheckEnd |N/A |Fired when spellchecking is disabled.
 |SpellcheckerLanguageChanged |`+{ language: string, prevLanguage: string }+` |Fired when the spellchecking language is changed.
-3+|
 |SpellcheckerUpdated |`+{ spelling: SpellingUpdate }+` |Fired when the editor content is checked for misspellings, and includes suggestions within xref:introduction-to-tiny-spellchecker.adoc#spelling-object[the `+spelling+` object].
 |===

--- a/modules/ROOT/partials/plugin-apis/tinymcespellchecker-apis.adoc
+++ b/modules/ROOT/partials/plugin-apis/tinymcespellchecker-apis.adoc
@@ -4,7 +4,6 @@
 |addIgnoredWords |words: `+string[]+`, lang?: `+string+` |Add an array of words to the `+spellchecker_ignore_list+` for a specific language. Add the array of words to all languages by omitting the `+lang+` parameter.
 |getLanguage |N/A |Get the current language enabled for spellchecking.
 |setLanguage |language: `+string+` |Set the current language for spellchecking. This must be a supported language code (case-sensitive). For a list of supported languages, see: xref:introduction-to-tiny-spellchecker.adoc#supported-languages[Spell Checker - `+Supported languages+`].
-3+|
 |getSpellingErrors |N/A |Returns an array of objects representing each existing misspelled word in the editor content, with each object using the keys `language` and `word`. 
 |===
 


### PR DESCRIPTION
**Ticket:** TINYDOC-3524

**Site:** [Staging branch](https://pr-4275.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/introduction-to-tiny-spellchecker/)

**Changes:**
* Removed the empty rows from the Spell Checker plugin page tables. The `APIs`, `Events`, and `Commands` tables each contained an empty spanning-cell row (`3+|` / `2+|`) that rendered as a blank row; all three have been removed.
* Added a `Persisting ignored words` section to the `spellchecker_ignore_list` option. It explains that words ignored at runtime (via the *Ignore* / *Ignore All* menu items or the `addIgnoredWords` API) apply only to the current session, and outlines how integrators can persist them across sessions by storing them (for example, when handling the `SpellcheckerIgnore` / `SpellcheckerIgnoreAll` events) and reapplying them through `spellchecker_ignore_list` on initialization. Behaviour validated against `tinymce-premium` source (`plugins/tinymcespellchecker/src/main/ts/api/Api.ts`), which confirms `addIgnoredWords` mutates only the in-memory ignore list and cache.
* Added a note to the Self-hosted Installation section stating that custom dictionaries are available only with a self-hosted spelling service and cannot be configured on Tiny Cloud, with links to the self-hosted deployment page and the custom dictionaries page.

### **Pre-checks:**

- [x] Branch is correctly prefixed: `hotfix/8/TINYDOC-3524`
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

### **Review:**

- [x] Documentation Team Lead has reviewed.
