### PR TITLE
TINYDOC-3571 - Add the Build with AI page for the agent skill and documentation MCP server

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -75,6 +75,7 @@
 **** Other Integrations
 ***** xref:bootstrap-zip.adoc[Bootstrap]
 ** xref:upgrading.adoc[Upgrading {productname}]
+** xref:ai-coding-agents.adoc[AI coding agents]
 * xref:how-to-guides.adoc[How-to guides]
 ** Learn the basics
 *** xref:basic-setup.adoc[Basic setup]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -1,5 +1,6 @@
 * xref:getting-started.adoc[Getting started]
 ** xref:introduction-to-tinymce.adoc[Introduction to {productname}]
+** xref:ai-coding-agents.adoc[Build with AI]
 ** xref:installation.adoc[Installation]
 *** xref:installation-cloud.adoc[Cloud]
 **** xref:cloud-quick-start.adoc[Quick start guide]
@@ -75,7 +76,6 @@
 **** Other Integrations
 ***** xref:bootstrap-zip.adoc[Bootstrap]
 ** xref:upgrading.adoc[Upgrading {productname}]
-** xref:ai-coding-agents.adoc[AI coding agents]
 * xref:how-to-guides.adoc[How-to guides]
 ** Learn the basics
 *** xref:basic-setup.adoc[Basic setup]

--- a/modules/ROOT/pages/ai-coding-agents.adoc
+++ b/modules/ROOT/pages/ai-coding-agents.adoc
@@ -14,11 +14,16 @@ This page describes how to give an AI coding agent access to the {productname} d
 [[connect-the-documentation-mcp-server]]
 == Connect the documentation MCP server
 
-The hosted {productname} documentation MCP server exposes semantic search across the published documentation, returning relevant extracts with links to their source pages. Any client that supports the https://modelcontextprotocol.io/[Model Context Protocol] (MCP) over HTTP can connect to it.
+The hosted {productname} documentation MCP server exposes semantic search across the published documentation, returning relevant extracts with links to their source pages. Any client that supports the https://modelcontextprotocol.io/[Model Context Protocol] (MCP) over streamable HTTP can connect to it.
+
+[NOTE]
+====
+This server provides documentation to an external coding agent. It is not related to the MCP tool calling available to the {productname} AI service, which is described in xref:tinymceai-on-premises-mcp.adoc[MCP and web integrations].
+====
 
 *Endpoint:* `+https://tinymcedocs.mcp.kapa.ai+`
 
-*Authentication:* The server is protected by OAuth. On the first connection the agent opens a browser window to complete sign-in, then stores the resulting token.
+*Authentication:* The server is protected by OAuth and requires a one-time sign-in. The first time the agent calls the server, a browser window opens to complete sign-in, after which the agent stores the resulting token. In Claude Code, if no sign-in prompt appears, run `+/mcp+`, select the server, and then select *Authenticate*.
 
 [[install-from-the-documentation-site]]
 === Install from the documentation site
@@ -123,7 +128,7 @@ Add the server to `+opencode.json+`:
 [[other-agents]]
 === Other agents
 
-Agents that accept a remote MCP server without a dedicated configuration file — such as Claude and ChatGPT — can connect using the endpoint directly:
+For any other agent, point its MCP client at the streamable HTTP endpoint and complete the sign-in described above. Agents that accept a remote MCP server without a dedicated configuration file, such as Claude and ChatGPT, can connect using the endpoint directly:
 
 [source,text]
 ----
@@ -133,11 +138,18 @@ https://tinymcedocs.mcp.kapa.ai
 [[read-the-documentation-as-markdown]]
 == Read the documentation as markdown
 
-Every documentation page is also published as markdown, which is more token-efficient than the rendered HTML page. Append `+index.md+` to any documentation page URL to retrieve it:
+Agents can read the documentation efficiently without the MCP server. Every documentation page is also published as markdown, which is more token-efficient than the rendered HTML page. Append `+index.md+` to any documentation page URL to retrieve it:
 
 [source,text]
 ----
 https://www.tiny.cloud/docs/tinymce/latest/basic-setup/index.md
