### PR TITLE
TINYDOC-3570: Tooltips could not be closed using `Esc`

### DIFF
--- a/modules/ROOT/pages/8.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.9.0-release-notes.adoc
@@ -82,7 +82,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 Previously, the tooltips shown in the **TinyMCE AI** sidebars did not respond to `+Esc+`. These sidebars use their own tooltips, which were not connected to the editor keyboard shortcut that closes tooltips, so an open tooltip remained on screen until the pointer or focus moved elsewhere. Keyboard users could not dismiss a tooltip that obscured the interface.
 
-In {productname} {release-version}, pressing `+Esc+` closes an open tooltip in the **TinyMCE AI** sidebars. When a tooltip is closed this way, `+Esc+` performs no other action, so focus stays where it was instead of returning to the editor content.
+In {productname} {release-version}, pressing `+Esc+` closes an open tooltip in the **TinyMCE AI** sidebars.
 
 For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
 

--- a/modules/ROOT/pages/8.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.9.0-release-notes.adoc
@@ -71,6 +71,21 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following fix.
+
+==== Tooltips could not be closed using `+Esc+`
+// #TINYMCE-14506
+
+Previously, the tooltips shown in the **TinyMCE AI** sidebars did not respond to `+Esc+`. These sidebars use their own tooltips, which were not connected to the editor keyboard shortcut that closes tooltips, so an open tooltip remained on screen until the pointer or focus moved elsewhere. Keyboard users could not dismiss a tooltip that obscured the interface.
+
+In {productname} {release-version}, pressing `+Esc+` closes an open tooltip in the **TinyMCE AI** sidebars. When a tooltip is closed this way, `+Esc+` performs no other action, so focus stays where it was instead of returning to the editor content.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement


### PR DESCRIPTION
**Ticket:** TINYDOC-3570 (TINYMCE-14506)

**Site:** [Staging](https://pr-4310.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.9.0-release-notes/#tooltips-could-not-be-closed-using-esc)

**Changes:**
* Added release note entry for TINYMCE-14506 to `modules/ROOT/pages/8.9.0-release-notes.adoc` (Accompanying Premium plugin changes, TinyMCE AI): Tooltips could not be closed using `Esc`.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
