### PR TITLE
TINYDOC-3566 - Fix textarea id selector in suggestededits-access-read live demo

### DIFF
--- a/modules/ROOT/examples/live-demos/suggestededits-access-read/index.js
+++ b/modules/ROOT/examples/live-demos/suggestededits-access-read/index.js
@@ -1,6 +1,6 @@
 const API_URL = 'https://demouserdirectory.tiny.cloud/v1/users';
 
-const tinymceElement = document.querySelector('textarea#suggestededits-access-feedback');
+const tinymceElement = document.querySelector('textarea#suggestededits-access-read');
 const model = JSON.parse(tinymceElement.getAttribute('suggestededits-model'));
 
 tinymce.init({


### PR DESCRIPTION
**Ticket:** TINYDOC-3566

**Site:** [Staging branch](https://pr-4297.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/suggestededits/#suggestededits_access)

**Changes:**
* `modules/ROOT/examples/live-demos/suggestededits-access-read/index.js` — corrected the `querySelector` call on line 3 to target `textarea#suggestededits-access-read` instead of `textarea#suggestededits-access-feedback`. The mismatched id belongs to the sibling `suggestededits-access-feedback` demo, so this was a copy-paste leftover. The `tinymce.init` selector on line 7 was already correct; only the element lookup was wrong.

---

### **What was broken**

**The "Edit on CodePen" export for that demo.** The CodePen payload is self-contained: only the demo's own HTML and JS are sent. The sibling textarea is absent there, so `tinymceElement` is `null` and the `getAttribute('suggestededits-model')` call on line 4 throws a `TypeError`, leaving the pen uninitialised.

**The demo on the docs page was not broken.** The live-demo widget renders every demo into one shared document — there is no per-demo iframe — and both demos are emitted by the same partial, `modules/ROOT/partials/configuration/suggestededits_access.adoc`. The wrong selector therefore still resolved, to the sibling demo's textarea on the same page. Both demos' `suggestededits-model` attributes are byte-for-byte identical, so the read demo received correct model data regardless.

That on-page behaviour held only by coincidence: it depended on the sibling demo staying co-located and the two models staying identical.

### **What the fix does**

* Repairs the CodePen export, which now resolves its own textarea and initialises.
* Makes the demo self-contained, so it no longer depends on a sibling demo being present on the same page or on the two models remaining identical.
* Leaves on-page rendering unchanged, since it already worked.

---

### **Verification**

* Local Antora build (`npx antora ./antora-playbook-local.yml`) completes with no errors or warnings.
* In the built page, all four Suggested Edits demos now have matching `querySelector` and `tinymce.init` selectors — 11 paired occurrences, all matching.
* Decoded the CodePen payload for this demo out of the built page: it contains its own `textarea#suggestededits-access-read` and not the sibling's, confirming the pen depended on an element it never ships. Payload composition was verified from the build; a pen was not opened and run.
* The two demo models were compared as parsed JSON and are identical, which is what confirms there is no on-page behaviour change.
* The sibling `suggestededits-access-feedback` demo is untouched.

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: `hotfix/8/TINYDOC-3566`
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
