### PR TITLE
TINYDOC-3564: Formatting could not be applied to and removed from editable child elements when a noneditable element was selected

### DIFF
--- a/modules/ROOT/pages/8.8.2-release-notes.adoc
+++ b/modules/ROOT/pages/8.8.2-release-notes.adoc
@@ -160,6 +160,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Formatting could not be applied to and removed from editable child elements when a noneditable element was selected
+// #TINYMCE-9142
+
+Previously, applying an inline format to a directly selected non-editable element had no effect, even when that element contained editable descendant elements. {productname} applied the format only for a range selection that spanned the same content, not when the non-editable element was selected on its own. Removing an inline format behaved the same way.
+
+In {productname} {release-version}, {productname} applies an inline format once to each editable descendant element within the selected non-editable element. Removing and toggling an inline format work the same way, and {productname} now detects a format that is already applied within an editable descendant element. A non-editable element without editable descendant elements remains unchanged, and {productname} does not apply the format beyond the enclosing non-editable element.
+
 
 [[security-fixes]]
 == Security fixes

--- a/modules/ROOT/partials/configuration/format_noneditable_selector.adoc
+++ b/modules/ROOT/partials/configuration/format_noneditable_selector.adoc
@@ -9,7 +9,7 @@ Wrappable formats include block formats that have the `wrapper` parameter set to
 
 Selector formats are not supported.
 
-NOTE: Elements with `contenteditable="false"` attributes that contain descendant elements with `contenteditable="true"` attributes are not wrappable.
+NOTE: Elements with `contenteditable="false"` attributes that contain descendant elements with `contenteditable="true"` attributes are not wrappable. From {productname} 8.8.2, selecting such an element and applying an inline format applies that format to each of its editable descendant elements instead of wrapping the element. Removing and toggling an inline format behave the same way.
 
 *Type:* `+String+`
 


### PR DESCRIPTION
**Ticket:** TINYDOC-3564 (TINYMCE-9142)

**Site:** [Staging](https://pr-4296.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.8.2-release-notes/#formatting-could-not-be-applied-to-and-removed-from-editable-child-elements-when-a-noneditable-element-was-selected)

**Changes:**
* Added release note entry for TINYMCE-9142 to `modules/ROOT/pages/8.8.2-release-notes.adoc`
* Updated `modules/ROOT/partials/configuration/format_noneditable_selector.adoc`

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
