### PR TITLE
TINYDOC-3570: Improved error message shown when an invalid URL is added as a context source.

### DIFF
--- a/modules/ROOT/pages/8.9.0-release-notes.adoc
+++ b/modules/ROOT/pages/8.9.0-release-notes.adoc
@@ -71,6 +71,21 @@ The {productname} {release-version} release includes an accompanying release of 
 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following improvement.
+
+==== Improved error message shown when an invalid URL is added as a context source
+// #TINYMCE-13715
+
+Previously, adding a malformed URL as a context source in the Chat sidebar reported `+Provided URL is not valid.+` That message did not indicate what part of the address to correct.
+
+In {productname} {release-version}, the **TinyMCE AI** plugin shows `+This URL isn't valid. Check the full, correct web address and try again.+` in the same situation. The message applies to the format of the address. A well-formed address that points to a page that cannot be reached is still accepted and sent for processing.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
 
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement


### PR DESCRIPTION
**Ticket:** TINYDOC-3570 (TINYMCE-13715)

**Site:** [Staging](https://pr-4321.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.9.0-release-notes/#improved-error-message-shown-when-an-invalid-url-is-added-as-a-context-source)

**Changes:**
* Added a TinyMCE AI improvement entry to `modules/ROOT/pages/8.9.0-release-notes.adoc` under Accompanying Premium plugin changes.

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