+----
+
+Markdown is available for every documented version of {productname}, not only the latest release. Replace `+latest+` with a version segment to retrieve the markdown for an earlier version:
+
+[source,text]
+----
+https://www.tiny.cloud/docs/tinymce/7/basic-setup/index.md
 ----
 
 Each page also includes a *Copy Markdown* button next to the page title, which copies the markdown URL of the current page to the clipboard for pasting into an agent prompt.
@@ -145,7 +157,7 @@ Each page also includes a *Copy Markdown* button next to the page title, which c
 [[llms-txt-files]]
 == llms.txt files
 
-Two plain text files summarize the documentation set for agents that accept a single bulk reference:
+Two plain text files summarize the documentation set for agents that accept a single bulk reference. Both files index the latest release:
 
 [cols="1,3",options="header"]
 |===

--- a/modules/ROOT/pages/ai-coding-agents.adoc
+++ b/modules/ROOT/pages/ai-coding-agents.adoc
@@ -4,7 +4,7 @@
 :description_short: Connect {productname} to AI coding agents.
 :keywords: ai, skill, agent skills, mcp, model context protocol, coding agent, claude code, cursor, codex, copilot, visual studio code, llms.txt, markdown
 
-AI coding agents produce better {productname} integrations when they work from the current documentation instead of relying on training data. The official *{productname} skill* teaches an agent how to add {productname} to a project: it selects an installation method, wires up the editor, configures plugins and the toolbar, and sets the credential for the chosen distribution channel. Install it with one command:
+The official *{productname} skill* teaches an AI coding agent how to add {productname} to a project: it selects an installation method, wires up the editor, configures plugins and the toolbar, loads the content styles, and sets the API key or license key. Install it with one command:
 
 [source,bash]
 ----
@@ -54,7 +54,7 @@ Copy the `+skills/tinymce/+` directory from the https://github.com/tinymce/skill
 [[connect-the-documentation-mcp-server]]
 == Connect the documentation MCP server
 
-The skill works on its own, but is more effective when the agent can also search the live documentation. The hosted {productname} documentation MCP server exposes semantic search across the published documentation, returning relevant extracts with links to their source pages. Any client that supports the https://modelcontextprotocol.io/[Model Context Protocol] (MCP) over streamable HTTP can connect to it.
+The skill works on its own, but is more effective when the agent can also search the live documentation. The hosted {productname} documentation https://modelcontextprotocol.io/[Model Context Protocol] (MCP) server exposes semantic search across the published documentation, returning relevant extracts with links to their source pages. Any client that supports MCP over streamable HTTP can connect to it.
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/ai-coding-agents.adoc
+++ b/modules/ROOT/pages/ai-coding-agents.adoc
@@ -1,20 +1,60 @@
 = Using {productname} with AI coding agents
 :navtitle: AI coding agents
-:description: Connect the {productname} documentation to AI coding agents using the hosted documentation MCP server, markdown pages, and llms.txt files.
-:description_short: Connect the documentation to AI coding agents.
-:keywords: ai, mcp, model context protocol, coding agent, claude code, cursor, codex, copilot, visual studio code, llms.txt, markdown
+:description: Teach AI coding agents to integrate {productname} using the official skill, the documentation MCP server, markdown pages, and llms.txt files.
+:description_short: Connect {productname} to AI coding agents.
+:keywords: ai, skill, agent skills, mcp, model context protocol, coding agent, claude code, cursor, codex, copilot, visual studio code, llms.txt, markdown
 
-AI coding agents produce better {productname} integrations when they read the current documentation instead of relying on training data. The {productname} documentation is published in three agent-readable forms: a hosted documentation MCP server for semantic search, a markdown version of every page, and `+llms.txt+` files that index the documentation set.
+AI coding agents produce better {productname} integrations when they work from the current documentation instead of relying on training data. The official *{productname} skill* teaches an agent how to add {productname} to a project: it selects an installation method, wires up the editor, configures plugins and the toolbar, and sets the credential for the chosen distribution channel. Install it with one command:
+
+[source,bash]
+----
+npx skills add tinymce/skills
+----
 
 [NOTE]
 ====
