### PR TITLE
TINYDOC-3570: Improved error message shown when the chat prompt exceeds the maximum length

### DIFF
--- a/modules/ROOT/pages/8.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.9.0-release-notes.adoc
@@ -71,6 +71,21 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following improvement.
+
+==== Improved error message shown when the chat prompt exceeds the maximum length
+// #TINYMCE-13659
+
+Previously, when the text typed into the Chat sidebar exceeded the maximum length that the AI service accepts for a single message, the request failed and the Chat sidebar reported it with the general message `+An error occurred while processing the AI response.+` That message did not identify the length of the typed text as the cause, so users could not tell that shortening the message would resolve the failure.
+
+In {productname} {release-version}, the **TinyMCE AI** plugin shows `+This prompt is too long. Try a shorter one.+` when the typed text exceeds that limit. This message applies to the typed message on its own, and is distinct from the message shown when a message and the conversation history together exceed the context limit of the AI service.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement


### PR DESCRIPTION
**Ticket:** TINYDOC-3570 (TINYMCE-13659)

**Site:** [Staging](https://pr-4315.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.9.0-release-notes/#improved-error-message-shown-when-the-chat-prompt-exceeds-the-maximum-length)

**Changes:**
* Added release note entry for TINYMCE-13659 to `modules/ROOT/pages/8.9.0-release-notes.adoc` (Accompanying Premium plugin changes, TinyMCE AI): Improved error message shown when the chat prompt exceeds the maximum length.

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
