### PR TITLE
TINYDOC-3568 - Revitalise the Cloud quick start guides and scope the AI agents page

### DIFF
--- a/modules/ROOT/examples/live-demos/cloud-quick-start/index.html
+++ b/modules/ROOT/examples/live-demos/cloud-quick-start/index.html
@@ -1,0 +1,9 @@
+<textarea id="cloud-quick-start">
+  <h1>Hello, World!</h1>
+  <p>This editor was configured with the plugins and toolbar from the quick start guide. Try the formatting controls, insert a <strong>table</strong> or an <strong>image</strong>, or open the code view to inspect the HTML.</p>
+  <ul>
+  <li>Select text to apply <strong>bold</strong>, <em>italic</em>, or a text color.</li>
+  <li>Use the <strong>Insert</strong> menu to add a link, media, or a special character.</li>
+  <li>Switch to full screen for a larger editing area.</li>
+  </ul>
+</textarea>

--- a/modules/ROOT/examples/live-demos/cloud-quick-start/index.js
+++ b/modules/ROOT/examples/live-demos/cloud-quick-start/index.js
@@ -1,0 +1,11 @@
+tinymce.init({
+  selector: 'textarea#cloud-quick-start',
+  plugins: [
+    'advlist', 'anchor', 'autolink', 'charmap', 'code', 'codesample', 'emoticons',
+    'fullscreen', 'help', 'image', 'insertdatetime', 'link', 'lists', 'media',
+    'preview', 'searchreplace', 'table', 'visualblocks', 'wordcount'
+  ],
+  menubar: 'file edit view insert format tools table help',
+  toolbar: 'undo redo | blocks fontfamily fontsize | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image media table | charmap emoticons codesample | code preview fullscreen | removeformat help',
+  height: 500
+});

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -75,6 +75,7 @@
 **** Other Integrations
 ***** xref:bootstrap-zip.adoc[Bootstrap]
 ** xref:upgrading.adoc[Upgrading {productname}]
+** xref:ai-coding-agents.adoc[AI coding agents]
 * xref:how-to-guides.adoc[How-to guides]
 ** Learn the basics
 *** xref:basic-setup.adoc[Basic setup]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -1,5 +1,6 @@
 * xref:getting-started.adoc[Getting started]
 ** xref:introduction-to-tinymce.adoc[Introduction to {productname}]
+** xref:ai-coding-agents.adoc[Build with AI]
 ** xref:installation.adoc[Installation]
 *** xref:installation-cloud.adoc[Cloud]
 **** xref:cloud-quick-start.adoc[Quick start guide]
@@ -75,7 +76,6 @@
 **** Other Integrations
 ***** xref:bootstrap-zip.adoc[Bootstrap]
 ** xref:upgrading.adoc[Upgrading {productname}]
-** xref:ai-coding-agents.adoc[AI coding agents]
 * xref:how-to-guides.adoc[How-to guides]
 ** Learn the basics
 *** xref:basic-setup.adoc[Basic setup]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -1,9 +1,10 @@
 * xref:getting-started.adoc[Getting started]
 ** xref:introduction-to-tinymce.adoc[Introduction to {productname}]
-** xref:ai-coding-agents.adoc[Build with AI]
+** xref:ai-coding-agents.adoc[Documentation for AI agents]
 ** xref:installation.adoc[Installation]
 *** xref:installation-cloud.adoc[Cloud]
 **** xref:cloud-quick-start.adoc[Quick start guide]
+**** xref:cloud-quick-start-ai.adoc[AI quick start guide]
 **** Supported Integrations
 ***** xref:react-cloud.adoc[React]
 ***** xref:angular-cloud.adoc[Angular]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -1,6 +1,6 @@
 * xref:getting-started.adoc[Getting started]
 ** xref:introduction-to-tinymce.adoc[Introduction to {productname}]
-** xref:ai-coding-agents.adoc[Documentation for AI agents]
+** xref:ai-coding-agents.adoc[Connect AI agents to the documentation]
 ** xref:installation.adoc[Installation]
 *** xref:installation-cloud.adoc[Cloud]
 **** xref:cloud-quick-start.adoc[Quick start guide]

--- a/modules/ROOT/pages/ai-coding-agents.adoc
+++ b/modules/ROOT/pages/ai-coding-agents.adoc
@@ -14,11 +14,16 @@ This page describes how to give an AI coding agent access to the {productname} d
 [[connect-the-documentation-mcp-server]]
 == Connect the documentation MCP server
 
-The hosted {productname} documentation MCP server exposes semantic search across the published documentation, returning relevant extracts with links to their source pages. Any client that supports the https://modelcontextprotocol.io/[Model Context Protocol] (MCP) over HTTP can connect to it.
+The hosted {productname} documentation MCP server exposes semantic search across the published documentation, returning relevant extracts with links to their source pages. Any client that supports the https://modelcontextprotocol.io/[Model Context Protocol] (MCP) over streamable HTTP can connect to it.
+
+[NOTE]
+====
+This server provides documentation to an external coding agent. It is not related to the MCP tool calling available to the {productname} AI service, which is described in xref:tinymceai-on-premises-mcp.adoc[MCP and web integrations].
+====
 
 *Endpoint:* `+https://tinymcedocs.mcp.kapa.ai+`
 
-*Authentication:* The server is protected by OAuth. On the first connection the agent opens a browser window to complete sign-in, then stores the resulting token.
+*Authentication:* The server is protected by OAuth and requires a one-time sign-in. The first time the agent calls the server, a browser window opens to complete sign-in, after which the agent stores the resulting token. In Claude Code, if no sign-in prompt appears, run `+/mcp+`, select the server, and then select *Authenticate*.
 
 [[install-from-the-documentation-site]]
 === Install from the documentation site
@@ -123,7 +128,7 @@ Add the server to `+opencode.json+`:
 [[other-agents]]
 === Other agents
 
-Agents that accept a remote MCP server without a dedicated configuration file — such as Claude and ChatGPT — can connect using the endpoint directly:
+For any other agent, point its MCP client at the streamable HTTP endpoint and complete the sign-in described above. Agents that accept a remote MCP server without a dedicated configuration file, such as Claude and ChatGPT, can connect using the endpoint directly:
 
 [source,text]
 ----
@@ -133,11 +138,18 @@ https://tinymcedocs.mcp.kapa.ai
 [[read-the-documentation-as-markdown]]
 == Read the documentation as markdown
 
-Every documentation page is also published as markdown, which is more token-efficient than the rendered HTML page. Append `+index.md+` to any documentation page URL to retrieve it:
+Agents can read the documentation efficiently without the MCP server. Every documentation page is also published as markdown, which is more token-efficient than the rendered HTML page. Append `+index.md+` to any documentation page URL to retrieve it:
 
 [source,text]
 ----
 https://www.tiny.cloud/docs/tinymce/latest/basic-setup/index.md
+----
+
+Markdown is available for every documented version of {productname}, not only the latest release. Replace `+latest+` with a version segment to retrieve the markdown for an earlier version:
+
+[source,text]
+----
+https://www.tiny.cloud/docs/tinymce/7/basic-setup/index.md
 ----
 
 Each page also includes a *Copy Markdown* button next to the page title, which copies the markdown URL of the current page to the clipboard for pasting into an agent prompt.
@@ -145,7 +157,7 @@ Each page also includes a *Copy Markdown* button next to the page title, which c
 [[llms-txt-files]]
 == llms.txt files
 
-Two plain text files summarize the documentation set for agents that accept a single bulk reference:
+Two plain text files summarize the documentation set for agents that accept a single bulk reference. Both files index the latest release:
 
 [cols="1,3",options="header"]
 |===

--- a/modules/ROOT/pages/ai-coding-agents.adoc
+++ b/modules/ROOT/pages/ai-coding-agents.adoc
@@ -4,7 +4,7 @@
 :description_short: Connect {productname} to AI coding agents.
 :keywords: ai, skill, agent skills, mcp, model context protocol, coding agent, claude code, cursor, codex, copilot, visual studio code, llms.txt, markdown
 
-AI coding agents produce better {productname} integrations when they work from the current documentation instead of relying on training data. The official *{productname} skill* teaches an agent how to add {productname} to a project: it selects an installation method, wires up the editor, configures plugins and the toolbar, and sets the credential for the chosen distribution channel. Install it with one command:
+The official *{productname} skill* teaches an AI coding agent how to add {productname} to a project: it selects an installation method, wires up the editor, configures plugins and the toolbar, loads the content styles, and sets the API key or license key. Install it with one command:
 
 [source,bash]
 ----
@@ -54,7 +54,7 @@ Copy the `+skills/tinymce/+` directory from the https://github.com/tinymce/skill
 [[connect-the-documentation-mcp-server]]
 == Connect the documentation MCP server
 
-The skill works on its own, but is more effective when the agent can also search the live documentation. The hosted {productname} documentation MCP server exposes semantic search across the published documentation, returning relevant extracts with links to their source pages. Any client that supports the https://modelcontextprotocol.io/[Model Context Protocol] (MCP) over streamable HTTP can connect to it.
+The skill works on its own, but is more effective when the agent can also search the live documentation. The hosted {productname} documentation https://modelcontextprotocol.io/[Model Context Protocol] (MCP) server exposes semantic search across the published documentation, returning relevant extracts with links to their source pages. Any client that supports MCP over streamable HTTP can connect to it.
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/ai-coding-agents.adoc
+++ b/modules/ROOT/pages/ai-coding-agents.adoc
@@ -1,20 +1,60 @@
 = Using {productname} with AI coding agents
 :navtitle: AI coding agents
-:description: Connect the {productname} documentation to AI coding agents using the hosted documentation MCP server, markdown pages, and llms.txt files.
-:description_short: Connect the documentation to AI coding agents.
-:keywords: ai, mcp, model context protocol, coding agent, claude code, cursor, codex, copilot, visual studio code, llms.txt, markdown
+:description: Teach AI coding agents to integrate {productname} using the official skill, the documentation MCP server, markdown pages, and llms.txt files.
+:description_short: Connect {productname} to AI coding agents.
+:keywords: ai, skill, agent skills, mcp, model context protocol, coding agent, claude code, cursor, codex, copilot, visual studio code, llms.txt, markdown
 
