### PR TITLE
TINYDOC-3563 - Add redirects for 404 URLs

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -2713,12 +2713,20 @@
     "redirect": "/docs/tinymce/6/"
   },
   {
+    "location": "/docs/tinymce/6/cloud-configuration-options/",
+    "redirect": "/docs/tinymce/latest/cloud-deployment-guide/"
+  },
+  {
     "location": "/docs/tinymce/6/cloud-quick-start.html",
     "redirect": "/docs/tinymce/6/"
   },
   {
     "location": "/docs/tinymce/6/code-plugin/",
     "redirect": "/docs/tinymce/6/code/"
+  },
+  {
+    "location": "/docs/tinymce/6/editor-instance/",
+    "redirect": "/docs/tinymce/latest/"
   },
   {
     "location": "/docs/tinymce/6/file-picker/",
@@ -2755,6 +2763,14 @@
   {
     "location": "/docs/tinymce/6/react-zip/",
     "redirect": "/docs/tinymce/6/react-zip-host/"
+  },
+  {
+    "location": "/docs/tinymce/6/toolbar-configuration/",
+    "redirect": "/docs/tinymce/latest/toolbar-configuration-options/"
+  },
+  {
+    "location": "/docs/tinymce/7/custom-ui-components/",
+    "redirect": "/docs/tinymce/latest/ui-components/"
   },
   {
     "location": "/docs/tinymce/7/export/",
@@ -2862,6 +2878,62 @@
     "redirect": "/docs/tinymce/6/"
   },
   {
+    "location": "/docs/tinymce/latest/7.0-release-notes/",
+    "redirect": "/docs/tinymce/7/7.0-release-notes/"
+  },
+  {
+    "location": "/docs/tinymce/latest/7.0.1-release-notes/",
+    "redirect": "/docs/tinymce/latest/release-notes/"
+  },
+  {
+    "location": "/docs/tinymce/latest/7.1-release-notes/",
+    "redirect": "/docs/tinymce/latest/release-notes/"
+  },
+  {
+    "location": "/docs/tinymce/latest/7.2-release-notes/",
+    "redirect": "/docs/tinymce/7/7.2-release-notes/"
+  },
+  {
+    "location": "/docs/tinymce/latest/7.2.1-release-notes/",
+    "redirect": "/docs/tinymce/latest/release-notes/"
+  },
+  {
+    "location": "/docs/tinymce/latest/7.3-release-notes/",
+    "redirect": "/docs/tinymce/latest/release-notes/"
+  },
+  {
+    "location": "/docs/tinymce/latest/7.4-release-notes/",
+    "redirect": "/docs/tinymce/latest/release-notes/"
+  },
+  {
+    "location": "/docs/tinymce/latest/7.4.1-release-notes/",
+    "redirect": "/docs/tinymce/latest/release-notes/"
+  },
+  {
+    "location": "/docs/tinymce/latest/7.5-release-notes/",
+    "redirect": "/docs/tinymce/latest/release-notes/"
+  },
+  {
+    "location": "/docs/tinymce/latest/7.6.0-release-notes/",
+    "redirect": "/docs/tinymce/latest/release-notes/"
+  },
+  {
+    "location": "/docs/tinymce/latest/7.6.1-release-notes/",
+    "redirect": "/docs/tinymce/latest/release-notes/"
+  },
+  {
+    "location": "/docs/tinymce/latest/bundle-hyperlinking-container/",
+    "redirect": "/docs/tinymce/latest/"
+  },
+  {
+    "location": "/docs/tinymce/latest/bundle-spelling-container/",
+    "redirect": "/docs/tinymce/latest/"
+  },
+  {
+    "location": "/docs/tinymce/latest/editor-premium-upgrade-promotion/",
+    "redirect": "/pricing/"
+  },
+  {
     "location": "/docs/tinymce/latest/export/",
     "redirect": "/docs/tinymce/latest/exportpdf/"
   },
@@ -2870,12 +2942,28 @@
     "redirect": "/docs/tinymce/latest/installation/"
   },
   {
+    "location": "/docs/tinymce/latest/introduction-to-premium-selfhosted-services/",
+    "redirect": "/docs/tinymce/latest/"
+  },
+  {
+    "location": "/docs/tinymce/latest/license",
+    "redirect": "/docs/tinymce/latest/license-key/"
+  },
+  {
     "location": "/docs/tinymce/latest/markdown/r/",
     "redirect": "/docs/tinymce/5/"
   },
   {
     "location": "/docs/tinymce/latest/mathequations/",
     "redirect": "/docs/tinymce/latest/math/"
+  },
+  {
+    "location": "/docs/tinymce/latest/migration-from-4x/",
+    "redirect": "/docs/tinymce/latest/migration-from-4x-to-8x/"
+  },
+  {
+    "location": "/docs/tinymce/latest/migration-from-5x/",
+    "redirect": "/docs/tinymce/latest/migration-guides/"
   },
   {
     "location": "/docs/tinymce/latest/migration-from-6x/",

--- a/redirects.json
+++ b/redirects.json
@@ -2883,11 +2883,11 @@
   },
   {
     "location": "/docs/tinymce/latest/7.0.1-release-notes/",
-    "redirect": "/docs/tinymce/latest/release-notes/"
+    "redirect": "/docs/tinymce/7/7.0.1-release-notes/"
   },
   {
     "location": "/docs/tinymce/latest/7.1-release-notes/",
-    "redirect": "/docs/tinymce/latest/release-notes/"
+    "redirect": "/docs/tinymce/7/7.1-release-notes/"
   },
   {
     "location": "/docs/tinymce/latest/7.2-release-notes/",
@@ -2895,31 +2895,31 @@
   },
   {
     "location": "/docs/tinymce/latest/7.2.1-release-notes/",
-    "redirect": "/docs/tinymce/latest/release-notes/"
+    "redirect": "/docs/tinymce/7/7.2.1-release-notes/"
   },
   {
     "location": "/docs/tinymce/latest/7.3-release-notes/",
-    "redirect": "/docs/tinymce/latest/release-notes/"
+    "redirect": "/docs/tinymce/7/7.3-release-notes/"
   },
   {
     "location": "/docs/tinymce/latest/7.4-release-notes/",
-    "redirect": "/docs/tinymce/latest/release-notes/"
+    "redirect": "/docs/tinymce/7/7.4-release-notes/"
   },
   {
     "location": "/docs/tinymce/latest/7.4.1-release-notes/",
-    "redirect": "/docs/tinymce/latest/release-notes/"
+    "redirect": "/docs/tinymce/7/7.4.1-release-notes/"
   },
   {
     "location": "/docs/tinymce/latest/7.5-release-notes/",
-    "redirect": "/docs/tinymce/latest/release-notes/"
+    "redirect": "/docs/tinymce/7/7.5-release-notes/"
   },
   {
     "location": "/docs/tinymce/latest/7.6.0-release-notes/",
-    "redirect": "/docs/tinymce/latest/release-notes/"
+    "redirect": "/docs/tinymce/7/7.6.0-release-notes/"
   },
   {
     "location": "/docs/tinymce/latest/7.6.1-release-notes/",
-    "redirect": "/docs/tinymce/latest/release-notes/"
+    "redirect": "/docs/tinymce/7/7.6.1-release-notes/"
   },
   {
     "location": "/docs/tinymce/latest/bundle-hyperlinking-container/",


### PR DESCRIPTION
Ticket: TINYDOC-3563

Changes:
* Added 22 redirect entries to `redirects.json` for documentation URLs currently returning 404, sourced from the ticket's filtered list. Entries are inserted in alphabetical order within the existing `/docs/tinymce/{6,7,latest}/` sections.
  * `/docs/tinymce/6/` — `cloud-configuration-options/`, `editor-instance/`, `toolbar-configuration/`
  * `/docs/tinymce/7/` — `custom-ui-components/`
  * `/docs/tinymce/latest/` — 7.0 through 7.6.1 release notes, `bundle-hyperlinking-container/`, `bundle-spelling-container/`, `editor-premium-upgrade-promotion/`, `introduction-to-premium-selfhosted-services/`, `license`, `migration-from-4x/`, `migration-from-5x/`

Deviation from ticket (v7 release-notes targets):
* The ticket routed `/docs/tinymce/latest/7.0-release-notes/` and `7.2-release-notes/` to their specific `/docs/tinymce/7/…` pages, but routed the other nine 7.x release-notes URLs to the generic `/docs/tinymce/latest/release-notes/` index. All eleven target pages exist and are live on the `/7/` line (`tinymce/7`), so this PR maps **every** `/docs/tinymce/latest/7.X-release-notes/` to its matching `/docs/tinymce/7/7.X-release-notes/` page for consistency and better UX (users land on the release notes they requested rather than a generic list).

Notes:
* All redirect targets were verified to exist: the `/latest/` targets resolve to published pages on `tinymce/8`, the `/docs/tinymce/7/…` targets to live v7 pages, and `/pricing/` and `/docs/tinymce/latest/` to valid site roots.
* Base branch is `main`, consistent with the previous redirects change (#4235), as `redirects.json` is site-level configuration that lives on `main`.

Pre-checks:
- [x] Branch prefixed with `feature/<version>/`, `hotfix/<version>/`, `staging/<version>/`, or `release/<version>/`.
- [x] `modules/ROOT/nav.adoc` has been updated `(if applicable)`. — N/A (redirects only)
- [x] Included a `release note` entry for any `New product features`. — N/A
- [x] If this is a minor release, updated `productminorversion`… — N/A

Review:
- [x] Documentation Team Lead has reviewed
