### PR TITLE
TINYDOC-3580 - Remove license_key from Comments callback live demos

### DIFF
--- a/modules/ROOT/examples/live-demos/comments-callback-with-mentions/index.js
+++ b/modules/ROOT/examples/live-demos/comments-callback-with-mentions/index.js
@@ -237,7 +237,6 @@ const tinycomments_fetch = (conversationUids, done) => {
 
 tinymce.init({
   selector: 'textarea#comments-callback-with-mentions',
-  license_key: 'gpl',
   toolbar: 'addcomment showcomments code | bold italic underline',
   menubar: 'file edit view insert format tools tc help',
   menu: {

--- a/modules/ROOT/examples/live-demos/comments-callback/index.js
+++ b/modules/ROOT/examples/live-demos/comments-callback/index.js
@@ -183,7 +183,6 @@ const tinycomments_fetch = (conversationUids, done) => {
 
 tinymce.init({
   selector: 'textarea#comments-callback',
-  license_key: 'gpl',
   toolbar: 'addcomment showcomments code | bold italic underline',
   menubar: 'file edit view insert format tools tc help',
   menu: {


### PR DESCRIPTION
**Ticket:** TINYDOC-3580

**Site:** [Staging branch](https://pr-4302.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/comments-callback-mode/)

**Changes:**
* Removed `license_key: 'gpl'` from `modules/ROOT/examples/live-demos/comments-callback/index.js`.
* Removed `license_key: 'gpl'` from `modules/ROOT/examples/live-demos/comments-callback-with-mentions/index.js`.

Comments is a premium plugin, so a GPL license key shown in the JS tab of these live demos is misleading.

Affected pages:
* [comments-callback-mode](https://www.tiny.cloud/docs/tinymce/latest/comments-callback-mode/)
* [comments-with-mentions](https://www.tiny.cloud/docs/tinymce/latest/comments-with-mentions/)

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: `hotfix/8/TINYDOC-3580`
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