-AI coding agents produce better {productname} integrations when they read the current documentation instead of relying on training data. The {productname} documentation is published in three agent-readable forms: a hosted documentation MCP server for semantic search, a markdown version of every page, and `+llms.txt+` files that index the documentation set.
+AI coding agents produce better {productname} integrations when they work from the current documentation instead of relying on training data. The official *{productname} skill* teaches an agent how to add {productname} to a project: it selects an installation method, wires up the editor, configures plugins and the toolbar, and sets the credential for the chosen distribution channel. Install it with one command:
+
+[source,bash]
+----
+npx skills add tinymce/skills
+----
 
 [NOTE]
 ====
-This page describes how to give an AI coding agent access to the {productname} documentation. It does not describe the in-editor AI features. For content generation inside the editor, see xref:tinymceai-introduction.adoc[{productname} AI].
+This page covers agent skills that help integrate {productname} into an application. It does not describe the in-editor AI features. For content generation inside the editor, see xref:tinymceai-introduction.adoc[{productname} AI].
 ====
+
+[[what-the-skill-does]]
+== What the skill does
+
+The skill loads when an agent is asked to install, set up, configure, or troubleshoot {productname}. It will:
+
+* Choose an installation method — {cloudname}, a package manager, or a `+.zip+` package.
+* Wire up the editor in vanilla JavaScript or an official React, Vue, Angular, Svelte, jQuery, web component, or Blazor wrapper.
+* Configure plugins, the toolbar, the menu bar, and content styles.
+* Set the API key or license key correctly for the chosen distribution channel.
+* Send version-specific questions to the live documentation instead of guessing.
+
+The skill deliberately excludes authoring custom plugins, upgrading between major versions, and {productname} 4. For those tasks, see the xref:migration-guides.adoc[migration guides].
+
+[[supported-agents]]
+== Supported agents
+
+The skill uses the open https://agentskills.io/home[Agent Skills] format, so it works in any agent that supports it, including Claude Code, Cursor, Codex, OpenCode, GitHub Copilot, Windsurf, Gemini, Cline, AMP, and Zed. The installer detects the agents present in a project and writes the skill to each.
+
+[[other-ways-to-install]]
+== Other ways to install
+
+[[claude-code-plugin-marketplace]]
+=== Claude Code plugin marketplace
+
+[source,text]
+----
+/plugin marketplace add tinymce/skills
+/plugin install tinymce@tinymce
+----
+
+[[manual-installation]]
+=== Manual installation
+
+Copy the `+skills/tinymce/+` directory from the https://github.com/tinymce/skills[`+tinymce/skills+`] repository into the agent's skills directory, for example `+.claude/skills/tinymce/+`.
 
 [[connect-the-documentation-mcp-server]]
 == Connect the documentation MCP server
 
-The hosted {productname} documentation MCP server exposes semantic search across the published documentation, returning relevant extracts with links to their source pages. Any client that supports the https://modelcontextprotocol.io/[Model Context Protocol] (MCP) over streamable HTTP can connect to it.
+The skill works on its own, but is more effective when the agent can also search the live documentation. The hosted {productname} documentation MCP server exposes semantic search across the published documentation, returning relevant extracts with links to their source pages. Any client that supports the https://modelcontextprotocol.io/[Model Context Protocol] (MCP) over streamable HTTP can connect to it.
 
 [NOTE]
 ====
@@ -177,5 +217,7 @@ Two plain text files summarize the documentation set for agents that accept a si
 
 [[feedback]]
 == Feedback
+
+Report guidance that is wrong, outdated, or missing from the skill by https://github.com/tinymce/skills/issues/new?template=skill-feedback.yml[opening an issue] in the https://github.com/tinymce/skills[`+tinymce/skills+`] repository, using the skill feedback template. Agents are encouraged to file these when the skill contradicts what actually worked.
 
 Report inaccurate or outdated documentation by opening an issue in the https://github.com/tinymce/tinymce-docs/issues[`+tinymce-docs+`] repository.

--- a/modules/ROOT/pages/ai-coding-agents.adoc
+++ b/modules/ROOT/pages/ai-coding-agents.adoc
@@ -1,0 +1,164 @@
+= Using {productname} with AI coding agents
+:navtitle: AI coding agents
+:description: Connect the {productname} documentation to AI coding agents using the hosted documentation MCP server, markdown pages, and llms.txt files.
+:description_short: Connect the documentation to AI coding agents.
+:keywords: ai, mcp, model context protocol, coding agent, claude code, cursor, codex, copilot, visual studio code, llms.txt, markdown
+
+AI coding agents produce better {productname} integrations when they read the current documentation instead of relying on training data. The {productname} documentation is published in three agent-readable forms: a hosted documentation MCP server for semantic search, a markdown version of every page, and `+llms.txt+` files that index the documentation set.
+
+[NOTE]
+====
+This page describes how to give an AI coding agent access to the {productname} documentation. It does not describe the in-editor AI features. For content generation inside the editor, see xref:tinymceai-introduction.adoc[{productname} AI].
+====
+
+[[connect-the-documentation-mcp-server]]
+== Connect the documentation MCP server
+
+The hosted {productname} documentation MCP server exposes semantic search across the published documentation, returning relevant extracts with links to their source pages. Any client that supports the https://modelcontextprotocol.io/[Model Context Protocol] (MCP) over HTTP can connect to it.
+
+*Endpoint:* `+https://tinymcedocs.mcp.kapa.ai+`
+
+*Authentication:* The server is protected by OAuth. On the first connection the agent opens a browser window to complete sign-in, then stores the resulting token.
+
+[[install-from-the-documentation-site]]
+=== Install from the documentation site
+
+Every page of this documentation includes an *Ask AI* widget. Open the widget and select *Use MCP* in the modal header to open the *Connect to AI Tools* menu, which provides copy-to-clipboard install commands, one-click installs for supported editors, and the raw server URL.
+
+The remaining sections describe the equivalent manual configuration.
+
+[[claude-code]]
+=== Claude Code
+
+[source,bash]
+----
+claude mcp add --transport http --scope project tinymce-docs https://tinymcedocs.mcp.kapa.ai
+----
+
+To configure the server manually, add it to `+.mcp.json+`:
+
+[source,json]
+----
+{
+  "mcpServers": {
+    "tinymce-docs": {
+      "type": "http",
+      "url": "https://tinymcedocs.mcp.kapa.ai"
+    }
+  }
+}
+----
+
+[[cursor]]
+=== Cursor
+
+Add the server to `+.cursor/mcp.json+`:
+
+[source,json]
+----
+{
+  "mcpServers": {
+    "tinymce-docs": {
+      "url": "https://tinymcedocs.mcp.kapa.ai"
+    }
+  }
+}
+----
+
+[[codex]]
+=== Codex
+
+[source,bash]
+----
+codex mcp add tinymce-docs --url https://tinymcedocs.mcp.kapa.ai
+----
+
+To configure the server manually, add it to `+~/.codex/config.toml+`:
+
+[source,toml]
+----
+[mcp_servers.tinymce-docs]
+url = "https://tinymcedocs.mcp.kapa.ai"
+startup_timeout_sec = 20
+tool_timeout_sec = 60
+enabled = true
+----
+
+[[visual-studio-code]]
+=== Visual Studio Code
+
+Add the server to `+.vscode/mcp.json+`:
+
+[source,json]
+----
+{
+  "servers": {
+    "tinymce-docs": {
+      "type": "http",
+      "url": "https://tinymcedocs.mcp.kapa.ai"
+    }
+  }
+}
+----
+
+[[opencode]]
+=== OpenCode
+
+Add the server to `+opencode.json+`:
+
+[source,json]
+----
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "tinymce-docs": {
+      "type": "remote",
+      "url": "https://tinymcedocs.mcp.kapa.ai",
+      "enabled": true
+    }
+  }
+}
+----
+
+[[other-agents]]
+=== Other agents
+
+Agents that accept a remote MCP server without a dedicated configuration file — such as Claude and ChatGPT — can connect using the endpoint directly:
+
+[source,text]
+----
+https://tinymcedocs.mcp.kapa.ai
+----
+
+[[read-the-documentation-as-markdown]]
+== Read the documentation as markdown
+
+Every documentation page is also published as markdown, which is more token-efficient than the rendered HTML page. Append `+index.md+` to any documentation page URL to retrieve it:
+
+[source,text]
+----
+https://www.tiny.cloud/docs/tinymce/latest/basic-setup/index.md
+----
+
+Each page also includes a *Copy Markdown* button next to the page title, which copies the markdown URL of the current page to the clipboard for pasting into an agent prompt.
+
+[[llms-txt-files]]
+== llms.txt files
+
+Two plain text files summarize the documentation set for agents that accept a single bulk reference:
+
+[cols="1,3",options="header"]
+|===
+|File |Contents
+
+|https://www.tiny.cloud/docs/llms.txt[`+llms.txt+`]
+|A concise overview of {productname}, with key links and code examples.
+
+|https://www.tiny.cloud/docs/llms-full.txt[`+llms-full.txt+`]
+|A full index of the documentation pages and their URLs.
+|===
+
+[[feedback]]
+== Feedback
+
+Report inaccurate or outdated documentation by opening an issue in the https://github.com/tinymce/tinymce-docs/issues[`+tinymce-docs+`] repository.

--- a/modules/ROOT/pages/ai-coding-agents.adoc
+++ b/modules/ROOT/pages/ai-coding-agents.adoc
@@ -25,6 +25,11 @@ This server provides documentation to an external coding agent. It is not relate
 
 *Authentication:* The server is protected by OAuth and requires a one-time sign-in. The first time the agent calls the server, a browser window opens to complete sign-in, after which the agent stores the resulting token. In Claude Code, if no sign-in prompt appears, run `+/mcp+`, select the server, and then select *Authenticate*.
 
+[IMPORTANT]
+====
+Each agent reads its own configuration file, and the files are not interchangeable. Claude Code reads `+.mcp.json+` and expects an `+mcpServers+` object, while Visual Studio Code reads `+.vscode/mcp.json+` and expects a `+servers+` object. An agent given another agent's file or key name reports no error and exposes no tools from the server. Use the section below that matches the agent in use.
+====
+
 [[install-from-the-documentation-site]]
 === Install from the documentation site
 

