### PR TITLE
TINYDOC-3570: Image with empty alt text would add role="presentation" instead of adding alt text when updated

### DIFF
--- a/modules/ROOT/pages/8.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.9.0-release-notes.adoc
@@ -160,6 +160,13 @@ For information on using Enhanced Skins & Icon Packs, see: xref:enhanced-skins-a
 
 // CCFR here.
 
+=== Image with empty alt text would add `+role="presentation"+` instead of adding alt text when updated
+// #TINYMCE-13738
+
+Previously, the xref:image.adoc[Image] plugin treated any image with an empty `+alt+` attribute as decorative. When xref:image.adoc#a11y_advanced_options[`+a11y_advanced_options+`] was disabled, the _Insert/Edit Image_ dialog did not show the *Image is decorative* option, so the dialog offered no way to change that state. Entering alternative text for such an image and saving the dialog applied `+role="presentation"+` and left the `+alt+` attribute empty, discarding the text that had been entered.
+
+In {productname} {release-version}, the Image plugin marks an image as decorative only when the _Insert/Edit Image_ dialog presents the accessibility options. Entering alternative text for an image with an empty `+alt+` attribute now applies that text to the image.
+
 
 [[security-fixes]]
 == Security fixes


### PR DESCRIPTION
**Ticket:** TINYDOC-3570 (TINYMCE-13738)

**Site:** [Staging](https://pr-4313.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.9.0-release-notes/#image-with-empty-alt-text-would-add-rolepresentation-instead-of-adding-alt-text-when-updated)

**Changes:**
* Added release note entry for TINYMCE-13738 to `modules/ROOT/pages/8.9.0-release-notes.adoc` (Bug fixes section): Image with empty alt text would add `role="presentation"` instead of adding alt text when updated.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
