### PR TITLE
TINYDOC-3579: Styles from the `content_style` option did not take precedence over `content_css` in the preview iframe.

### DIFF
--- a/modules/ROOT/pages/8.9.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.9.1-release-notes.adoc
@@ -81,7 +81,7 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== Styles from the `+content_style+` option did not take precedence over `+content_css+` in the preview iframe
 // #TINYMCE-14748
 
-Previously, the **Suggested Edits** plugin added the styles from the xref:add-css-options.adoc#content_style[`+content_style+`] option to the preview before the stylesheets loaded by the xref:add-css-options.adoc#content_css[`+content_css+`] option. The styles from both options carry equal specificity, so the `+content_css+` stylesheets overrode the `+content_style+` rules. The preview then rendered content differently from the editor content. The difference was clearest in body width and padding, two properties that `+content_style+` commonly sets.
+Previously, the **Suggested Edits** plugin added the styles from the xref:add-css-options.adoc#content_style[`+content_style+`] option to the preview before the stylesheets loaded by the xref:add-css-options.adoc#content_css[`+content_css+`] option. The styles from both options carry equal specificity, so the `+content_css+` stylesheets overrode the `+content_style+` rules. 
 
 In {productname} {release-version}, the **Suggested Edits** plugin adds the styles from `+content_style+` after the stylesheets loaded by `+content_css+`, matching the order that {productname} uses in the editor content. Styles from `+content_style+` now apply in the preview, so the preview renders consistently with the editor content.
 

--- a/modules/ROOT/pages/8.9.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.9.1-release-notes.adoc
@@ -72,6 +72,38 @@ The {productname} {release-version} release includes an accompanying release of 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
 
+=== Suggested Edits
+
+The {productname} {release-version} release includes an accompanying release of the **Suggested Edits** premium plugin.
+
+**Suggested Edits** includes the following fix.
+
+==== Styles from the `+content_style+` option did not take precedence over `+content_css+` in the preview iframe
+// #TINYMCE-14748
+
+Previously, the **Suggested Edits** plugin added the styles from the xref:add-css-options.adoc#content_style[`+content_style+`] option to the preview before the stylesheets loaded by the xref:add-css-options.adoc#content_css[`+content_css+`] option. The styles from both options carry equal specificity, so the `+content_css+` stylesheets overrode the `+content_style+` rules. The preview then rendered content differently from the editor content. The difference was clearest in body width and padding, two properties that `+content_style+` commonly sets.
+
+In {productname} {release-version}, the **Suggested Edits** plugin adds the styles from `+content_style+` after the stylesheets loaded by `+content_css+`, matching the order that {productname} uses in the editor content. Styles from `+content_style+` now apply in the preview, so the preview renders consistently with the editor content.
+
+For information on the **Suggested Edits** plugin, see: xref:suggestededits.adoc[Suggested Edits].
+
+
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following fix.
+
+==== Styles from the `+content_style+` option did not take precedence over `+content_css+` in the preview iframe
+// #TINYMCE-14748
+
+Previously, the **TinyMCE AI** plugin added the styles from the xref:add-css-options.adoc#content_style[`+content_style+`] option to the preview before the stylesheets loaded by the xref:add-css-options.adoc#content_css[`+content_css+`] option. The styles from both options carry equal specificity, so the `+content_css+` stylesheets overrode the `+content_style+` rules. The preview then rendered content differently from the editor content. The difference was clearest in body width and padding, two properties that `+content_style+` commonly sets.
+
+In {productname} {release-version}, the **TinyMCE AI** plugin adds the styles from `+content_style+` after the stylesheets loaded by `+content_css+`, matching the order that {productname} uses in the editor content. Styles from `+content_style+` now apply in the preview, so the preview renders consistently with the editor content.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
+
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement
 

--- a/modules/ROOT/pages/8.9.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.9.1-release-notes.adoc
@@ -97,7 +97,7 @@ The {productname} {release-version} release includes an accompanying release of 
 ==== Styles from the `+content_style+` option did not take precedence over `+content_css+` in the preview iframe
 // #TINYMCE-14748
 
-Previously, the **TinyMCE AI** plugin added the styles from the xref:add-css-options.adoc#content_style[`+content_style+`] option to the preview before the stylesheets loaded by the xref:add-css-options.adoc#content_css[`+content_css+`] option. The styles from both options carry equal specificity, so the `+content_css+` stylesheets overrode the `+content_style+` rules. The preview then rendered content differently from the editor content. The difference was clearest in body width and padding, two properties that `+content_style+` commonly sets.
+Previously, the **TinyMCE AI** plugin added the styles from the xref:add-css-options.adoc#content_style[`+content_style+`] option to the preview before the stylesheets loaded by the xref:add-css-options.adoc#content_css[`+content_css+`] option. The styles from both options carry equal specificity, so the `+content_css+` stylesheets overrode the `+content_style+` rules.
 
 In {productname} {release-version}, the **TinyMCE AI** plugin adds the styles from `+content_style+` after the stylesheets loaded by `+content_css+`, matching the order that {productname} uses in the editor content. Styles from `+content_style+` now apply in the preview, so the preview renders consistently with the editor content.
 


### PR DESCRIPTION
**Ticket:** TINYDOC-3579 (TINYMCE-14748)

**Site:** [Staging](https://pr-4341.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.9.1-release-notes/#styles-from-the-content_style-option-did-not-take-precedence-over-content_css-in-the-preview-iframe)

**Changes:**
* Added release note entry for TINYMCE-14748 to `modules/ROOT/pages/8.9.1-release-notes.adoc` (Accompanying Premium plugin changes section, **Suggested Edits**): Styles from the `content_style` option did not take precedence over `content_css` in the preview iframe.
* Added release note entry for TINYMCE-14748 to `modules/ROOT/pages/8.9.1-release-notes.adoc` (Accompanying Premium plugin changes section, **TinyMCE AI**): same fix, [second entry](https://pr-4341.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.9.1-release-notes/#styles-from-the-content_style-option-did-not-take-precedence-over-content_css-in-the-preview-iframe-2).

### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