--- a/modules/ROOT/pages/ai-coding-agents.adoc
+++ b/modules/ROOT/pages/ai-coding-agents.adoc
@@ -1,60 +1,22 @@
-= Using {productname} with AI coding agents
-:navtitle: Build with AI
-:description: Teach AI coding agents to integrate {productname} using the official skill, the documentation MCP server, markdown pages, and llms.txt files.
-:description_short: Connect {productname} to AI coding agents.
-:keywords: ai, skill, agent skills, mcp, model context protocol, coding agent, claude code, cursor, codex, copilot, visual studio code, llms.txt, markdown
+= Connecting AI coding agents to the {productname} documentation
+:navtitle: Documentation for AI agents
+:description: Give AI coding agents access to the {productname} documentation through the documentation MCP server, Context7, markdown pages, and llms.txt files.
+:description_short: Give AI coding agents access to the {productname} documentation.
+:keywords: ai, mcp, model context protocol, coding agent, claude code, cursor, codex, copilot, visual studio code, context7, llms.txt, markdown
 
-The official *{productname} skill* teaches an AI coding agent how to add {productname} to a project: it selects an installation method, wires up the editor, configures plugins and the toolbar, loads the content styles, and sets the API key or license key. Install it with one command:
+An AI coding agent works from its training data unless it is given something better. This page describes the ways to put the current {productname} documentation in front of an agent: a documentation https://modelcontextprotocol.io/[Model Context Protocol] (MCP) server, markdown versions of every page, and the `+llms.txt+` summaries. Each method applies to any {productname} installation, whether it is served from the {cloudname} or self-hosted.
 
-[source,bash]
-----
-npx skills add tinymce/skills
-----
+TIP: To add {productname} to a project with an AI coding agent, see the xref:cloud-quick-start-ai.adoc[{cloudname} AI quick start guide].
 
 [NOTE]
 ====
-This page covers agent skills that help integrate {productname} into an application. It does not describe the in-editor AI features. For content generation inside the editor, see xref:tinymceai-introduction.adoc[{productname} AI].
+This page covers giving external coding agents access to this documentation. It does not describe the in-editor AI features. For content generation inside the editor, see xref:tinymceai-introduction.adoc[{productname} AI].
 ====
-
-[[what-the-skill-does]]
-== What the skill does
-
-The skill loads when an agent is asked to install, set up, configure, or troubleshoot {productname}. It will:
-
-* Choose an installation method — {cloudname}, a package manager, or a `+.zip+` package.
-* Wire up the editor in vanilla JavaScript or an official React, Vue, Angular, Svelte, jQuery, web component, or Blazor wrapper.
-* Configure plugins, the toolbar, the menu bar, and content styles.
-* Set the API key or license key correctly for the chosen distribution channel.
-* Send version-specific questions to the live documentation instead of guessing.
-
-The skill deliberately excludes authoring custom plugins, upgrading between major versions, and {productname} 4. For those tasks, see the xref:migration-guides.adoc[migration guides].
-
-[[supported-agents]]
-== Supported agents
-
-The skill uses the open https://agentskills.io/home[Agent Skills] format, so it works in any agent that supports it, including Claude Code, Cursor, Codex, OpenCode, GitHub Copilot, Windsurf, Gemini, Cline, AMP, and Zed. The installer detects the agents present in a project and writes the skill to each.
-
-[[other-ways-to-install]]
-== Other ways to install
-
-[[claude-code-plugin-marketplace]]
-=== Claude Code plugin marketplace
-
-[source,text]
-----
-/plugin marketplace add tinymce/skills
-/plugin install tinymce@tinymce
-----
-
-[[manual-installation]]
-=== Manual installation
-
-Copy the `+skills/tinymce/+` directory from the https://github.com/tinymce/skills[`+tinymce/skills+`] repository into the agent's skills directory, for example `+.claude/skills/tinymce/+`.
 
 [[connect-the-documentation-mcp-server]]
 == Connect the documentation MCP server
 
-The skill works on its own, but is more effective when the agent can also search the live documentation. The hosted {productname} documentation https://modelcontextprotocol.io/[Model Context Protocol] (MCP) server exposes semantic search across the published documentation, returning relevant extracts with links to their source pages. Any client that supports MCP over streamable HTTP can connect to it. This server supplies documentation to an external coding agent, and is separate from the MCP tool calling available to the {productname} AI service, described in xref:tinymceai-on-premises-mcp.adoc[MCP and web integrations].
+The hosted {productname} documentation MCP server exposes semantic search across the published documentation, returning relevant extracts with links to their source pages. Any client that supports MCP over streamable HTTP can connect to it. This server supplies documentation to an external coding agent, and is separate from the MCP tool calling available to the {productname} AI service, described in xref:tinymceai-on-premises-mcp.adoc[MCP and web integrations].
 
 *Endpoint:* `+https://tinymcedocs.mcp.kapa.ai+`
 
@@ -62,7 +24,7 @@ The skill works on its own, but is more effective when the agent can also search
 
 [IMPORTANT]
 ====
-Each agent reads its own configuration file, and the files are not interchangeable. Claude Code reads `+.mcp.json+` and expects an `+mcpServers+` object, while Visual Studio Code reads `+.vscode/mcp.json+` and expects a `+servers+` object. An agent given another agent's file or key name reports no error and exposes no tools from the server. Use the section below that matches the agent in use.
+Each agent reads its own configuration file, and the files are not interchangeable. Claude Code reads `+.mcp.json+` and expects an `+mcpServers+` object, while Visual Studio Code reads `+.vscode/mcp.json+` and expects a `+servers+` object. An agent given another agent's file or key name reports no error and exposes no tools from the server. Expand the entry below that matches the agent in use.
 ====
 
 [[install-from-the-documentation-site]]
@@ -70,11 +32,17 @@ Each agent reads its own configuration file, and the files are not interchangeab
 
 Every page of this documentation includes an *Ask AI* widget. Open the widget and select *Use MCP* in the modal header to open the *Connect to AI Tools* menu, which provides copy-to-clipboard install commands, one-click installs for supported editors, and the raw server URL.
 
-The remaining sections describe the equivalent manual configuration.
+The entries below describe the equivalent manual configuration.
+
+[[manual-mcp-configuration]]
+=== Manual configuration by agent
+
+Each agent below is configured independently. Expand the entry for the agent in use.
 
 [[claude-code]]
-=== Claude Code
-
+.Claude Code
+[%collapsible]
+====
 [source,bash]
 ----
 claude mcp add --transport http --scope project tinymce-docs https://tinymcedocs.mcp.kapa.ai
@@ -93,10 +61,12 @@ To configure the server manually, add it to `+.mcp.json+`:
   }
 }
 ----
+====
 
 [[cursor]]
-=== Cursor
-
+.Cursor
+[%collapsible]
+====
 Add the server to `+.cursor/mcp.json+`:
 
 [source,json]
@@ -109,10 +79,12 @@ Add the server to `+.cursor/mcp.json+`:
   }
 }
 ----
+====
 
 [[codex]]
-=== Codex
-
+.Codex
+[%collapsible]
+====
 [source,bash]
 ----
 codex mcp add tinymce-docs --url https://tinymcedocs.mcp.kapa.ai
@@ -128,10 +100,12 @@ startup_timeout_sec = 20
 tool_timeout_sec = 60
 enabled = true
 ----
+====
 
 [[visual-studio-code]]
-=== Visual Studio Code
-
+.Visual Studio Code
+[%collapsible]
+====
 Add the server to `+.vscode/mcp.json+`:
 
 [source,json]
@@ -145,10 +119,12 @@ Add the server to `+.vscode/mcp.json+`:
   }
 }
 ----
+====
 
 [[opencode]]
-=== OpenCode
-
+.OpenCode
+[%collapsible]
+====
 Add the server to `+opencode.json+`:
 
 [source,json]
@@ -164,16 +140,28 @@ Add the server to `+opencode.json+`:
   }
 }
 ----
+====
 
 [[other-agents]]
-=== Other agents
-
+.Other agents
+[%collapsible]
+====
 For any other agent, point its MCP client at the streamable HTTP endpoint and complete the sign-in described above. Agents that accept a remote MCP server without a dedicated configuration file, such as Claude and ChatGPT, can connect using the endpoint directly:
 
 [source,text]
 ----
 https://tinymcedocs.mcp.kapa.ai
 ----
+====
+
+[[context7]]
+== Connect Context7
+
+https://context7.com/[Context7] is a general-purpose documentation MCP server that also indexes the {productname} documentation. Where the {productname} documentation MCP server returns extracts from the published site, Context7 serves version-specific library documentation across many projects from a single server, which suits an agent already using it for other libraries.
+
+*Library:* `+tinymce/docs+` at https://context7.com/tinymce/tinymce-docs[`+context7.com/tinymce/tinymce-docs+`]
+
+Configure Context7 following its own installation instructions, then reference the `+tinymce/docs+` library in prompts so the agent resolves {productname} questions against it.
 
 [[read-the-documentation-as-markdown]]
 == Read the documentation as markdown
@@ -213,6 +201,4 @@ Two plain text files summarize the documentation set for agents that accept a si
 [[feedback]]
 == Feedback
 
-Report guidance that is wrong, outdated, or missing from the skill by https://github.com/tinymce/skills/issues/new?template=skill-feedback.yml[opening an issue] in the https://github.com/tinymce/skills[`+tinymce/skills+`] repository, using the skill feedback template. Agents are encouraged to file these when the skill contradicts what actually worked.
-
-Report inaccurate or outdated documentation by opening an issue in the https://github.com/tinymce/tinymce-docs/issues[`+tinymce-docs+`] repository.
+Report inaccurate or outdated documentation by opening an issue in the https://github.com/tinymce/tinymce-docs/issues[`+tinymce-docs+`] repository. Agents are encouraged to file these when the documentation contradicts what actually worked.

--- a/modules/ROOT/pages/ai-coding-agents.adoc
+++ b/modules/ROOT/pages/ai-coding-agents.adoc
@@ -1,5 +1,5 @@
 = Using {productname} with AI coding agents
