### PR TITLE
TINYDOC-3435 - Document undo level grouping and IME typing behavior

### DIFF
--- a/modules/ROOT/partials/configuration/custom_undo_redo_levels.adoc
+++ b/modules/ROOT/partials/configuration/custom_undo_redo_levels.adoc
@@ -27,22 +27,17 @@ The `+custom_undo_redo_levels+` option controls the depth of the undo stack, whi
 
 === Creating finer-grained undo levels
 
-To add undo levels at chosen points, call the xref:apis/tinymce.undomanager.adoc#add[UndoManager `+add()+`] method. Because continuous typing is otherwise merged into one level, a timer can be used to add periodic checkpoints while the editor has focus. A new level is only recorded when the content has changed since the previous level.
+To add undo levels at chosen points, call the xref:apis/tinymce.undomanager.adoc#add[UndoManager `+add()+`] method. Because continuous typing is otherwise merged into one level, periodic checkpoints can be added with xref:apis/tinymce.util.delay.adoc#setEditorInterval[`+tinymce.util.Delay.setEditorInterval+`], which behaves like the browser `+setInterval+` but stops automatically when the editor is removed. A new level is only recorded when the content has changed since the previous level.
 
 [source,js]
 ----
 tinymce.init({
   selector: 'textarea',  // change this value according to your HTML
   setup: (editor) => {
-    let checkpoint;
-
-    editor.on('focus', () => {
-      checkpoint = window.setInterval(() => editor.undoManager.add(), 5000);
-    });
-
-    editor.on('blur', () => {
-      window.clearInterval(checkpoint);
-    });
+    // Add an undo checkpoint every five seconds.
+    tinymce.util.Delay.setEditorInterval(editor, () => {
+      editor.undoManager.add();
+    }, 5000);
   }
 });
 ----

--- a/modules/ROOT/partials/configuration/custom_undo_redo_levels.adoc
+++ b/modules/ROOT/partials/configuration/custom_undo_redo_levels.adoc
@@ -16,3 +16,33 @@ tinymce.init({
   custom_undo_redo_levels: 10
 });
 ----
+
+=== How typing is grouped into undo levels
+
+{productname} groups consecutive typing into a single undo level. A new undo level begins only when a boundary event occurs, such as pressing a navigation key (arrow keys, `+Home+`, `+End+`, `+Page Up+`, or `+Page Down+`), clicking in the content, moving focus away from the editor, or running an editor command. Until a boundary event occurs, all text typed since the previous level is merged into one level. As a result, a single undo can remove everything typed since the last boundary event.
+
+This grouping applies regardless of the language or input method. It is more noticeable when typing with an Input Method Editor (IME), for example when entering Chinese, Japanese, or Korean, because a whole composed phrase or sentence can be added without a boundary event. In that case, a single undo can remove a large block of text.
+
+The `+custom_undo_redo_levels+` option controls the depth of the undo stack, which is the number of levels retained. It does not change how typing is grouped into a level. There is no built-in option to create a separate undo level for each keystroke.
+
+=== Creating finer-grained undo levels
+
+To add undo levels at chosen points, call the xref:apis/tinymce.undomanager.adoc#add[UndoManager `+add()+`] method. Because continuous typing is otherwise merged into one level, a timer can be used to add periodic checkpoints while the editor has focus. A new level is only recorded when the content has changed since the previous level.
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your HTML
+  setup: (editor) => {
+    let checkpoint;
+
+    editor.on('focus', () => {
+      checkpoint = window.setInterval(() => editor.undoManager.add(), 5000);
+    });
+
+    editor.on('blur', () => {
+      window.clearInterval(checkpoint);
+    });
+  }
+});
+----


### PR DESCRIPTION
**Ticket:** TINYDOC-3435

**Site:** [Staging](https://pr-4287.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/content-behavior-options/#custom_undo_redo_levels)

## Changes

Closes a documentation gap where users could not understand why a single Ctrl+Z can undo a large block of typed text — most visibly when typing Chinese, Japanese, or Korean via an Input Method Editor (IME).

Added two subsections to the `custom_undo_redo_levels` option (`modules/ROOT/partials/configuration/custom_undo_redo_levels.adoc`, rendered on the Content behavior options page):

- **How typing is grouped into undo levels** — explains that consecutive typing is merged into one undo level until a boundary event (navigation keys, clicking, blur, or an executed command) closes it; that this is input-method independent but more noticeable with IME input where a whole composed phrase can become one level; and that `custom_undo_redo_levels` controls stack *depth*, not grouping *granularity*, with no built-in per-keystroke option.
- **Creating finer-grained undo levels** — documents the supported workaround of calling `UndoManager.add()` at chosen checkpoints, with a timer-based example, and cross-links the UndoManager API.

## Validation

- Behavior verified against `tinymce` source (`core/main/ts/undo/Setup.ts`, `TypingState.ts`): typing coalescing, boundary events, and the absence of composition-event handling.
- Workaround corrected against source — `blur` and `SaveContent` already create undo levels automatically (`Setup.ts:60`), so the example uses a timer, which is the accurate way to add finer-grained checkpoints during continuous typing.

Prepared for documentation team review.
