### PR TITLE
TINYDOC-3570: The tinymceai_chat_fetch_sources option can now nominate default sources for chat conversations.

### DIFF
--- a/modules/ROOT/pages/8.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.9.0-release-notes.adoc
@@ -77,7 +77,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 **TinyMCE AI** includes the following addition.
 
-==== The `tinymceai_chat_fetch_sources` option can now nominate default sources for chat conversations.
+==== The `tinymceai_chat_fetch_sources` option can now specify default sources for chat conversations.
 // #TINYMCE-14777
 
 Previously, the **TinyMCE AI** plugin applied only the current document to the context of a new AI Chat conversation. Users had to manually add every other context source, such as a style guide or reference document, to each new conversation.

--- a/modules/ROOT/pages/8.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.9.0-release-notes.adoc
@@ -84,7 +84,7 @@ Previously, the **TinyMCE AI** plugin applied only the current document to the c
 
 In {productname} {release-version}, the function supplied to xref:tinymceai.adoc#tinymceai_chat_fetch_sources[`+tinymceai_chat_fetch_sources+`] can resolve to an object with a `+menu+` property, holding the source groups shown in the sources menu, and a `+defaults+` property, holding an array of source identifiers. The plugin adds each source listed in `+defaults+` to the context of every new conversation, and shows it as selected in the sources menu. Users can remove a default source from a conversation and add it again from the sources menu.
 
-Identifiers listed in `+defaults+` without a matching source in `+menu.sources+` are not added to the context, and the plugin reports them as an error in the browser console.
+Identifiers listed in `+defaults+` without a matching source in `+sources+` are not added to the context, and the plugin logs an error in the browser console.
 
 The option continues to accept a function that resolves to an array of source groups, so existing configurations are unaffected.
 

--- a/modules/ROOT/pages/8.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.9.0-release-notes.adoc
@@ -80,7 +80,7 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== The `tinymceai_chat_fetch_sources` option can now nominate default sources for chat conversations.
 // #TINYMCE-14777
 
-Previously, the **TinyMCE AI** plugin applied only the current document to the context of a new AI Chat conversation. Users had to add every other context source, such as a style guide or a reference document, to each new conversation by hand.
+Previously, the **TinyMCE AI** plugin applied only the current document to the context of a new AI Chat conversation. Users had to manually add every other context source, such as a style guide or reference document, to each new conversation.
 
 In {productname} {release-version}, the function supplied to xref:tinymceai.adoc#tinymceai_chat_fetch_sources[`+tinymceai_chat_fetch_sources+`] can resolve to an object with a `+menu+` property, holding the source groups shown in the sources menu, and a `+defaults+` property, holding an array of source identifiers. The plugin adds each source listed in `+defaults+` to the context of every new conversation, and shows it as selected in the sources menu. Users can remove a default source from a conversation and add it again from the sources menu.
 

--- a/modules/ROOT/pages/8.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.9.0-release-notes.adoc
@@ -71,6 +71,23 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following addition.
+
+==== New option `tinymceai_chat_default_sources` to allow specifying predefined sources as chat default context.
+// #TINYMCE-14703
+
+Previously, the **TinyMCE AI** plugin applied only the current document to the context of a new AI Chat conversation. Users had to add every other context source, such as a style guide or a reference document, to each new conversation by hand.
+
+In {productname} {release-version}, the **TinyMCE AI** plugin supports the xref:tinymceai.adoc#tinymceai_chat_default_sources[`+tinymceai_chat_default_sources+`] option. The option accepts an array of source identifiers taken from the list supplied by xref:tinymceai.adoc#tinymceai_chat_fetch_sources[`+tinymceai_chat_fetch_sources+`], and the plugin applies those sources to the context of every new conversation. Users can remove a default source from a conversation and add it again from the sources menu.
+
+For details on configuring conversation context, see xref:tinymceai-chat.adoc#context-configuration[Adding custom context sources].
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement

--- a/modules/ROOT/pages/8.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.9.0-release-notes.adoc
@@ -77,12 +77,16 @@ The {productname} {release-version} release includes an accompanying release of 
 
 **TinyMCE AI** includes the following addition.
 