-:navtitle: AI coding agents
+:navtitle: Build with AI
 :description: Teach AI coding agents to integrate {productname} using the official skill, the documentation MCP server, markdown pages, and llms.txt files.
 :description_short: Connect {productname} to AI coding agents.
 :keywords: ai, skill, agent skills, mcp, model context protocol, coding agent, claude code, cursor, codex, copilot, visual studio code, llms.txt, markdown

--- a/modules/ROOT/pages/ai-coding-agents.adoc
+++ b/modules/ROOT/pages/ai-coding-agents.adoc
@@ -54,12 +54,7 @@ Copy the `+skills/tinymce/+` directory from the https://github.com/tinymce/skill
 [[connect-the-documentation-mcp-server]]
 == Connect the documentation MCP server
 
-The skill works on its own, but is more effective when the agent can also search the live documentation. The hosted {productname} documentation https://modelcontextprotocol.io/[Model Context Protocol] (MCP) server exposes semantic search across the published documentation, returning relevant extracts with links to their source pages. Any client that supports MCP over streamable HTTP can connect to it.
-
-[NOTE]
-====
-This server provides documentation to an external coding agent. It is not related to the MCP tool calling available to the {productname} AI service, which is described in xref:tinymceai-on-premises-mcp.adoc[MCP and web integrations].
-====
+The skill works on its own, but is more effective when the agent can also search the live documentation. The hosted {productname} documentation https://modelcontextprotocol.io/[Model Context Protocol] (MCP) server exposes semantic search across the published documentation, returning relevant extracts with links to their source pages. Any client that supports MCP over streamable HTTP can connect to it. This server supplies documentation to an external coding agent, and is separate from the MCP tool calling available to the {productname} AI service, described in xref:tinymceai-on-premises-mcp.adoc[MCP and web integrations].
 
 *Endpoint:* `+https://tinymcedocs.mcp.kapa.ai+`
 

--- a/modules/ROOT/pages/ai-coding-agents.adoc
+++ b/modules/ROOT/pages/ai-coding-agents.adoc
@@ -205,4 +205,4 @@ Two plain text files summarize the documentation set for agents that accept a si
 [[feedback]]
 == Feedback
 
-Report inaccurate or outdated documentation by opening an issue in the https://github.com/tinymce/tinymce-docs/issues[`+tinymce-docs+`] repository. Agents are encouraged to file these when the documentation contradicts what actually worked.
+Report inaccurate or outdated documentation by opening an issue in the https://github.com/tinymce/tinymce-docs/issues[tinymce-docs GitHub repository]. Agents are encouraged to file these when the documentation contradicts what actually worked.

--- a/modules/ROOT/pages/ai-coding-agents.adoc
+++ b/modules/ROOT/pages/ai-coding-agents.adoc
@@ -13,11 +13,6 @@ An AI coding agent works from its training data unless it is given something bet
 
 TIP: To add {productname} to a project with an AI coding agent, see the xref:cloud-quick-start-ai.adoc[{cloudname} AI quick start guide].
 
-[TIP]
-====
-This page covers giving an external coding agent access to this documentation. It does not cover the AI features inside the editor. For the MCP tool calling and web integrations available to the {productname} AI service, see xref:tinymceai-on-premises-mcp.adoc[MCP and web integrations]. For content generation inside the editor, see xref:tinymceai-introduction.adoc[{productname} AI].
-====
-
 [[connect-the-documentation-mcp-server]]
 == Connect the {productname} documentation MCP server
 

--- a/modules/ROOT/pages/ai-coding-agents.adoc
+++ b/modules/ROOT/pages/ai-coding-agents.adoc
@@ -1,26 +1,31 @@
 = Connecting AI coding agents to the {productname} documentation
-:navtitle: Documentation for AI agents
+:navtitle: Connect AI agents to the documentation
 :description: Give AI coding agents access to the {productname} documentation through the documentation MCP server, Context7, markdown pages, and llms.txt files.
 :description_short: Give AI coding agents access to the {productname} documentation.
 :keywords: ai, mcp, model context protocol, coding agent, claude code, cursor, codex, copilot, visual studio code, context7, llms.txt, markdown
 
-An AI coding agent works from its training data unless it is given something better. This page describes the ways to put the current {productname} documentation in front of an agent: a documentation https://modelcontextprotocol.io/[Model Context Protocol] (MCP) server, markdown versions of every page, and the `+llms.txt+` summaries. Each method applies to any {productname} installation, whether it is served from the {cloudname} or self-hosted.
+An AI coding agent works from its training data unless it is given something better. This page describes four ways to put the current {productname} documentation in front of an agent. They are alternatives rather than steps, and any of them can be used together. Each applies to any {productname} installation, whether it is served from the {cloudname} or self-hosted.
+
+* xref:#connect-the-documentation-mcp-server[{productname} documentation MCP server] -- a hosted https://modelcontextprotocol.io/[Model Context Protocol] (MCP) server that serves this documentation and nothing else. Suits any agent that supports MCP.
+* xref:#context7[Context7] -- a general-purpose documentation MCP server that also indexes the {productname} documentation. Suits an agent already using Context7 for other libraries.
+* xref:#read-the-documentation-as-markdown[Markdown pages] -- every documentation page is also published as markdown at its own URL. Suits an agent without MCP support, or a prompt that already names the page.
+* xref:#llms-txt-files[`+llms.txt+` files] -- two plain text summaries of the whole documentation set, for an agent that accepts a single bulk reference.
 
 TIP: To add {productname} to a project with an AI coding agent, see the xref:cloud-quick-start-ai.adoc[{cloudname} AI quick start guide].
 
-[NOTE]
+[TIP]
 ====
-This page covers giving external coding agents access to this documentation. It does not describe the in-editor AI features. For content generation inside the editor, see xref:tinymceai-introduction.adoc[{productname} AI].
+This page covers giving an external coding agent access to this documentation. It does not cover the AI features inside the editor. For the MCP tool calling and web integrations available to the {productname} AI service, see xref:tinymceai-on-premises-mcp.adoc[MCP and web integrations]. For content generation inside the editor, see xref:tinymceai-introduction.adoc[{productname} AI].
 ====
 
 [[connect-the-documentation-mcp-server]]
-== Connect the documentation MCP server
+== Connect the {productname} documentation MCP server
 
-The hosted {productname} documentation MCP server exposes semantic search across the published documentation, returning relevant extracts with links to their source pages. Any client that supports MCP over streamable HTTP can connect to it. This server supplies documentation to an external coding agent, and is separate from the MCP tool calling available to the {productname} AI service, described in xref:tinymceai-on-premises-mcp.adoc[MCP and web integrations].
+The {productname} documentation MCP server is hosted by Tiny and serves this documentation set alone. It exposes semantic search across the published pages, returning relevant extracts with links to their source. Any client that supports MCP over streamable HTTP can connect to it.
 
 *Endpoint:* `+https://tinymcedocs.mcp.kapa.ai+`
 
-*Authentication:* The server is protected by OAuth and requires a one-time sign-in. The first time the agent calls the server, a browser window opens to complete sign-in, after which the agent stores the resulting token. In Claude Code, if no sign-in prompt appears, run `+/mcp+`, select the server, and then select *Authenticate*.
+*Authentication:* The server is protected by OAuth and requires a one-time sign-in. The first time the agent calls the server, a browser window opens to complete sign-in, after which the agent stores the resulting token. If no sign-in prompt appears, trigger authentication from the agent's own MCP configuration, as described in the entry for that agent below.
 
 [IMPORTANT]
 ====
@@ -43,6 +48,8 @@ Each agent below is configured independently. Expand the entry for the agent in 
 .Claude Code
 [%collapsible]
 ====
+If no sign-in prompt appears, run `+/mcp+`, select the server, and then select *Authenticate*.
+
 [source,bash]
 ----
 claude mcp add --transport http --scope project tinymce-docs https://tinymcedocs.mcp.kapa.ai
@@ -157,7 +164,7 @@ https://tinymcedocs.mcp.kapa.ai
 [[context7]]
 == Connect Context7
 
-https://context7.com/[Context7] is a general-purpose documentation MCP server that also indexes the {productname} documentation. Where the {productname} documentation MCP server returns extracts from the published site, Context7 serves version-specific library documentation across many projects from a single server, which suits an agent already using it for other libraries.
+https://context7.com/[Context7] is a general-purpose documentation MCP server that serves version-specific library documentation for many projects, including {productname}, from a single server. An agent already using Context7 for other libraries can reach the {productname} documentation without adding a second server.
 
 *Library:* `+tinymce/docs+` at https://context7.com/tinymce/tinymce-docs[`+context7.com/tinymce/tinymce-docs+`]
 
@@ -179,6 +186,8 @@ Markdown is available for every documented version of {productname}, not only th
 ----
 https://www.tiny.cloud/docs/tinymce/7/basic-setup/index.md
 ----
+
+The current major version is always served from `+latest+`. A request for that version by number, such as `+/docs/tinymce/{productmajorversion}/basic-setup/index.md+`, redirects to its `+latest+` address, so an agent retrieving markdown by version number needs to follow redirects. Earlier versions are served directly.
 
 Each page also includes a *Copy Markdown* button next to the page title, which copies the markdown URL of the current page to the clipboard for pasting into an agent prompt.
 

