### PR TITLE
Fix AsciiDoc build warnings and broken cross-references

### DIFF
--- a/modules/ROOT/pages/8.7.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.7.0-release-notes.adoc
@@ -455,7 +455,7 @@ In {productname} {release-version}, `Backspace` removes only the newline and lea
 === CSS custom property names and color values in the style attribute were lowercased when parsed
 // #TINY-11524
 
-Previously, the {productname} style parser lowercased CSS custom property names (such as `--MyColor`) and `color` and `background-color` values when reading the `style` attribute. This altered case-sensitive values, including CSS custom properties, template placeholders such as `{{FooBar}}`, and hex colors such as `#AABBCC`, so the affected styling sometimes did not render as authored.
+Previously, the {productname} style parser lowercased CSS custom property names (such as `--MyColor`) and `color` and `background-color` values when reading the `style` attribute. This altered case-sensitive values, including CSS custom properties, template placeholders such as `+{{FooBar}}+`, and hex colors such as `#AABBCC`, so the affected styling sometimes did not render as authored.
 
 In {productname} {release-version}, the style parser preserves the original case of CSS custom property names and `color` and `background-color` values. Standard property names are still lowercased, and other processing, such as RGB-to-hex conversion, shorthand merging, and security filtering, is unchanged. Case-sensitive colors and custom properties now stay exactly as authored.
 

--- a/modules/ROOT/pages/editor-command-identifiers.adoc
+++ b/modules/ROOT/pages/editor-command-identifiers.adoc
@@ -214,7 +214,7 @@ include::partial$commands/core-table-cmds.adoc[]
 Commands are available for the following plugins:
 
 * xref:advancedlists[Advanced Lists]
-* xref:Enhanced Tables[Enhanced Tables]
+* xref:enhanced-tables[Enhanced Tables]
 * xref:anchor[Anchor]
 * xref:tinymceai[TinyMCE AI]
 * xref:autoresize[Autoresize]
@@ -226,14 +226,14 @@ Commands are available for the following plugins:
 * xref:directionality[Directionality]
 * xref:enhancedcodeeditor[Enhanced Code Editor]
 * xref:emoticons[Emoticons]
-* xref:exportpdf[Export to PDF]
-* xref:exportword[Export to Word]
+* xref:export-pdf[Export to PDF]
+* xref:export-word[Export to Word]
 * xref:footnotes[Footnotes]
 * xref:formatpainter[Format Painter]
 * xref:fullscreen[Full Screen]
 * xref:help[Help]
 * xref:image[Image]
-* xref:importword[Import from Word]
+* xref:import-word[Import from Word]
 * xref:editimage[Image Editing]
 * xref:insertdatetime[Insert Date/Time]
 * xref:link[Link]
