### PR TITLE
TINYDOC-3560: The menubar now scrolls horizontally on narrow viewports instead of wrapping

### DIFF
--- a/modules/ROOT/pages/8.8.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.8.1-release-notes.adoc
@@ -160,6 +160,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== The menubar could wrap over multiple rows on narrow viewports, such as at high browser zoom levels, leaving little or no visible space for the editable area. The menubar now scrolls horizontally instead.
+// #TINYMCE-14233
+
+Previously, on narrow viewports, such as at high browser zoom levels, the menubar could wrap across multiple rows. In fullscreen mode, this left little or no visible space for the editable area, which made the editor difficult to use at high zoom levels.
+
+In {productname} {release-version}, the menubar scrolls horizontally on narrow viewports instead of wrapping. The editable area keeps its visible space, and all menus remain reachable by scrolling the menubar.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
**Ticket:** TINYDOC-3560 (TINYMCE-14233)

**Site:** [Staging](https://pr-4285.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.8.1-release-notes/#the-menubar-could-wrap-over-multiple-rows-on-narrow-viewports-such-as-at-high-browser-zoom-levels-leaving-little-or-no-visible-space-for-the-editable-area-the-menubar-now-scrolls-horizontally-instead)

**Changes:**
* Added release note entry for TINYMCE-14233 to `modules/ROOT/pages/8.8.1-release-notes.adoc` (Bug fixes section): The menubar now scrolls horizontally on narrow viewports, such as at high browser zoom levels, instead of wrapping over multiple rows.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.
