### PR TITLE
TINYDOC-3570: New option `tinymceai_chat_default_sources` to allow specifying predefined sources as chat default context.

### DIFF
--- a/modules/ROOT/pages/8.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.9.0-release-notes.adoc
@@ -71,6 +71,23 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following addition.
+
+==== New option `tinymceai_chat_default_sources` to allow specifying predefined sources as chat default context.
+// #TINYMCE-14703
+
+Previously, the **TinyMCE AI** plugin applied only the current document to the context of a new AI Chat conversation. Users had to add every other context source, such as a style guide or a reference document, to each new conversation by hand.
+
+In {productname} {release-version}, the **TinyMCE AI** plugin supports the xref:tinymceai.adoc#tinymceai_chat_default_sources[`+tinymceai_chat_default_sources+`] option. The option accepts an array of source identifiers taken from the list supplied by xref:tinymceai.adoc#tinymceai_chat_fetch_sources[`+tinymceai_chat_fetch_sources+`], and the plugin applies those sources to the context of every new conversation. Users can remove a default source from a conversation and add it again from the sources menu.
+
+For details on configuring conversation context, see xref:tinymceai-chat.adoc#context-configuration[Adding custom context sources].
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement

--- a/modules/ROOT/pages/tinymceai-chat.adoc
+++ b/modules/ROOT/pages/tinymceai-chat.adoc
@@ -160,6 +160,8 @@ To add custom external sources for users to select from, configure:
 
 Full schemas, return types, and examples are documented under xref:tinymceai.adoc#tinymceai_chat_fetch_sources[Chat configuration options].
 
+To apply a custom source to every new conversation without requiring users to select it, list its ID in xref:tinymceai.adoc#tinymceai_chat_default_sources[`tinymceai_chat_default_sources`].
+
 [source,js]
 ----
 tinymce.init({

--- a/modules/ROOT/pages/tinymceai.adoc
+++ b/modules/ROOT/pages/tinymceai.adoc
@@ -98,6 +98,7 @@ tinymce.init({
     const filename = `\$\{id\}.pdf`;
     return { type: 'file', file: new File([blob], filename, { type: blob.type }) };
   },
+  tinymceai_chat_default_sources: [ 'doc-1' ],
   tinymceai_quickactions_custom: [
     { title: 'Explain like I am five', prompt: 'Explain the following text in simple terms.', type: 'chat' }
   ]

--- a/modules/ROOT/partials/configuration/tinymceai_options.adoc
+++ b/modules/ROOT/partials/configuration/tinymceai_options.adoc
@@ -252,6 +252,50 @@ tinymce.init({
 });
 ----
 
+[[tinymceai_chat_default_sources]]
+=== `+tinymceai_chat_default_sources+`
+
+Adds one or more sources to the context of every new chat conversation, alongside the current document. Without this option, users add each source to a conversation themselves.
+
+Takes an array of source identifiers. Each identifier is the `+id+` of a source supplied by xref:tinymceai.adoc#tinymceai_chat_fetch_sources[`tinymceai_chat_fetch_sources`], and the content of each source is loaded through xref:tinymceai.adoc#tinymceai_chat_fetch_source[`tinymceai_chat_fetch_source`]. Identifiers that do not match a supplied source are ignored.
+
+Users can remove a default source from a conversation and add it again from the sources menu.
+
+*Type:* `+Array+` (`+string[]+`)
+
+*Default value:* `+[]+`
+
+.Example
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',
+  plugins: 'tinymceai',
+  toolbar: 'tinymceai-chat tinymceai-quickactions tinymceai-review',
+  tinymceai_chat_fetch_sources: async () => [
+    {
+      label: 'My Documents',
+      icon: 'folder',
+      sources: [
+        { id: 'doc-1', label: 'Style guide', type: 'file' },
+        { id: 'doc-2', label: 'Document 2', type: 'file' }
+      ]
+    }
+  ],
+  tinymceai_chat_fetch_source: async (id) => {
+    const res = await fetch(`/api/documents/\$\{id\}`);
+    const blob = await res.blob();
+    const filename = `\$\{id\}.pdf`;
+    return { type: 'file', file: new File([blob], filename, { type: blob.type }) };
+  },
+  tinymceai_chat_default_sources: [ 'doc-1' ],
+  // Required for authentication
+  tinymceai_token_provider: () => {
+    return fetch('/api/token').then(r => r.json());
+  }
+});
+----
+
 [[tinymceai_chat_welcome_message]]
 === `+tinymceai_chat_welcome_message+`
 


### PR DESCRIPTION
**Ticket:** TINYDOC-3570 (TINYMCE-14703), TINYDOC-3561

**Site:** [Staging](https://pr-4306.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.9.0-release-notes/#new-option-tinymceai_chat_default_sources-to-allow-specifying-predefined-sources-as-chat-default-context)

**Changes:**
* Added release note entry for TINYMCE-14703 to `modules/ROOT/pages/8.9.0-release-notes.adoc`.
* Added the `tinymceai_chat_default_sources` section to  modules/ROOT/partials/configuration/tinymceai_options.adoc`, under Options for Chat (TINYDOC-3561).
* Added `tinymceai_chat_default_sources` to the complete setup example in `modules/ROOT/pages/tinymceai.adoc`.
* Added a cross-reference to the new option from Adding custom context sources in `modules/ROOT/pages/tinymceai-chat.adoc`.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [ ] Documentation Team Lead has reviewed.
