### PR TITLE
TINYDOC-3514 - Narrow the tiny.cloud link-check exclusion to the documentation path `/latest`

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -39,14 +39,28 @@ max_cache_age = "2d"
 # --- Structural excludes (not link rot) ---
 include_mail = false    # skip mailto: links
 exclude = [
-  # The site's own domains: self-referential links, UI-bundle chrome (CSS,
-  # favicons, footer images) and canonical URLs. base_url resolves root-relative
-  # links to these, and this filter then drops them. They are validated by the
-  # build/deploy pipeline; HTTP-checking them here would hammer our own
-  # production site (a rate-limit storm that fails thousands of links) and 404 on
-  # pages that a PR has added but not yet deployed. Internal .adoc cross-links are
-  # still verified locally (relative links resolve on disk) and by Antora at build.
-  '^https?://([a-z0-9-]+\.)*tiny\.cloud',
+  # Self-referential documentation links, plus the UI-bundle chrome (CSS,
+  # favicons, footer images) and canonical URLs that base_url resolves under the
+  # same path. A pull request routinely adds a page and links to it before that
+  # page is published, so checking these would 404 on content that is about to
+  # exist. They are not left unverified: Antora resolves internal cross-links at
+  # build time, and the deploy pipeline covers the published site.
+  #
+  # Scoped to the /docs path, not the whole domain. A domain-wide pattern also
+  # swallows the marketing and product pages (/pricing, /contact, /signup,
+  # /my-account, /legal ...), where a 404 is genuine link rot that nothing else
+  # in the pipeline catches.
+  '^https?://(www\.)?tiny\.cloud/docs(/|$)',
+  # The TinyMCE AI API base URL. Documented as a base URL in prose, where
+  # Asciidoctor auto-links it into a real anchor, so the checker does see it. It
+  # answers authenticated requests on its sub-paths and 404s on the root by
+  # design; those sub-paths (/docs, /v1 ...) are still checked.
+  '^https?://tinymceai\.api\.tiny\.cloud/?$',
+  # JWT claim names, not links. RFC 7519 namespaces private claims as URIs, so
+  # these are identifiers that are never fetched and the host does not resolve
+  # by design. Asciidoctor auto-links them out of the inline code they appear
+  # in, which is the only reason the checker sees them at all.
+  '^https?://claims\.tiny\.cloud',
   # Loopback / local addresses that only exist during a build or in examples
   '^https?://localhost',
   '^https?://127\.0\.0\.1',

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -41,5 +41,9 @@ https://malavkhatri.com/
 # Bot detection -> 403:
 https://stackoverflow.com/
 https://www.graylog.org/
+# Tiny's support portal. Reachable in a browser; refuses automated checkers.
+# Previously covered by the domain-wide tiny.cloud exclude in .lychee.toml,
+# which has since been narrowed to the documentation path.
+https://support.tiny.cloud/
 # MCP endpoint: rejects HEAD/GET with 405 by design, it is not a web page.
 https://tinymcedocs.mcp.kapa.ai/


### PR DESCRIPTION
**Ticket:** TINYDOC-3514

**Site:** [Staging](https://pr-4333.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/) (CI-only change; no page content differs)

Follow-up to #4277. `.lychee.toml` excluded the whole `tiny.cloud` domain, so a pull request whose only changed link is on that domain passed having checked nothing — the job reported "0 of the PR's link(s) render as anchors" and went green. Reproduced on #4332: a link to a hard 404 under `/pricing/` passed before this change, and fails with it ([run](https://github.com/tinymce/tinymce-docs/actions/runs/33456797682)).

The exclusion was written for documentation pages a pull request adds before they are published. That covers `tiny.cloud/docs`, not the marketing and product pages, where a 404 is real link rot.

**Changes:**
* `.lychee.toml`: replaced `'^https?://([a-z0-9-]+\.)*tiny\.cloud'` with three scoped rules — `/docs` self-links, the TinyMCE AI API base URL (404s on its root by design), and `claims.tiny.cloud` (JWT claim names, not links).
* `.lycheeignore`: added `https://support.tiny.cloud/` (403 to automated checkers, reachable in a browser), previously covered by the domain-wide pattern.

**Note:** each branch was built and every `tiny.cloud` anchor the change newly exposes was probed — 66 on `/8`, 60 on `/7`, 48 on `/6`, 83 on `/5`, none unhealthy. Applied identically to #4333 (`/latest`), #4334 (v7), #4335 (v6), #4336 (v5).

---

### **Pre-checks:**

- [x] Branch is correctly prefixed: `hotfix/8/TINYDOC-3514-narrow-exclusion`
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
