### PR TITLE
TINYDOC-3570: Improved error message shown when the document is too long for a quick action or review.

### DIFF
--- a/modules/ROOT/pages/8.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.9.0-release-notes.adoc
@@ -71,6 +71,21 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following improvement.
+
+==== Improved error message shown when the document is too long for a quick action or review
+// #TINYMCE-13662
+
+Previously, when the document content exceeded the context limit of the AI service, a quick action or review failed and reported the general message `+An error occurred while processing the AI response.+` That message did not identify the length of the document as the cause.
+
+In {productname} {release-version}, the **TinyMCE AI** plugin shows `+This document is too long for the AI to process at once.+` when a quick action or review fails for this reason. The message states the limit without suggesting a corrective action, because the full document is always sent to the AI service.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement


### PR DESCRIPTION
**Ticket:** TINYDOC-3570 (TINYMCE-13662)

**Site:** [Staging](https://pr-4320.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.9.0-release-notes/#improved-error-message-shown-when-the-document-is-too-long-for-a-quick-action-or-review)

**Changes:**
* Added a TinyMCE AI improvement entry to `modules/ROOT/pages/8.9.0-release-notes.adoc` under Accompanying Premium plugin changes.

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
