### PR TITLE
TINYDOC-3560: Applying or removing formatting on a multi-cell table selection incorrectly styled list items in cells that were not selected

### DIFF
--- a/modules/ROOT/pages/8.8.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.8.1-release-notes.adoc
@@ -160,6 +160,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Applying or removing formatting on a multi-cell table selection incorrectly styled list items in cells that were not selected.
+// #TINYMCE-13235
+
+Previously, applying or removing inline formatting, such as bold, font color, or font size, across a multi-cell table selection incorrectly styled list items in cells that were not part of the selection. {productname} resolved the affected list items from the overall selection range rather than from the selected cells, so list items in neighboring cells received the formatting.
+
+In {productname} {release-version}, {productname} resolves the affected list items from the selected table cells directly. Only the list items within the selected cells now receive the formatting, and list items in unselected cells remain unchanged.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
**Ticket:** TINYDOC-3560 (TINYMCE-13235)

**Site:** [Staging](https://pr-4284.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.8.1-release-notes/#applying-or-removing-formatting-on-a-multi-cell-table-selection-incorrectly-styled-list-items-in-cells-that-were-not-selected)

**Changes:**
* Added release note entry for TINYMCE-13235 to `modules/ROOT/pages/8.8.1-release-notes.adoc` (Bug fixes section): Applying or removing formatting on a multi-cell table selection incorrectly styled list items in cells that were not selected.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.
