### PR TITLE
TINYDOC-3432 - Document Vue 3 prop-driven content updates in the Vue technical reference

### DIFF
--- a/modules/ROOT/partials/integrations/vue-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/vue-tech-ref.adoc
@@ -19,6 +19,7 @@
 ** xref:toolbar[`+toolbar+`]
 ** xref:tinymce-script-src[`+tinymce-script-src+`]
 * xref:form-input-bindings-v-model[Form Input Bindings: `+v-model+`]
+** xref:updating-the-editor-content-from-a-parent-component[Updating the editor content from a parent component]
 * xref:event-binding[Event binding]
 
 [[installing-the-tinymce-vuejs-integration-using-npm]]
@@ -434,6 +435,81 @@ The `+v-model+` directive can be used to create a two-way data binding. For exam
 ----
 
 For information on `+v-model+` and form input bindings, see: link:https://vuejs.org/guide/essentials/forms.html[Vue.js documentation - Form Input Bindings].
+
+[[updating-the-editor-content-from-a-parent-component]]
+=== Updating the editor content from a parent component
+
+When `+v-model+` (or an explicit `+@update:modelValue+` listener) is bound, the component watches the bound value and updates the editor whenever a parent component reassigns it. On each change, the component calls `+editor.setContent()+` with the new value, so no manual editor call is required.
+
+To avoid resetting the editor unnecessarily, the update runs only when all of the following are true:
+
+* The new value is a string.
+* The new value differs from the previous bound value.
+* The new value differs from the current editor content, compared using the xref:output-format[`+output-format+`] format.
+
+The final guard prevents a redundant `+setContent()+` call, and the loss of cursor position that would accompany it, during the normal editing round trip where an edit emits `+update:modelValue+` and updates the bound value in the parent.
+
+==== Example: updating content through `+v-model+`
+
+Reassigning the bound value in the parent updates the editor to match:
+
+[source,html]
+----
+<template>
+  <editor v-model="content" />
+  <button @click="setContent">Update content</button>
+</template>
+
+<script>
+import Editor from '@tinymce/tinymce-vue';
+
+export default {
+  components: { editor: Editor },
+  data() {
+    return { content: '<p>Initial content.</p>' };
+  },
+  methods: {
+    setContent() {
+      this.content = '<p>Updated from the parent.</p>';
+    }
+  }
+};
+</script>
+----
+
+==== Updating content without `+v-model+`
+
+The content watcher is only active when `+v-model+` or an `+@update:modelValue+` listener is bound. When content is supplied as a one-way prop without `+v-model+`, reassigning that prop does not update the editor.
+
+In that case, obtain the editor instance from the `+init+` event and call `+editor.setContent()+` directly:
+
+[source,html]
+----
+<template>
+  <editor :init="{ /* your other settings */ }" @init="storeEditor" />
+</template>
+
+<script>
+import Editor from '@tinymce/tinymce-vue';
+
+export default {
+  components: { editor: Editor },
+  data() {
+    return { editorRef: null };
+  },
+  methods: {
+    storeEditor(event, editor) {
+      this.editorRef = editor;
+    },
+    updateContent(html) {
+      if (this.editorRef) {
+        this.editorRef.setContent(html);
+      }
+    }
+  }
+};
+</script>
+----
 
 [[event-binding]]
 == Event binding

--- a/modules/ROOT/partials/integrations/vue-tech-ref.adoc
+++ b/modules/ROOT/partials/integrations/vue-tech-ref.adoc
@@ -477,39 +477,7 @@ export default {
 </script>
 ----
 
-==== Updating content without `+v-model+`
-
-The content watcher is only active when `+v-model+` or an `+@update:modelValue+` listener is bound. When content is supplied as a one-way prop without `+v-model+`, reassigning that prop does not update the editor.
-
-In that case, obtain the editor instance from the `+init+` event and call `+editor.setContent()+` directly:
-
-[source,html]
-----
-<template>
-  <editor :init="{ /* your other settings */ }" @init="storeEditor" />
-</template>
-
-<script>
-import Editor from '@tinymce/tinymce-vue';
-
-export default {
-  components: { editor: Editor },
-  data() {
-    return { editorRef: null };
-  },
-  methods: {
-    storeEditor(event, editor) {
-      this.editorRef = editor;
-    },
-    updateContent(html) {
-      if (this.editorRef) {
-        this.editorRef.setContent(html);
-      }
-    }
-  }
-};
-</script>
-----
+This watcher is only active when `+v-model+` or an `+@update:modelValue+` listener is bound. Without it, reassigning a one-way content prop does not update the editor; use xref:event-binding[the `+init+` event] to obtain the editor instance and call its content APIs directly.
 
 [[event-binding]]
 == Event binding


### PR DESCRIPTION
**Ticket:** TINYDOC-3432

**Site:** `https://pr-4282.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/vue-ref/#updating-the-editor-content-from-a-parent-component`

**Changes:**

Extends the `v-model` section of the Vue.js technical reference (`modules/ROOT/partials/integrations/vue-tech-ref.adoc`, included by `vue-ref.adoc`) to answer a recurring Kapa question: how the `@tinymce/tinymce-vue` editor updates when a parent component changes the bound content prop after mount.

This brings the Vue reference to parity with the React, Angular, and Svelte references, which already document how each wrapper reacts to parent-driven content updates.

Added a new "Updating the editor content from a parent component" subsection (plus a TOC entry) documenting, verified against `@tinymce/tinymce-vue` v6.3.1 source:

- The component watches the `v-model`/`modelValue` value and calls `editor.setContent()` when a parent reassigns it.
- The guard conditions that prevent a redundant `setContent()` and cursor reset during the normal edit → `update:modelValue` round trip (value is a string, differs from the previous value, and differs from the current editor content compared using `output-format`).
- A `v-model` code example showing a parent reassigning the bound value.
- A single sentence noting that without `v-model` the watcher is inactive, cross-referencing the existing Event binding section for obtaining the editor instance (rather than duplicating that guidance or promoting a binding bypass).
