### PR TITLE
TINYDOC-3570: Chat welcome actions moved focus into the editor and reset the content scroll position

### DIFF
--- a/modules/ROOT/pages/8.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.9.0-release-notes.adoc
@@ -71,6 +71,21 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following fix.
+
+==== Chat welcome actions moved focus into the editor and reset the content scroll position
+// #TINYMCE-14749
+
+Previously, selecting a welcome action in the AI Chat sidebar moved focus into the editor before running the action's command. Focusing the editor scrolls the content to the current selection, and when no selection had been made, that position was the start of the content. Users who had scrolled through a document lost that scroll position as soon as a welcome action was selected.
+
+In {productname} {release-version}, the **TinyMCE AI** plugin runs welcome action commands without moving focus into the editor. Selecting a welcome action leaves the editor scroll position and focus unchanged. Welcome actions are configured with the xref:tinymceai.adoc#tinymceai_chat_welcome_actions[`+tinymceai_chat_welcome_actions+`] option.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement

--- a/modules/ROOT/partials/configuration/tinymceai_options.adoc
+++ b/modules/ROOT/partials/configuration/tinymceai_options.adoc
@@ -290,7 +290,7 @@ Each item in the array is one of the following:
 * A `+String+`, or an object with a `+text+` property (`+{ text: 'string' }+`), shown as descriptive text.
 * An action object, shown as a clickable button, with the following properties:
 ** `+title+` (`+String+`): The label shown on the button.
-** `+command+` (`+String+`): The editor command run when the button is selected, using `+editor.execCommand(command, false, value)+`. This can be a Quick Action or Chat command, the core `+ToggleSidebar+` command, or any other registered editor command, such as `+Bold+`. For the AI command names, see xref:editor-command-identifiers.adoc#tinymceai[TinyMCE AI].
+** `+command+` (`+String+`): The editor command run when the button is selected. The command runs without moving focus into the editor, so the editor scroll position is preserved. This can be a Quick Action or Chat command, the core `+ToggleSidebar+` command, or any other registered editor command, such as `+Bold+`. For the AI command names, see xref:editor-command-identifiers.adoc#tinymceai[TinyMCE AI].
 ** `+value+` (optional): The argument passed to the command. The accepted value matches the command, for example a language label for `+TinyMCEAIQuickActionTranslate+`, a `+{ prompt, displayedPrompt }+` object for `+TinyMCEAIChatPrompt+`, or a sidebar name such as `+'tinymceai-review'+` for `+ToggleSidebar+`.
 ** `+icon+` (optional `+String+`): The name of the icon shown on the button, using any editor icon identifier. When omitted, an icon is selected automatically based on the command.
 


### PR DESCRIPTION
**Ticket:** TINYDOC-3570 (TINYMCE-14749)

**Site:** [Staging](https://pr-4309.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.9.0-release-notes/#chat-welcome-actions-moved-focus-into-the-editor-and-reset-the-content-scroll-position)

**Changes:**
* Added release note entry for TINYMCE-14749 to `modules/ROOT/pages/8.9.0-release-notes.adoc` (Accompanying Premium plugin changes, TinyMCE AI): Chat welcome actions moved focus into the editor and reset the content scroll position.
* Updated the `tinymceai_chat_welcome_actions` `command` property description in `modules/ROOT/partials/configuration/tinymceai_options.adoc` to state that the command runs without moving focus into the editor.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