-This page describes how to give an AI coding agent access to the {productname} documentation. It does not describe the in-editor AI features. For content generation inside the editor, see xref:tinymceai-introduction.adoc[{productname} AI].
+This page covers agent skills that help integrate {productname} into an application. It does not describe the in-editor AI features. For content generation inside the editor, see xref:tinymceai-introduction.adoc[{productname} AI].
 ====
+
+[[what-the-skill-does]]
+== What the skill does
+
+The skill loads when an agent is asked to install, set up, configure, or troubleshoot {productname}. It will:
+
+* Choose an installation method — {cloudname}, a package manager, or a `+.zip+` package.
+* Wire up the editor in vanilla JavaScript or an official React, Vue, Angular, Svelte, jQuery, web component, or Blazor wrapper.
+* Configure plugins, the toolbar, the menu bar, and content styles.
+* Set the API key or license key correctly for the chosen distribution channel.
+* Send version-specific questions to the live documentation instead of guessing.
+
+The skill deliberately excludes authoring custom plugins, upgrading between major versions, and {productname} 4. For those tasks, see the xref:migration-guides.adoc[migration guides].
+
+[[supported-agents]]
+== Supported agents
+
+The skill uses the open https://agentskills.io/home[Agent Skills] format, so it works in any agent that supports it, including Claude Code, Cursor, Codex, OpenCode, GitHub Copilot, Windsurf, Gemini, Cline, AMP, and Zed. The installer detects the agents present in a project and writes the skill to each.
+
+[[other-ways-to-install]]
+== Other ways to install
+
+[[claude-code-plugin-marketplace]]
+=== Claude Code plugin marketplace
+
+[source,text]
+----
+/plugin marketplace add tinymce/skills
+/plugin install tinymce@tinymce
+----
+
+[[manual-installation]]
+=== Manual installation
+
+Copy the `+skills/tinymce/+` directory from the https://github.com/tinymce/skills[`+tinymce/skills+`] repository into the agent's skills directory, for example `+.claude/skills/tinymce/+`.
 
 [[connect-the-documentation-mcp-server]]
 == Connect the documentation MCP server
 
-The hosted {productname} documentation MCP server exposes semantic search across the published documentation, returning relevant extracts with links to their source pages. Any client that supports the https://modelcontextprotocol.io/[Model Context Protocol] (MCP) over streamable HTTP can connect to it.
+The skill works on its own, but is more effective when the agent can also search the live documentation. The hosted {productname} documentation MCP server exposes semantic search across the published documentation, returning relevant extracts with links to their source pages. Any client that supports the https://modelcontextprotocol.io/[Model Context Protocol] (MCP) over streamable HTTP can connect to it.
 
 [NOTE]
 ====
@@ -177,5 +217,7 @@ Two plain text files summarize the documentation set for agents that accept a si
 
 [[feedback]]
 == Feedback
+
+Report guidance that is wrong, outdated, or missing from the skill by https://github.com/tinymce/skills/issues/new?template=skill-feedback.yml[opening an issue] in the https://github.com/tinymce/skills[`+tinymce/skills+`] repository, using the skill feedback template. Agents are encouraged to file these when the skill contradicts what actually worked.
 
 Report inaccurate or outdated documentation by opening an issue in the https://github.com/tinymce/tinymce-docs/issues[`+tinymce-docs+`] repository.

