### PR TITLE
TINYDOC-3514 - TEMPORARY link check probe (do not merge)

### DIFF
--- a/modules/ROOT/pages/zz-linkcheck-probe.adoc
+++ b/modules/ROOT/pages/zz-linkcheck-probe.adoc
@@ -1,0 +1,20 @@
+= Link check probe
+:navtitle: Link check probe
+:description: Temporary page used to verify the pull request link check. Not for merge.
+:keywords: probe
+
+Temporary probe page. This must not be merged.
+
+A live link that should pass: https://github.com/tinymce/tinymce[TinyMCE repository].
+
+A dead link that should be reported: https://archive.tinymce.com[archived site].
+
+The URL below sits inside a code sample and must NOT be checked:
+
+[source,js]
+----
+tinymce.init({
+  selector: 'textarea',
+  content_css: 'https://archive.tinymce.com/broken-in-code-sample.css'
+});
+----


### PR DESCRIPTION
Throwaway PR used to verify the optimised PR-time link check. Not for merge; will be closed once CI has been inspected.

Expected result: 3 candidate links from the diff, 2 of them rendering as anchors and checked, 1 reported broken (`archive.tinymce.com` in prose). The identical URL inside the `[source,js]` block must not be checked.