### PR TITLE
TINYDOC-3564: The caret could be positioned incorrectly in some cases when scrolling while a context toolbar was open

### DIFF
--- a/modules/ROOT/pages/8.8.2-release-notes.adoc
+++ b/modules/ROOT/pages/8.8.2-release-notes.adoc
@@ -160,6 +160,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== The caret could be positioned incorrectly in some cases when scrolling while a context toolbar was open.
+// #TINYMCE-14415
+
+Previously, the caret could move to an unexpected position while a context toolbar was open, such as a toolbar from the xref:quickbars.adoc[Quick Toolbars] plugin. To position a context toolbar relative to the selection, {productname} measured the caret position. When that selection had no measurable dimensions, such as a collapsed selection in an empty paragraph, {productname} altered it while taking the measurement. The caret then appeared to jump, and subsequent edits took effect at the wrong position.
+
+In {productname} {release-version}, {productname} restores the selection after measuring the caret position. The caret now stays where it was placed, including when the page scrolls with a context toolbar open.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
**Ticket:** TINYDOC-3564 (TINYMCE-14415)

**Site:** [Staging](https://pr-4294.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.8.2-release-notes/#the-caret-could-be-positioned-incorrectly-in-some-cases-when-scrolling-while-a-context-toolbar-was-open)

**Changes:**
* Added release note entry for TINYMCE-14415 to `modules/ROOT/pages/8.8.2-release-notes.adoc` (Bug fixes section): The caret could be positioned incorrectly in some cases when scrolling while a context toolbar was open.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
