### PR TITLE
TINYDOC-3607: Link the Trust Center from the security guide and clarify the Accessibility Checker scope.

### DIFF
--- a/modules/ROOT/pages/a11ychecker.adoc
+++ b/modules/ROOT/pages/a11ychecker.adoc
@@ -1,6 +1,6 @@
 = Accessibility Checker plugin
 :navtitle: Accessibility Checker
-:description: Checks the contents of the editor for WCAG & Section 508 accessibility problems.
+:description: Checks the content authored in the editor for WCAG and Section 508 accessibility problems.
 :keywords: a11y, accessibility, WCAG
 :pluginname: Accessibility Checker
 :plugincode: a11ychecker
@@ -9,7 +9,9 @@
 
 include::partial$misc/admon-premium-plugin.adoc[]
 
-The `+a11ychecker+` premium plugin allows you to check the HTML in the editor for various WCAG & Section 508 accessibility problems. It has an auto-repair feature that lets the user fix identified problems.
+The `+a11ychecker+` premium plugin allows you to check the HTML authored in the editor for various WCAG and Section 508 accessibility problems. It has an auto-repair feature that lets the user fix identified problems.
+
+NOTE: The {pluginname} plugin evaluates the content authored in the editor. It does not evaluate the accessibility of the {productname} user interface, and the rules it applies are not a statement of conformance for {productname} itself. For information on using the editor with a keyboard or a screen reader, see the xref:tinymce-and-screenreaders.adoc[Accessible navigation guide].
 
 == Interactive example
 

--- a/modules/ROOT/pages/security.adoc
+++ b/modules/ROOT/pages/security.adoc
@@ -12,6 +12,7 @@ NOTE: The following is _general_ security advice that may be relevant to a websi
 * xref:what-we-do-to-maintain-security-for-tinymce[What we do to maintain security for {productname}]
 ** xref:scripts-and-xss-vulnerabilities[Scripts and XSS vulnerabilities]
 ** xref:keeping-dependencies-up-to-date[Keeping dependencies up-to-date]
+* xref:security-assurance-and-compliance[Security assurance and compliance]
 * xref:enforcing-https-with-hsts[Enforcing HTTPS with HSTS]
 * xref:configuring-content-security-policy-csp-for-tinymce[Configuring Content Security Policy (CSP) for {productname}]
 * xref:general-security-risks-for-user-input-elements[General security risks for user input elements]
@@ -61,6 +62,13 @@ From the 1st of January 2020, Security Advisories for patched XSS vulnerabilitie
 === Keeping dependencies up-to-date
 
 To protect our users, {companyname} ensures that the {productname} dependencies are updated before the next version (major or minor) is released.
+
+[[security-assurance-and-compliance]]
+== Security assurance and compliance
+
+{companyname} publishes its security and compliance posture, including the frameworks it maintains, in the link:https://trust.tiny.cloud/[{companyname} Trust Center].
+
+The Trust Center also holds the supporting documentation, such as audit reports, penetration test reports, and a completed security posture questionnaire. These documents are made available on request through the Trust Center.
 
 [[enforcing-https-with-hsts]]
 == Enforcing HTTPS with HSTS


### PR DESCRIPTION
**Ticket:** TINYDOC-3607

**Site:** [Staging branch](https://pr-4346.tinymce-docs.iad.staging.tiny.cloud/docs/tinymce/latest/security/#security-assurance-and-compliance)

**Changes:**

A reader evaluating {productname} had no route from the documentation to any compliance evidence, and the only conformance language in the documentation described the wrong subject.

`modules/ROOT/pages/security.adoc`

* Added a *Security assurance and compliance* section linking the Trust Center and describing what it holds: audit reports, penetration test reports, and a security posture questionnaire, available on request.
* Added the matching entry to the page's Overview list.

`modules/ROOT/pages/a11ychecker.adoc`

* Corrected the `:description:` metadata, which read "Checks the contents of the editor for WCAG & Section 508 accessibility problems." This is the text rendered in search results and on index cards, and an evaluator skimming it can read it as a conformance claim for the editor. It is not one — the plugin evaluates content authored in the editor.
* Added a note stating that the plugin evaluates authored content, does not evaluate the accessibility of the {productname} user interface, and that the rules it applies are not a statement of conformance for {productname} itself, with a cross-reference to the Accessible navigation guide.

### **Pre-checks:**

- [x] Branch is correctly prefixed:
- [x] Files have been included where required (if applicable).
- [x] Build passes without console errors, warnings, or issues.


### **Review:**

- [x] Documentation Team Lead has reviewed.