--- a/modules/ROOT/pages/ai-coding-agents.adoc
+++ b/modules/ROOT/pages/ai-coding-agents.adoc
@@ -1,0 +1,164 @@
+= Using {productname} with AI coding agents
+:navtitle: AI coding agents
+:description: Connect the {productname} documentation to AI coding agents using the hosted documentation MCP server, markdown pages, and llms.txt files.
+:description_short: Connect the documentation to AI coding agents.
+:keywords: ai, mcp, model context protocol, coding agent, claude code, cursor, codex, copilot, visual studio code, llms.txt, markdown
+
+AI coding agents produce better {productname} integrations when they read the current documentation instead of relying on training data. The {productname} documentation is published in three agent-readable forms: a hosted documentation MCP server for semantic search, a markdown version of every page, and `+llms.txt+` files that index the documentation set.
+
+[NOTE]
+====
+This page describes how to give an AI coding agent access to the {productname} documentation. It does not describe the in-editor AI features. For content generation inside the editor, see xref:tinymceai-introduction.adoc[{productname} AI].
+====
+
+[[connect-the-documentation-mcp-server]]
+== Connect the documentation MCP server
+
+The hosted {productname} documentation MCP server exposes semantic search across the published documentation, returning relevant extracts with links to their source pages. Any client that supports the https://modelcontextprotocol.io/[Model Context Protocol] (MCP) over HTTP can connect to it.
+
+*Endpoint:* `+https://tinymcedocs.mcp.kapa.ai+`
+
+*Authentication:* The server is protected by OAuth. On the first connection the agent opens a browser window to complete sign-in, then stores the resulting token.
+
+[[install-from-the-documentation-site]]
+=== Install from the documentation site
+
+Every page of this documentation includes an *Ask AI* widget. Open the widget and select *Use MCP* in the modal header to open the *Connect to AI Tools* menu, which provides copy-to-clipboard install commands, one-click installs for supported editors, and the raw server URL.
+
+The remaining sections describe the equivalent manual configuration.
+
+[[claude-code]]
+=== Claude Code
+
+[source,bash]
+----
+claude mcp add --transport http --scope project tinymce-docs https://tinymcedocs.mcp.kapa.ai
+----
+
+To configure the server manually, add it to `+.mcp.json+`:
+
+[source,json]
+----
+{
+  "mcpServers": {
+    "tinymce-docs": {
+      "type": "http",
+      "url": "https://tinymcedocs.mcp.kapa.ai"
+    }
+  }
+}
+----
+
+[[cursor]]
+=== Cursor
+
+Add the server to `+.cursor/mcp.json+`:
+
+[source,json]
+----
+{
+  "mcpServers": {
+    "tinymce-docs": {
+      "url": "https://tinymcedocs.mcp.kapa.ai"
+    }
+  }
+}
+----
+
+[[codex]]
+=== Codex
+
+[source,bash]
+----
+codex mcp add tinymce-docs --url https://tinymcedocs.mcp.kapa.ai
+----
+
+To configure the server manually, add it to `+~/.codex/config.toml+`:
+
+[source,toml]
+----
+[mcp_servers.tinymce-docs]
+url = "https://tinymcedocs.mcp.kapa.ai"
+startup_timeout_sec = 20
+tool_timeout_sec = 60
+enabled = true
+----
+
+[[visual-studio-code]]
+=== Visual Studio Code
+
+Add the server to `+.vscode/mcp.json+`:
+
+[source,json]
+----
+{
+  "servers": {
+    "tinymce-docs": {
+      "type": "http",
+      "url": "https://tinymcedocs.mcp.kapa.ai"
+    }
+  }
+}
+----
+
+[[opencode]]
+=== OpenCode
+
+Add the server to `+opencode.json+`:
+
+[source,json]
+----
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "tinymce-docs": {
+      "type": "remote",
+      "url": "https://tinymcedocs.mcp.kapa.ai",
+      "enabled": true
+    }
+  }
+}
+----
+
+[[other-agents]]
+=== Other agents
+
+Agents that accept a remote MCP server without a dedicated configuration file — such as Claude and ChatGPT — can connect using the endpoint directly:
+
+[source,text]
+----
+https://tinymcedocs.mcp.kapa.ai
+----
+
+[[read-the-documentation-as-markdown]]
+== Read the documentation as markdown
+
+Every documentation page is also published as markdown, which is more token-efficient than the rendered HTML page. Append `+index.md+` to any documentation page URL to retrieve it:
+
+[source,text]
+----
+https://www.tiny.cloud/docs/tinymce/latest/basic-setup/index.md
+----
+
+Each page also includes a *Copy Markdown* button next to the page title, which copies the markdown URL of the current page to the clipboard for pasting into an agent prompt.
+
+[[llms-txt-files]]
+== llms.txt files
+
+Two plain text files summarize the documentation set for agents that accept a single bulk reference:
+
+[cols="1,3",options="header"]
+|===
+|File |Contents
+
+|https://www.tiny.cloud/docs/llms.txt[`+llms.txt+`]
+|A concise overview of {productname}, with key links and code examples.
+
+|https://www.tiny.cloud/docs/llms-full.txt[`+llms-full.txt+`]
+|A full index of the documentation pages and their URLs.
+|===
+
+[[feedback]]
+== Feedback
+
+Report inaccurate or outdated documentation by opening an issue in the https://github.com/tinymce/tinymce-docs/issues[`+tinymce-docs+`] repository.