-==== New option `tinymceai_chat_default_sources` to allow specifying predefined sources as chat default context.
-// #TINYMCE-14703
+==== The `tinymceai_chat_fetch_sources` option can now nominate default sources for chat conversations.
+// #TINYMCE-14777
 
 Previously, the **TinyMCE AI** plugin applied only the current document to the context of a new AI Chat conversation. Users had to add every other context source, such as a style guide or a reference document, to each new conversation by hand.
 
-In {productname} {release-version}, the **TinyMCE AI** plugin supports the xref:tinymceai.adoc#tinymceai_chat_default_sources[`+tinymceai_chat_default_sources+`] option. The option accepts an array of source identifiers taken from the list supplied by xref:tinymceai.adoc#tinymceai_chat_fetch_sources[`+tinymceai_chat_fetch_sources+`], and the plugin applies those sources to the context of every new conversation. Users can remove a default source from a conversation and add it again from the sources menu.
+In {productname} {release-version}, the function supplied to xref:tinymceai.adoc#tinymceai_chat_fetch_sources[`+tinymceai_chat_fetch_sources+`] can resolve to an object with a `+menu+` property, holding the source groups shown in the sources menu, and a `+defaults+` property, holding an array of source identifiers. The plugin adds each source listed in `+defaults+` to the context of every new conversation, and shows it as selected in the sources menu. Users can remove a default source from a conversation and add it again from the sources menu.
+
+Identifiers listed in `+defaults+` without a matching source in `+menu.sources+` are not added to the context, and the plugin reports them as an error in the browser console.
+
+The option continues to accept a function that resolves to an array of source groups, so existing configurations are unaffected.
 
 For details on configuring conversation context, see xref:tinymceai-chat.adoc#context-configuration[Adding custom context sources].
 

--- a/modules/ROOT/pages/tinymceai-chat.adoc
+++ b/modules/ROOT/pages/tinymceai-chat.adoc
@@ -160,7 +160,7 @@ To add custom external sources for users to select from, configure:
 
 Full schemas, return types, and examples are documented under xref:tinymceai.adoc#tinymceai_chat_fetch_sources[Chat configuration options].
 
-To apply a custom source to every new conversation without requiring users to select it, list its ID in xref:tinymceai.adoc#tinymceai_chat_default_sources[`tinymceai_chat_default_sources`].
+To apply a custom source to every new conversation without requiring users to select it, return an object from xref:tinymceai.adoc#tinymceai_chat_fetch_sources[`+tinymceai_chat_fetch_sources+`] and list the source ID in its `+defaults+` property.
 
 [source,js]
 ----

--- a/modules/ROOT/pages/tinymceai-chat.adoc
+++ b/modules/ROOT/pages/tinymceai-chat.adoc
@@ -160,6 +160,8 @@ To add custom external sources for users to select from, configure:
 
 Full schemas, return types, and examples are documented under xref:tinymceai.adoc#tinymceai_chat_fetch_sources[Chat configuration options].
 