--- a/modules/ROOT/pages/cloud-quick-start-ai.adoc
+++ b/modules/ROOT/pages/cloud-quick-start-ai.adoc
@@ -1,0 +1,162 @@
+= Quick start: {productname} from {cloudname} with an AI coding agent
+:navtitle: AI quick start guide
+:description_short: Add {productname} {productmajorversion} from the {cloudname} using the official agent skill.
+:description: Add a {productname} {productmajorversion} editor to an application by installing the official agent skill and asking an AI coding agent to do the setup, then connect a documentation MCP server to configure the editor further.
+:keywords: quick start, ai, agent skill, agent skills, coding agent, mcp, model context protocol, claude code, cursor, codex, copilot, context7, kapa, cloud
+:productSource: cloud
+
+{productname} {productmajorversion} is a powerful and flexible rich text editor that can be embedded in web applications. This quick start covers how to add a {productname} editor to an application by installing the official https://github.com/tinymce/tinymce-ai-skills[{productname} agent skill] and letting an AI coding agent perform the setup.
+
+TIP: For the equivalent step-by-step setup without an AI coding agent, see the xref:cloud-quick-start.adoc[{cloudname} quick start guide].
+
+include::partial$misc/admon-account-creation-and-social-option.adoc[]
+
+[[install-the-skill]]
+== Install the {productname} skill
+
+The official {productname} skill teaches an AI coding agent how to add {productname} to a project. Install it into the agent (Claude Code, Codex, Cursor, GitHub Copilot, and others) with a single command:
+
+[source,bash]
+----
+npx skills add tinymce/tinymce-ai-skills
+----
+
+The installer detects the agents present in the project and writes the skill to each. The skill uses the open https://agentskills.io/[Agent Skills] format, so it works in any agent that supports that format.
+
+Once installed, the skill loads on its own whenever the agent is asked to install, set up, configure, or troubleshoot {productname}. No extra prompting is required.
+
+To install without the command-line interface, follow the per-agent instructions under *Manual installation* in the https://github.com/tinymce/tinymce-ai-skills[`+tinymce/tinymce-ai-skills+`] README. Report guidance that is wrong, outdated, or missing from the skill by https://github.com/tinymce/tinymce-ai-skills/issues[opening an issue] in the same repository.
+
+[[add-the-editor]]
+== Add {productname} to an application
+
+Ask the agent to add {productname} wherever a rich text editor is needed, for example:
+
+[quote]
+____
+Add a {productname} editor to the comment box on my post page.
+____
+
+The skill guides the agent through the whole setup: detecting the environment (vanilla JavaScript or a framework such as React, Next.js, Vue, or Angular), generating the integration code, recommending plugins for the use case, and wiring in the API key. During setup the agent prompts for a {cloudname} API key, which is created when signing up to the link:{accountsignup}/[{cloudname}]. Signing up also provides a trial of the xref:plugins.adoc#premium-plugins[Premium Plugins].
+
+The result is a working, correctly configured editor. For a vanilla JavaScript project using the full set of {cloudname} plugins, the generated page resembles the following:
+
+[source,html,subs="attributes+"]
+----
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <script src="{cdnurl}" referrerpolicy="origin" crossorigin="anonymous"></script>
+  </head>
+
+  <body>
+    <textarea id="mytextarea">Hello, World!</textarea>
+    <script>
+      tinymce.init({
+        selector: '#mytextarea',
+        plugins: [
+          // Core editing features
+          'anchor', 'autolink', 'charmap', 'codesample', 'emoticons', 'link', 'lists',
+          'media', 'searchreplace', 'table', 'visualblocks', 'wordcount',
+          // Premium features
+          'checklist', 'mediaembed', 'casechange', 'formatpainter', 'pageembed',
+          'a11ychecker', 'tinymcespellchecker', 'permanentpen', 'powerpaste', 'advtable',
+          'advcode', 'advtemplate', 'tinymceai', 'uploadcare', 'mentions', 'tinycomments',
+          'tableofcontents', 'footnotes', 'mergetags', 'autocorrect', 'typography',
+          'inlinecss', 'markdown', 'importword', 'exportword', 'exportpdf'
+        ],
+        toolbar: 'undo redo | tinymceai-chat tinymceai-quickactions tinymceai-review | blocks fontfamily fontsize | bold italic underline strikethrough | link media table mergetags | addcomment showcomments | spellcheckdialog a11ycheck typography uploadcare | align lineheight | checklist numlist bullist indent outdent | emoticons charmap | removeformat',
+
+        // Comments: 'embedded' stores comments in the content, with no server required
+        tinycomments_mode: 'embedded',
+
+        // Merge Tags: without a list, the toolbar button and menu item are hidden
+        mergetags_list: [
+          { value: 'Person.Name.First', title: 'First name' },
+          { value: 'Person.Name.Last', title: 'Last name' },
+          { value: 'Person.Email', title: 'Email' }
+        ],
+
+        // Advanced Templates: returns the template categories to offer
+        advtemplate_list: () => Promise.resolve([
+          {
+            id: 'general',
+            title: 'General',
+            items: [
+              { id: 'signoff', title: 'Sign-off', content: '<p>Kind regards,</p>' }
+            ]
+          }
+        ]),
+
+        // Mentions: replace with a request to a user directory
+        mentions_fetch: (query, success) => success([
+          { id: 'ada', name: 'Ada Lovelace' },
+          { id: 'alan', name: 'Alan Turing' }
+        ].filter((user) => user.name.toLowerCase().includes(query.term.toLowerCase()))),
+
+        // TinyMCE AI: the trial demo identity service issues tokens during evaluation
+        tinymceai_token_provider: async () => {
+          await fetch('https://demo.api.tiny.cloud/1/no-api-key/auth/random', { method: 'POST', credentials: 'include' });
+          return await fetch('https://demo.api.tiny.cloud/1/no-api-key/jwt/tinymceai', { credentials: 'include' })
+            .then((resp) => resp.text())
+            .then((token) => ({ token }));
+        },
+
+        // Media Optimizer: replace with an Uploadcare public key
+        uploadcare_public_key: 'your-uploadcare-public-key'
+      });
+    </script>
+  </body>
+</html>
+----
+
+Replace the `+no-api-key+` placeholder in the script URL with the API key. The premium plugins above require a {cloudname} plan or trial that includes them.
+
+Two options in this configuration need values that are specific to the account before the plugin they belong to will work:
+
+* `+uploadcare_public_key+` requires an Uploadcare public key, available from the link:{accountpageurl}/media-optimizer/[{accountpage}]. See xref:uploadcare.adoc[Media Optimizer].
+* `+tinymceai_token_provider+` uses the trial demo identity service above, which is intended for evaluation only. For production, return a token from an application endpoint. See xref:tinymceai-jwt-authentication-intro.adoc[{productname} AI JWT authentication].
+
+The remaining options are mandatory for their plugins and are shown with working values that can be replaced with real data: `+tinycomments_mode+`, `+mergetags_list+`, `+advtemplate_list+`, and `+mentions_fetch+`.
+
+[[approve-the-domain]]
+== Approve the application domain
+
+An application served from any origin other than `+localhost+` requires its domain to be added to the approved domains stored against the API key. Add the domain on the link:{accountpageurl}/domains/[{accountpage}] to clear the following notice on the editor:
+
+[WARNING]
+====
+**This domain is not registered with {cloudname}. Please see the quick start guide or create an account.**
+====
+
+Local development on `+localhost+` works without this step, so it can be deferred until the application is deployed or served from a custom host. For the diagnostic steps when the notice persists, see xref:cloud-troubleshooting.adoc#domain-not-registered[Domain not registered].
+
+[[connect-live-documentation]]
+== Configure further using live documentation
+
+Taking the configuration deeper, by adding plugins, tailoring toolbars and menus, or refining behavior against the current API, is more reliable when the agent reads the published documentation instead of relying on its training data. Connect one of the following https://modelcontextprotocol.io/[Model Context Protocol] (MCP) servers:
+
+[cols="1,3",options="header"]
+|===
+|Server |Description
+
+|https://tinymcedocs.mcp.kapa.ai[{productname} documentation MCP]
+|Semantic search across the published {productname} documentation, returning relevant extracts with links to their source pages. For the endpoint, authentication, and per-agent configuration, see xref:ai-coding-agents.adoc#connect-the-documentation-mcp-server[Connect the documentation MCP server].
+
+|https://context7.com/tinymce/tinymce-docs[Context7]
+|A general-purpose documentation MCP server. Point it at the `+tinymce/docs+` library to serve version-specific {productname} documentation to the agent. The skill checks for Context7 before generating code, so this is the server it uses when both are available.
+|===
+
+With a server connected, ask the agent for the change required and it applies the change using current guidance, for example:
+
+[quote]
+____
+Add the Table and Word Count plugins, and put a word counter in the status bar.
+____
+
+Agents that do not support MCP can read the documentation as markdown or from the `+llms.txt+` files instead. See xref:ai-coding-agents.adoc#read-the-documentation-as-markdown[Read the documentation as markdown].
+
+include::partial$misc/quickstart-next-steps.adoc[]

--- a/modules/ROOT/pages/cloud-quick-start-ai.adoc
+++ b/modules/ROOT/pages/cloud-quick-start-ai.adoc
@@ -9,8 +9,6 @@
 
 TIP: For the equivalent step-by-step setup without an AI coding agent, see the xref:cloud-quick-start.adoc[{cloudname} quick start guide].
 
-include::partial$misc/admon-account-creation-and-social-option.adoc[]
-
 [[install-the-skill]]
 == Install the {productname} skill
 
@@ -37,100 +35,19 @@ ____
 Add a {productname} editor to the comment box on my post page.
 ____
 
-The skill guides the agent through the whole setup: detecting the environment (vanilla JavaScript or a framework such as React, Next.js, Vue, or Angular), generating the integration code, recommending plugins for the use case, and wiring in the API key. During setup the agent prompts for a {cloudname} API key, which is created when signing up to the link:{accountsignup}/[{cloudname}]. Signing up also provides a trial of the xref:plugins.adoc#premium-plugins[Premium Plugins].
+The skill takes the agent through the whole setup:
 
-The result is a working, correctly configured editor. For a vanilla JavaScript project using the full set of {cloudname} plugins, the generated page resembles the following:
+* Detecting the environment, whether that is vanilla JavaScript or a framework such as React, Next.js, Vue, or Angular.
+* Prompting for the {cloudname} account that supplies the API key. An account is created by signing up to the link:{accountsignup}/[{cloudname}], which also provides a trial of the xref:plugins.adoc#premium-plugins[Premium Plugins].
+* Selecting the plugins, toolbar, and menu that suit the use case.
+* Generating the integration code, wiring in the API key, and setting the options that the selected plugins require.
 
