### PR TITLE
TINYDOC-3593: Correct the AI license key environment variable spelling and flag the license key placeholder.

### DIFF
--- a/modules/ROOT/pages/tinymceai-on-premises-getting-started.adoc
+++ b/modules/ROOT/pages/tinymceai-on-premises-getting-started.adoc
@@ -122,7 +122,7 @@ If the AI service needs to reach the host machine (for example a self-hosted Oll
 [source,bash]
 ----
 # --- Required: AI service license key provided by Tiny ---
-AI_LICENCE_KEY='paste-ai-licence-key-here'
+AI_LICENSE_KEY='paste-ai-license-key-here'
 
 # --- Required: strong secret used to log into the Management Panel ---
 MANAGEMENT_SECRET='replace-with-strong-secret'
@@ -142,9 +142,9 @@ AI_API_SECRET='paste-api-secret-here'
 
 [IMPORTANT]
 ====
- * `AI_LICENCE_KEY` activates the AI service container.
+ * `AI_LICENSE_KEY` activates the AI service container.
  * The `license_key` init option in `tinymce.init()` activates premium {productname} features in the self-hosted editor. 
- * These are different credentials from different sources — they are not interchangeable. See the xref:tinymceai-on-premises.adoc#_credentials[Credentials] section on the Overview page.
+ * These are different credentials from different sources — they are not interchangeable. See the xref:tinymceai-on-premises.adoc#credentials[Credentials] section on the Overview page.
 ====
 
 === Start MySQL and Redis
@@ -181,14 +181,14 @@ Use the matching network name in `--network` below. First, load the `.env` file:
 set -a && source .env && set +a
 ----
 
-Then start the AI service container. The `docker run` command maps the friendly `.env` names onto the service's own environment variables — for example, `AI_LICENCE_KEY` is passed to the container as `LICENSE_KEY`, and `MANAGEMENT_SECRET` as `ENVIRONMENTS_MANAGEMENT_SECRET_KEY`:
+Then start the AI service container. The `docker run` command maps the friendly `.env` names onto the service's own environment variables — for example, `AI_LICENSE_KEY` is passed to the container as `LICENSE_KEY`, and `MANAGEMENT_SECRET` as `ENVIRONMENTS_MANAGEMENT_SECRET_KEY`:
 
 [source,bash]
 ----
 docker run --init -d -p 8000:8000 \
   --network <compose-network-name> \
   --name ai-service \
-  -e LICENSE_KEY="$AI_LICENCE_KEY" \
+  -e LICENSE_KEY="$AI_LICENSE_KEY" \
   -e ENVIRONMENTS_MANAGEMENT_SECRET_KEY="$MANAGEMENT_SECRET" \
   -e DATABASE_DRIVER='mysql' \
   -e DATABASE_HOST='mysql' \
@@ -249,7 +249,7 @@ Server is listening on port 8000.
 
 [WARNING]
 --
-If the container exits immediately, run `docker logs ai-service`. The most common causes are documented in the xref:tinymceai-on-premises-troubleshooting.adoc[Troubleshooting] guide. The top three are: malformed `AI_LICENCE_KEY` (line breaks from word wrap), missing PostgreSQL schema, and JSON syntax error in `PROVIDERS`.
+If the container exits immediately, run `docker logs ai-service`. The most common causes are documented in the xref:tinymceai-on-premises-troubleshooting.adoc[Troubleshooting] guide. The top three are: malformed `AI_LICENSE_KEY` (line breaks from word wrap), missing PostgreSQL schema, and JSON syntax error in `PROVIDERS`.
 --
 
 === Create an environment and access key
@@ -380,6 +380,8 @@ app.listen(PORT, () => {
   console.log('AI Service: ' + AI_SERVICE_URL);
 });
 ----
+
+NOTE: Replace `'your-license-key'` in the `token-server.js` listing with the {productname} editor license key. This is the editor license key described in the xref:tinymceai-on-premises.adoc#credentials[Credentials] section, not the AI service `AI_LICENSE_KEY`. For details on obtaining and applying it, see xref:license-key.adoc[License key].
 
 === Install and run
 


### PR DESCRIPTION
**Ticket:** TINYDOC-3593

**Site:** [Staging branch](https://pr-4344.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/tinymceai-on-premises-getting-started/#create-the-env-file)

**Changes:**

`modules/ROOT/pages/tinymceai-on-premises-getting-started.adoc`

* Renamed all five occurrences of the `.env` alias `AI_LICENCE_KEY` to `AI_LICENSE_KEY` for consistent US English spelling, across the `.env` example, the `[IMPORTANT]` admonition, the prose describing the environment variable mapping, the `docker run` block, and the `[WARNING]` admonition. The placeholder value on the same line was also normalized (`paste-ai-licence-key-here` to `paste-ai-license-key-here`).
* Left `LICENSE_KEY` (the container's own environment variable) and `license_key` (the `tinymce.init()` option) unchanged, as both are fixed API surface. The `[IMPORTANT]` admonition explaining that these are separate, non-interchangeable credentials is unchanged apart from the renamed alias.
* Added a `NOTE` admonition after the `token-server.js` listing instructing the reader to replace `'your-license-key'` with the editor license key, distinguishing it from the AI service license key and linking to the [License key](https://www.tiny.cloud/docs/tinymce/latest/license-key/) page. The listing itself is unmodified.
* Corrected the anchor on two cross-references to the Credentials section of the on-premises overview page. Both pointed at `#_credentials`, which does not exist on that page; the correct anchor is `#credentials`. One of these was pre-existing and produced a broken link.

### **Pre-checks:**

- [x] Branch is correctly prefixed.
- [x] Build passes without console errors, warnings, or issues.

### **Review:**

- [x] Documentation Team Lead has reviewed.