@@ -266,7 +266,7 @@ The following commands require the xref:advlist.adoc[Advanced Lists (`+advlist+`
 
 include::partial$commands/advlist-cmds.adoc[leveloffset=+3]
 
-[[Enhanced Tables]]
+[[enhanced-tables]]
 ==== Enhanced Tables
 
 The following commands require the xref:advtable.adoc[Enhanced Tables (`+advtable+`)] plugin.

--- a/modules/ROOT/pages/full-featured-open-source-demo.adoc
+++ b/modules/ROOT/pages/full-featured-open-source-demo.adoc
@@ -15,7 +15,7 @@ The following plugins are excluded from this example:
 |Excluded plugins |Notes
 
 |link:{plugindirectory}[All premium plugins].
-|Use the xref:full-featured-premium-demo[Full featured demo including Premium Plugins]
+|Use the xref:full-featured-premium-demo.adoc[Full featured demo including Premium Plugins]
 
 |xref:autoresize.adoc[Autoresize]
 |Resizes the editor to fit the content.

--- a/modules/ROOT/pages/license-key.adoc
+++ b/modules/ROOT/pages/license-key.adoc
@@ -302,14 +302,14 @@ a| * Verify that the license key is correctly copied from your link:https://www.
 * Ensure there are no extra spaces or characters in the key
 * Check if the key matches your deployment type (Cloud vs Self-hosted)
 
-| xref:load-error[Load error (Cloud)]
+| xref:#load-error-cloud[Load error (Cloud)]
 | The editor is disabled because the TinyMCE API key could not be validated. The TinyMCE Commercial License Key Manager plugin is required for the provided API key to be validated but could not be loaded.
 | The editor is disabled because the TinyMCE API key could not be validated.
 a| * Verify that your API key is valid
 * Check if your subscription is active
 * Visit the link:https://support.tiny.cloud[Support Portal] if the issue persists
 
-| xref:load-error[Load error (Self-Hosted)]
+| xref:#load-error-selfhosted[Load error (Self-Hosted)]
 | The editor is disabled because the license key provided is invalid. The TinyMCE Commercial License Key Manager plugin is required for the provided license key to be validated but could not be loaded.
 | The editor is disabled because the TinyMCE license key could not be validated.
 a| * Check if the license key matches your deployment type: GPL or commercial, Cloud or Self-hosted

--- a/modules/ROOT/pages/tinymceai-api-quick-start.adoc
+++ b/modules/ROOT/pages/tinymceai-api-quick-start.adoc
@@ -86,7 +86,7 @@ link:https://tinymceai.api.tiny.cloud/docs[Complete API Documentation]: Full API
 After setting up the JWT endpoint, continue with:
 
 * xref:tinymceai-models.adoc[AI Models]: Choose the right model for your use case.
-* xref:tinymceai-models.adoc#verifying-model-limits-for-integration[Verify model limits]: Match the configured model id to `GET /v1/models/{version}` and read `limits` and `capabilities`.
+* xref:tinymceai-models.adoc#verifying-model-limits-for-integration[Verify model limits]: Match the configured model id to `GET /v1/models/\{version}` and read `limits` and `capabilities`.
 * xref:tinymceai-permissions.adoc[Permissions]: Set up user access control for production.
 * xref:tinymceai-streaming.adoc[Streaming]: Learn how to handle real-time streaming responses.
 * xref:tinymceai-chat.adoc#conversations-api[Chat API]: Start with interactive AI discussions.

--- a/modules/ROOT/pages/tinymceai-chat.adoc
+++ b/modules/ROOT/pages/tinymceai-chat.adoc
@@ -62,7 +62,7 @@ The model can be changed at any time using the same dropdown. Messages sent afte
 
 Model selection for AI chat can be configured using these options:
 
-* `tinymceai_default_model`: Sets the default model for new chat sessions. The value is a **model configuration id** (for example `+agent-1+`, `+gpt-5.4+`, or `+claude-4-5-haiku+`) that must be among the models allowed by the JWT and subscription. The xref:tinymceai-models.adoc#supported-models-table[Supported Models] table lists the documented names and ids. For the list the service returns for a given environment, use `GET /v1/models/{version}` or the in-editor model selector when xref:tinymceai.adoc#tinymceai_allow_model_selection[+tinymceai_allow_model_selection+] is enabled; see xref:tinymceai-models.adoc#checking-compatibility[Checking compatibility].
+* `tinymceai_default_model`: Sets the default model for new chat sessions. The value is a **model configuration id** (for example `+agent-1+`, `+gpt-5.4+`, or `+claude-4-5-haiku+`) that must be among the models allowed by the JWT and subscription. The xref:tinymceai-models.adoc#supported-models-table[Supported Models] table lists the documented names and ids. For the list the service returns for a given environment, use `GET /v1/models/\{version}` or the in-editor model selector when xref:tinymceai.adoc#tinymceai_allow_model_selection[+tinymceai_allow_model_selection+] is enabled; see xref:tinymceai-models.adoc#checking-compatibility[Checking compatibility].
 * `tinymceai_allow_model_selection`: When `true`, users can pick from models the service exposes in the UI; when `false`, the default model is used without a selector (defaults to `true`).
 
 [source,js]

--- a/modules/ROOT/pages/tinymceai-jwt-authentication-intro.adoc
+++ b/modules/ROOT/pages/tinymceai-jwt-authentication-intro.adoc
@@ -24,7 +24,7 @@ During a {cloudname} trial, a demo identity service is available for the {plugin
 [[trial-quick-start]]
 === Quick start
 
-The following is the simplest way to use the demo identity service. Replace `{apiKey}` with the trial API key from the link:{accountpageurl}[Customer Portal].
+The following is the simplest way to use the demo identity service. Replace `\{apiKey}` with the trial API key from the link:{accountpageurl}[Customer Portal].
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/tinymceai-limits.adoc
+++ b/modules/ROOT/pages/tinymceai-limits.adoc
@@ -26,7 +26,7 @@ Context limits control how much content can be attached to conversations to ensu
 [[file-limits]]
 === File Limits
 
-Supported attachment types include PDF, DOCX, PNG, JPEG, Markdown, HTML, and plain text. Exact per-file, per-conversation, and PDF page limits depend on the model in use. Read the `limits` object for that model from `GET /v1/models/{version}` (see xref:tinymceai-models.adoc#verifying-model-limits-for-integration[Verifying limits for a configured model] and xref:tinymceai-models.adoc#model-information[Model Information]). For schema details, see the https://tinymceai.api.tiny.cloud/docs#tag/Models[Models API] OpenAPI documentation.
+Supported attachment types include PDF, DOCX, PNG, JPEG, Markdown, HTML, and plain text. Exact per-file, per-conversation, and PDF page limits depend on the model in use. Read the `limits` object for that model from `GET /v1/models/\{version}` (see xref:tinymceai-models.adoc#verifying-model-limits-for-integration[Verifying limits for a configured model] and xref:tinymceai-models.adoc#model-information[Model Information]). For schema details, see the https://tinymceai.api.tiny.cloud/docs#tag/Models[Models API] OpenAPI documentation.
 
 [[context-optimization-tips]]
 === Context Optimization Tips
@@ -36,14 +36,14 @@ Compress images and split large documents into smaller sections. Use text format
 [[model-specific-limits]]
 == Model-Specific Limits
 
-Different AI models have varying capabilities and limitations that affect context processing. Each model exposes numeric caps and capability flags in the `GET /v1/models/{version}` response: find the object in `items` whose `id` matches the model in use, then read `limits` (for example context length and file size ceilings, often in bytes) and `capabilities`. See xref:tinymceai-models.adoc#verifying-model-limits-for-integration[Verifying limits for a configured model].
+Different AI models have varying capabilities and limitations that affect context processing. Each model exposes numeric caps and capability flags in the `GET /v1/models/\{version}` response: find the object in `items` whose `id` matches the model in use, then read `limits` (for example context length and file size ceilings, often in bytes) and `capabilities`. See xref:tinymceai-models.adoc#verifying-model-limits-for-integration[Verifying limits for a configured model].
 
 Models also have response timeouts, file processing timeouts, web resource timeouts, and streaming response limits. All models include content moderation for inappropriate content, safety checks, and moderation response time limits.
 
 [[next-steps]]
 == Next Steps
 
-* xref:tinymceai-models.adoc#model-information[Model Information] documents the `GET /v1/models/{version}` request; each item in the response includes `limits` and capabilities for that model.
+* xref:tinymceai-models.adoc#model-information[Model Information] documents the `GET /v1/models/\{version}` request; each item in the response includes `limits` and capabilities for that model.
 * xref:tinymceai-permissions.adoc[Set up Permissions] to control user access.
 * xref:tinymceai-chat.adoc[Explore Chat] for context management.
 * https://tinymceai.api.tiny.cloud/docs[API Documentation]: Complete API reference for TinyMCE AI.

--- a/modules/ROOT/pages/tinymceai-models.adoc
+++ b/modules/ROOT/pages/tinymceai-models.adoc
@@ -172,7 +172,7 @@ Plugin configuration, API parameters, and per-feature options do not grant acces
 
 [NOTE]
 ====
-The set of models and capabilities can change between major {productname} releases. That kind of change is not treated as a breaking change for the editor. Use the plugin's model selection dropdown or `GET /v1/models/{version}` to see what the environment offers and the model limitations.
+The set of models and capabilities can change between major {productname} releases. That kind of change is not treated as a breaking change for the editor. Use the plugin's model selection dropdown or `GET /v1/models/\{version}` to see what the environment offers and the model limitations.
 ====
 
 .Example: Set default model in plugin configuration
@@ -204,7 +204,7 @@ Compatibility versions allow {pluginname} to introduce new models and capabiliti
 To see available models for a compatibility version:
 
 * **Through the plugin**: Available models are shown in the model selection dropdown when `tinymceai_allow_model_selection` is enabled. See xref:tinymceai.adoc#tinymceai_allow_model_selection[`tinymceai_allow_model_selection`] for configuration.
-* **Through the API**: Check the `GET /v1/models/{version}` endpoint. The API response includes model capabilities, limits, and availability. See xref:tinymceai-models.adoc#model-information[Model Information] for an example.
+* **Through the API**: Check the `GET /v1/models/\{version}` endpoint. The API response includes model capabilities, limits, and availability. See xref:tinymceai-models.adoc#model-information[Model Information] for an example.
 
 [[verifying-model-limits-for-integration]]
 === Verifying limits for a configured model
@@ -214,7 +214,7 @@ Follow these steps to read limits and capabilities for the model the integration
 * *Align base URL and credentials*
 ** Call the same HTTP base URL the editor uses for {pluginname} requests. If the base URL and JWT do not belong to the same environment, the response is an authorization error rather than model metadata.
 * *List models for the compatibility version*
-** Request `GET /v1/models/{version}` with the compatibility version the integration targets (often `1`). Use the https://tinymceai.api.tiny.cloud/docs#tag/Models[Models API] OpenAPI definition to confirm `{version}` when unsure.
+** Request `GET /v1/models/\{version}` with the compatibility version the integration targets (often `1`). Use the https://tinymceai.api.tiny.cloud/docs#tag/Models[Models API] OpenAPI definition to confirm `\{version}` when unsure.
 * *Pick the matching `items[]` entry*
 ** In the JSON `items` array, select the object whose `id` matches the model in configuration (`tinymceai_default_model`) or in API bodies (`model`).
 * *Read `limits` and `capabilities`*
@@ -259,14 +259,14 @@ Web scraping extracts and processes content from web pages so the AI can analyze
 [[model-limitations]]
 == Model Limitations
 
-Per-model caps (context length, attachment sizes, PDF page totals, and similar) are returned in the `limits` object for each entry in `GET /v1/models/{version}`. Those values are **the limits the service applies at runtime** and can differ by model (for example stricter `maxImageSize` than `maxFileSize` for some providers). See xref:tinymceai-models.adoc#verifying-model-limits-for-integration[Verifying limits for a configured model] for how to match the integration’s model id to the correct `items[]` entry.
+Per-model caps (context length, attachment sizes, PDF page totals, and similar) are returned in the `limits` object for each entry in `GET /v1/models/\{version}`. Those values are **the limits the service applies at runtime** and can differ by model (for example stricter `maxImageSize` than `maxFileSize` for some providers). See xref:tinymceai-models.adoc#verifying-model-limits-for-integration[Verifying limits for a configured model] for how to match the integration’s model id to the correct `items[]` entry.
 
 The sections below cover moderation, descriptions, and deprecation. Attachment limits are documented only under xref:tinymceai-models.adoc#file-processing-limits[File processing limits], using the live models API so values stay aligned with the service.
 
 [[file-processing-limits]]
 === File Processing Limits
 
-{pluginname} supports common attachment types in Chat conversations, including PDF, DOCX, images, Markdown, HTML, and plain text. Per-file and per-conversation ceilings—including maximum sizes, attachment counts, and PDF page totals—are returned per model in the `limits` object from `GET /v1/models/{version}`. Those numbers are **the current limits the service applies**; they can change with the service and vary by model, so read the `limits` object from that response at runtime for each model the integration uses. Field names, units, and schema updates are defined in the https://tinymceai.api.tiny.cloud/docs#tag/Models[Models API] OpenAPI documentation.
+{pluginname} supports common attachment types in Chat conversations, including PDF, DOCX, images, Markdown, HTML, and plain text. Per-file and per-conversation ceilings—including maximum sizes, attachment counts, and PDF page totals—are returned per model in the `limits` object from `GET /v1/models/\{version}`. Those numbers are **the current limits the service applies**; they can change with the service and vary by model, so read the `limits` object from that response at runtime for each model the integration uses. Field names, units, and schema updates are defined in the https://tinymceai.api.tiny.cloud/docs#tag/Models[Models API] OpenAPI documentation.
 
 For the request flow and how to match a configured model id to the correct `items[]` entry, see xref:tinymceai-models.adoc#verifying-model-limits-for-integration[Verifying limits for a configured model]. Typical `limits` keys include `maxFileSize`, `maxImageSize`, `maxFiles`, `maxTotalFileSize`, and `maxTotalPdfFilePages`.
 

--- a/modules/ROOT/pages/tinymceai-on-premises-mcp.adoc
+++ b/modules/ROOT/pages/tinymceai-on-premises-mcp.adoc
@@ -192,7 +192,7 @@ The AI service does not host the callback page. The integrating web application 
 
 Replace `my-server` with the key from `MCP_SERVERS`. In production, add error handling, a loading indicator, and validation for missing `code` or `state` parameters.
 
-In the example above, the callback page calls `/api/mcp/oauth/{serverName}/complete` on the integrating application's own server rather than directly on the AI service. This is the proxy pattern described below.
+In the example above, the callback page calls `/api/mcp/oauth/\{serverName}/complete` on the integrating application's own server rather than directly on the AI service. This is the proxy pattern described below.
 
 [[mcp-oauth-proxy]]
 ==== Browser integration and proxy endpoints
@@ -203,10 +203,10 @@ The backend generates a JWT (the same token used for conversations), attaches it
 
 A typical integration requires four proxy routes:
 
-* `GET /api/mcp/oauth/status` -> `GET {AI_SERVICE_URL}/v1/mcp/oauth/status`
-* `POST /api/mcp/oauth/{serverName}/initialize` -> `POST {AI_SERVICE_URL}/v1/mcp/oauth/{serverName}/initialize`
-* `POST /api/mcp/oauth/{serverName}/complete` -> `POST {AI_SERVICE_URL}/v1/mcp/oauth/{serverName}/complete`
-* `DELETE /api/mcp/oauth/{serverName}` -> `DELETE {AI_SERVICE_URL}/v1/mcp/oauth/{serverName}`
+* `GET /api/mcp/oauth/status` -> `GET \{AI_SERVICE_URL}/v1/mcp/oauth/status`
+* `POST /api/mcp/oauth/\{serverName}/initialize` -> `POST \{AI_SERVICE_URL}/v1/mcp/oauth/\{serverName}/initialize`
+* `POST /api/mcp/oauth/\{serverName}/complete` -> `POST \{AI_SERVICE_URL}/v1/mcp/oauth/\{serverName}/complete`
+* `DELETE /api/mcp/oauth/\{serverName}` -> `DELETE \{AI_SERVICE_URL}/v1/mcp/oauth/\{serverName}`
 
 [[mcp-oauth-endpoints]]
 ==== REST endpoints

--- a/modules/ROOT/partials/commands/tinymceai-cmds.adoc
+++ b/modules/ROOT/partials/commands/tinymceai-cmds.adoc
@@ -1,5 +1,5 @@
 [[tinymceai-toggling-sidebars]]
-=== Toggling the AI Chat and AI Review sidebars
+== Toggling the AI Chat and AI Review sidebars
 
 AI Chat and AI Review use sidebars registered by the plugin. To show or hide them programmatically, use the core `+ToggleSidebar+` command (listed in the xref:editor-command-identifiers.adoc#miscellaneous-core-commands[Miscellaneous Core Commands] table), not a command defined by the `+tinymceai+` plugin. Pass the sidebar identifier as the third argument:
 
@@ -22,7 +22,7 @@ tinymce.activeEditor.execCommand('ToggleSidebar', false, 'tinymceai-review');
 NOTE: These commands work regardless of xref:tinymceai.adoc#tinymceai_sidebar_type[`tinymceai_sidebar_type`] (`+'static'+` or `+'floating'+`). The `+ToggleSidebar+` event and `+queryCommandValue('ToggleSidebar')+` also behave the same for both sidebar types.
 
 [[tinymceai-plugin-commands]]
-=== TinyMCE AI plugin commands
+== TinyMCE AI plugin commands
 
 The xref:tinymceai.adoc[`tinymceai`] plugin registers the following editor commands. They mirror the Quick Actions and related UI: each invocation returns immediately while the plugin performs any network and UI work asynchronously.
 

--- a/modules/ROOT/partials/configuration/newdocument_content.adoc
+++ b/modules/ROOT/partials/configuration/newdocument_content.adoc
@@ -9,7 +9,7 @@ This option sets the content a new editor contains when the xref:available-menu-
 
 === Example: using `+newdocument_content+`
 
-This example shows `+newdocument_content+` being used with the xref:content-behavior-options.adoc#editable_root[`+editable_root+`] option to set an editable element within a non-editable root.
+This example shows `+newdocument_content+` being used with the xref:non-editable-content-options.adoc#editable_root[`+editable_root+`] option to set an editable element within a non-editable root.
 
 [source,js]
 ----

--- a/modules/ROOT/partials/configuration/smart_paste.adoc
+++ b/modules/ROOT/partials/configuration/smart_paste.adoc
@@ -14,7 +14,7 @@ To disable the `+smart_paste+` functionality, set `+smart_paste+` to `+false+`. 
 
 *Possible values:* `+true+`, `+false+`
 
-NOTE: Setting the xref:powerpaste_autolink_urls[`+powerpaste_autolink_urls+`] option to `+false+` overrides the auto-linking feature of the `+smart_paste+` option.
+NOTE: Setting the xref:powerpaste-options.adoc#powerpaste_autolink_urls[`+powerpaste_autolink_urls+`] option to `+false+` overrides the auto-linking feature of the `+smart_paste+` option.
 
 === Example: using `+smart_paste+`
 


### PR DESCRIPTION
**Ticket:** N/A — documentation build hygiene (no associated ticket)

**Site:** [Staging branch](https://pr-4290.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/)

**Changes:**

Resolves all Antora/Asciidoctor build warnings on the `tinymce/8` line (26 → 0) and repairs a set of broken cross-references. Verified with a full build: **0 errors, 0 warnings**.

* **Escaped literal curly-brace tokens** that were being parsed as attribute references (and dropped from output): REST/MCP path parameters `{version}`, `{serverName}`, `{AI_SERVICE_URL}`; the trial placeholder `{apiKey}`; and the Handlebars example `{{FooBar}}`.
* **Corrected heading levels** in the TinyMCE AI commands partial (sections were one level too deep under "TinyMCE AI").
* **Repaired broken cross-references** — mismatched anchor ids, a missing `.adoc` extension, and wrong target pages in shared partials.

### Visual review — staging deep links

Each link opens the changed section on the staging preview (available once the preview build finishes). Escaped tokens should now render literally (for example `GET /v1/models/{version}`); repaired links should resolve to a real target.

**Curly-brace escapes**

- [x] [`tinymceai-models.adoc` → Verifying limits](https://pr-4290.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/tinymceai-models/#verifying-model-limits-for-integration) — `{version}` in the `GET /v1/models/{version}` paths
- [x] [`tinymceai-limits.adoc` → File limits](https://pr-4290.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/tinymceai-limits/#file-limits) — `{version}`
- [x] [`tinymceai-chat.adoc` → Model selection](https://pr-4290.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/tinymceai-chat/#model-selection-configuration) — `{version}`
- [x] [`tinymceai-api-quick-start.adoc` → Next steps](https://pr-4290.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/tinymceai-api-quick-start/#next-steps) — `{version}`
- [x] [`tinymceai-jwt-authentication-intro.adoc` → Quick start](https://pr-4290.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/tinymceai-jwt-authentication-intro/#trial-quick-start) — `{apiKey}`
- [x] [`tinymceai-on-premises-mcp.adoc` → Proxy endpoints](https://pr-4290.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/tinymceai-on-premises-mcp/#mcp-oauth-proxy) — `{serverName}` / `{AI_SERVICE_URL}` in the four proxy routes
- [x] [`8.7.0-release-notes.adoc` → CSS custom property section](https://pr-4290.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/#css-custom-property-names-and-color-values-in-the-style-attribute-were-lowercased-when-parsed) — `{{FooBar}}` example

**Heading levels**

- [x] [`tinymceai-cmds.adoc` → Toggling sidebars](https://pr-4290.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/editor-command-identifiers/#tinymceai-toggling-sidebars) and [Plugin commands](https://pr-4290.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/editor-command-identifiers/#tinymceai-plugin-commands) — should nest correctly under **TinyMCE AI**

**Repaired cross-references**

- [x] [`editor-command-identifiers.adoc` → Plugin Commands list](https://pr-4290.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/editor-command-identifiers/#plugin-commands) — Export to PDF / Export to Word / Import from Word now jump to their sections; [Enhanced Tables](https://pr-4290.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/editor-command-identifiers/#enhanced-tables) anchor renamed
- [x] [`license-key.adoc` → Load error (Cloud)](https://pr-4290.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/license-key/#load-error-cloud) and [Load error (Self-Hosted)](https://pr-4290.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/license-key/#load-error-selfhosted) — table links now resolve
- [x] [`full-featured-open-source-demo.adoc`](https://pr-4290.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/full-featured-open-source-demo/) — "Full featured demo including Premium Plugins" link in the excluded-plugins table resolves
- [x] [`smart_paste.adoc` → in Copy and paste](https://pr-4290.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/copy-and-paste/#smart_paste) — `powerpaste_autolink_urls` note links to `powerpaste-options`
- [x] [`newdocument_content.adoc` → in Content behavior](https://pr-4290.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/content-behavior-options/#example-using-newdocument_content) — `editable_root` link points to `non-editable-content-options`

### **Pre-checks:**

- [x] Branch is correctly prefixed: `hotfix/8/docs-build-warnings`
- [x] Build passes without console errors, warnings, or issues.
- [x] `modules/ROOT/nav.adoc` has been updated (not applicable).
- [x] Files added for new product features include a release note entry (not applicable).