-[source,html,subs="attributes+"]
-----
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-
-    <script src="{cdnurl}" referrerpolicy="origin" crossorigin="anonymous"></script>
-  </head>
-
-  <body>
-    <textarea id="mytextarea">Hello, World!</textarea>
-    <script>
-      tinymce.init({
-        selector: '#mytextarea',
-        plugins: [
-          // Core editing features
-          'anchor', 'autolink', 'charmap', 'codesample', 'emoticons', 'link', 'lists',
-          'media', 'searchreplace', 'table', 'visualblocks', 'wordcount',
-          // Premium features
-          'checklist', 'mediaembed', 'casechange', 'formatpainter', 'pageembed',
-          'a11ychecker', 'tinymcespellchecker', 'permanentpen', 'powerpaste', 'advtable',
-          'advcode', 'advtemplate', 'tinymceai', 'uploadcare', 'mentions', 'tinycomments',
-          'tableofcontents', 'footnotes', 'mergetags', 'autocorrect', 'typography',
-          'inlinecss', 'markdown', 'importword', 'exportword', 'exportpdf'
-        ],
-        toolbar: 'undo redo | tinymceai-chat tinymceai-quickactions tinymceai-review | blocks fontfamily fontsize | bold italic underline strikethrough | link media table mergetags | addcomment showcomments | spellcheckdialog a11ycheck typography uploadcare | align lineheight | checklist numlist bullist indent outdent | emoticons charmap | removeformat',
-
-        // Comments: 'embedded' stores comments in the content, with no server required
-        tinycomments_mode: 'embedded',
-
-        // Merge Tags: without a list, the toolbar button and menu item are hidden
-        mergetags_list: [
-          { value: 'Person.Name.First', title: 'First name' },
-          { value: 'Person.Name.Last', title: 'Last name' },
-          { value: 'Person.Email', title: 'Email' }
-        ],
-
-        // Advanced Templates: returns the template categories to offer
-        advtemplate_list: () => Promise.resolve([
-          {
-            id: 'general',
-            title: 'General',
-            items: [
-              { id: 'signoff', title: 'Sign-off', content: '<p>Kind regards,</p>' }
-            ]
-          }
-        ]),
-
-        // Mentions: replace with a request to a user directory
-        mentions_fetch: (query, success) => success([
-          { id: 'ada', name: 'Ada Lovelace' },
-          { id: 'alan', name: 'Alan Turing' }
-        ].filter((user) => user.name.toLowerCase().includes(query.term.toLowerCase()))),
-
-        // TinyMCE AI: the trial demo identity service issues tokens during evaluation
-        tinymceai_token_provider: async () => {
-          await fetch('https://demo.api.tiny.cloud/1/no-api-key/auth/random', { method: 'POST', credentials: 'include' });
-          return await fetch('https://demo.api.tiny.cloud/1/no-api-key/jwt/tinymceai', { credentials: 'include' })
-            .then((resp) => resp.text())
-            .then((token) => ({ token }));
-        },
-
-        // Media Optimizer: replace with an Uploadcare public key
-        uploadcare_public_key: 'your-uploadcare-public-key'
-      });
-    </script>
-  </body>
-</html>
-----
-
-Replace the `+no-api-key+` placeholder in the script URL with the API key. The premium plugins above require a {cloudname} plan or trial that includes them.
-
-Two options in this configuration need values that are specific to the account before the plugin they belong to will work:
-
-* `+uploadcare_public_key+` requires an Uploadcare public key, available from the link:{accountpageurl}/media-optimizer/[{accountpage}]. See xref:uploadcare.adoc[Media Optimizer].
-* `+tinymceai_token_provider+` uses the trial demo identity service above, which is intended for evaluation only. For production, return a token from an application endpoint. See xref:tinymceai-jwt-authentication-intro.adoc[{productname} AI JWT authentication].
-
-The remaining options are mandatory for their plugins and are shown with working values that can be replaced with real data: `+tinycomments_mode+`, `+mergetags_list+`, `+advtemplate_list+`, and `+mentions_fetch+`.
+The result is an editor configured for the project at hand, rather than a generic configuration to be adapted afterwards.
 
 [[approve-the-domain]]
 == Approve the application domain
 
-An application served from any origin other than `+localhost+` requires its domain to be added to the approved domains stored against the API key. Add the domain on the link:{accountpageurl}/domains/[{accountpage}] to clear the following notice on the editor:
-
-[WARNING]
-====
-**This domain is not registered with {cloudname}. Please see the quick start guide or create an account.**
-====
+An application served from any origin other than `+localhost+` requires its domain to be added to the approved domains stored against the API key. Until the domain is approved, the editor displays the notice "This domain is not registered with {cloudname}. Please see the quick start guide or create an account." Add the domain on the link:{accountpageurl}/domains/[{accountpage}] to clear it.
 
 Local development on `+localhost+` works without this step, so it can be deferred until the application is deployed or served from a custom host. For the diagnostic steps when the notice persists, see xref:cloud-troubleshooting.adoc#domain-not-registered[Domain not registered].
 

--- a/modules/ROOT/pages/cloud-quick-start-ai.adoc
+++ b/modules/ROOT/pages/cloud-quick-start-ai.adoc
@@ -56,11 +56,20 @@ Taking the configuration deeper, by adding plugins, tailoring toolbars and menus
 |Server |Description
 
 |https://tinymcedocs.mcp.kapa.ai[{productname} documentation MCP]
-|Semantic search across the published {productname} documentation, returning relevant extracts with links to their source pages. For the endpoint, authentication, and per-agent configuration, see xref:ai-coding-agents.adoc#connect-the-documentation-mcp-server[Connect the documentation MCP server].
+|Semantic search across the published {productname} documentation, returning relevant extracts with links to their source pages. For the per-agent configuration files, see xref:ai-coding-agents.adoc#connect-the-documentation-mcp-server[Connect the {productname} documentation MCP server].
 
 |https://context7.com/tinymce/tinymce-docs[Context7]
 |A general-purpose documentation MCP server. Point it at the `+tinymce/docs+` library to serve version-specific {productname} documentation to the agent. The skill checks for Context7 before generating code, so this is the server it uses when both are available.
 |===
+
+To connect the {productname} documentation MCP server, point the agent's MCP client at the following endpoint and complete the one-time OAuth sign-in:
+
+[source,text]
+----
+https://tinymcedocs.mcp.kapa.ai
+----
+
+Copy-to-clipboard install commands and one-click installs for supported editors are also available from the *Ask AI* widget on any documentation page, under *Use MCP*.
 
 With a server connected, ask the agent for the change required and it applies the change using current guidance, for example:
 

--- a/modules/ROOT/pages/cloud-quick-start-ai.adoc
+++ b/modules/ROOT/pages/cloud-quick-start-ai.adoc
@@ -12,18 +12,18 @@ TIP: For the equivalent step-by-step setup without an AI coding agent, see the x
 [[install-the-skill]]
 == Install the {productname} skill
 
-The official {productname} skill teaches an AI coding agent how to add {productname} to a project. Install it into the agent (Claude Code, Codex, Cursor, GitHub Copilot, and others) with a single command:
+The official {productname} skill teaches an AI coding agent how to add {productname} to a project. From the project directory, install it into the agent (Claude Code, Codex, Cursor, GitHub Copilot, and others) with a single command:
 
 [source,bash]
 ----
 npx skills add tinymce/tinymce-ai-skills
 ----
 
-The installer detects the agents present in the project and writes the skill to each. The skill uses the open https://agentskills.io/[Agent Skills] format, so it works in any agent that supports that format.
+The installer downloads the skill, detects the agents present in the project, and writes the skill to each. Cloning the repository beforehand is not required. The skill uses the open https://agentskills.io/[Agent Skills] format, so it works in any agent that supports that format.
 
 Once installed, the skill loads on its own whenever the agent is asked to install, set up, configure, or troubleshoot {productname}. No extra prompting is required.
 
-To install without the command-line interface, follow the per-agent instructions under *Manual installation* in the https://github.com/tinymce/tinymce-ai-skills[`+tinymce/tinymce-ai-skills+`] README. Report guidance that is wrong, outdated, or missing from the skill by https://github.com/tinymce/tinymce-ai-skills/issues[opening an issue] in the same repository.
+To install without the command-line interface, follow the per-agent instructions under *Manual installation* in the https://github.com/tinymce/tinymce-ai-skills[tinymce-ai-skills README]. Report guidance that is wrong, outdated, or missing from the skill by https://github.com/tinymce/tinymce-ai-skills/issues[opening an issue] in the same repository.
 
 [[add-the-editor]]
 == Add {productname} to an application
@@ -49,7 +49,9 @@ include::partial$install/approve-domain-cloud.adoc[]
 [[connect-live-documentation]]
 == Configure further using live documentation
 
-Taking the configuration deeper, by adding plugins, tailoring toolbars and menus, or refining behavior against the current API, is more reliable when the agent reads the published documentation instead of relying on its training data. Connect one of the following https://modelcontextprotocol.io/[Model Context Protocol] (MCP) servers:
+Taking the configuration deeper, by adding plugins, tailoring toolbars and menus, or refining behavior against the current API, is more reliable when the agent reads the published documentation instead of relying on its training data. The sections below cover the main options; for all four, including the per-agent configuration files, see xref:ai-coding-agents.adoc[Connect AI agents to the documentation].
+
+Connect one of the following https://modelcontextprotocol.io/[Model Context Protocol] (MCP) servers:
 
 [cols="1,3",options="header"]
 |===
@@ -59,7 +61,7 @@ Taking the configuration deeper, by adding plugins, tailoring toolbars and menus
 |Semantic search across the published {productname} documentation, returning relevant extracts with links to their source pages. For the per-agent configuration files, see xref:ai-coding-agents.adoc#connect-the-documentation-mcp-server[Connect the {productname} documentation MCP server].
 
 |https://context7.com/tinymce/tinymce-docs[Context7]
-|A general-purpose documentation MCP server. Point it at the `+tinymce/docs+` library to serve version-specific {productname} documentation to the agent. The skill checks for Context7 before generating code, so this is the server it uses when both are available.
+|A general-purpose documentation MCP server. Point it at the `+tinymce/docs+` library to serve version-specific {productname} documentation to the agent. The skill checks for Context7 before generating code, so this is the server it uses when both are available. For the setup steps, see xref:ai-coding-agents.adoc#context7[Connect Context7].
 |===
 
 To connect the {productname} documentation MCP server, point the agent's MCP client at the following endpoint and complete the one-time OAuth sign-in:
