### PR TITLE
TINYDOC-3564: Sanitizing malformed HTML in the editor content could throw an error

### DIFF
--- a/modules/ROOT/pages/8.8.2-release-notes.adoc
+++ b/modules/ROOT/pages/8.8.2-release-notes.adoc
@@ -160,6 +160,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Sanitizing malformed HTML in the editor content could throw an error
+// #TINYMCE-14701
+
+Previously, {productname} could throw an error while sanitizing editor content that contained malformed HTML, and the browser console reported `+TypeError: a node selected for removal could not be detached from its tree and cannot be safely returned; refusing to sanitize in place+`. The error occurred in {productname} 8.8.0 and 8.8.1, which bundled version 3.4.11 of the DOMPurify sanitization library.
+
+In {productname} {release-version}, {productname} bundles version 3.4.12 of DOMPurify, which resolves the underlying issue. The editor now sanitizes content that contains malformed HTML without throwing an error.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
**Ticket:** TINYDOC-3564 (TINYMCE-14701)

**Site:** [Staging](https://pr-4295.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.8.2-release-notes/#sanitizing-malformed-html-in-the-editor-content-could-throw-an-error)

**Changes:**
* Added release note entry for TINYMCE-14701 to `modules/ROOT/pages/8.8.2-release-notes.adoc`

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] ~~`modules/ROOT/nav.adoc` has been updated (if applicable).~~
- [x] Files have been included where required (if applicable).
- [x] ~~Files removed have been deleted, not just excluded from the build (if applicable).~~
- [x] ~~Files added for **New product features** include a `release note` entry.~~
- [x] ~~Major or minor version changes have updated the `supported-versions.adoc` table.~~
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
