### PR TITLE
TINYDOC-3596: Consolidate the duplicated keyboard shortcut tables and add reciprocal accessibility cross-links.

### DIFF
--- a/modules/ROOT/pages/keyboard-shortcuts.adoc
+++ b/modules/ROOT/pages/keyboard-shortcuts.adoc
@@ -4,6 +4,8 @@
 :description: Complete list of keyboard shortcuts.
 :keywords: keyboard, shortcuts
 
+This page is the complete reference for the keyboard shortcuts provided by {productname}. For a task-by-task explanation of how to use the focus and navigation shortcuts with a screen reader, see the xref:tinymce-and-screenreaders.adoc[Accessible navigation guide]. For the configuration options that affect keyboard and screen reader support, see xref:accessibility.adoc[Accessibility options].
+
 [[editor-keyboard-shortcuts]]
 == Editor keyboard shortcuts
 
@@ -40,9 +42,10 @@ This is a list of available keyboard shortcuts within the editor body.
 |Find |Ctrl+F |⌘+F |xref:searchreplace.adoc[searchreplace]
 |===
 
+[[accessibility-keyboard-shortcuts]]
 == Accessibility keyboard shortcuts
 
-This is a list of available keyboard shortcuts within the editor user interface.
+This is a list of available keyboard shortcuts within the editor user interface. The shortcuts that move focus into the editor user interface from the content area, such as *Alt+F9* (or *⌥+F9*), are listed in xref:#editor-keyboard-shortcuts[Editor keyboard shortcuts].
 
 [cols=",,",options="header"]
 |===

--- a/modules/ROOT/pages/tinymce-and-screenreaders.adoc
+++ b/modules/ROOT/pages/tinymce-and-screenreaders.adoc
@@ -8,22 +8,14 @@
 
 == Keyboard shortcuts
 
-The following *Alt+key* and *Option+key* shortcuts can only be used when the content area of the editor has focus.
+The *Alt+key* and *Option+key* shortcuts that move focus out of the content area, such as *Alt+F9* (or *⌥+F9*), can only be used when the content area of the editor has focus.
 
-[cols=",,",options="header"]
-|===
-|Task |Windows or Linux |macOS
-|Focus/jump to menu bar |Alt+F9 |⌥+F9
-|Focus/jump to toolbar |Alt+F10 |⌥+F10
-|Focus/jump to element path |Alt+F11 |⌥+F11
-|Focus/jump to notification |Alt+F12 |⌥+F12
-|Close menu/submenu/dialog |Esc |Esc
-|Return to the editor content area |Esc |Esc
-|Navigate left/right through menu/toolbar |Tab and the Arrow Keys |Tab and the Arrow Keys
-|Open the {productname} Help dialog |Alt+0 |⌥+0
-|===
+The complete list of shortcuts is maintained on the xref:keyboard-shortcuts.adoc[{productname} Keyboard shortcuts] page:
 
-For additional navigation keyboard shortcuts and shortcuts for applying some commonly-used formats, see: xref:keyboard-shortcuts.adoc[Keyboard shortcuts].
+* xref:keyboard-shortcuts.adoc#editor-keyboard-shortcuts[Editor keyboard shortcuts] lists the shortcuts that move focus to the menu bar, the toolbar, the element path, and notifications, along with the shortcuts for applying commonly-used formats.
+* xref:keyboard-shortcuts.adoc#accessibility-keyboard-shortcuts[Accessibility keyboard shortcuts] lists the shortcuts for moving between menus, toolbar buttons, and dialog controls within the editor user interface.
+
+The sections that follow describe how to use these shortcuts to complete each navigation task.
 
 == How to work with the editor
 

--- a/modules/ROOT/partials/configuration/accessibility-keyboard-navigation.adoc
+++ b/modules/ROOT/partials/configuration/accessibility-keyboard-navigation.adoc
@@ -13,21 +13,12 @@ The editor provides two main ways to access formatting and editing features:
 
 [TIP]
 ====
-When a feature appears only in a contextual toolbar (for example, editing alternative text for an image), use the keyboard shortcut to focus the contextual toolbar. See the table below.
+When a feature appears only in a contextual toolbar (for example, editing alternative text for an image), press *Ctrl+F9* to focus the contextual toolbar.
 ====
 
 === Keyboard shortcuts for editor navigation
 
-[cols="1,2,2",options="header"]
-|===
-|Action |Windows or Linux |macOS
-|Focus the menu bar |Alt+F9 |⌥+F9
-|Focus the toolbar |Alt+F10 |⌥+F10
-|Focus the element path (footer) |Alt+F11 |⌥+F11
-|Focus notifications |Alt+F12 |⌥+F12
-|Focus the contextual toolbar |Ctrl+F9 |Ctrl+F9
-|Open the Help dialog |Alt+0 |⌥+0
-|===
+The shortcuts that move focus to the menu bar, the toolbar, the contextual toolbar, the element path, and notifications are listed in xref:keyboard-shortcuts.adoc#editor-keyboard-shortcuts[Editor keyboard shortcuts]. The shortcuts for moving between individual menus, toolbar buttons, and dialog controls are listed in xref:keyboard-shortcuts.adoc#accessibility-keyboard-shortcuts[Accessibility keyboard shortcuts]. For a task-by-task explanation of these shortcuts, see the xref:tinymce-and-screenreaders.adoc[Accessible navigation guide].
 
 The contextual toolbar appears when the cursor is on content that has context-specific actions, such as an image or a link. For example, to edit alternative text for an image using only the keyboard:
 


### PR DESCRIPTION
**Ticket:** TINYDOC-3596

**Site:** [Staging branch](https://pr-4345.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/keyboard-shortcuts/#accessibility-keyboard-shortcuts)

**Changes:**

The focus-jump shortcuts (Alt+F9 to Alt+F12 and Alt+0) were maintained in three separate places. The ticket identified two of them; a third copy exists in the `accessibility-keyboard-navigation.adoc` partial, which renders on the Accessibility options page. This change makes `keyboard-shortcuts.adoc` the single authoritative reference for the shortcut tables and replaces the other two copies with cross-references.

### **Pre-checks:**

- [x] Branch is correctly prefixed:
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.

---

### **Review:**

- [x] Documentation Team Lead has reviewed.