--- a/modules/ROOT/pages/ai-coding-agents.adoc
+++ b/modules/ROOT/pages/ai-coding-agents.adoc
@@ -25,6 +25,11 @@ This server provides documentation to an external coding agent. It is not relate
 
 *Authentication:* The server is protected by OAuth and requires a one-time sign-in. The first time the agent calls the server, a browser window opens to complete sign-in, after which the agent stores the resulting token. In Claude Code, if no sign-in prompt appears, run `+/mcp+`, select the server, and then select *Authenticate*.
 
+[IMPORTANT]
+====
+Each agent reads its own configuration file, and the files are not interchangeable. Claude Code reads `+.mcp.json+` and expects an `+mcpServers+` object, while Visual Studio Code reads `+.vscode/mcp.json+` and expects a `+servers+` object. An agent given another agent's file or key name reports no error and exposes no tools from the server. Use the section below that matches the agent in use.
+====
+
 [[install-from-the-documentation-site]]
 === Install from the documentation site
 

--- a/modules/ROOT/pages/ai-coding-agents.adoc
+++ b/modules/ROOT/pages/ai-coding-agents.adoc
@@ -1,5 +1,5 @@
 = Using {productname} with AI coding agents
-:navtitle: AI coding agents
+:navtitle: Build with AI
 :description: Teach AI coding agents to integrate {productname} using the official skill, the documentation MCP server, markdown pages, and llms.txt files.
 :description_short: Connect {productname} to AI coding agents.
 :keywords: ai, skill, agent skills, mcp, model context protocol, coding agent, claude code, cursor, codex, copilot, visual studio code, llms.txt, markdown

--- a/modules/ROOT/pages/ai-coding-agents.adoc
+++ b/modules/ROOT/pages/ai-coding-agents.adoc
@@ -54,12 +54,7 @@ Copy the `+skills/tinymce/+` directory from the https://github.com/tinymce/skill
 [[connect-the-documentation-mcp-server]]
 == Connect the documentation MCP server
 
-The skill works on its own, but is more effective when the agent can also search the live documentation. The hosted {productname} documentation https://modelcontextprotocol.io/[Model Context Protocol] (MCP) server exposes semantic search across the published documentation, returning relevant extracts with links to their source pages. Any client that supports MCP over streamable HTTP can connect to it.
-
-[NOTE]
-====
-This server provides documentation to an external coding agent. It is not related to the MCP tool calling available to the {productname} AI service, which is described in xref:tinymceai-on-premises-mcp.adoc[MCP and web integrations].
-====
+The skill works on its own, but is more effective when the agent can also search the live documentation. The hosted {productname} documentation https://modelcontextprotocol.io/[Model Context Protocol] (MCP) server exposes semantic search across the published documentation, returning relevant extracts with links to their source pages. Any client that supports MCP over streamable HTTP can connect to it. This server supplies documentation to an external coding agent, and is separate from the MCP tool calling available to the {productname} AI service, described in xref:tinymceai-on-premises-mcp.adoc[MCP and web integrations].
 
 *Endpoint:* `+https://tinymcedocs.mcp.kapa.ai+`
 

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -20,8 +20,14 @@ xref:installation.adoc[Installation]
 
 Learn how to install {productname} via {cloudname}, package managers, self-hosted zips for various integration options.
 
