### PR TITLE
TINYDOC-3570: Improved error message shown when a chat message exceeds the AI context limit

### DIFF
--- a/modules/ROOT/pages/8.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.9.0-release-notes.adoc
@@ -80,7 +80,7 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== Improved error message shown when a chat message exceeds the AI context limit
 // #TINYMCE-13661
 
-Previously, when a chat message and the conversation history together exceeded the context limit of the AI service, the Chat sidebar reported the failure with the general message `+An error occurred while processing the AI response.+` That message did not identify the size of the request as the cause, so users could not tell whether to shorten the message, start a new conversation, or try again unchanged.
+Previously, when a chat message combined with the conversation history together exceeded the context limit of the AI service, the Chat sidebar reported the failure with the general message `+An error occurred while processing the AI response.+` That message did not identify the size of the request as the cause, so users could not tell whether to shorten the message, start a new conversation, or try again unchanged.
 
 In {productname} {release-version}, the **TinyMCE AI** plugin shows `+This message is too long for the AI to process. Try a shorter message, or start a new chat.+` when the AI service reports that a chat request exceeds the context limit. The message names the cause and describes the two ways to continue.
 

--- a/modules/ROOT/pages/8.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.9.0-release-notes.adoc
@@ -71,6 +71,21 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following improvement.
+
+==== Improved error message shown when a chat message exceeds the AI context limit
+// #TINYMCE-13661
+
+Previously, when a chat message and the conversation history together exceeded the context limit of the AI service, the Chat sidebar reported the failure with the general message `+An error occurred while processing the AI response.+` That message did not identify the size of the request as the cause, so users could not tell whether to shorten the message, start a new conversation, or try again unchanged.
+
+In {productname} {release-version}, the **TinyMCE AI** plugin shows `+This message is too long for the AI to process. Try a shorter message, or start a new chat.+` when the AI service reports that a chat request exceeds the context limit. The message names the cause and describes the two ways to continue.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement


### PR DESCRIPTION
**Ticket:** TINYDOC-3570 (TINYMCE-13661)

**Site:** [Staging](https://pr-4314.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.9.0-release-notes/#improved-error-message-shown-when-a-chat-message-exceeds-the-ai-context-limit)

**Changes:**
* Added release note entry for TINYMCE-13661 to `modules/ROOT/pages/8.9.0-release-notes.adoc` (Accompanying Premium plugin changes, TinyMCE AI): Improved error message shown when a chat message exceeds the AI context limit.

---

### **Pre-checks:**

- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
