### PR TITLE
TINYDOC-3514 - Add external link checking to pull requests v6

### DIFF
--- a/.github/workflows/link-check-pr.yml
+++ b/.github/workflows/link-check-pr.yml
@@ -1,0 +1,259 @@
+name: Link Check
+
+# Blocking check for external link rot introduced by a pull request.
+#
+# This is deliberately a separate workflow from the preview deployment. The
+# preview job publishes to S3, and a link problem must not be reported as a
+# failed deployment: the two have different causes, different owners and
+# different urgency. Keeping them apart also means this check can be a required
+# status check without infrastructure flakiness in the deploy path blocking
+# merges.
+#
+# Only the links a pull request touched are checked. Pre-existing rot elsewhere
+# in the site is not this check's concern; blocking a PR on rot it did not
+# introduce would make the gate unmergeable and it would be switched off.
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  link-check:
+    name: Check links changed by this PR
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Checkout branch
+      uses: actions/checkout@v5
+      with:
+        # Full history so the link check can diff against the base branch.
+        fetch-depth: 0
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v5
+      with:
+        cache: 'yarn'
+        node-version: 22
+
+    - name: Collect links added or changed by this PR
+      id: touched
+      env:
+        BASE: ${{ github.event.pull_request.base.ref }}
+      run: |
+        git fetch --no-tags --quiet origin "$BASE"
+
+        # Candidate URLs from the diff. Permissive on purpose: this only narrows
+        # what gets checked, and every candidate must still be confirmed as a
+        # rendered anchor below, so a bad match is inert rather than a false
+        # failure.
+        git diff "origin/${BASE}...HEAD" -- '*.adoc' \
+          | grep '^+' | grep -v '^+++' \
+          | grep -oE "https?://[^][<>\"^\`)+,|' ]+" \
+          | sed -E 's/[.,;:]+$//' | sed -E 's#/+$##' \
+          | LC_ALL=C sort -u > touched-urls.txt || true
+
+        count=$(wc -l < touched-urls.txt | tr -d '[:space:]')
+        echo "count=${count}" >> "$GITHUB_OUTPUT"
+        echo "This pull request changed ${count} candidate link(s)."
+
+    - name: Install dependencies
+      if: steps.touched.outputs.count != '0'
+      run: yarn install
+
+    # The local playbook builds only this branch, which is all a PR link check
+    # needs. The production playbook additionally pulls the other published
+    # versions from the remote, and checking those is the deploy pipeline's
+    # concern, not this check's.
+    #
+    # The output segment differs per branch: only the playbooks that set
+    # latest_version_segment produce build/site/tinymce/latest, and the others
+    # produce build/site/tinymce/<version>. The glob below therefore must not name
+    # a segment — a glob that matches nothing is only a lychee [WARN], so the check
+    # would pass silently while verifying nothing.
+    - name: Build this branch
+      if: steps.touched.outputs.count != '0'
+      run: yarn antora ./antora-playbook-local.yml
+
+    # Restores lychee's on-disk request cache. Without this the cache settings in
+    # .lychee.toml have no effect, because each run starts on a clean runner.
+    - name: Restore link checker cache
+      if: steps.touched.outputs.count != '0'
+      uses: actions/cache@v4
+      with:
+        path: .lycheecache
+        key: lychee-${{ github.run_id }}
+        restore-keys: lychee-
+
+    # No network requests: this only lists the links lychee would check. Running
+    # lychee's own extractor over the BUILT HTML is what keeps code samples out of
+    # the results — its HTML parser sees only real <a href> anchors, so URLs
+    # inside [source] blocks and Antora attributes substituted at build time can
+    # never reach the checker. Measured over 400 commits of real history,
+    # extracting from raw .adoc text produced a 16% false-failure rate.
+    #
+    # lychee-action@v2 is a floating major tag, so its default checker version can
+    # move without a change here. Both steps pin the checker explicitly.
+    - name: List links rendered in the built site
+      if: steps.touched.outputs.count != '0'
+      uses: lycheeverse/lychee-action@v2
+      with:
+        args: --config .lychee.toml --dump --no-progress './build/site/tinymce/**/*.html'
+        lycheeVersion: v0.24.2
+        output: lychee/rendered.txt
+        token: ${{ secrets.GITHUB_TOKEN }}
+        fail: false
+        jobSummary: false
+
+    - name: Narrow to links this PR touched
+      id: narrow
+      run: |
+        mkdir -p lychee
+        : > to-check.txt
+        if [ -s lychee/rendered.txt ]; then
+          # Trailing-slash tolerant on both sides so a cosmetic difference does
+          # not drop a genuine match. LC_ALL is pinned because comm silently
+          # under-matches when its two inputs disagree on collation, which would
+          # let a broken link through.
+          sed -E 's#/+$##' lychee/rendered.txt | LC_ALL=C sort -u > rendered-normalised.txt
+          LC_ALL=C sort -u touched-urls.txt > touched-normalised.txt
+          LC_ALL=C comm -12 rendered-normalised.txt touched-normalised.txt > to-check.txt
+        fi
+        count=$(wc -l < to-check.txt | tr -d '[:space:]')
+        echo "count=${count}" >> "$GITHUB_OUTPUT"
+        echo "${count} of the PR's link(s) render as anchors and will be checked."
+
+    # The only step that touches the network.
+    - name: Check links this PR touched
+      id: lychee
+      if: steps.narrow.outputs.count != '0'
+      uses: lycheeverse/lychee-action@v2
+      with:
+        args: --config .lychee.toml --no-progress --timeout 15 --max-retries 1 to-check.txt
+        lycheeVersion: v0.24.2
+        format: json
+        output: lychee/results.json
+        token: ${{ secrets.GITHUB_TOKEN }}
+        fail: false
+        jobSummary: false
+
+    # Reporting, labelling and failing are separate steps so that the label is
+    # kept accurate even on the run that fails: a single step that exits non-zero
+    # would skip its own labelling.
+    - name: Report broken links
+      id: report
+      env:
+        TOUCHED: ${{ steps.touched.outputs.count }}
+        CHECKED: ${{ steps.narrow.outputs.count }}
+      run: |
+        {
+          echo "## External link check"
+          echo
+          echo "Links changed by this pull request: ${TOUCHED}"
+          echo "Links checked (those that render as anchors): ${CHECKED}"
+          echo
+        } >> "$GITHUB_STEP_SUMMARY"
+
+        if [ "${CHECKED}" -eq 0 ]; then
+          echo "No changed links needed checking." >> "$GITHUB_STEP_SUMMARY"
+          echo "verified=true" >> "$GITHUB_OUTPUT"
+          echo "broken=0" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # A missing report means the checker did not run to completion. Nothing
+        # was verified either way, so report that plainly and leave any existing
+        # label alone rather than asserting a state that was never established.
+        if [ ! -f lychee/results.json ]; then
+          echo "The link checker produced no report, so this pull request could not be verified." >> "$GITHUB_STEP_SUMMARY"
+          echo "verified=false" >> "$GITHUB_OUTPUT"
+          echo "broken=0" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Trim any trailing content after the JSON object: the root object is the
+        # only one closing at column 0, so this is an exact cut.
+        sed -n '1,/^}$/p' lychee/results.json > lychee/results.clean.json
+
+        jq -r '.error_map // {} | to_entries[] | .value[]
+               | [.url, (.status.text // "unknown")] | @tsv' \
+          lychee/results.clean.json | LC_ALL=C sort -u > broken.tsv
+
+        broken=$(wc -l < broken.tsv | tr -d '[:space:]')
+        echo "verified=true" >> "$GITHUB_OUTPUT"
+        echo "broken=${broken}" >> "$GITHUB_OUTPUT"
+
+        if [ "${broken}" -eq 0 ]; then
+          echo "No broken links were introduced by this pull request." >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+
+        {
+          echo "### Broken links introduced by this pull request"
+          echo
+          echo "| Link | Reason |"
+          echo "|------|--------|"
+          awk -F'\t' '{ printf "| %s | %s |\n", $1, $2 }' broken.tsv
+          echo
+          echo "Fix the link, or add it to \`.lycheeignore\` if the host blocks automated checkers but the page is reachable in a browser."
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    # The label tracks the current state of the pull request: applied when this
+    # run finds broken links, removed as soon as a later run comes back clean, so
+    # it clears itself once the author pushes a fix.
+    #
+    # Nothing is changed when the checker could not verify the links, because the
+    # absence of a result is not evidence that the links are healthy.
+    #
+    # Labelling is best-effort: a pull request from a fork gets a read-only token,
+    # and losing the label there must not turn into a failed check that hides the
+    # real result.
+    - name: Update link-rot label
+      if: always() && steps.report.outputs.verified == 'true'
+      continue-on-error: true
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BROKEN: ${{ steps.report.outputs.broken }}
+        PR: ${{ github.event.pull_request.number }}
+        LABEL: link-rot
+      run: |
+        if [ "${BROKEN}" -gt 0 ]; then
+          gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR}/labels" \
+            -f "labels[]=${LABEL}" > /dev/null
+          echo "Applied the ${LABEL} label."
+        else
+          # 404 simply means the label was not present, which is the desired state.
+          if gh api -X DELETE "repos/${GITHUB_REPOSITORY}/issues/${PR}/labels/${LABEL}" > /dev/null 2>&1; then
+            echo "Removed the ${LABEL} label."
+          else
+            echo "No ${LABEL} label to remove."
+          fi
+        fi
+
+    # Surfaces the failure on the check itself. This does not block merging: the
+    # check is not a required status check, so the red cross is a signal to the
+    # author rather than a gate.
+    - name: Fail when this PR introduces broken links
+      if: steps.report.outputs.broken != '0' || steps.report.outputs.verified != 'true'
+      run: |
+        if [ "${{ steps.report.outputs.verified }}" != "true" ]; then
+          echo "::error::The link checker produced no report, so this pull request could not be verified."
+          exit 1
+        fi
+
+        while IFS=$'\t' read -r url reason; do
+          echo "::error::Broken link: ${url} (${reason})"
+        done < broken.tsv
+
+        exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ AGENTS.md
 .claudeignore
 CLAUDE.md
 .mcp.json
+# lychee link checker (local cache + CI report output)
+.lycheecache
+lychee/

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,58 @@
+# lychee link-checker configuration
+# https://github.com/lycheeverse/lychee
+#
+# Policy: a link is only "broken" if it fails to resolve or returns a genuine
+# error (4xx/5xx). Redirects and rate-limiting are treated as healthy. Hosts
+# that block automated checkers (403 to bots) are curated in .lycheeignore.
+
+# --- Request behaviour ---
+timeout = 30            # seconds before a request is considered timed out
+max_retries = 3         # retry transient failures (covers flaky 5xx / network blips)
+retry_wait_time = 2     # seconds between retries
+max_concurrency = 16
+max_redirects = 10      # follow redirect chains to their final destination
+
+# A browser-like user agent reduces false 403s from bot-hostile hosts.
+user_agent = "Mozilla/5.0 (compatible; TinyMCE-Docs-Link-Checker/1.0; +https://www.tiny.cloud/docs)"
+
+# Resolve root-relative links (leading "/") against the live domain instead of
+# erroring on them. The site is served from https://www.tiny.cloud/docs/, so a
+# link like "/docs/_/css/site.css" or "/roadmap/" becomes an absolute URL that
+# is HTTP-checked. Relative page-to-page links are still resolved locally on
+# disk, so internal cross-reference integrity is still verified.
+# NOTE: an `exclude = ["^/"]` pattern does NOT suppress these — lychee raises the
+# "cannot resolve root-relative link" error before the exclude filter runs, so a
+# base_url is the correct mechanism.
+base_url = "https://www.tiny.cloud"
+
+# --- What counts as success ---
+# Redirects are followed, so the final status is what matters; the 3xx codes are
+# listed defensively for chains that exceed max_redirects. 429 = rate-limited,
+# not dead. 403 is NOT accepted globally (that would hide genuinely dead pages) —
+# bot-hostile hosts are curated per-URL in .lycheeignore instead.
+accept = ["200..=206", "301", "302", "307", "308", "429"]
+
+# --- Caching (keeps PR-time runs fast) ---
+cache = true
+max_cache_age = "2d"
+
+# --- Structural excludes (not link rot) ---
+include_mail = false    # skip mailto: links
+exclude = [
+  # The site's own domains: self-referential links, UI-bundle chrome (CSS,
+  # favicons, footer images) and canonical URLs. base_url resolves root-relative
+  # links to these, and this filter then drops them. They are validated by the
+  # build/deploy pipeline; HTTP-checking them here would hammer our own
+  # production site (a rate-limit storm that fails thousands of links) and 404 on
+  # pages that a PR has added but not yet deployed. Internal .adoc cross-links are
+  # still verified locally (relative links resolve on disk) and by Antora at build.
+  '^https?://([a-z0-9-]+\.)*tiny\.cloud',
+  # Loopback / local addresses that only exist during a build or in examples
+  '^https?://localhost',
+  '^https?://127\.0\.0\.1',
+  '^https?://0\.0\.0\.0',
+  # GitHub action URLs that require auth and are not real navigational links
+  '^https://github\.com/[^/]+/[^/]+/(edit|new|delete)/',
+  # Internal Jira referenced in tickets/notes, not public docs
+  '^https://[a-z]+\.atlassian\.net',
+]

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,45 @@
+# .lycheeignore — curated allow-list of URLs/patterns lychee should skip.
+# Works like .gitignore, but for links. One URL or regex per line.
+#
+# Add an entry here ONLY after manually confirming the link works in a browser.
+# This is the escape hatch for hosts that return 403/429 to automated checkers
+# but are perfectly valid for readers (LinkedIn, Instagram, some CDNs, etc.).
+#
+# Seed entries below are commented out; uncomment / extend as the baseline crawl
+# surfaces real false positives. Keep this list minimal — genuinely dead links
+# must NOT be parked here.
+
+# Verified alive in a browser but rejected by the automated checker
+# (bot detection / rate limiting):
+https://www.stylemanual.gov.au/
+# Footer "join our Slack" link: tinyurl -> join.slack.com invite. Valid, but
+# tinyurl/Slack return 403 to bots. Appears on every page.
+https://www.tinyurl.com/tinyslack
+
+# Hosts that serve a JS/WAF challenge or 403/999 to automated checkers but load
+# fine in a browser. Verified reachable manually; cannot be checked by any bot,
+# so checking them only produces false failures.
+https://www.npmjs.com/
+https://codepen.io/
+https://dotnet.microsoft.com/
+https://platform.openai.com/
+https://help.openai.com/
+https://www.researchgate.net/
+https://researchgate.net/
+https://benmarshall.me/
+https://malavkhatri.com/
+
+# Common social hosts that block automated checkers — uncomment if they surface:
+# https://www.linkedin.com/
+# https://www.instagram.com/
+# https://www.facebook.com/
+# https://twitter.com/
+# https://x.com/
+
+# Verified by a full-site scan (2026-08-20): reachable in a browser, but the
+# automated checker is refused.
+# Bot detection -> 403:
+https://stackoverflow.com/
+https://www.graylog.org/
+# MCP endpoint: rejects HEAD/GET with 405 by design, it is not a web page.
+https://tinymcedocs.mcp.kapa.ai/

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "./-scripts/api-reference.sh",
     "build-local-ref": "./-scripts/api-reference-local.sh",
+    "check-links": "lychee --config .lychee.toml --no-progress './build/site/**/*.html'",
     "clean": "rm -rf ./build",
     "nodemon": "nodemon --exec yarn antora ./antora-playbook.yml",
     "nodemon-dev": "nodemon --exec yarn antora ./antora-playbook-local.yml",


### PR DESCRIPTION
**Ticket:** TINYDOC-3514

**Site:** CI-only change; no page content differs.

Ports the pull request link check to the `tinymce/6` line. The workflow and both configuration files are byte-identical to the `tinymce/8` version in #4277.

A broken link in a changed `.adoc` fails the `Link Check` check and applies the `link-rot` label; pushing a fix clears both on the next run. It does not block merging. Only links the pull request touched are checked, so existing rot on this line will not fail unrelated pull requests.

**Changes:**
* Added `.github/workflows/link-check-pr.yml`.
* Added `.lychee.toml` and `.lycheeignore`.
* Added a `check-links` script to `package.json` and cache/report output paths to `.gitignore`.

**Note:** the build glob deliberately does not name a version segment. This branch's local playbook has no `latest_version_segment`, so it builds to `build/site/tinymce/6` rather than `.../latest`; a glob that matches nothing is only a lychee `[WARN]`, which would have let the check pass silently while verifying nothing. Merge #4277 first.

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: `hotfix/6/TINYDOC-3514`
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
