### PR TITLE
TINYDOC-3570: New option `tinycomments_always_show_highlights` to keep comment highlights visible while the sidebar is closed.

### DIFF
--- a/modules/ROOT/pages/8.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.9.0-release-notes.adoc
@@ -71,6 +71,28 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== Comments
+
+The {productname} {release-version} release includes an accompanying release of the **Comments** premium plugin.
+
+**Comments** includes the following additions.
+
+==== New option `+tinycomments_always_show_highlights+` to keep comment highlights visible while the sidebar is closed
+// #TINYMCE-14726
+
+Previously, the Comments plugin highlighted commented content only while the Comments sidebar was open. Closing the sidebar removed the highlighting from the editor content, so commented content was easy to overlook and users could overwrite it without warning.
+
+In {productname} {release-version}, the Comments plugin offers the xref:comments-embedded-mode.adoc#tinycomments_always_show_highlights[`+tinycomments_always_show_highlights+`] option. When this option is set to `+true+`, commented content remains highlighted whether the Comments sidebar is open or closed. This option defaults to `+false+`, which preserves the existing behavior.
+
+==== Selecting a comment highlight opens the Comments sidebar
+// #TINYMCE-14726
+
+Previously, the Comments plugin removed the highlighting while the Comments sidebar was closed, so users could not reopen a conversation from the editor content.
+
+In {productname} {release-version}, when the xref:comments-embedded-mode.adoc#tinycomments_always_show_highlights[`+tinycomments_always_show_highlights+`] option is set to `+true+`, selecting highlighted content reopens the closed Comments sidebar.
+
+For information on the **Comments** plugin, see: xref:introduction-to-tiny-comments.adoc[Comments].
+
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement

--- a/modules/ROOT/pages/comments-callback-mode.adoc
+++ b/modules/ROOT/pages/comments-callback-mode.adoc
@@ -83,6 +83,8 @@ include::partial$configuration/fetch_users.adoc[leveloffset=+1]
 
 include::partial$configuration/tinycomments_fetch_author_info.adoc[leveloffset=+1]
 
+include::partial$configuration/tinycomments_always_show_highlights.adoc[leveloffset=+1]
+
 include::partial$plugins/comments-open-sidebar.adoc[]
 
 include::partial$plugins/comments-highlighting-css.adoc[]

--- a/modules/ROOT/pages/comments-embedded-mode.adoc
+++ b/modules/ROOT/pages/comments-embedded-mode.adoc
@@ -64,6 +64,8 @@ include::partial$configuration/tinycomments_can_delete_comment.adoc[leveloffset=
 
 include::partial$configuration/tinycomments_can_edit_comment.adoc[leveloffset=+1]
 
+include::partial$configuration/tinycomments_always_show_highlights.adoc[leveloffset=+1]
+
 include::partial$plugins/comments-open-sidebar.adoc[]
 
 include::partial$plugins/comments-highlighting-css.adoc[]

--- a/modules/ROOT/partials/configuration/tinycomments_always_show_highlights.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_always_show_highlights.adoc
@@ -20,7 +20,7 @@ tinymce.init({
   plugins: 'tinycomments',
   toolbar: 'addcomment showcomments',
   tinycomments_mode: 'embedded',
-  user_id: 'embedded_journalist',
+  user_id: 'author',
   tinycomments_always_show_highlights: true
 });
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_always_show_highlights.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_always_show_highlights.adoc
@@ -15,12 +15,14 @@ When this option is set to `+true+`, {productname} highlights commented content 
 
 [source,js]
 ----
+const currentAuthor = 'embedded_journalist';
+
 tinymce.init({
   selector: 'textarea',  // change this value according to your html
   plugins: 'tinycomments',
   toolbar: 'addcomment showcomments',
   tinycomments_mode: 'embedded',
-  user_id: 'author',
+  user_id: currentAuthor,
   tinycomments_always_show_highlights: true
 });
 ----

--- a/modules/ROOT/partials/configuration/tinycomments_always_show_highlights.adoc
+++ b/modules/ROOT/partials/configuration/tinycomments_always_show_highlights.adoc
@@ -1,0 +1,26 @@
+[[tinycomments_always_show_highlights]]
+== `+tinycomments_always_show_highlights+`
+
+_Optional_: The {pluginname} plugin offers the `+tinycomments_always_show_highlights+` option to keep the highlighting on commented content visible while the {pluginname} sidebar is closed. By default, {productname} highlights commented content only while the sidebar is open, and removes the highlighting from the editor content once the sidebar is closed.
+
+When this option is set to `+true+`, {productname} highlights commented content whether the sidebar is open or closed, and selecting highlighted content reopens the closed {pluginname} sidebar.
+
+*Type:* `+Boolean+`
+
+*Default value:* `+false+`
+
+*Possible values:* `+true+`, `+false+`
+
+=== Example: using `+tinycomments_always_show_highlights+`
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',  // change this value according to your html
+  plugins: 'tinycomments',
+  toolbar: 'addcomment showcomments',
+  tinycomments_mode: 'embedded',
+  user_id: 'embedded_journalist',
+  tinycomments_always_show_highlights: true
+});
+----


### PR DESCRIPTION
**Ticket:** TINYDOC-3570 (TINYMCE-14726)

**Site:** [Staging](https://pr-4308.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.9.0-release-notes/#new-option-tinycomments_always_show_highlights-to-keep-comment-highlights-visible-while-the-sidebar-is-closed)

**Changes:**
* Added release note entries for TINYMCE-14726 to `modules/ROOT/pages/8.9.0-release-notes.adoc`, under Accompanying Premium plugin changes (Comments): one for the new `tinycomments_always_show_highlights` option, and one for opening the Comments sidebar by selecting a comment highlight.
* Added `modules/ROOT/partials/configuration/tinycomments_always_show_highlights.adoc` documenting the new option (Boolean, default `false`).
* Included the new option partial under Options in `modules/ROOT/pages/comments-embedded-mode.adoc`.
* Included the new option partial under Options in `modules/ROOT/pages/comments-callback-mode.adoc`.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
