### PR TITLE
TINYDOC-3560: Suggestion cards remained dimmed when selected with Show edits turned off

### DIFF
--- a/modules/ROOT/pages/8.8.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.8.1-release-notes.adoc
@@ -71,6 +71,21 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Suggested Edits
+
+The {productname} {release-version} release includes an accompanying release of the **Suggested Edits** premium plugin.
+
+**Suggested Edits** includes the following fix.
+
+==== Suggestion cards remained dimmed when selected with Show edits turned off
+// #TINYMCE-14675
+
+Previously, in the Suggested Edits plugin, selecting a suggestion card while the **Show edits** toggle was turned off left the card dimmed rather than showing it as active. This regression, introduced in {productname} 8.1, made it difficult to identify which card was active when reviewing the completed version of the document.
+
+In {productname} {release-version}, {productname} dims a suggestion card only when it is not the active card. Selecting a card now restores its full appearance even when **Show edits** is turned off, so the active card remains distinguishable during review.
+
+For information on the **Suggested Edits** plugin, see: xref:suggestededits.adoc[Suggested Edits].
+
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement


### PR DESCRIPTION
### **Ticket:**

TINYDOC-3560 (TINYMCE-14675)

### **Site:**

[Staging](https://pr-4283.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.8.1-release-notes/#suggestion-cards-remained-dimmed-when-selected-with-show-edits-turned-off)

### **Changes:**

Added release note entry for TINYMCE-14675 to `modules/ROOT/pages/8.8.1-release-notes.adoc` (Accompanying Premium plugin changes → Suggested Edits section): fix for suggestion cards remaining dimmed when selected with the **Show edits** toggle turned off.

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.