+To apply a custom source to every new conversation without requiring users to select it, list its ID in xref:tinymceai.adoc#tinymceai_chat_default_sources[`tinymceai_chat_default_sources`].
+
 [source,js]
 ----
 tinymce.init({

--- a/modules/ROOT/pages/tinymceai-chat.adoc
+++ b/modules/ROOT/pages/tinymceai-chat.adoc
@@ -178,9 +178,9 @@ tinymce.init({
     }
   ],
   tinymceai_chat_fetch_source: async (id) => {
-    const res = await fetch(`/api/documents/\$\{id\}`);
+    const res = await fetch(`/api/documents/${id}`);
     const blob = await res.blob();
-    const filename = `\$\{id\}.pdf`;
+    const filename = `${id}.pdf`;
     return { type: 'file', file: new File([blob], filename, { type: blob.type }) };
   },
   // Required for authentication

--- a/modules/ROOT/pages/tinymceai.adoc
+++ b/modules/ROOT/pages/tinymceai.adoc
@@ -98,7 +98,6 @@ tinymce.init({
     const filename = `\$\{id\}.pdf`;
     return { type: 'file', file: new File([blob], filename, { type: blob.type }) };
   },
-  tinymceai_chat_default_sources: [ 'doc-1' ],
   tinymceai_quickactions_custom: [
     { title: 'Explain like I am five', prompt: 'Explain the following text in simple terms.', type: 'chat' }
   ]

--- a/modules/ROOT/pages/tinymceai.adoc
+++ b/modules/ROOT/pages/tinymceai.adoc
@@ -98,6 +98,7 @@ tinymce.init({
     const filename = `\$\{id\}.pdf`;
     return { type: 'file', file: new File([blob], filename, { type: blob.type }) };
   },
+  tinymceai_chat_default_sources: [ 'doc-1' ],
   tinymceai_quickactions_custom: [
     { title: 'Explain like I am five', prompt: 'Explain the following text in simple terms.', type: 'chat' }
   ]

--- a/modules/ROOT/pages/tinymceai.adoc
+++ b/modules/ROOT/pages/tinymceai.adoc
@@ -93,9 +93,9 @@ tinymce.init({
     }
   ],
   tinymceai_chat_fetch_source: async (id) => {
-    const res = await fetch(`/api/documents/\$\{id\}`);
+    const res = await fetch(`/api/documents/${id}`);
     const blob = await res.blob();
-    const filename = `\$\{id\}.pdf`;
+    const filename = `${id}.pdf`;
     return { type: 'file', file: new File([blob], filename, { type: blob.type }) };
   },
   tinymceai_quickactions_custom: [

--- a/modules/ROOT/partials/configuration/tinymceai_options.adoc
+++ b/modules/ROOT/partials/configuration/tinymceai_options.adoc
@@ -178,17 +178,28 @@ These options configure the AI Chat sidebar, where users have interactive conver
 [[tinymceai_chat_fetch_sources]]
 === `+tinymceai_chat_fetch_sources+`
 
-Populates the sources menu with submenus of files and web resources. Users can select these sources as additional context for chat conversations.
+Populates the sources menu with submenus of files and web resources. Users can select these sources as additional context for chat conversations. The option can also nominate default sources, which the {pluginname} plugin adds to the context of every new conversation.
 
-Takes a function that returns a Promise resolving to an array of additional context source groups. Each group has `+label+`, optional `+icon+`, and `+sources+` array. Each source has `+id+`, `+label+`, and `+type+` (`+'web-resource'+` or `+'file'+`). A source's `+id+` is used to fetch its content through xref:tinymceai.adoc#tinymceai_chat_fetch_source[`tinymceai_chat_fetch_source`].
+Takes a function that returns a Promise resolving to either of the following:
 
-*Type:* `+Function+` (`+() => Promise<Array>+`)
+* An array of source groups.
+* An object with a `+menu+` property, holding the array of source groups as `+menu.sources+`, and a `+defaults+` property, holding an array of source identifiers.
+
+Each source group has `+label+`, optional `+icon+`, and `+sources+` array. Each source has `+id+`, `+label+`, and `+type+` (`+'web-resource'+` or `+'file'+`). A source's `+id+` is used to fetch its content through xref:tinymceai.adoc#tinymceai_chat_fetch_source[`tinymceai_chat_fetch_source`].
+
+Both shapes are supported. Returning an array populates the sources menu without nominating any default sources.
+
+Each identifier listed in `+defaults+` must match the `+id+` of a source listed in `+menu.sources+`. The plugin adds each matching source to the context of every new conversation, and shows it as selected in the sources menu. Identifiers without a matching source are not added to the context, and the plugin reports them as an error in the browser console. Users can remove a default source from a conversation and add it again from the sources menu.
+
+If `+menu.sources+` is missing or empty, the plugin reports an error in the browser console and populates no sources.
+
+*Type:* `+Function+` (`+() => Promise<Array | Object>+`)
 
 *Possible Values:* For source `+type+` property: `+'web-resource'+`, `+'file'+`
 
 *Default value:* `+() => Promise.resolve([])+`
 
-.Example
+.Example: populating the sources menu
 [source,js]
 ----
 tinymce.init({
@@ -205,6 +216,41 @@ tinymce.init({
       ]
     }
   ],
+  tinymceai_chat_fetch_source: async (id) => {
+    const res = await fetch(`/api/documents/\$\{id\}`);
+    const blob = await res.blob();
+    const filename = `\$\{id\}.pdf`;
+    return { type: 'file', file: new File([blob], filename, { type: blob.type }) };
+  },
+  // Required for authentication
+  tinymceai_token_provider: () => {
+    return fetch('/api/token').then(r => r.json());
+  }
+});
+----
+
+.Example: nominating default sources
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',
+  plugins: 'tinymceai',
+  toolbar: 'tinymceai-chat tinymceai-quickactions tinymceai-review',
+  tinymceai_chat_fetch_sources: async () => ({
+    defaults: [ 'doc-1' ],
+    menu: {
+      sources: [
+        {
+          label: 'My Documents',
+          icon: 'folder',
+          sources: [
+            { id: 'doc-1', label: 'Style guide', type: 'file' },
+            { id: 'url-1', label: 'Web Page', type: 'web-resource' }
+          ]
+        }
+      ]
+    }
+  }),
   tinymceai_chat_fetch_source: async (id) => {
     const res = await fetch(`/api/documents/\$\{id\}`);
     const blob = await res.blob();
@@ -245,50 +291,6 @@ tinymce.init({
     const filename = `\$\{id\}.pdf`;
     return { type: 'file', file: new File([blob], filename, { type: blob.type }) };
   },
-  // Required for authentication
-  tinymceai_token_provider: () => {
-    return fetch('/api/token').then(r => r.json());
-  }
-});
-----
-
-[[tinymceai_chat_default_sources]]
-=== `+tinymceai_chat_default_sources+`
-
-Adds one or more sources to the context of every new chat conversation, alongside the current document. Without this option, users add each source to a conversation themselves.
-
-Takes an array of source identifiers. Each identifier is the `+id+` of a source supplied by xref:tinymceai.adoc#tinymceai_chat_fetch_sources[`tinymceai_chat_fetch_sources`], and the content of each source is loaded through xref:tinymceai.adoc#tinymceai_chat_fetch_source[`tinymceai_chat_fetch_source`]. Identifiers that do not match a supplied source are ignored.
-
-Users can remove a default source from a conversation and add it again from the sources menu.
-
-*Type:* `+Array+` (`+string[]+`)
-
-*Default value:* `+[]+`
-
-.Example
-[source,js]
-----
-tinymce.init({
-  selector: 'textarea',
-  plugins: 'tinymceai',
-  toolbar: 'tinymceai-chat tinymceai-quickactions tinymceai-review',
-  tinymceai_chat_fetch_sources: async () => [
-    {
-      label: 'My Documents',
-      icon: 'folder',
-      sources: [
-        { id: 'doc-1', label: 'Style guide', type: 'file' },
-        { id: 'doc-2', label: 'Document 2', type: 'file' }
-      ]
-    }
-  ],
-  tinymceai_chat_fetch_source: async (id) => {
-    const res = await fetch(`/api/documents/\$\{id\}`);
-    const blob = await res.blob();
-    const filename = `\$\{id\}.pdf`;
-    return { type: 'file', file: new File([blob], filename, { type: blob.type }) };
-  },
-  tinymceai_chat_default_sources: [ 'doc-1' ],
   // Required for authentication
   tinymceai_token_provider: () => {
     return fetch('/api/token').then(r => r.json());

--- a/modules/ROOT/partials/configuration/tinymceai_options.adoc
+++ b/modules/ROOT/partials/configuration/tinymceai_options.adoc
@@ -238,8 +238,7 @@ tinymce.init({
   toolbar: 'tinymceai-chat tinymceai-quickactions tinymceai-review',
   tinymceai_chat_fetch_sources: async () => ({
     defaults: [ 'doc-1' ],
-    menu: {
-      sources: [
+    menu: [
         {
           label: 'My Documents',
           icon: 'folder',
@@ -249,7 +248,6 @@ tinymce.init({
           ]
         }
       ]
-    }
   }),
   tinymceai_chat_fetch_source: async (id) => {
     const res = await fetch(`/api/documents/\$\{id\}`);

--- a/modules/ROOT/partials/configuration/tinymceai_options.adoc
+++ b/modules/ROOT/partials/configuration/tinymceai_options.adoc
@@ -183,15 +183,15 @@ Populates the sources menu with submenus of files and web resources. Users can s
 Takes a function that returns a Promise resolving to either of the following:
 
 * An array of source groups.
-* An object with a `+menu+` property, holding the array of source groups as `+menu.sources+`, and a `+defaults+` property, holding an array of source identifiers.
+* An object with a `+menu+` property, holding the array of source groups, and a `+defaults+` property, holding an array of source identifiers.
 
 Each source group has `+label+`, optional `+icon+`, and `+sources+` array. Each source has `+id+`, `+label+`, and `+type+` (`+'web-resource'+` or `+'file'+`). A source's `+id+` is used to fetch its content through xref:tinymceai.adoc#tinymceai_chat_fetch_source[`tinymceai_chat_fetch_source`].
 
 Both shapes are supported. Returning an array populates the sources menu without nominating any default sources.
 
-Each identifier listed in `+defaults+` must match the `+id+` of a source listed in `+menu.sources+`. The plugin adds each matching source to the context of every new conversation, and shows it as selected in the sources menu. Identifiers without a matching source are not added to the context, and the plugin reports them as an error in the browser console. Users can remove a default source from a conversation and add it again from the sources menu.
+Each identifier listed in `+defaults+` must match the `+id+` of a source listed in `+sources+`. The plugin adds each matching source to the context of every new conversation, and shows it as selected in the sources menu. Identifiers without a matching source are not added to the context, and the plugin logs an error in the browser console. Users can remove a default source from a conversation and add it again from the sources menu.
 
-If `+menu.sources+` is missing or empty, the plugin reports an error in the browser console and populates no sources.
+If `+menu+` is missing or empty, the plugin logs an error in the browser console and populates no sources.
 
 *Type:* `+Function+` (`+() => Promise<Array | Object>+`)
 
@@ -239,15 +239,15 @@ tinymce.init({
   tinymceai_chat_fetch_sources: async () => ({
     defaults: [ 'doc-1' ],
     menu: [
-        {
-          label: 'My Documents',
-          icon: 'folder',
-          sources: [
-            { id: 'doc-1', label: 'Style guide', type: 'file' },
-            { id: 'url-1', label: 'Web Page', type: 'web-resource' }
-          ]
-        }
-      ]
+      {
+        label: 'My Documents',
+        icon: 'folder',
+        sources: [
+          { id: 'doc-1', label: 'Style guide', type: 'file' },
+          { id: 'url-1', label: 'Web Page', type: 'web-resource' }
+        ]
+      }
+    ]
   }),
   tinymceai_chat_fetch_source: async (id) => {
     const res = await fetch(`/api/documents/\$\{id\}`);

--- a/modules/ROOT/partials/configuration/tinymceai_options.adoc
+++ b/modules/ROOT/partials/configuration/tinymceai_options.adoc
@@ -271,7 +271,7 @@ A function that fetches the content for an additional source by ID. Receives the
 
 *Possible Values:* For return object `+type+` property: `+'file'+`, `+'web-resource'+`
 
-*Default value:* `+(id) => Promise.resolve(\`Should fetch additional source with given \$\{id\}\`)+`
+*Default value:* `+++(id) => Promise.resolve(`Should fetch additional source with given ${id}`)+++`
 
 .Example
 [source,js]

--- a/modules/ROOT/partials/configuration/tinymceai_options.adoc
+++ b/modules/ROOT/partials/configuration/tinymceai_options.adoc
@@ -217,9 +217,9 @@ tinymce.init({
     }
   ],
   tinymceai_chat_fetch_source: async (id) => {
-    const res = await fetch(`/api/documents/\$\{id\}`);
+    const res = await fetch(`/api/documents/${id}`);
     const blob = await res.blob();
-    const filename = `\$\{id\}.pdf`;
+    const filename = `${id}.pdf`;
     return { type: 'file', file: new File([blob], filename, { type: blob.type }) };
   },
   // Required for authentication
@@ -250,9 +250,9 @@ tinymce.init({
     ]
   }),
   tinymceai_chat_fetch_source: async (id) => {
-    const res = await fetch(`/api/documents/\$\{id\}`);
+    const res = await fetch(`/api/documents/${id}`);
     const blob = await res.blob();
-    const filename = `\$\{id\}.pdf`;
+    const filename = `${id}.pdf`;
     return { type: 'file', file: new File([blob], filename, { type: blob.type }) };
   },
   // Required for authentication
@@ -284,9 +284,9 @@ tinymce.init({
     { label: 'Docs', sources: [{ id: 'doc-1', label: 'Document 1', type: 'file' }] }
   ],
   tinymceai_chat_fetch_source: async (id) => {
-    const res = await fetch(`/api/documents/\$\{id\}`);
+    const res = await fetch(`/api/documents/${id}`);
     const blob = await res.blob();
-    const filename = `\$\{id\}.pdf`;
+    const filename = `${id}.pdf`;
     return { type: 'file', file: new File([blob], filename, { type: blob.type }) };
   },
   // Required for authentication

--- a/modules/ROOT/partials/configuration/tinymceai_options.adoc
+++ b/modules/ROOT/partials/configuration/tinymceai_options.adoc
@@ -252,6 +252,50 @@ tinymce.init({
 });
 ----
 
+[[tinymceai_chat_default_sources]]
+=== `+tinymceai_chat_default_sources+`
+
+Adds one or more sources to the context of every new chat conversation, alongside the current document. Without this option, users add each source to a conversation themselves.
+
+Takes an array of source identifiers. Each identifier is the `+id+` of a source supplied by xref:tinymceai.adoc#tinymceai_chat_fetch_sources[`tinymceai_chat_fetch_sources`], and the content of each source is loaded through xref:tinymceai.adoc#tinymceai_chat_fetch_source[`tinymceai_chat_fetch_source`]. Identifiers that do not match a supplied source are ignored.
+
+Users can remove a default source from a conversation and add it again from the sources menu.
+
+*Type:* `+Array+` (`+string[]+`)
+
+*Default value:* `+[]+`
+
+.Example
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',
+  plugins: 'tinymceai',
+  toolbar: 'tinymceai-chat tinymceai-quickactions tinymceai-review',
+  tinymceai_chat_fetch_sources: async () => [
+    {
+      label: 'My Documents',
+      icon: 'folder',
+      sources: [
+        { id: 'doc-1', label: 'Style guide', type: 'file' },
+        { id: 'doc-2', label: 'Document 2', type: 'file' }
+      ]
+    }
+  ],
+  tinymceai_chat_fetch_source: async (id) => {
+    const res = await fetch(`/api/documents/\$\{id\}`);
+    const blob = await res.blob();
+    const filename = `\$\{id\}.pdf`;
+    return { type: 'file', file: new File([blob], filename, { type: blob.type }) };
+  },
+  tinymceai_chat_default_sources: [ 'doc-1' ],
+  // Required for authentication
+  tinymceai_token_provider: () => {
+    return fetch('/api/token').then(r => r.json());
+  }
+});
+----
+
 [[tinymceai_chat_welcome_message]]
 === `+tinymceai_chat_welcome_message+`
 


### PR DESCRIPTION
**Ticket:** TINYDOC-3570 (TINYMCE-14777), TINYDOC-3561

**Site:** [Staging](https://pr-4318.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.9.0-release-notes/#the-tinymceai_chat_fetch_sources-option-can-now-specify-default-sources-for-chat-conversations)

TINYMCE-14777 supersedes the `tinymceai_chat_default_sources` option added under TINYMCE-14703, which was removed before release. Default Chat sources are now nominated through the existing `tinymceai_chat_fetch_sources` option. Replaces #4306, which was closed when the branch was renamed.

**Changes:**
* Rewrote the `tinymceai_chat_fetch_sources` section in `modules/ROOT/partials/configuration/tinymceai_options.adoc` to cover both accepted shapes (the original array of source groups, and an object holding `menu.sources` plus a `defaults` array), the defaults semantics, and the console error cases.
* Removed the `tinymceai_chat_default_sources` section from `modules/ROOT/partials/configuration/tinymceai_options.adoc`.
* Updated the release note entry in `modules/ROOT/pages/8.9.0-release-notes.adoc` for TINYMCE-14777, noting that the array form still works and is not a breaking change.
* Removed `tinymceai_chat_default_sources` from the complete setup example in `modules/ROOT/pages/tinymceai.adoc`.
* Pointed the default sources cross-reference in `modules/ROOT/pages/tinymceai-chat.adoc` at `tinymceai_chat_fetch_sources` and its `defaults` property.

**Note:** the implemented shape differs from the ticket description. The ticket specifies `menu: [ ...groups ]`, but `plugins/tinymceai/src/main/ts/ui/Sources.ts` on `rc/8.9` defines `menu: { sources: ExternalSourcesList[] }`, nesting the groups one level deeper. The documented shape follows the implementation, confirmed against `DefaultChatSourcesTest.ts` and `DemoApp.ts`.

---

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