@@ -78,6 +80,6 @@ ____
 Add the Table and Word Count plugins, and put a word counter in the status bar.
 ____
 
-Agents that do not support MCP can read the documentation as markdown or from the `+llms.txt+` files instead. See xref:ai-coding-agents.adoc#read-the-documentation-as-markdown[Read the documentation as markdown].
+Agents that do not support MCP can read the documentation as markdown or from the `+llms.txt+` files instead. See xref:ai-coding-agents.adoc#read-the-documentation-as-markdown[Read the documentation as markdown] and xref:ai-coding-agents.adoc#llms-txt-files[llms.txt files].
 
 include::partial$misc/quickstart-next-steps.adoc[]

--- a/modules/ROOT/pages/cloud-quick-start-ai.adoc
+++ b/modules/ROOT/pages/cloud-quick-start-ai.adoc
@@ -44,12 +44,7 @@ The skill takes the agent through the whole setup:
 
 The result is an editor configured for the project at hand, rather than a generic configuration to be adapted afterwards.
 
-[[approve-the-domain]]
-== Approve the application domain
-
-An application served from any origin other than `+localhost+` requires its domain to be added to the approved domains stored against the API key. Until the domain is approved, the editor displays the notice "This domain is not registered with {cloudname}. Please see the quick start guide or create an account." Add the domain on the link:{accountpageurl}/domains/[{accountpage}] to clear it.
-
-Local development on `+localhost+` works without this step, so it can be deferred until the application is deployed or served from a custom host. For the diagnostic steps when the notice persists, see xref:cloud-troubleshooting.adoc#domain-not-registered[Domain not registered].
+include::partial$install/approve-domain-cloud.adoc[]
 
 [[connect-live-documentation]]
 == Configure further using live documentation

--- a/modules/ROOT/pages/cloud-quick-start.adoc
+++ b/modules/ROOT/pages/cloud-quick-start.adoc
@@ -1,46 +1,55 @@
 = Quick start: {productname} from {cloudname}
 :navtitle: Quick start: Cloud
 :page-aliases: quick-start.adoc
-:description_short: Setup a basic {productname} {productmajorversion} editor using the {cloudname}.
-:description: Get an instance of {productname} {productmajorversion} up and running using the {cloudname}. Initialize the editor on a textarea element using its ID with tinymce.init and the selector option.
-:keywords: tinymce, script, textarea, selector, id, #mytextarea, tinymce.init, initialize, quick start
+:description_short: Add a {productname} {productmajorversion} editor to a web page using the {cloudname}.
+:description: Add a {productname} {productmajorversion} editor to a web page using the {cloudname}. Load the script from the content delivery network, set the API key, and initialize the editor on a textarea element with tinymce.init.
+:keywords: quick start, cloud, cdn, script, textarea, selector, tinymce.init, api key, approved domains
 :productSource: cloud
-
 
 {productname} {productmajorversion} is a powerful and flexible rich text editor that can be embedded in web applications. This quick start covers how to add a {productname} editor to a web page using the {cloudname}.
 
+TIP: To have an AI coding agent perform this setup instead, see the xref:cloud-quick-start-ai.adoc[AI quick start guide].
+
 include::partial$misc/admon-account-creation-and-social-option.adoc[]
 
-== Include the {productname} script
+[[add-the-script]]
+== Add the {productname} script
 
-Include the following script tag in the `+<head>+` of a HTML file:
+Add the following script tag to the `+<head>+` of an HTML file. It loads {productname} from the {cloudname} content delivery network (CDN):
 
 [source,html,subs="attributes+"]
 ----
 <script src="{cdnurl}" referrerpolicy="origin" crossorigin="anonymous"></script>
 ----
 
-== Initialize {productname}
+[[add-the-api-key]]
+== Add the API key
 
-include::partial$install/initialize-editor-cloud.adoc[]
+The script URL contains a `+no-api-key+` placeholder. Replace it with the {cloudname} API key, which is created when signing up to the link:{accountsignup}/[{cloudname}]. Signing up also provides a trial of the xref:plugins.adoc#premium-plugins[Premium Plugins].
 
-Adding this content to the HTML file and opening it in a web browser will load a {productname} editor, such as:
-
-liveDemo::default[]
-
-== Update the "no-api-key" placeholder
-
-Update the `+no-api-key+` placeholder in the source script URL (`+<script src=https://.../no-api-key/tinymce/{productmajorversion}/tinymce.min.js+/>`) with your {cloudname} API key, which is created when signing up to the link:{accountsignup}/[{cloudname}].
-
-Providing a valid API key also removes the notice:
+Until a valid API key is in place, the editor displays the following notice:
 
 [WARNING]
 ====
 **This domain is not registered with {cloudname}. Please see the quick start guide or create an account.**
 ====
 
-Signing up for a {cloudname} API key will also provide a trial of the xref:plugins.adoc#premium-plugins[Premium Plugins].
+[[initialize-the-editor]]
+== Initialize the editor
 
-include::partial$install/save-content.adoc[]
+include::partial$install/initialize-editor-cloud.adoc[]
+
+Opening the page in a web browser loads a {productname} editor:
+
+liveDemo::cloud-quick-start[]
+
+The demo above runs the same configuration as the example. For an editor with every premium plugin enabled, see the xref:full-featured-premium-demo.adoc[full featured demo].
+
+[[approve-the-domain]]
+== Approve the application domain
+
+An application served from any origin other than `+localhost+` requires its domain to be added to the approved domains stored against the API key. Add the domain on the link:{accountpageurl}/domains/[{accountpage}] to clear the domain registration notice.
+
+Local development on `+localhost+` works without this step, so it can be deferred until the application is deployed or served from a custom host. For the diagnostic steps when the notice persists, see xref:cloud-troubleshooting.adoc#domain-not-registered[Domain not registered].
 
 include::partial$misc/quickstart-next-steps.adoc[]

