### PR TITLE
TINYDOC-3494 - Add guidance for disabling or stripping HTML formatting

### DIFF
--- a/modules/ROOT/pages/content-filtering.adoc
+++ b/modules/ROOT/pages/content-filtering.adoc
@@ -11,13 +11,13 @@ Use `+valid_elements+` to define which elements and attributes are allowed, `+in
 
 {productname} validates and cleans content against a schema whenever content is set, pasted, or retrieved. The schema defines which elements and attributes are allowed, and any element or attribute outside the schema is removed when the content is parsed. The content filtering options on this page configure that schema:
 
-* `+valid_elements+` replaces the set of allowed elements and attributes.
-* `+extended_valid_elements+` adds to the existing set rather than replacing it.
-* `+invalid_elements+` removes specific elements from the content, keeping their text.
+* xref:#valid_elements[`+valid_elements+`] replaces the set of allowed elements and attributes.
+* xref:#extended_valid_elements[`+extended_valid_elements+`] adds to the existing set rather than replacing it.
+* xref:#invalid_elements[`+invalid_elements+`] removes specific elements from the content, keeping their text.
 
 For a reference of the underlying validation and parsing mechanism, see the xref:apis/tinymce.html.schema.adoc[Schema] and xref:apis/tinymce.html.domparser.adoc[DomParser] API documentation.
 
-To restrict content to a limited subset of formatting, set `+valid_elements+` to only the elements and attributes that should be kept. Any element outside the list is removed and its text content is preserved.
+To restrict content to a limited subset of formatting, set xref:#valid_elements[`+valid_elements+`] to only the elements and attributes that should be kept. Any element outside the list is removed and its text content is preserved.
 
 [source,js]
 ----
@@ -29,7 +29,7 @@ tinymce.init({
 
 This configuration keeps paragraphs, line breaks, links (with their `+href+` attribute), and bold and italic text, converting `+b+` to `+strong+` and `+i+` to `+em+`. All other elements, such as headings, tables, and inline styles, are stripped and their text is retained.
 
-To remove only specific formatting while keeping everything else, use `+invalid_elements+`.
+To remove only specific formatting while keeping everything else, use xref:#invalid_elements[`+invalid_elements+`].
 
 [source,js]
 ----
@@ -49,7 +49,7 @@ tinymce.init({
 });
 ----
 
-For a complete reference of the element and attribute syntax used by `+valid_elements+`, `+extended_valid_elements+`, and `+invalid_elements+`, see the option descriptions below. To customize how content is styled and defined rather than restricted, see xref:content-formatting.adoc[Content formats].
+For a complete reference of the element and attribute syntax used by xref:#valid_elements[`+valid_elements+`], xref:#extended_valid_elements[`+extended_valid_elements+`], and xref:#invalid_elements[`+invalid_elements+`], see the option descriptions below. To customize how content is styled and defined rather than restricted, see xref:content-formatting.adoc[Content formats].
 
 include::partial$configuration/allow_conditional_comments.adoc[]
 

--- a/modules/ROOT/pages/content-filtering.adoc
+++ b/modules/ROOT/pages/content-filtering.adoc
@@ -9,11 +9,13 @@ Use `+valid_elements+` to define which elements and attributes are allowed, `+in
 [[disabling-or-stripping-html-formatting]]
 == Disabling or stripping HTML formatting
 
-{productname} validates and cleans content against a schema whenever content is set, pasted, or retrieved. The schema is represented by the xref:apis/tinymce.html.schema.adoc[Schema] API, and content is parsed against it by the xref:apis/tinymce.html.domparser.adoc[DomParser] API, which removes any element or attribute that the schema does not allow. The content filtering options on this page configure that schema:
+{productname} validates and cleans content against a schema whenever content is set, pasted, or retrieved. The schema defines which elements and attributes are allowed, and any element or attribute outside the schema is removed when the content is parsed. The content filtering options on this page configure that schema:
 