+|
+[.lead]
+xref:ai-coding-agents.adoc[AI coding agents]
+
+Connect the {productname} documentation to AI coding agents using the documentation MCP server, markdown pages, and `+llms.txt+` files.
+
 // Empty cell to even out rows
-// | 
+|
 
 |===
 

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -22,7 +22,7 @@ Learn how to install {productname} via {cloudname}, package managers, self-hoste
 
 |
 [.lead]
-xref:ai-coding-agents.adoc[AI coding agents]
+xref:ai-coding-agents.adoc[Build with AI]
 
 Connect the {productname} documentation to AI coding agents using the documentation MCP server, markdown pages, and `+llms.txt+` files.
 


### PR DESCRIPTION
**Ticket:** TINYDOC-3571

**Related:** TINYDOC-3572 (the `tinymce/skills` repository this page documents), TINYDOC-3568 / docs-antora-ui#44 (the Ask AI widget half)

**Site:** [Staging branch](https://pr-4301.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/ai-coding-agents/)

**Changes:**
* Added `modules/ROOT/pages/ai-coding-agents.adoc` — a new Getting started page covering both halves of agent support: the official **TinyMCE agent skill** (`npx skills add tinymce/skills`) and the documentation access surfaces.
* Skill sections: what the skill does, supported agents, and alternative install paths (Claude Code plugin marketplace, manual copy).
* Documentation access sections: the hosted Kapa MCP server (`https://tinymcedocs.mcp.kapa.ai`) with per-agent configuration for Claude Code, Cursor, Codex, Visual Studio Code and OpenCode; the markdown form of every page; and the `llms.txt` / `llms-full.txt` files.
* Added a nav entry under Getting started, after Upgrading TinyMCE, and a third cell in the Getting started index table.

This is the documentation half of the AI widget MCP work. The other half is docs-antora-ui#44, which enables the **Use MCP** menu in the Ask AI widget; the page's "Install from the documentation site" section describes that menu and goes live when the UI bundle redeploys.

> [!IMPORTANT]
> **Do not merge before `tinymce/skills` is public (TINYDOC-3572).** The page documents `npx skills add tinymce/skills` and `/plugin marketplace add tinymce/skills`. Both git-clone the repository, so while it is private they fail for anyone outside the org. The repository, its manifests, and the release tags are ready; only the visibility switch is outstanding.

Notes for review:
* Every command on the page has been run end to end against the live repository — `npx skills add tinymce/skills` installs the skill, and the MCP endpoint responds.
* Verified against production: `.md` pages are served for every documented major version (`/5/`, `/6/`, `/7/`, `/latest/`), so the page documents version-segmented markdown rather than scoping it to latest.
* Verified the MCP endpoint is OAuth-protected via Kapa's public authorization server. The page does not name specific SSO providers, since that could not be confirmed.
* The `Accept: text/markdown` header is not supported by our docs site, so only the `index.md` URL form is documented.
* The IMPORTANT admonition about configuration files not being interchangeable comes from a real failure during testing: `claude mcp add` writes `.mcp.json`, which VS Code does not read, and the result is valid JSON with no error and no tools.
* Version scoping of the MCP server itself is not addressed, matching the open question in docs-antora-ui#44.

---

### **Pre-checks:**

- [x] Branch is correctly prefixed:
- **Feature:** `feature/<version>/DOC-XXXX` (e.g., `feature/8.0.0/DOC-1234`)
- **Hotfix:** `hotfix/<version>/DOC-XXXX` (e.g., `hotfix/8.0.0/DOC-1234`)
- **EPIC:** `release/<ver>` (e.g., `release/8.0.0` for major releases)

- [x] `modules/ROOT/nav.adoc` has been updated (if applicable).
- [x] Files have been included where required (if applicable).
- [ ] Files removed have been deleted, not just excluded from the build (if applicable).
- [ ] Files added for **New product features** include a `release note` entry.
- [ ] Major or minor version changes have updated the `supported-versions.adoc` table.
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [ ] Documentation Team Lead has reviewed.