--- a/modules/ROOT/pages/cloud-quick-start.adoc
+++ b/modules/ROOT/pages/cloud-quick-start.adoc
@@ -27,7 +27,7 @@ Add the following script tag to the `+<head>+` of an HTML file. It loads {produc
 
 The script URL contains a `+no-api-key+` placeholder. Replace it with the {cloudname} API key, which is created when signing up to the link:{accountsignup}/[{cloudname}]. Signing up also provides a trial of the xref:plugins.adoc#premium-plugins[Premium Plugins].
 
-Until a valid API key is in place, the editor displays the notice "This domain is not registered with {cloudname}. Please see the quick start guide or create an account."
+Until a valid API key is in place, the editor displays a domain registration notice.
 
 [[initialize-the-editor]]
 == Initialize the editor
@@ -40,11 +40,6 @@ liveDemo::cloud-quick-start[]
 
 The demo above runs the same configuration as the example. For an editor with every premium plugin enabled, see the xref:full-featured-premium-demo.adoc[full featured demo].
 
-[[approve-the-domain]]
-== Approve the application domain
-
-An application served from any origin other than `+localhost+` requires its domain to be added to the approved domains stored against the API key. Add the domain on the link:{accountpageurl}/domains/[{accountpage}] to clear the domain registration notice.
-
-Local development on `+localhost+` works without this step, so it can be deferred until the application is deployed or served from a custom host. For the diagnostic steps when the notice persists, see xref:cloud-troubleshooting.adoc#domain-not-registered[Domain not registered].
+include::partial$install/approve-domain-cloud.adoc[]
 
 include::partial$misc/quickstart-next-steps.adoc[]

--- a/modules/ROOT/pages/cloud-quick-start.adoc
+++ b/modules/ROOT/pages/cloud-quick-start.adoc
@@ -27,12 +27,7 @@ Add the following script tag to the `+<head>+` of an HTML file. It loads {produc
 
 The script URL contains a `+no-api-key+` placeholder. Replace it with the {cloudname} API key, which is created when signing up to the link:{accountsignup}/[{cloudname}]. Signing up also provides a trial of the xref:plugins.adoc#premium-plugins[Premium Plugins].
 
-Until a valid API key is in place, the editor displays the following notice:
-
-[WARNING]
-====
-**This domain is not registered with {cloudname}. Please see the quick start guide or create an account.**
-====
+Until a valid API key is in place, the editor displays the notice "This domain is not registered with {cloudname}. Please see the quick start guide or create an account."
 
 [[initialize-the-editor]]
 == Initialize the editor

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -22,9 +22,9 @@ Learn how to install {productname} via {cloudname}, package managers, self-hoste
 
 |
 [.lead]
-xref:ai-coding-agents.adoc[Build with AI]
+xref:ai-coding-agents.adoc[Documentation for AI agents]
 
-Connect the {productname} documentation to AI coding agents using the documentation MCP server, markdown pages, and `+llms.txt+` files.
+Give AI coding agents access to the {productname} documentation using the documentation MCP server, Context7, markdown pages, and `+llms.txt+` files.
 
 // Empty cell to even out rows
 |

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -20,8 +20,14 @@ xref:installation.adoc[Installation]
 
 Learn how to install {productname} via {cloudname}, package managers, self-hosted zips for various integration options.
 
+|
+[.lead]
+xref:ai-coding-agents.adoc[AI coding agents]
+
+Connect the {productname} documentation to AI coding agents using the documentation MCP server, markdown pages, and `+llms.txt+` files.
+
 // Empty cell to even out rows
-// | 
+|
 
 |===
 

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -22,7 +22,7 @@ Learn how to install {productname} via {cloudname}, package managers, self-hoste
 
 |
 [.lead]
-xref:ai-coding-agents.adoc[AI coding agents]
+xref:ai-coding-agents.adoc[Build with AI]
 
 Connect the {productname} documentation to AI coding agents using the documentation MCP server, markdown pages, and `+llms.txt+` files.
 

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -22,7 +22,7 @@ Learn how to install {productname} via {cloudname}, package managers, self-hoste
 
 |
 [.lead]
-xref:ai-coding-agents.adoc[Documentation for AI agents]
+xref:ai-coding-agents.adoc[Connect AI agents to the documentation]
 
 Give AI coding agents access to the {productname} documentation using the documentation MCP server, Context7, markdown pages, and `+llms.txt+` files.
 

--- a/modules/ROOT/pages/installation-cloud.adoc
+++ b/modules/ROOT/pages/installation-cloud.adoc
@@ -3,7 +3,9 @@
 :description: Get started with TinyMCE using the Tiny Cloud CDN - the fastest way to get {productname} up and running.
 :keywords: tinymce cloud, cdn, cloud hosting
 
-== Cloud quick start guide
+== Cloud quick start guides
+
+Two paths lead to a working editor. Follow the step-by-step guide, or install the official agent skill and let an AI coding agent perform the setup.
 
 [cols=2*a]
 |===
@@ -13,7 +15,13 @@
 xref:cloud-quick-start.adoc[Cloud quick start guide]
 
 Get started with {productname} using the {cloudname} in minutes.
+
 |
+[.lead]
+xref:cloud-quick-start-ai.adoc[AI quick start guide]
+
+Install the official {productname} agent skill and have an AI coding agent add and configure the editor.
+
 |===
 
 == Integrations

--- a/modules/ROOT/pages/installation.adoc
+++ b/modules/ROOT/pages/installation.adoc
@@ -6,6 +6,8 @@
 
 == Quick start guides
 
+Two paths lead to a working editor. Follow the step-by-step guide, or install the official agent skill and let an AI coding agent perform the setup.
+
 [cols=2*a]
 |===
 
@@ -14,7 +16,13 @@
 xref:cloud-quick-start.adoc[Cloud quick start]
 
 Get started with {productname} using the {cloudname} in minutes.
+
 |
+[.lead]
+xref:cloud-quick-start-ai.adoc[AI quick start]
+
+Install the official {productname} agent skill and have an AI coding agent add and configure the editor.
+
 |===
 
 == Integrations

--- a/modules/ROOT/partials/install/approve-domain-cloud.adoc
+++ b/modules/ROOT/partials/install/approve-domain-cloud.adoc
@@ -1,6 +1,6 @@
 [[approve-the-domain]]
 == Approve the application domain
 
-An application served from any origin other than `+localhost+` requires its domain to be added to the approved domains stored against the API key. Until the domain is approved, the editor displays the notice "This domain is not registered with {cloudname}. Please see the quick start guide or create an account." Add the domain on the link:{accountpageurl}/domains/[{accountpage}] to clear it.
+An application served from any origin other than `+localhost+` requires its domain to be added to the approved domains stored against the API key. Until the domain is approved, the editor displays the notice "This domain is not registered with {cloudname}. Please see the quick start guide or create an account." To remove the notice, add the domain to the approved domains in the link:{accountpageurl}/domains/[{accountpage}].
 
 Local development on `+localhost+` works without this step, so it can be deferred until the application is deployed or served from a custom host. For the diagnostic steps when the notice persists, see xref:cloud-troubleshooting.adoc#domain-not-registered[Domain not registered].

--- a/modules/ROOT/partials/install/approve-domain-cloud.adoc
+++ b/modules/ROOT/partials/install/approve-domain-cloud.adoc
@@ -1,0 +1,6 @@
+[[approve-the-domain]]
+== Approve the application domain
+
+An application served from any origin other than `+localhost+` requires its domain to be added to the approved domains stored against the API key. Until the domain is approved, the editor displays the notice "This domain is not registered with {cloudname}. Please see the quick start guide or create an account." Add the domain on the link:{accountpageurl}/domains/[{accountpage}] to clear it.
+
+Local development on `+localhost+` works without this step, so it can be deferred until the application is deployed or served from a custom host. For the diagnostic steps when the notice persists, see xref:cloud-troubleshooting.adoc#domain-not-registered[Domain not registered].

--- a/modules/ROOT/partials/install/initialize-editor-cloud.adoc
+++ b/modules/ROOT/partials/install/initialize-editor-cloud.adoc
@@ -1,6 +1,6 @@
 Initialize {productname} {productmajorversion} on any element (or elements) on the web page by passing a `+selector+` to `+tinymce.init()+`. The `+selector+` value can be any valid https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors[CSS selector].
 
-For example, to initialize a {productname} {productmajorversion} instance at the textarea element, pass the selector `+#mytextarea+` to `+tinymce.init()+`.
+The `+plugins+` and `+toolbar+` options determine which features the editor provides. The following example initializes the editor on a `+textarea+` with the identifier `+mytextarea+`, and configures a menu bar and a toolbar covering the most commonly used editing features:
 
 [source,html,subs="attributes+"]
 ----
@@ -14,14 +14,22 @@ For example, to initialize a {productname} {productmajorversion} instance at the
   </head>
 
   <body>
-    <h1>{productname} Quick Start Guide</h1>
     <textarea id="mytextarea">Hello, World!</textarea>
     <script>
       tinymce.init({
-        selector: '#mytextarea'
+        selector: '#mytextarea',
+        plugins: [
+          'advlist', 'anchor', 'autolink', 'charmap', 'code', 'codesample', 'emoticons',
+          'fullscreen', 'help', 'image', 'insertdatetime', 'link', 'lists', 'media',
+          'preview', 'searchreplace', 'table', 'visualblocks', 'wordcount'
+        ],
+        menubar: 'file edit view insert format tools table help',
+        toolbar: 'undo redo | blocks fontfamily fontsize | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image media table | charmap emoticons codesample | code preview fullscreen | removeformat help',
+        height: 500
       });
     </script>
   </body>
 </html>
 ----
 
+Every plugin above is included with {productname}, so this configuration requires no further setup. To start from a minimal editor instead, pass only the `+selector+` and add options as needed.

--- a/modules/ROOT/partials/misc/quickstart-next-steps.adoc
+++ b/modules/ROOT/partials/misc/quickstart-next-steps.adoc
@@ -8,6 +8,9 @@ endif::[]
 ifeval::["{productSource}" == "package-manager"]
 * Installing premium plugins, see: xref:npm-projects.adoc#install-premium-plugins[Installing premium plugins from NPM].
 endif::[]
+ifeval::["{productSource}" == "cloud"]
+* Getting and setting the editor content, see: xref:apis/tinymce.editor.adoc#getContent[`+getContent+`] and xref:apis/tinymce.editor.adoc#setContent[`+setContent+`].
+endif::[]
 * Customizing {productname}, see: xref:basic-setup.adoc[Basic Setup].
 * The three editor modes, see:
 ** xref:use-tinymce-classic.adoc[{productname} classic editing mode].


### PR DESCRIPTION
**Ticket:** TINYDOC-3568

**Site:**
* [Quick start: TinyMCE from Tiny Cloud with an AI coding agent](https://pr-4316.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/cloud-quick-start-ai/)
* [Connecting AI coding agents to the TinyMCE documentation](https://pr-4316.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/ai-coding-agents/)
* [Quick start: TinyMCE from Tiny Cloud](https://pr-4316.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/cloud-quick-start/)

**Changes:**

Second iteration of the Build with AI work. Based on `hotfix/8/TINYDOC-3568` so the diff shows only the changes made in this iteration. Covers the review feedback on #4301 and the feedback gathered on this preview.

*New AI quick start guide*
* Adds `cloud-quick-start-ai.adoc`, an AI-agent path for the Cloud quick start: install the skill, prompt the agent, approve the domain, then configure further against live documentation.
* The setup step sets expectations for what the skill does rather than showing a generated configuration. Publishing one example configuration would become a maintenance liability against the skill, and it undercuts the point of the page, which is that the skill produces a configuration suited to the project rather than a one-size-fits-all snippet.
* The "Configure further" step gives the documentation MCP endpoint and the *Ask AI* widget shortcut inline, so a reader who already knows MCP can connect without leaving the page. The per-agent configuration files remain on the AI agents page.
* Both quick starts are interlinked at the top so readers landing on either one see the alternative.
* Linked from `installation.adoc` and `installation-cloud.adoc` as a second quick start card, and added to `nav.adoc` below the existing quick start guide.

*AI agents page*
* Scoped `ai-coding-agents.adoc` to documentation access only: the documentation MCP server, Context7, markdown pages, and `llms.txt`. The agent skill currently covers Cloud setups only, so the skill material sits on the Cloud AI quick start where the claim holds.
* The introduction now names all four access methods up front as a linked menu, stating that they are alternatives rather than steps. Read in page order, the sections previously implied a sequence and Context7 arrived as a surprise.
* Retitled the MCP section to "Connect the TinyMCE documentation MCP server" and split the opening paragraph, which was trying to establish that the server is TinyMCE-specific and distinguish it from the editor's own MCP tool calling in a single sentence.
* Authentication guidance is agent-neutral; the Claude Code `/mcp` instruction moved into the Claude Code entry with the other tool-specific advice.
* Per-agent MCP configuration snippets are collapsed into accordions.
* Adds a Context7 section.
* Documents that versioned markdown URLs for the current major version redirect to `latest`, so an agent retrieving markdown by version number needs to follow redirects. Verified: `/docs/tinymce/8/basic-setup/index.md` returns 302, `/docs/tinymce/7/basic-setup/index.md` returns 200.
* Navigation title is "Connect AI agents to the documentation" so the entry reads as a step within Getting started.

*Cloud quick start guide*
* Restructured to four steps: add the script, add the API key, initialize the editor, approve the domain. The API key step moved ahead of initialization so the `no-api-key` placeholder is explained the first time it appears.
* The editor example and the live demo now show a representative configuration (19 open-source plugins, a menu bar, and a full toolbar) instead of a bare `tinymce.init({selector})`. New `cloud-quick-start` live demo runs the same configuration as the example so the two cannot drift.
* Adds an "Approve the application domain" step, previously undocumented on this page.
* That step is a shared partial, `partials/install/approve-domain-cloud.adoc`, included by both Cloud quick starts so the two cannot diverge.
* The editor's domain registration notice is quoted as plain text rather than rendered in a warning admonition, which read as a fault on the documentation site rather than a message shown by the editor.
* "Save the content from the editor" moves into Next steps, gated on `productSource` so only the two Cloud quick starts change. The npm, zip, php, and dotnet pages render as before.
* Refreshed the page metadata and description.

---

### **Pre-checks:**

- [x] Branch is correctly prefixed
- [x] `modules/ROOT/nav.adoc` has been updated (if applicable).
- [x] Files have been included where required (if applicable).
- [x] Files removed have been deleted, not just excluded from the build (if applicable).
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
