### PR TITLE
TINYDOC-3579: Menus in the TinyMCE AI sidebars showed unnecessary scrollbars when the sidebar type was set to 'floating'.

### DIFF
--- a/modules/ROOT/pages/8.9.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.9.1-release-notes.adoc
@@ -72,6 +72,22 @@ The {productname} {release-version} release includes an accompanying release of 
 For information on the **<Premium plugin name 1>** plugin, see: xref:<plugincode>.adoc[<Premium plugin name 1>].
 
 
+=== TinyMCE AI
+
+The {productname} {release-version} release includes an accompanying release of the **TinyMCE AI** premium plugin.
+
+**TinyMCE AI** includes the following fix.
+
+==== Menus in the TinyMCE AI sidebars showed unnecessary scrollbars when the sidebar type was set to 'floating'
+// #TINYMCE-14570
+
+Previously, menus opened from the **TinyMCE AI** sidebars showed unnecessary scrollbars. With the xref:tinymceai.adoc#tinymceai_sidebar_type[`+tinymceai_sidebar_type+`] option set to `+'floating'+`, the menu for adding context sources, the model selection dropdown, and the menu on a chat history item each showed a second vertical scrollbar or a horizontal scrollbar. This regression, introduced in {productname} 8.5, made those menus harder to read and to scroll.
+
+In {productname} {release-version}, the **TinyMCE AI** plugin no longer applies its own overflow and width constraints to these menus. Each menu in the Chat sidebar and the Review sidebar now shows a single scrollbar, and only when its content does not fit.
+
+For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
+
+
 [[accompanying-premium-plugin-end-of-life-announcement]]
 == Accompanying Premium plugin end-of-life announcement
 

--- a/modules/ROOT/pages/8.9.1-release-notes.adoc
+++ b/modules/ROOT/pages/8.9.1-release-notes.adoc
@@ -83,7 +83,7 @@ The {productname} {release-version} release includes an accompanying release of 
 
 Previously, menus opened from the **TinyMCE AI** sidebars showed unnecessary scrollbars. With the xref:tinymceai.adoc#tinymceai_sidebar_type[`+tinymceai_sidebar_type+`] option set to `+'floating'+`, the menu for adding context sources, the model selection dropdown, and the menu on a chat history item each showed a second vertical scrollbar or a horizontal scrollbar. This regression, introduced in {productname} 8.5, made those menus harder to read and to scroll.
 
-In {productname} {release-version}, the **TinyMCE AI** plugin no longer applies its own overflow and width constraints to these menus. Each menu in the Chat sidebar and the Review sidebar now shows a single scrollbar, and only when its content does not fit.
+In {productname} {release-version}, the **TinyMCE AI** plugin no longer applies its own overflow constraint to these menus, and sizes each menu to the space available to it rather than to the full width of its container. Menus in the Chat sidebar and the Review sidebar now show a single scrollbar, and only when the content does not fit.
 
 For information on the **TinyMCE AI** plugin, see: xref:tinymceai.adoc[TinyMCE AI].
 


### PR DESCRIPTION
**Ticket:** TINYDOC-3579 (TINYMCE-14570)

**Site:** [Staging](https://pr-4343.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/8.9.1-release-notes/#menus-in-the-tinymce-ai-sidebars-showed-unnecessary-scrollbars-when-the-sidebar-type-was-set-to-floating)

**Changes:**
* Added release note entry for TINYMCE-14570 to `modules/ROOT/pages/8.9.1-release-notes.adoc` (Accompanying Premium plugin changes section, **TinyMCE AI**): menus in the TinyMCE AI sidebars showed unnecessary scrollbars when the sidebar type was set to `'floating'`.


### **Pre-checks:**

- [x] ~~Branch is correctly prefixed~~ (release-note branch)
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