-* `+valid_elements+` replaces the set of allowed elements and attributes. Internally this calls `+schema.setValidElements()+`.
-* `+extended_valid_elements+` adds to the existing set rather than replacing it. Internally this calls `+schema.addValidElements()+`.
+* `+valid_elements+` replaces the set of allowed elements and attributes.
+* `+extended_valid_elements+` adds to the existing set rather than replacing it.
 * `+invalid_elements+` removes specific elements from the content, keeping their text.
+
+For a reference of the underlying validation and parsing mechanism, see the xref:apis/tinymce.html.schema.adoc[Schema] and xref:apis/tinymce.html.domparser.adoc[DomParser] API documentation.
 
 To restrict content to a limited subset of formatting, set `+valid_elements+` to only the elements and attributes that should be kept. Any element outside the list is removed and its text content is preserved.
 

--- a/modules/ROOT/pages/content-filtering.adoc
+++ b/modules/ROOT/pages/content-filtering.adoc
@@ -15,6 +15,8 @@ Use `+valid_elements+` to define which elements and attributes are allowed, `+in
 * xref:#extended_valid_elements[`+extended_valid_elements+`] adds to the existing set rather than replacing it.
 * xref:#invalid_elements[`+invalid_elements+`] removes specific elements from the content, keeping their text.
 
+Of these options, only xref:#valid_elements[`+valid_elements+`] and xref:#invalid_elements[`+invalid_elements+`] restrict content. xref:#extended_valid_elements[`+extended_valid_elements+`] widens the default schema, so it is used to permit additional elements rather than to strip them. For its syntax and examples, see the option description below.
+
 For a reference of the underlying validation and parsing mechanism, see the xref:apis/tinymce.html.schema.adoc[Schema] and xref:apis/tinymce.html.domparser.adoc[DomParser] API documentation.
 
 To restrict content to a limited subset of formatting, set xref:#valid_elements[`+valid_elements+`] to only the elements and attributes that should be kept. Any element outside the list is removed and its text content is preserved.
@@ -28,6 +30,8 @@ tinymce.init({
 ----
 
 This configuration keeps paragraphs, line breaks, links (with their `+href+` attribute), and bold and italic text, converting `+b+` to `+strong+` and `+i+` to `+em+`. All other elements, such as headings, tables, and inline styles, are stripped and their text is retained.
+
+When a stripped element is a block element, such as a heading, the text it contained is left without a parent block and is rewrapped in the block element set by xref:#forced_root_block[`+forced_root_block+`], which is `+p+` by default. For example, an `+<h1>+` removed by the configuration above is returned as a `+<p>+` containing the original heading text.
 
 To remove only specific formatting while keeping everything else, use xref:#invalid_elements[`+invalid_elements+`].
 

--- a/modules/ROOT/pages/content-filtering.adoc
+++ b/modules/ROOT/pages/content-filtering.adoc
@@ -6,6 +6,49 @@
 
 Use `+valid_elements+` to define which elements and attributes are allowed, `+invalid_elements+` to block specific elements, and `+extended_valid_elements+` to add or modify rules. For paste-time filtering, use the `+PastePreProcess+` and `+PastePostProcess+` events or the xref:introduction-to-powerpaste.adoc[PowerPaste] plugin options.
 
+[[disabling-or-stripping-html-formatting]]
+== Disabling or stripping HTML formatting
+
+{productname} validates and cleans content against a schema whenever content is set, pasted, or retrieved. The schema is represented by the xref:apis/tinymce.html.schema.adoc[Schema] API, and content is parsed against it by the xref:apis/tinymce.html.domparser.adoc[DomParser] API, which removes any element or attribute that the schema does not allow. The content filtering options on this page configure that schema:
+
+* `+valid_elements+` replaces the set of allowed elements and attributes. Internally this calls `+schema.setValidElements()+`.
+* `+extended_valid_elements+` adds to the existing set rather than replacing it. Internally this calls `+schema.addValidElements()+`.
+* `+invalid_elements+` removes specific elements from the content, keeping their text.
+
+To restrict content to a limited subset of formatting, set `+valid_elements+` to only the elements and attributes that should be kept. Any element outside the list is removed and its text content is preserved.
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  valid_elements: 'p,br,a[href],strong/b,em/i'
+});
+----
+
+This configuration keeps paragraphs, line breaks, links (with their `+href+` attribute), and bold and italic text, converting `+b+` to `+strong+` and `+i+` to `+em+`. All other elements, such as headings, tables, and inline styles, are stripped and their text is retained.
+
+To remove only specific formatting while keeping everything else, use `+invalid_elements+`.
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  invalid_elements: 'strong,b,em,i,u,span'
+});
+----
+
+To remove all formatting from pasted content so that only plain text is inserted, set xref:copy-and-paste.adoc#paste_as_text[paste_as_text] to `+true+`.
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  paste_as_text: true
+});
+----
+
+For a complete reference of the element and attribute syntax used by `+valid_elements+`, `+extended_valid_elements+`, and `+invalid_elements+`, see the option descriptions below. To customize how content is styled and defined rather than restricted, see xref:content-formatting.adoc[Content formats].
+
 include::partial$configuration/allow_conditional_comments.adoc[]
 
 include::partial$configuration/allow_html_in_comments.adoc[]

--- a/modules/ROOT/pages/content-formatting.adoc
+++ b/modules/ROOT/pages/content-formatting.adoc
@@ -2,6 +2,8 @@
 :navtitle: Content formats
 :description: These options change the way the editor handles the input and output of content. This will help you to create clean, maintainable and readable content.
 
+The options on this page define and customize the text formats available in the editor. To restrict, disable, or strip HTML formatting from content, such as limiting the allowed elements or removing formatting from pasted text, see xref:content-filtering.adoc#disabling-or-stripping-html-formatting[Disabling or stripping HTML formatting].
+
 include::partial$configuration/formats.adoc[]
 
 include::partial$configuration/format_empty_lines.adoc[]


### PR DESCRIPTION
**Ticket:** TINYDOC-3494

**Site:** [Staging](https://pr-4286.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/content-filtering/#disabling-or-stripping-html-formatting)

## Changes

Closes a documentation gap where users searching for how to disable or strip HTML formatting could not find direct guidance. The relevant configuration options (`valid_elements`, `invalid_elements`, `extended_valid_elements`, `paste_as_text`) already exist on the Content filtering page, but there was no worked guidance for restricting or stripping formatting, and no path to it from the Content formats page where these users typically land.

- **`modules/ROOT/pages/content-filtering.adoc`** — Added a new "Disabling or stripping HTML formatting" section that:
  - Explains, at a behavioral level, that content is validated and cleaned against a schema when it is set, pasted, or retrieved, and that anything outside the schema is removed.
  - Describes what each option does (`valid_elements` replaces the allowed set, `extended_valid_elements` adds to it, `invalid_elements` removes named elements) and links each option mention to its section anchor on the page.
  - Clarifies that of the three options only `valid_elements` and `invalid_elements` restrict content, while `extended_valid_elements` widens the default schema and is therefore not a stripping mechanism, with a pointer to its option description lower on the page.
  - Notes that when a stripped element is a block element, the text it contained is rewrapped in the block element set by `forced_root_block` (`p` by default), so a removed `<h1>` is returned as a `<p>`.
  - Provides three worked examples: restricting content to an allowed subset with `valid_elements`, removing specific formatting with `invalid_elements`, and stripping all formatting from pasted content with `paste_as_text`.
  - Cross-references the `Schema` and `DomParser` API reference pages and the Content formats page.
- **`modules/ROOT/pages/content-formatting.adoc`** — Added a pointer from the Content formats page to the new guidance so users looking to restrict or strip formatting are directed to the correct page.

## Validation

- Option behavior verified against `tinymce` source (`core/main/ts/api/html/Schema.ts`, `DomParser.ts`).
- Root block rewrapping verified against `DomParser.ts` (`addRootBlocks`, called for root content after filtering) and the `forced_root_block` default of `p` in `core/main/ts/api/Options.ts`.
- Guidance describes option behavior only; no internal implementation functions are referenced.
- Local Antora build passes with no warnings for the changed pages; all cross-references resolve (option section anchors including `forced_root_block`, `apis/tinymce.html.schema`, `apis/tinymce.html.domparser`, `copy-and-paste#paste_as_text`, `content-filtering#disabling-or-stripping-html-formatting`).

Prepared for documentation team review.
